### PR TITLE
[receiver/prometheus] Add fallback_scrape_protocol during config validation

### DIFF
--- a/.chloggen/prom-scrape-config-protocol.yaml
+++ b/.chloggen/prom-scrape-config-protocol.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Collector failing to start up if Prometheus receiver is present in config without 'fallback_scrape_protocol'.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38018]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/datadogexporter/examples/collector-metrics.yaml
+++ b/exporter/datadogexporter/examples/collector-metrics.yaml
@@ -4,7 +4,6 @@ receivers:
       scrape_configs:
       - job_name: 'otelcol'
         scrape_interval: 10s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
         static_configs:
         - targets: ['0.0.0.0:8888']
 

--- a/exporter/datadogexporter/examples/ootb-ec2.yaml
+++ b/exporter/datadogexporter/examples/ootb-ec2.yaml
@@ -39,7 +39,6 @@ receivers:
       scrape_configs:
       - job_name: 'otelcol'
         scrape_interval: 10s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
         static_configs:
         - targets: ['0.0.0.0:8888']
 

--- a/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
@@ -11,7 +11,6 @@ receivers:
       scrape_configs:
         - job_name: 'otelcol'
           scrape_interval: 1s
-          fallback_scrape_protocol: "PrometheusText1.0.0"
           static_configs:
             - targets: [ '${env:PROM_SERVER}' ]
 

--- a/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
@@ -11,7 +11,6 @@ receivers:
       scrape_configs:
         - job_name: 'otelcol'
           scrape_interval: 1s
-          fallback_scrape_protocol: "PrometheusText1.0.0"
           static_configs:
             - targets: [ '${env:PROM_SERVER}' ]
           metric_relabel_configs:

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -103,6 +103,15 @@ func (cfg *PromConfig) Validate() error {
 	if err != nil {
 		return err
 	}
+	// Since Prometheus 3.0, the scrape manager started to fail scrapes that don't have proper
+	// Content-Type headers, but they provided an extra configuration option to fallback to the
+	// previous behavior. We need to make sure that this option is set for all scrape configs
+	// to avoid introducing a breaking change.
+	for _, sc := range scrapeConfigs {
+		if sc.ScrapeFallbackProtocol == "" {
+			sc.ScrapeFallbackProtocol = promconfig.PrometheusText0_0_4
+		}
+	}
 
 	for _, sc := range scrapeConfigs {
 		if err := validateHTTPClientConfig(&sc.HTTPClientConfig); err != nil {

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -63,7 +63,6 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	configWarnings(set.Logger, cfg.(*Config))
-	addDefaultFallbackScrapeProtocol(cfg.(*Config))
 	return newPrometheusReceiver(set, cfg.(*Config), nextConsumer), nil
 }
 
@@ -73,14 +72,6 @@ func configWarnings(logger *zap.Logger, cfg *Config) {
 			if rc.TargetLabel == "__name__" {
 				logger.Warn("metric renaming using metric_relabel_configs will result in unknown-typed metrics without a unit or description", zap.String("job", sc.JobName))
 			}
-		}
-	}
-}
-
-func addDefaultFallbackScrapeProtocol(cfg *Config) {
-	for _, sc := range cfg.PrometheusConfig.ScrapeConfigs {
-		if sc.ScrapeFallbackProtocol == "" {
-			sc.ScrapeFallbackProtocol = promconfig.PrometheusText1_0_0
 		}
 	}
 }

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -62,22 +61,4 @@ func TestMultipleCreate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, secondRcvr.Start(context.Background(), host))
 	require.NoError(t, secondRcvr.Shutdown(context.Background()))
-}
-
-func TestDefaultFallbackScrapeProtocol(t *testing.T) {
-	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config_fallback_scrape_protocol.yaml"))
-	require.NoError(t, err)
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
-	require.NoError(t, err)
-	assert.NoError(t, sub.Unmarshal(cfg))
-
-	_, err = factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	require.NoError(t, err)
-
-	// During receiver creation, scrapeconfig without fallback scrape protocol set, should be set to 'PrometheusText1.0.0'.
-	assert.Equal(t, promconfig.PrometheusText1_0_0, cfg.(*Config).PrometheusConfig.ScrapeConfigs[0].ScrapeFallbackProtocol)
-	assert.Equal(t, promconfig.OpenMetricsText1_0_0, cfg.(*Config).PrometheusConfig.ScrapeConfigs[1].ScrapeFallbackProtocol)
 }

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -109,7 +109,6 @@ receivers:
       scrape_configs:
         - job_name: 'test'
           scrape_interval: 100ms
-          fallback_scrape_protocol: "PrometheusText1.0.0"
           static_configs:
             - targets: [%q]
 

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
-	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/require"
@@ -258,7 +257,6 @@ func TestLabelNameLimitConfig(t *testing.T) {
 	testComponent(t, targets, nil, func(cfg *PromConfig) {
 		// set label limit in scrape_config
 		for _, scrapeCfg := range cfg.ScrapeConfigs {
-			scrapeCfg.ScrapeFallbackProtocol = promconfig.PrometheusText1_0_0
 			scrapeCfg.LabelNameLengthLimit = 20
 		}
 	})

--- a/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
+++ b/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
@@ -15,10 +15,8 @@ prometheus/withScrape:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
 prometheus/withOnlyScrape:
   config:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-file-sd-config-json.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-file-sd-config-json.yaml
@@ -3,6 +3,5 @@ prometheus:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
         file_sd_configs:
         - files: ["./testdata/sd-config-with-null-target-group.json"]

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-file-sd-config-yaml.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-file-sd-config-yaml.yaml
@@ -3,6 +3,5 @@ prometheus:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
         file_sd_configs:
         - files: ["./testdata/sd-config-with-null-target-group.yaml"]

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-nonexistent-scrape-config.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-nonexistent-scrape-config.yaml
@@ -17,4 +17,3 @@ prometheus/withOnlyScrape:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-unsupported-features.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-unsupported-features.yaml
@@ -5,7 +5,6 @@ prometheus:
     scrape_configs:
       - job_name: 'demo'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
     remote_write:
       - url: "https://example.org/write"
 

--- a/receiver/prometheusreceiver/testdata/nonexistent-prometheus-sd-file-config.yaml
+++ b/receiver/prometheusreceiver/testdata/nonexistent-prometheus-sd-file-config.yaml
@@ -3,6 +3,5 @@ prometheus:
     scrape_configs:
       - job_name: 'test'
         scrape_interval: 5s
-        fallback_scrape_protocol: "PrometheusText1.0.0"
         file_sd_configs:
         - files: ["./testdata/nonexistent-sd-file.json"]


### PR DESCRIPTION
#### Description
During the release process, we noticed a breaking change in the Prometheus receiver caused by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36873.

In that PR, I tried adding a fallback scrape protocol by default everytime the PrometheusReceiver was built, but it turned out that config validation happened even before the component was created. And the collector fails startup with invalid configuration

This PR moves the addition of scrape protocol to the validation step.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37902

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
