### PR TITLE
[chore] [exporter/splunk_hec] Remove dead code

### DIFF
--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -67,15 +67,9 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 		return err
 	}
 
-	// Do not drain the response when 429 or 502 status code is returned.
-	// HTTP client will not reuse the same connection unless it is drained.
-	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18281 for more details.
-	if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusBadGateway {
-		if _, errCopy := io.Copy(io.Discard, resp.Body); errCopy != nil {
-			return errCopy
-		}
-	}
-	return nil
+	// Drain the response body to avoid leaking connections.
+	_, errCopy := io.Copy(io.Discard, resp.Body)
+	return errCopy // TODO: Do not return error here. Draining errors is not a failure in data sending.
 }
 
 var _ hecWorker = &defaultHecWorker{}


### PR DESCRIPTION
`splunk.HandleHTTPCode` always returns an error for any codes other than 2xx. So, the removed condition is always true. The body isn't read for `http.StatusTooManyRequests` and `http.StatusServiceUnavailable` error codes anyway. It's only read for `http.StatusBadRequest`, `http.StatusUnauthorized` and explicitly drained for `2xx`. 

I kept the existing behavior of returning the draining errors, but this is wrong. Response body draining errors should not be considered data delivery failures which trigger the retry mechanism by default. I'll fix it in a follow-up PR.

Another fix to do as a follow-up is to ensure the body is drained for all error codes except for `http.StatusTooManyRequests` and `http.StatusServiceUnavailable`.