### PR TITLE
processor/deltatocumulative: cleanup metrics

### DIFF
--- a/.chloggen/cleanup-metrics.yaml
+++ b/.chloggen/cleanup-metrics.yaml
@@ -1,0 +1,38 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: removes legacy and clean up existing metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38079]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  renamed:
+    - `otelcol_deltatocumulative.datapoints.processed` to `otelcol_deltatocumulative_datapoints`
+    - `otelcol_deltatocumulative.datapoints.dropped` to `otelcol_deltatocumulative_datapoints{error="..."}`
+    - `otelcol_deltatocumulative.max_stale` to `otelcol_deltatocumulative_max_stale`
+    - `otelcol_deltatocumulative.streams.limit` to `otelcol_deltatocumulative_streams_limit`
+    - `otelcol_deltatocumulative.streams.tracked` to `otelcol_deltatocumulative_streams_tracked`
+  removed (already unused):
+    - `otelcol_deltatocumulative.datapoints.linear`
+    - `otelcol_deltatocumulative.streams.tracked.linear`
+    - `otelcol_deltatocumulative.streams.evicted`
+    - `otelcol_deltatocumulative.gaps.length`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/documentation.md
+++ b/processor/deltatocumulativeprocessor/documentation.md
@@ -6,15 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol_deltatocumulative.datapoints.dropped
-
-number of datapoints dropped due to given 'reason'
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {datapoint} | Sum | Int | true |
-
-### otelcol_deltatocumulative.datapoints.linear
+### otelcol_deltatocumulative_datapoints
 
 total number of datapoints processed. may have 'error' attribute, if processing failed
 
@@ -22,31 +14,7 @@ total number of datapoints processed. may have 'error' attribute, if processing 
 | ---- | ----------- | ---------- | --------- |
 | {datapoint} | Sum | Int | true |
 
-### otelcol_deltatocumulative.datapoints.processed
-
-number of datapoints processed
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {datapoint} | Sum | Int | true |
-
-### otelcol_deltatocumulative.gaps.length
-
-total duration where data was expected but not received
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| s | Sum | Int | true |
-
-### otelcol_deltatocumulative.streams.evicted
-
-number of streams evicted
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {stream} | Sum | Int | true |
-
-### otelcol_deltatocumulative.streams.limit
+### otelcol_deltatocumulative_streams_limit
 
 upper limit of tracked streams
 
@@ -54,7 +22,7 @@ upper limit of tracked streams
 | ---- | ----------- | ---------- |
 | {stream} | Gauge | Int |
 
-### otelcol_deltatocumulative.streams.max_stale
+### otelcol_deltatocumulative_streams_max_stale
 
 duration after which streams inactive streams are dropped
 
@@ -62,15 +30,7 @@ duration after which streams inactive streams are dropped
 | ---- | ----------- | ---------- |
 | s | Gauge | Int |
 
-### otelcol_deltatocumulative.streams.tracked
-
-number of streams tracked
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {dps} | Sum | Int | false |
-
-### otelcol_deltatocumulative.streams.tracked.linear
+### otelcol_deltatocumulative_streams_tracked
 
 number of streams tracked
 

--- a/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
@@ -25,18 +25,13 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                                 metric.Meter
-	mu                                    sync.Mutex
-	registrations                         []metric.Registration
-	DeltatocumulativeDatapointsDropped    metric.Int64Counter
-	DeltatocumulativeDatapointsLinear     metric.Int64Counter
-	DeltatocumulativeDatapointsProcessed  metric.Int64Counter
-	DeltatocumulativeGapsLength           metric.Int64Counter
-	DeltatocumulativeStreamsEvicted       metric.Int64Counter
-	DeltatocumulativeStreamsLimit         metric.Int64Gauge
-	DeltatocumulativeStreamsMaxStale      metric.Int64Gauge
-	DeltatocumulativeStreamsTracked       metric.Int64UpDownCounter
-	DeltatocumulativeStreamsTrackedLinear metric.Int64ObservableUpDownCounter
+	meter                            metric.Meter
+	mu                               sync.Mutex
+	registrations                    []metric.Registration
+	DeltatocumulativeDatapoints      metric.Int64Counter
+	DeltatocumulativeStreamsLimit    metric.Int64Gauge
+	DeltatocumulativeStreamsMaxStale metric.Int64Gauge
+	DeltatocumulativeStreamsTracked  metric.Int64ObservableUpDownCounter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -50,12 +45,12 @@ func (tbof telemetryBuilderOptionFunc) apply(mb *TelemetryBuilder) {
 	tbof(mb)
 }
 
