### PR TITLE
[extension/oidcauth] exposing config for supported JWT algorithms

### DIFF
--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// The claim that holds the subject's group membership information.
 	// Optional.
 	GroupsClaim string `mapstructure:"groups_claim"`
+
+	// The supported signing algorithms for the JWT. Defaults to 'RS256' via jose-go.
+	// Optional
+	SigningAlgs []string `mapstructure:"signing_algs"`
 }
 
 func (c *Config) Validate() error {

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -67,7 +67,8 @@ func (e *oidcExtension) start(ctx context.Context, _ component.Host) error {
 		return fmt.Errorf("failed to get configuration from the auth server: %w", err)
 	}
 	e.verifier = e.provider.Verifier(&oidc.Config{
-		ClientID: e.cfg.Audience,
+		ClientID:             e.cfg.Audience,
+		SupportedSigningAlgs: e.cfg.SigningAlgs,
 	})
 	return nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
After debugging an issue with the OIDC authenticator for half the day due to not being able to get logs and traces with errors for the `401 Unauthorized` result, I dug into the code and saw that the JWT token verifier only works with `RS256` tokens. 

As all the logic for verification is delegated to other packages, it could be fine just to pass through the config option for supported algorithms directly.

An empty string array there defaults internally to `RS256` so no more changes were necessary to keep the current defaults.