### PR TITLE
Introduce issuegenerator to open issues when tests fail on main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -676,4 +676,3 @@ jobs:
           mkdir -p ./internal/tools/testresults/hostmetricsreceiver
           mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
           ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/
-          

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -652,3 +652,28 @@ jobs:
                 return
               }
             }
+
+  flakytests-generate-issues:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    needs: [unittest-matrix]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: test-results-*
+          path: ./internal/tools/testresults/
+      - name: Install Tools
+        run: make install-tools
+      - name: Generate Issues
+        run: |
+          # We want to start by generating issues of a single component
+          # As we mature the usage of issuegenerator, we can extend it to
+          # generate issues for multiple components.
+          #
+          # We'll start with the hostmetricsreceiver.
+          mkdir -p ./internal/tools/testresults/hostmetricsreceiver
+          mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
+          ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/
+          


### PR DESCRIPTION
#### Description
This PR extends the current unit test workflow to download the artifacts we started uploading at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37941. Further docs can be found here: https://github.com/actions/download-artifact

I'm also moving files around to make sure we start small. Generating issues only for the `hostmetricsreceiver` component. Once we notice that is working well I plan to raise another PR to cover all components of contrib

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36761
