### PR TITLE
[chore][pkg/ottl] Move MetricPathGetSetter into ctxmetric

### DIFF
--- a/pkg/ottl/contexts/internal/ctxmetric/context.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/context.go
@@ -3,7 +3,13 @@
 
 package ctxmetric // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 
+import "go.opentelemetry.io/collector/pdata/pmetric"
+
 const (
 	Name   = "metric"
 	DocRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlmetric"
 )
+
+type Context interface {
+	GetMetric() pmetric.Metric
+}

--- a/pkg/ottl/contexts/internal/ctxmetric/metric.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+package ctxmetric // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 
 import (
 	"context"
@@ -10,16 +10,11 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 )
 
-type MetricContext interface {
-	GetMetric() pmetric.Metric
-}
-
-func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+func PathGetSetter[K Context](path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return nil, ctxerror.New("nil", "nil", ctxmetric.Name, ctxmetric.DocRef)
+		return nil, ctxerror.New("nil", "nil", Name, DocRef)
 	}
 	switch path.Name() {
 	case "name":
@@ -37,11 +32,11 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 	case "data_points":
 		return accessDataPoints[K](), nil
 	default:
-		return nil, ctxerror.New(path.Name(), path.String(), ctxmetric.Name, ctxmetric.DocRef)
+		return nil, ctxerror.New(path.Name(), path.String(), Name, DocRef)
 	}
 }
 
-func accessName[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessName[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Name(), nil
@@ -55,7 +50,7 @@ func accessName[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessDescription[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessDescription[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Description(), nil
@@ -69,7 +64,7 @@ func accessDescription[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessUnit[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessUnit[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Unit(), nil
@@ -83,7 +78,7 @@ func accessUnit[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessType[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessType[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetMetric().Type()), nil
@@ -96,7 +91,7 @@ func accessType[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessAggTemporality[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()
@@ -127,7 +122,7 @@ func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessIsMonotonic[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessIsMonotonic[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()
@@ -148,7 +143,7 @@ func accessIsMonotonic[K MetricContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessDataPoints[K MetricContext]() ottl.StandardGetSetter[K] {
+func accessDataPoints[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()

--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package ctxmetric_test
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
 )
 
@@ -110,7 +111,7 @@ func Test_MetricPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := MetricPathGetSetter[*metricContext](tt.path)
+			accessor, err := ctxmetric.PathGetSetter[*metricContext](tt.path)
 			assert.NoError(t, err)
 
 			metric := createMetricTelemetry()

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -30,6 +30,7 @@ const ContextName = ctxdatapoint.Name
 var (
 	_ internal.ResourceContext             = (*TransformContext)(nil)
 	_ internal.InstrumentationScopeContext = (*TransformContext)(nil)
+	_ ctxmetric.Context                    = (*TransformContext)(nil)
 	_ zapcore.ObjectMarshaler              = (*TransformContext)(nil)
 )
 
@@ -299,7 +300,7 @@ func (pep *pathExpressionParser) parseHigherContextPath(context string, path ott
 	case ctxscope.LegacyName:
 		return internal.ScopePathGetSetter(ctxdatapoint.Name, path)
 	case ctxmetric.Name:
-		return internal.MetricPathGetSetter(path)
+		return ctxmetric.PathGetSetter(path)
 	default:
 		var fullPath string
 		if path != nil {

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -25,7 +25,7 @@ const ContextName = ctxmetric.Name
 var (
 	_ internal.ResourceContext             = TransformContext{}
 	_ internal.InstrumentationScopeContext = TransformContext{}
-	_ internal.MetricContext               = TransformContext{}
+	_ ctxmetric.Context                    = TransformContext{}
 )
 
 type TransformContext struct {
@@ -193,7 +193,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 		}
 		return accessCacheKey(path.Keys()), nil
 	default:
-		return internal.MetricPathGetSetter[TransformContext](path)
+		return ctxmetric.PathGetSetter[TransformContext](path)
 	}
 }
 


### PR DESCRIPTION
This just moves the MetricPathGetSetter into the new ctxmetric package, and renames exported elements accordingly. 

I'll pursue this pattern with the other contexts if this looks good.