### PR TITLE
[exporter/stefexporter] Fix incorrectly implemented STEF exporter zstd compression option

### DIFF
--- a/.chloggen/tigran_stefcompression.yaml
+++ b/.chloggen/tigran_stefcompression.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stefexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix incorrectly implemented STEF exporter zstd compression option.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38088]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: STEF exporter now correctly supports zstd compression (observed <1 byte per datapoint for hostmetricsreceiver).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/stefexporter/exporter.go
+++ b/exporter/stefexporter/exporter.go
@@ -34,7 +34,7 @@ import (
 // sending the data itself.
 type stefExporter struct {
 	set         component.TelemetrySettings
-	cfg         *Config
+	cfg         Config
 	compression stefpkg.Compression
 
 	// connMutex is taken when connecting, disconnecting or checking connection status.
@@ -70,14 +70,16 @@ func (w *loggerWrapper) Errorf(_ context.Context, format string, v ...any) {
 func newStefExporter(set component.TelemetrySettings, cfg *Config) *stefExporter {
 	exp := &stefExporter{
 		set:     set,
-		cfg:     cfg,
+		cfg:     *cfg,
 		ackCond: internal.NewCancellableCond(),
 	}
 
 	exp.compression = stefpkg.CompressionNone
-	if cfg.Compression == "zstd" {
+	if exp.cfg.Compression == "zstd" {
 		exp.compression = stefpkg.CompressionZstd
 	}
+	// Disable built-in grpc compression. STEF has its own zstd compression support.
+	exp.cfg.Compression = ""
 	return exp
 }
 

--- a/exporter/stefexporter/go.mod
+++ b/exporter/stefexporter/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.120.1-0.20250219144032-c2af75d88e89
 	go.opentelemetry.io/collector/component/componenttest v0.120.1-0.20250219144032-c2af75d88e89
+	go.opentelemetry.io/collector/config/configcompression v1.26.1-0.20250219144032-c2af75d88e89
 	go.opentelemetry.io/collector/config/configgrpc v0.120.1-0.20250219144032-c2af75d88e89
 	go.opentelemetry.io/collector/config/configretry v1.26.1-0.20250219144032-c2af75d88e89
 	go.opentelemetry.io/collector/config/configtls v1.26.1-0.20250219144032-c2af75d88e89
@@ -50,7 +51,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.26.1-0.20250219144032-c2af75d88e89 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.120.1-0.20250219144032-c2af75d88e89 // indirect
-	go.opentelemetry.io/collector/config/configcompression v1.26.1-0.20250219144032-c2af75d88e89 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.26.1-0.20250219144032-c2af75d88e89 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.26.1-0.20250219144032-c2af75d88e89 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.120.1-0.20250219144032-c2af75d88e89 // indirect


### PR DESCRIPTION
### Description

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38088

Previously the compression option was incorrectly set both for STEF Writer and gRPC Client. This was unnecessary and also did not work if the destination gRPC receiver did not enable zstd compressor.

This change correctly removes the zstd compression option from gRPC client and only sets it as a STEF Writer option.

Interestingly, with zstd enabled we get less than 1 byte per metric data point with STEF exporter and hostmetrics receiver!

```
$ ./stefmockserver_darwin_arm64
2025/02/20 11:28:48.335835 Listening for STEF/gRPC on port 4320
2025/02/20 11:49:55.002889 Incoming STEF/gRPC connection.
Records: 1285639, Messages: 4420, Bytes: 1139887, Bytes/point: 0.89, Acks: 4424, Last ACKID: 1285639
```

### Testing Done

Added zstd compression option to TestExport unit test.

Tested manually with STEF Server here https://github.com/splunk/stef/tree/main/otelcol/cmd/stefmockserver

Built Collector contrib via `make otelcontribcol`. Used the following config for testing:

```yaml
receivers:
  hostmetrics:
    collection_interval: 1s
    scrapers:
      load:
      filesystem:
      memory:
      network:
      paging:
      processes:

exporters:
  debug:
  stef:
    endpoint: localhost:4320
    compressions: zstd
    tls:
      insecure: true

processors:

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      processors: []
      exporters: [debug,stef]
```

