### PR TITLE
[exporter/splunk_hec] Mute errors from draining the response body

### DIFF
--- a/.chloggen/hec-exporter-mute-response-body-draining-errors.yaml
+++ b/.chloggen/hec-exporter-mute-response-body-draining-errors.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/splunk_hec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not pass errors from draining the response body to the pipeline as a export failure.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38118]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -68,8 +68,9 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 	}
 
 	// Drain the response body to avoid leaking connections.
-	_, errCopy := io.Copy(io.Discard, resp.Body)
-	return errCopy // TODO: Do not return error here. Draining errors is not a failure in data sending.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return nil
 }
 
 var _ hecWorker = &defaultHecWorker{}


### PR DESCRIPTION
Do not pass errors from draining the response body to the pipeline as a export failure. The request is successfully sent, but this error currently is defaulted to retry and cause double publishing.
