### PR TITLE
[chore][exporter/datadog] fix integration test

### DIFF
--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -14,81 +14,29 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/featuregate"
 
 	commonTestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
-	pkgdatadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 )
 
-func TestIntegrationInternalMetrics_WithRemapping(t *testing.T) {
-	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
-	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), false))
-	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
-	}()
-
-	expectedMetrics := map[string]struct{}{
-		// Datadog internal metrics on trace and stats writers, with the otelcol_ prefix
-		"otelcol_datadog_otlp_translator_resources_missing_source": {},
-		"otelcol_datadog_trace_agent_stats_writer_bytes":           {},
-		"otelcol_datadog_trace_agent_stats_writer_retries":         {},
-		"otelcol_datadog_trace_agent_stats_writer_stats_buckets":   {},
-		"otelcol_datadog_trace_agent_stats_writer_stats_entries":   {},
-		"otelcol_datadog_trace_agent_stats_writer_payloads":        {},
-		"otelcol_datadog_trace_agent_stats_writer_client_payloads": {},
-		"otelcol_datadog_trace_agent_stats_writer_errors":          {},
-		"otelcol_datadog_trace_agent_stats_writer_splits":          {},
-		"otelcol_datadog_trace_agent_trace_writer_bytes":           {},
-		"otelcol_datadog_trace_agent_trace_writer_retries":         {},
-		"otelcol_datadog_trace_agent_trace_writer_spans":           {},
-		"otelcol_datadog_trace_agent_trace_writer_traces":          {},
-		"otelcol_datadog_trace_agent_trace_writer_payloads":        {},
-		"otelcol_datadog_trace_agent_trace_writer_errors":          {},
-		"otelcol_datadog_trace_agent_trace_writer_events":          {},
-
-		// OTel collector internal metrics
-		"otelcol_process_memory_rss":                     {},
-		"otelcol_process_runtime_total_sys_memory_bytes": {},
-		"otelcol_process_uptime":                         {},
-		"otelcol_process_cpu_seconds":                    {},
-		"otelcol_process_runtime_heap_alloc_bytes":       {},
-		"otelcol_process_runtime_total_alloc_bytes":      {},
-		"otelcol_receiver_accepted_metric_points":        {},
-		"otelcol_receiver_accepted_spans":                {},
-		"otelcol_exporter_queue_capacity":                {},
-		"otelcol_exporter_queue_size":                    {},
-		"otelcol_exporter_sent_spans":                    {},
-		"otelcol_exporter_sent_metric_points":            {},
-	}
-	testIntegrationInternalMetrics(t, expectedMetrics)
-}
-
-func TestIntegrationInternalMetrics_WithoutRemapping(t *testing.T) {
-	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
-	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), true))
-	defer func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
-	}()
-
+func TestIntegrationInternalMetrics(t *testing.T) {
 	expectedMetrics := map[string]struct{}{
 		// Datadog internal metrics on trace and stats writers
-		"datadog_otlp_translator_resources_missing_source": {},
-		"datadog_trace_agent_stats_writer_bytes":           {},
-		"datadog_trace_agent_stats_writer_retries":         {},
-		"datadog_trace_agent_stats_writer_stats_buckets":   {},
-		"datadog_trace_agent_stats_writer_stats_entries":   {},
-		"datadog_trace_agent_stats_writer_payloads":        {},
-		"datadog_trace_agent_stats_writer_client_payloads": {},
-		"datadog_trace_agent_stats_writer_errors":          {},
-		"datadog_trace_agent_stats_writer_splits":          {},
-		"datadog_trace_agent_trace_writer_bytes":           {},
-		"datadog_trace_agent_trace_writer_retries":         {},
-		"datadog_trace_agent_trace_writer_spans":           {},
-		"datadog_trace_agent_trace_writer_traces":          {},
-		"datadog_trace_agent_trace_writer_payloads":        {},
-		"datadog_trace_agent_trace_writer_errors":          {},
-		"datadog_trace_agent_trace_writer_events":          {},
+		"datadog.otlp_translator.resources.missing_source": {},
+		"datadog.trace_agent.stats_writer.bytes":           {},
+		"datadog.trace_agent.stats_writer.retries":         {},
+		"datadog.trace_agent.stats_writer.stats_buckets":   {},
+		"datadog.trace_agent.stats_writer.stats_entries":   {},
+		"datadog.trace_agent.stats_writer.payloads":        {},
+		"datadog.trace_agent.stats_writer.client_payloads": {},
+		"datadog.trace_agent.stats_writer.errors":          {},
+		"datadog.trace_agent.stats_writer.splits":          {},
+		"datadog.trace_agent.trace_writer.bytes":           {},
+		"datadog.trace_agent.trace_writer.retries":         {},
+		"datadog.trace_agent.trace_writer.spans":           {},
+		"datadog.trace_agent.trace_writer.traces":          {},
+		"datadog.trace_agent.trace_writer.payloads":        {},
+		"datadog.trace_agent.trace_writer.errors":          {},
+		"datadog.trace_agent.trace_writer.events":          {},
 
 		// OTel collector internal metrics
 		"otelcol_process_memory_rss":                     {},


### PR DESCRIPTION
#### Description
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36873 the prometheus receiver can now keep dots in metric names rather than converting them to underscores. E.g. say there is a metric `my.metric` scraped from prometheus receiver, its name is `my_metric`  before 0.120.0 vs. `my.metric` now. This should have broken some datadog integration tests, but those are skipped in race detector (which is always on in CIs) so the failures did not show up in CIs.