### PR TITLE
Adding documentation for spanmetrics output

### DIFF
--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -224,6 +224,39 @@ target_info{job="shippingservice", instance="...", ...} 1
 calls_total{span_name="/Address", service_name="shippingservice", span_kind="SPAN_KIND_SERVER", status_code="STATUS_CODE_UNSET", ...} 142
 ```
 
+### Output Metrics
+
+#### Viewing Span Metrics in Prometheus
+
+You can observe the output from the `spanmetrics` connector in Prometheus by visiting [http://localhost:9090/graph](http://localhost:9090/graph).  
+Navigate to the **Graph** or **Explore** section and enter a metric name to visualize the data.
+
+#### Available Metrics
+
+### `traces_span_metrics_calls_total`
+This metric provides the total number of span calls, categorized by various attributes.
+
+#### Example Data:
+```plaintext
+{
+  http_method="GET",
+  http_status_code="200",
+  job="go-trace-demo",
+  service_name="go-trace-demo",
+  span_kind="SPAN_KIND_INTERNAL",
+  span_name="handle_request"
+}
+```
+
+### `traces_span_metrics_duration_milliseconds_bucket`
+Histogram-based metric representing the distribution of span durations across predefined buckets.
+
+### `traces_span_metrics_duration_milliseconds_count`
+The total number of spans recorded.
+
+### `traces_span_metrics_duration_milliseconds_sum`
+The cumulative duration of all spans in milliseconds.
+
 ### More Examples
 
 For more example configuration covering various other use cases, please visit the [testdata directory](../../connector/spanmetricsconnector/testdata).


### PR DESCRIPTION
#### Description

Added output of span metric connector into the readme based on the given example.

#### Link to tracking issue
Fixes [Issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36030) 

#### Testing

Used sample go application to generate the spans. Then below otel config used for get spanmetrics metrics into prometheus.

```
receivers:
  otlp:
    protocols:
      http:
        endpoint: 0.0.0.0:4318
      grpc:
        endpoint: 0.0.0.0:4317

processors:
  batch:
    timeout: 10s
    send_batch_size: 1000

exporters:
  prometheusremotewrite:
    endpoint: "http://prometheus:9090/api/v1/write"
    tls:
      insecure: true
    target_info:
      enabled: true

  debug:
    verbosity: detailed

connectors:
  spanmetrics:
    histogram:
      explicit:
        buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]
    dimensions:
      - name: http.method
        default: GET
      - name: http.status_code
    exemplars:
      enabled: true
    exclude_dimensions: ['status.code']
    dimensions_cache_size: 1000
    aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"
    metrics_flush_interval: 15s
    metrics_expiration: 5m
    events:
      enabled: true
      dimensions:
        - name: exception.type
        - name: exception.message
    resource_metrics_key_attributes:
      - service.name
      - telemetry.sdk.language
      - telemetry.sdk.name

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [spanmetrics]
    metrics:
      receivers: [spanmetrics]
      processors: [batch]
      exporters: [prometheusremotewrite, debug]

  telemetry:
    logs:
      level: debug
```

#### Documentation
Updated the readme 
