### PR TITLE
[webhookeventreceiver] allow multiple logs per request

### DIFF
--- a/.chloggen/webhookeventreceiver-multi-line.yaml
+++ b/.chloggen/webhookeventreceiver-multi-line.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow the request body to have multiple log lines using line breaks
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38042]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds new `split_logs_at_newline` option that changes the request body to be split into multiple log lines at each newline.
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -31,6 +31,7 @@ The following settings are optional:
 * `required_header` (optional):  
     * `key` (required if `required_header` config option is set): Represents the key portion of the required header.
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
+* `split_logs_at_newline` (default: false): If true, the receiver will split logs at newlines in the incoming event body.
 
 Example:
 ```yaml
@@ -43,6 +44,7 @@ receivers:
         required_header:
             key: "required-header-key"
             value: "required-header-value"
+        split_logs_at_newline: false
 ```
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with a detailed sample configuration in [testdata/config.yaml](./testdata/config.yaml)
 

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -31,9 +31,38 @@ The following settings are optional:
 * `required_header` (optional):  
     * `key` (required if `required_header` config option is set): Represents the key portion of the required header.
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
-* `split_logs_at_newline` (default: false): If true, the receiver will split logs at newlines in the incoming event body.
+* `split_logs_at_newline` (default: false): If true, the receiver will create a separate log record for each line in the request body.
 
-Example:
+### Split logs at newline example
+
+If the setting is unconfigured or set to `false`, the receiver will create a single log record with the entire request body as the "body" of that record.
+
+If the webhook body looks like the following, use `split_logs_at_newline: false`: 
+
+```yaml
+{
+"name": "francis",
+"city": "newyork"
+}
+a fifth line
+```
+
+A single log record will be created with the multi-line JSON object as the "body" of that record, even the "fifth line" outside the JSON object will be included.
+
+If the body looks like the following, use `split_logs_at_newline: true`:
+
+```yaml
+{ "name": "francis", "city": "newyork" }
+{ "name": "john", "city": "paris" }
+a third line
+```
+
+Three log records will be created from this example. The first two are JSON body objects and the third is just the string "a third line".
+
+This receiver does not attempt to marshal the body into a structured format as it is received so it cannot make a more intelligent determination about where the split records. 
+
+### Configuration Example
+
 ```yaml
 receivers:
     webhookevent:
@@ -46,5 +75,6 @@ receivers:
             value: "required-header-value"
         split_logs_at_newline: false
 ```
+
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with a detailed sample configuration in [testdata/config.yaml](./testdata/config.yaml)
 

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -21,11 +21,12 @@ var (
 // Config defines configuration for the Generic Webhook receiver.
 type Config struct {
 	confighttp.ServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	ReadTimeout             string                   `mapstructure:"read_timeout"`    // wait time for reading request headers in ms. Default is 500ms.
-	WriteTimeout            string                   `mapstructure:"write_timeout"`   // wait time for writing request response in ms. Default is 500ms.
-	Path                    string                   `mapstructure:"path"`            // path for data collection. Default is /events
-	HealthPath              string                   `mapstructure:"health_path"`     // path for health check api. Default is /health_check
-	RequiredHeader          RequiredHeader           `mapstructure:"required_header"` // optional setting to set a required header for all requests to have
+	ReadTimeout             string                   `mapstructure:"read_timeout"`          // wait time for reading request headers in ms. Default is 500ms.
+	WriteTimeout            string                   `mapstructure:"write_timeout"`         // wait time for writing request response in ms. Default is 500ms.
+	Path                    string                   `mapstructure:"path"`                  // path for data collection. Default is /events
+	HealthPath              string                   `mapstructure:"health_path"`           // path for health check api. Default is /health_check
+	RequiredHeader          RequiredHeader           `mapstructure:"required_header"`       // optional setting to set a required header for all requests to have
+	SplitLogsAtNewLine      bool                     `mapstructure:"split_logs_at_newline"` // optional setting to split logs into multiple log records
 }
 
 type RequiredHeader struct {

--- a/receiver/webhookeventreceiver/factory.go
+++ b/receiver/webhookeventreceiver/factory.go
@@ -38,10 +38,11 @@ func NewFactory() receiver.Factory {
 // Default configuration for the generic webhook receiver
 func createDefaultConfig() component.Config {
 	return &Config{
-		Path:         defaultPath,
-		HealthPath:   defaultHealthPath,
-		ReadTimeout:  defaultReadTimeout,
-		WriteTimeout: defaultWriteTimeout,
+		Path:               defaultPath,
+		HealthPath:         defaultHealthPath,
+		ReadTimeout:        defaultReadTimeout,
+		WriteTimeout:       defaultWriteTimeout,
+		SplitLogsAtNewLine: false,
 	}
 }
 

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -17,7 +17,7 @@ import (
 
 func reqToLog(sc *bufio.Scanner,
 	query url.Values,
-	_ *Config,
+	cfg *Config,
 	settings receiver.Settings,
 ) (plog.Logs, int) {
 	if cfg.SplitLogsAtNewLine {

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -20,17 +20,21 @@ func reqToLog(sc *bufio.Scanner,
 	_ *Config,
 	settings receiver.Settings,
 ) (plog.Logs, int) {
-	// we simply dont split the data passed into scan (i.e. scan the whole thing)
-	// the downside to this approach is that only 1 log per request can be handled.
-	// NOTE: logs will contain these newline characters which could have formatting
-	// consequences downstream.
-	split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-		if !atEOF {
-			return 0, nil, nil
+	if cfg.SplitLogsAtNewLine {
+		sc.Split(bufio.ScanLines)
+	} else {
+		// we simply dont split the data passed into scan (i.e. scan the whole thing)
+		// the downside to this approach is that only 1 log per request can be handled.
+		// NOTE: logs will contain these newline characters which could have formatting
+		// consequences downstream.
+		split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+			if !atEOF {
+				return 0, nil, nil
+			}
+			return 0, data, bufio.ErrFinalToken
 		}
-		return 0, data, bufio.ErrFinalToken
+		sc.Split(split)
 	}
-	sc.Split(split)
 
 	log := plog.NewLogs()
 	resourceLog := log.ResourceLogs().AppendEmpty()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add a configuration that allows users to choose the original behavior or the newer multi-line behavior.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38037

