### PR TITLE
[chore] Remove parallelism to fix race condition

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -222,7 +222,7 @@ jobs:
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gendistributions" and commit the changes in this PR.' && exit 1)
       - name: CodeGen
         run: |
-          make -j2 generate
+          make generate
           if [[ -n $(git status -s) ]]; then
             echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.'
             exit 1


### PR DESCRIPTION
I'm seeing the following error in CI on many PRs:

```
Running target 'fmt' in module 'extension/observer/ecsobserver' as part of group 'all'
make --no-print-directory -C extension/observer/ecsobserver fmt
/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/.tools/gofumpt -l -w .
error: size of generated_package_test.go changed during reading (from 169 to >=170 bytes)
make[3]: *** [../../../Makefile.Common:201: fmt] Error 2
```

Best I can tell this is a race condition between the `fmt` and `generate` targets. This is an attempt to reduce possibility for race condition by reducing parallelism in the check and target that are failing.