### PR TITLE
[chore] File issue when update-otel workflow fails

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -19,6 +19,7 @@ jobs:
           repository: open-telemetry/opentelemetry-collector
       - name: Update to latest opentelemetry-collector release and create a PR
         run: |
+          exec > >(tee log.out) 2>&1
           cd opentelemetry-collector-contrib
           git config user.name opentelemetrybot
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
@@ -30,3 +31,23 @@ jobs:
           gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release"
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      - name: File an issue if the workflow failed
+        if: failure()
+        run: |
+          template=$(cat <<'END'
+          [Link to job log](%s)
+          
+          <details>
+          <summary>Last 100 lines of log</summary>
+
+          ```
+          %s
+          ```
+          </details>
+          END
+          )
+          job_url="$(gh run view ${{ github.run_id }} -R ${{ github.repository }} --json jobs -q '.jobs[] | select(.name == "update-otel") | .url')"
+          body="$(printf "$template" "$job_url" "$(tail -n100 log.out)")"
+          gh issue create -R ${{ github.repository }} -t 'update-otel workflow failed' -b "$body" -l 'ci-cd'
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -47,7 +47,7 @@ jobs:
           END
           )
           job_url="$(gh run view ${{ github.run_id }} -R ${{ github.repository }} --json jobs -q '.jobs[] | select(.name == "update-otel") | .url')"
-          body="$(printf "$template" "$job_url" "$(tail -n100 log.out)")"
+          body="$(printf "$template" "$job_url" "$(tail -n100 log.out | tail -c63K)")"
           gh issue create -R ${{ github.repository }} -t 'update-otel workflow failed' -b "$body" -l 'ci-cd'
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
#### Description
This PR records the output of the `update-otel` workflow into a file, and creates an issue with 'ci-cd' label containing the last 100 lines and a link to the full log if the main step fails.

#### Link to tracking issue
Resolves #37679

#### Testing
I tested the code on my fork, with a dummy job that always fails ([workflow logs](https://github.com/jade-guiton-dd/opentelemetry-collector-contrib/actions/runs/13396711147), [resulting issue](https://github.com/jade-guiton-dd/opentelemetry-collector-contrib/issues/8)).
