### PR TITLE
[testbed] fix load gen worker tick interval math to avoid div by zero

### DIFF
--- a/.chloggen/fix-testbed-div-by-zero.yaml
+++ b/.chloggen/fix-testbed-div-by-zero.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: testbed
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix batch interval calculation to avoid possible division by zero
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/testbed/testbed/load_generator_test.go
+++ b/testbed/testbed/load_generator_test.go
@@ -1,0 +1,58 @@
+package testbed
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_perWorkerTickDuration(t *testing.T) {
+	for _, test := range []struct {
+		name                                          string
+		expectedTickDuration                          time.Duration
+		dataItemsPerSecond, itemsPerBatch, numWorkers int
+	}{
+		// Because of the way perWorkerTickDuration calculates the tick interval using dataItemsPerSecond,
+		// it is important to test its behavior with respect to a one-second Duration in particular.
+		{
+			name:                 "less than one second",
+			expectedTickDuration: 100 * time.Millisecond,
+			dataItemsPerSecond:   100,
+			itemsPerBatch:        5,
+			numWorkers:           2,
+		},
+		{
+			name:                 "exactly one second",
+			expectedTickDuration: time.Second,
+			dataItemsPerSecond:   100,
+			itemsPerBatch:        5,
+			numWorkers:           20,
+		},
+		{
+			name:                 "more than one second",
+			expectedTickDuration: 5 * time.Second,
+			dataItemsPerSecond:   100,
+			itemsPerBatch:        5,
+			numWorkers:           100,
+		},
+		{
+			name:                 "default batch size and worker count",
+			expectedTickDuration: 8103727, // ~8.1ms
+			dataItemsPerSecond:   1234,
+			itemsPerBatch:        10,
+			numWorkers:           1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			subject := &ProviderSender{
+				options: LoadOptions{
+					DataItemsPerSecond: test.dataItemsPerSecond,
+					ItemsPerBatch:      test.itemsPerBatch,
+				},
+			}
+			actual := subject.perWorkerTickDuration(test.numWorkers)
+			if actual != test.expectedTickDuration {
+				t.Errorf("got %v; want %v", actual, test.expectedTickDuration)
+			}
+		})
+	}
+}

--- a/testbed/testbed/load_generator_test.go
+++ b/testbed/testbed/load_generator_test.go
@@ -12,7 +12,8 @@ func Test_perWorkerTickDuration(t *testing.T) {
 		dataItemsPerSecond, itemsPerBatch, numWorkers int
 	}{
 		// Because of the way perWorkerTickDuration calculates the tick interval using dataItemsPerSecond,
-		// it is important to test its behavior with respect to a one-second Duration in particular.
+		// it is important to test its behavior with respect to a one-second Duration in particular because
+		// certain combinations of configuration could previously cause a divide-by-zero panic.
 		{
 			name:                 "less than one second",
 			expectedTickDuration: 100 * time.Millisecond,
@@ -28,7 +29,7 @@ func Test_perWorkerTickDuration(t *testing.T) {
 			numWorkers:           20,
 		},
 		{
-			name:                 "more than one second",
+			name:                 "more than one second (would previously trigger divide-by-zero panic)",
 			expectedTickDuration: 5 * time.Second,
 			dataItemsPerSecond:   100,
 			itemsPerBatch:        5,


### PR DESCRIPTION
#### Description

Previously, certain combinations of load generation options could lead to an attempt to divide by zero, resulting in a panic. Specifically, if the desired batches per second of a single worker was calculated to be less than one, integer division caused it to be rounded to zero before using it as the divisor in subsequent calculations.

#### Testing

The logic was refactored into a standalone method and tested by unit tests added in this PR.