-// RegisterDeltatocumulativeStreamsTrackedLinearCallback sets callback for observable DeltatocumulativeStreamsTrackedLinear metric.
-func (builder *TelemetryBuilder) RegisterDeltatocumulativeStreamsTrackedLinearCallback(cb metric.Int64Callback) error {
+// RegisterDeltatocumulativeStreamsTrackedCallback sets callback for observable DeltatocumulativeStreamsTracked metric.
+func (builder *TelemetryBuilder) RegisterDeltatocumulativeStreamsTrackedCallback(cb metric.Int64Callback) error {
 	reg, err := builder.meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		cb(ctx, &observerInt64{inst: builder.DeltatocumulativeStreamsTrackedLinear, obs: o})
+		cb(ctx, &observerInt64{inst: builder.DeltatocumulativeStreamsTracked, obs: o})
 		return nil
-	}, builder.DeltatocumulativeStreamsTrackedLinear)
+	}, builder.DeltatocumulativeStreamsTracked)
 	if err != nil {
 		return err
 	}
@@ -93,56 +88,26 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
-	builder.DeltatocumulativeDatapointsDropped, err = builder.meter.Int64Counter(
-		"otelcol_deltatocumulative.datapoints.dropped",
-		metric.WithDescription("number of datapoints dropped due to given 'reason'"),
-		metric.WithUnit("{datapoint}"),
-	)
-	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeDatapointsLinear, err = builder.meter.Int64Counter(
-		"otelcol_deltatocumulative.datapoints.linear",
+	builder.DeltatocumulativeDatapoints, err = builder.meter.Int64Counter(
+		"otelcol_deltatocumulative_datapoints",
 		metric.WithDescription("total number of datapoints processed. may have 'error' attribute, if processing failed"),
 		metric.WithUnit("{datapoint}"),
 	)
 	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeDatapointsProcessed, err = builder.meter.Int64Counter(
-		"otelcol_deltatocumulative.datapoints.processed",
-		metric.WithDescription("number of datapoints processed"),
-		metric.WithUnit("{datapoint}"),
-	)
-	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeGapsLength, err = builder.meter.Int64Counter(
-		"otelcol_deltatocumulative.gaps.length",
-		metric.WithDescription("total duration where data was expected but not received"),
-		metric.WithUnit("s"),
-	)
-	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeStreamsEvicted, err = builder.meter.Int64Counter(
-		"otelcol_deltatocumulative.streams.evicted",
-		metric.WithDescription("number of streams evicted"),
-		metric.WithUnit("{stream}"),
-	)
-	errs = errors.Join(errs, err)
 	builder.DeltatocumulativeStreamsLimit, err = builder.meter.Int64Gauge(
-		"otelcol_deltatocumulative.streams.limit",
+		"otelcol_deltatocumulative_streams_limit",
 		metric.WithDescription("upper limit of tracked streams"),
 		metric.WithUnit("{stream}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.DeltatocumulativeStreamsMaxStale, err = builder.meter.Int64Gauge(
-		"otelcol_deltatocumulative.streams.max_stale",
+		"otelcol_deltatocumulative_streams_max_stale",
 		metric.WithDescription("duration after which streams inactive streams are dropped"),
 		metric.WithUnit("s"),
 	)
 	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeStreamsTracked, err = builder.meter.Int64UpDownCounter(
-		"otelcol_deltatocumulative.streams.tracked",
-		metric.WithDescription("number of streams tracked"),
-		metric.WithUnit("{dps}"),
-	)
-	errs = errors.Join(errs, err)
-	builder.DeltatocumulativeStreamsTrackedLinear, err = builder.meter.Int64ObservableUpDownCounter(
-		"otelcol_deltatocumulative.streams.tracked.linear",
+	builder.DeltatocumulativeStreamsTracked, err = builder.meter.Int64ObservableUpDownCounter(
+		"otelcol_deltatocumulative_streams_tracked",
 		metric.WithDescription("number of streams tracked"),
 		metric.WithUnit("{dps}"),
 	)

--- a/processor/deltatocumulativeprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/deltatocumulativeprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -21,25 +21,9 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 	return set
 }
 
-func AssertEqualDeltatocumulativeDatapointsDropped(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+func AssertEqualDeltatocumulativeDatapoints(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.datapoints.dropped",
-		Description: "number of datapoints dropped due to given 'reason'",
-		Unit:        "{datapoint}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.datapoints.dropped")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualDeltatocumulativeDatapointsLinear(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.datapoints.linear",
+		Name:        "otelcol_deltatocumulative_datapoints",
 		Description: "total number of datapoints processed. may have 'error' attribute, if processing failed",
 		Unit:        "{datapoint}",
 		Data: metricdata.Sum[int64]{
@@ -48,90 +32,42 @@ func AssertEqualDeltatocumulativeDatapointsLinear(t *testing.T, tt *componenttes
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.datapoints.linear")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualDeltatocumulativeDatapointsProcessed(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.datapoints.processed",
-		Description: "number of datapoints processed",
-		Unit:        "{datapoint}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.datapoints.processed")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualDeltatocumulativeGapsLength(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.gaps.length",
-		Description: "total duration where data was expected but not received",
-		Unit:        "s",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.gaps.length")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualDeltatocumulativeStreamsEvicted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.streams.evicted",
-		Description: "number of streams evicted",
-		Unit:        "{stream}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.streams.evicted")
+	got, err := tt.GetMetric("otelcol_deltatocumulative_datapoints")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
 func AssertEqualDeltatocumulativeStreamsLimit(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.streams.limit",
+		Name:        "otelcol_deltatocumulative_streams_limit",
 		Description: "upper limit of tracked streams",
 		Unit:        "{stream}",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.streams.limit")
+	got, err := tt.GetMetric("otelcol_deltatocumulative_streams_limit")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
 func AssertEqualDeltatocumulativeStreamsMaxStale(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.streams.max_stale",
+		Name:        "otelcol_deltatocumulative_streams_max_stale",
 		Description: "duration after which streams inactive streams are dropped",
 		Unit:        "s",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.streams.max_stale")
+	got, err := tt.GetMetric("otelcol_deltatocumulative_streams_max_stale")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
 func AssertEqualDeltatocumulativeStreamsTracked(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.streams.tracked",
+		Name:        "otelcol_deltatocumulative_streams_tracked",
 		Description: "number of streams tracked",
 		Unit:        "{dps}",
 		Data: metricdata.Sum[int64]{
@@ -140,23 +76,7 @@ func AssertEqualDeltatocumulativeStreamsTracked(t *testing.T, tt *componenttest.
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.streams.tracked")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
-func AssertEqualDeltatocumulativeStreamsTrackedLinear(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_deltatocumulative.streams.tracked.linear",
-		Description: "number of streams tracked",
-		Unit:        "{dps}",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: false,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_deltatocumulative.streams.tracked.linear")
+	got, err := tt.GetMetric("otelcol_deltatocumulative_streams_tracked")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/processor/deltatocumulativeprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/deltatocumulativeprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -21,31 +21,14 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
-	require.NoError(t, tb.RegisterDeltatocumulativeStreamsTrackedLinearCallback(func(_ context.Context, observer metric.Int64Observer) error {
+	require.NoError(t, tb.RegisterDeltatocumulativeStreamsTrackedCallback(func(_ context.Context, observer metric.Int64Observer) error {
 		observer.Observe(1)
 		return nil
 	}))
-	tb.DeltatocumulativeDatapointsDropped.Add(context.Background(), 1)
-	tb.DeltatocumulativeDatapointsLinear.Add(context.Background(), 1)
-	tb.DeltatocumulativeDatapointsProcessed.Add(context.Background(), 1)
-	tb.DeltatocumulativeGapsLength.Add(context.Background(), 1)
-	tb.DeltatocumulativeStreamsEvicted.Add(context.Background(), 1)
+	tb.DeltatocumulativeDatapoints.Add(context.Background(), 1)
 	tb.DeltatocumulativeStreamsLimit.Record(context.Background(), 1)
 	tb.DeltatocumulativeStreamsMaxStale.Record(context.Background(), 1)
-	tb.DeltatocumulativeStreamsTracked.Add(context.Background(), 1)
-	AssertEqualDeltatocumulativeDatapointsDropped(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualDeltatocumulativeDatapointsLinear(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualDeltatocumulativeDatapointsProcessed(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualDeltatocumulativeGapsLength(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualDeltatocumulativeStreamsEvicted(t, testTel,
+	AssertEqualDeltatocumulativeDatapoints(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualDeltatocumulativeStreamsLimit(t, testTel,
@@ -55,9 +38,6 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualDeltatocumulativeStreamsTracked(t, testTel,
-		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualDeltatocumulativeStreamsTrackedLinear(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/processor/deltatocumulativeprocessor/internal/telemetry/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/telemetry/metrics.go
@@ -25,7 +25,7 @@ func New(set component.TelemetrySettings) (Metrics, error) {
 	if err != nil {
 		return Metrics{}, err
 	}
-	err = telb.RegisterDeltatocumulativeStreamsTrackedLinearCallback(func(_ context.Context, observer metric.Int64Observer) error {
+	err = telb.RegisterDeltatocumulativeStreamsTrackedCallback(func(_ context.Context, observer metric.Int64Observer) error {
 		observer.Observe(int64((*m.tracked)()))
 		return nil
 	})
@@ -44,7 +44,7 @@ type Metrics struct {
 }
 
 func (m *Metrics) Datapoints() Counter {
-	return Counter{Int64Counter: m.DeltatocumulativeDatapointsLinear}
+	return Counter{Int64Counter: m.DeltatocumulativeDatapoints}
 }
 
 func (m *Metrics) WithTracked(streams func() int) {

--- a/processor/deltatocumulativeprocessor/metadata.yaml
+++ b/processor/deltatocumulativeprocessor/metadata.yaml
@@ -12,14 +12,7 @@ status:
 telemetry:
   metrics:
     # streams
-    deltatocumulative.streams.tracked:
-      description: number of streams tracked
-      unit: "{dps}"
-      sum:
-        value_type: int
-        monotonic: false
-      enabled: true
-    deltatocumulative.streams.tracked.linear:
+    deltatocumulative_streams_tracked:
       description: number of streams tracked
       unit: "{dps}"
       sum:
@@ -27,51 +20,22 @@ telemetry:
         monotonic: false
         async: true
       enabled: true
-    deltatocumulative.streams.limit:
+    deltatocumulative_streams_limit:
       description: upper limit of tracked streams
       unit: "{stream}"
       gauge:
         value_type: int
       enabled: true
-    deltatocumulative.streams.evicted:
-      description: number of streams evicted
-      unit: "{stream}"
-      sum:
-        value_type: int
-        monotonic: true
-      enabled: true
-    deltatocumulative.streams.max_stale:
+    deltatocumulative_streams_max_stale:
       description: duration after which streams inactive streams are dropped
       unit: "s"
       gauge:
         value_type: int
       enabled: true
     # datapoints
-    deltatocumulative.datapoints.processed:
-      description: number of datapoints processed
-      unit: "{datapoint}"
-      sum:
-        value_type: int
-        monotonic: true
-      enabled: true
-    deltatocumulative.datapoints.dropped:
-      description: number of datapoints dropped due to given 'reason'
-      unit: "{datapoint}"
-      sum:
-        value_type: int
-        monotonic: true
-      enabled: true
-
-    deltatocumulative.datapoints.linear:
+    deltatocumulative_datapoints:
       description: total number of datapoints processed. may have 'error' attribute, if processing failed
       unit: "{datapoint}"
-      sum:
-        value_type: int
-        monotonic: true
-      enabled: true
-    deltatocumulative.gaps.length:
-      description: total duration where data was expected but not received
-      unit: "s"
       sum:
         value_type: int
         monotonic: true

--- a/processor/deltatocumulativeprocessor/testdata/exponential/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/exponential/1.test
@@ -92,5 +92,5 @@ resourceMetrics:
                     bucketCounts: [3,7,5,0,0]
 
 -- telemetry --
-updown otelcol_deltatocumulative.streams.tracked.linear:
+updown otelcol_deltatocumulative_streams_tracked:
 - int: 2

--- a/processor/deltatocumulativeprocessor/testdata/histograms/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/histograms/1.test
@@ -49,5 +49,5 @@ resourceMetrics:
                   bucketCounts: [   1, 2, 3, 4]
 
 -- telemetry --
-updown otelcol_deltatocumulative.streams.tracked.linear:
+updown otelcol_deltatocumulative_streams_tracked:
 - int: 1

--- a/processor/deltatocumulativeprocessor/testdata/limit/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/limit/1.test
@@ -47,9 +47,9 @@ resourceMetrics:
                 - {timeUnixNano: 1, asDouble: 1, attributes: [{key: series, value: {stringValue: "9"}}]}
 
 -- telemetry --
-counter otelcol_deltatocumulative.datapoints.linear:
+counter otelcol_deltatocumulative_datapoints:
   - int: 10
     attr: {}
 
-updown otelcol_deltatocumulative.streams.tracked.linear:
+updown otelcol_deltatocumulative_streams_tracked:
   - int: 10

--- a/processor/deltatocumulativeprocessor/testdata/limit/2.test
+++ b/processor/deltatocumulativeprocessor/testdata/limit/2.test
@@ -49,11 +49,11 @@ resourceMetrics:
               # - {timeUnixNano: 2, asDouble: 2, attributes: [{key: series, value: {stringValue: "x"}}]} # dropped
 
 -- telemetry --
-counter otelcol_deltatocumulative.datapoints.linear:
+counter otelcol_deltatocumulative_datapoints:
   - int: 20
     attr: {}
   - int: 1
     attr: {error: "limit"}
 
-updown otelcol_deltatocumulative.streams.tracked.linear:
+updown otelcol_deltatocumulative_streams_tracked:
   - int: 10

--- a/processor/deltatocumulativeprocessor/testdata/notemporality-ignored/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/notemporality-ignored/1.test
@@ -69,8 +69,8 @@ resourceMetrics:
                       value: 25
 
 -- telemetry --
-counter otelcol_deltatocumulative.datapoints.linear:
+counter otelcol_deltatocumulative_datapoints:
 - int: 1
 
-updown otelcol_deltatocumulative.streams.tracked.linear:
+updown otelcol_deltatocumulative_streams_tracked:
 - int: 1

--- a/processor/deltatocumulativeprocessor/testdata/timestamps/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/timestamps/1.test
@@ -36,7 +36,7 @@ resourceMetrics:
                 - {startTimeUnixNano: 1000, timeUnixNano: 1400, asDouble: 0}
 
 -- telemetry --
-counter otelcol_deltatocumulative.datapoints.linear:
+counter otelcol_deltatocumulative_datapoints:
 - int: 3
 - attr: {error: "delta.ErrOutOfOrder"}
   int: 1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Cleans up metrics from the linear-codepath migration. This should have been part of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36498

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated to new metric names

<!--Describe the documentation added.-->
#### Documentation

Updated

<!--Please delete paragraphs that you did not use before submitting.-->
