### PR TITLE
Add issue generation from fkaly tests for all archs

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -68,6 +68,13 @@ jobs:
         run: make install-tools
       - name: Run Unit Tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
+      - name: Run Unit Tests With JUnit and Coverage
+        run: make gotest-with-junit-and-cover GROUP=${{ matrix.group }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ runner.os }}-${{ matrix.group }}
+          path: internal/tools/testresults/
+          retention-days: 4
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-24.04
@@ -84,3 +91,27 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+
+  flakytests-generate-issues:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    needs: [arm-unittest-matrix]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: test-results-*
+          path: ./internal/tools/testresults/
+      - name: Install Tools
+        run: make install-tools
+      - name: Generate Issues
+        run: |
+          # We want to start by generating issues of a single component
+          # As we mature the usage of issuegenerator, we can extend it to
+          # generate issues for multiple components.
+          #
+          # We'll start with the hostmetricsreceiver.
+          mkdir -p ./internal/tools/testresults/hostmetricsreceiver
+          mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
+          ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -92,7 +92,7 @@ jobs:
             false
           fi
 
-  flakytests-generate-issues:
+  arm-flakytests-generate-issues:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     needs: [arm-unittest-matrix]

--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -105,7 +105,7 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
-  flakytests-generate-issues:
+  darwin-flakytests-generate-issues:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     needs: [darwin-unittest-matrix]

--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -82,6 +82,13 @@ jobs:
         run: unzip testbinaries.zip
       - name: Run Unit Tests
         run: make -j2 gorunbuilttest GROUP=cgo
+      - name: Run Unit Tests With JUnit and Coverage
+        run: make gotest-with-junit-and-cover
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ runner.os }}
+          path: internal/tools/testresults/
+          retention-days: 4
   darwin-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Darwin') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: macos-latest
@@ -98,3 +105,26 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+  flakytests-generate-issues:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    needs: [darwin-unittest-matrix]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: test-results-*
+          path: ./internal/tools/testresults/
+      - name: Install Tools
+        run: make install-tools
+      - name: Generate Issues
+        run: |
+          # We want to start by generating issues of a single component
+          # As we mature the usage of issuegenerator, we can extend it to
+          # generate issues for multiple components.
+          #
+          # We'll start with the hostmetricsreceiver.
+          mkdir -p ./internal/tools/testresults/hostmetricsreceiver
+          mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
+          ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -104,7 +104,7 @@ jobs:
             false
           fi
 
-  flakytests-generate-issues:
+  windows-flakytests-generate-issues:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     needs: [windows-unittest-matrix]

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -79,6 +79,13 @@ jobs:
         run: make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
       - name: Run Unit tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
+      - name: Run Unit Tests With JUnit and Coverage
+        run: make gotest-with-junit-and-cover GROUP=${{ matrix.group }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ runner.os }}-${{ matrix.group }}
+          path: internal/tools/testresults/
+          retention-days: 4
   windows-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: windows-latest
@@ -96,3 +103,27 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+
+  flakytests-generate-issues:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    needs: [windows-unittest-matrix]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          pattern: test-results-*
+          path: ./internal/tools/testresults/
+      - name: Install Tools
+        run: make install-tools
+      - name: Generate Issues
+        run: |
+          # We want to start by generating issues of a single component
+          # As we mature the usage of issuegenerator, we can extend it to
+          # generate issues for multiple components.
+          #
+          # We'll start with the hostmetricsreceiver.
+          mkdir -p ./internal/tools/testresults/hostmetricsreceiver
+          mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
+          ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/


### PR DESCRIPTION
Addressing feedback from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38177, adds the same automation for the other archs

@mx-psi 