### PR TITLE
[processor/resourcedetection] fix typo in EC2 component docs

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/ec2/documentation.md
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/documentation.md
@@ -16,4 +16,4 @@
 | host.id | The host.id | Any Str | true |
 | host.image.id | The host image id | Any Str | true |
 | host.name | The hostname | Any Str | true |
-| host.type | The host id | Any Str | true |
+| host.type | The host type | Any Str | true |


### PR DESCRIPTION
#### Description
Fixes a typo in the EC2 component documentation where host.type was described as "the host id" instead of "the host type"