### PR TITLE
[chore] amend changelog for prometheus receiver change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 ### 🛑 Breaking changes 🛑
 
+- `receiver/prometheus`: Prometheus receiver now uses scrapers in Prometheus 3.0. (#36873)
+  There are a number of breaking changes in Prometheus 3.0. Learn more about those changes and migration guide on https://prometheus.io/docs/prometheus/latest/migration/.
 - `all`: Added support for go1.24, bumped minimum version to 1.23 (#37875)
 - `elasticsearchexporter`: Use go-elasticsearch/v8, require minimum version of ES 7.17.x or 8.x (#32454)
 - `elasticsearchexporter`: Remove dedot config. ECS mode now always dedots, no others dedot at all. (#33772)


### PR DESCRIPTION
#### Description
Add a changelog amending #36873.  There are indeed several breaking changes associated with the 3.0 version update:  https://prometheus.io/docs/prometheus/latest/migration/

#### Link to tracking issue
related to http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38097