### PR TITLE
[chore] update permissions for ping-codeowners-new-issues workflow

### DIFF
--- a/.github/workflows/ping-codeowners-on-new-issue.yml
+++ b/.github/workflows/ping-codeowners-on-new-issue.yml
@@ -3,8 +3,12 @@ on:
   issues:
     types: [opened]
 
+permissions: read-all
+
 jobs:
   ping-owners-on-new-issue:
+    permissions:
+      issues: write
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:


### PR DESCRIPTION
Reduce the scope of permissions given to the github token.
