### PR TITLE
[chore] Run BenchmarkReadExistingLogs at higher scale

### DIFF
--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -6,6 +6,7 @@ package file
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -20,35 +21,10 @@ import (
 )
 
 func BenchmarkReadExistingLogs(b *testing.B) {
-	testCases := []struct {
-		numLines int
-	}{
-		{
-			numLines: 0,
-		},
-		{
-			numLines: 1,
-		},
-		{
-			numLines: 2,
-		},
-		{
-			numLines: 10,
-		},
-		{
-			numLines: 20,
-		},
-		{
-			numLines: 100,
-		},
-		{
-			numLines: 1000,
-		},
-	}
-
-	for _, tc := range testCases {
-		b.Run(fmt.Sprintf("%d-lines", tc.numLines), func(b *testing.B) {
-			benchmarkReadExistingLogs(b, tc.numLines)
+	for n := range 6 { // powers of 10
+		numLines := int(math.Pow(10, float64(n)))
+		b.Run(fmt.Sprintf("%d-lines", numLines), func(b *testing.B) {
+			benchmarkReadExistingLogs(b, numLines)
 		})
 	}
 }


### PR DESCRIPTION
This PR has the BenchmarkReadExistingLogs benchmark run at each order of magnitude, up to 100,000 lines per file.

```
go test -benchmem -run=^$ -bench ^BenchmarkReadExistingLogs$ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file -race -v -count=1

goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file
cpu: Apple M4 Pro
BenchmarkReadExistingLogs
BenchmarkReadExistingLogs/1-lines
BenchmarkReadExistingLogs/1-lines-14         	    3182	    384916 ns/op	  126458 B/op	     215 allocs/op
BenchmarkReadExistingLogs/10-lines
BenchmarkReadExistingLogs/10-lines-14        	    2709	    458240 ns/op	  141818 B/op	     280 allocs/op
BenchmarkReadExistingLogs/100-lines
BenchmarkReadExistingLogs/100-lines-14       	    1015	   1077129 ns/op	  284335 B/op	     906 allocs/op
BenchmarkReadExistingLogs/1000-lines
BenchmarkReadExistingLogs/1000-lines-14      	     165	   7215992 ns/op	 1733706 B/op	    7208 allocs/op
BenchmarkReadExistingLogs/10000-lines
BenchmarkReadExistingLogs/10000-lines-14     	      16	  68408219 ns/op	16194153 B/op	   70187 allocs/op
BenchmarkReadExistingLogs/100000-lines
BenchmarkReadExistingLogs/100000-lines-14    	       2	 684563562 ns/op	160923128 B/op	  700202 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file	19.951s
```