### PR TITLE
[chore][pkg/ottl] Define PathGetSetter in ctxspanevent

### DIFF
--- a/pkg/ottl/contexts/internal/ctxspanevent/context.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/context.go
@@ -3,7 +3,14 @@
 
 package ctxspanevent // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxspanevent"
 
+import "go.opentelemetry.io/collector/pdata/ptrace"
+
 const (
 	Name   = "spanevent"
 	DocRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlspanevent"
 )
+
+type Context interface {
+	GetSpanEvent() ptrace.SpanEvent
+	GetEventIndex() (int64, error)
+}

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ctxspanevent // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxspanevent"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+)
+
+func PathGetSetter[K Context](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+	if path == nil {
+		return nil, ctxerror.New("nil", "nil", Name, DocRef)
+	}
+	switch path.Name() {
+	case "time_unix_nano":
+		return accessSpanEventTimeUnixNano[K](), nil
+	case "time":
+		return accessSpanEventTime[K](), nil
+	case "name":
+		return accessSpanEventName[K](), nil
+	case "attributes":
+		if path.Keys() == nil {
+			return accessSpanEventAttributes[K](), nil
+		}
+		return accessSpanEventAttributesKey(path.Keys()), nil
+	case "dropped_attributes_count":
+		return accessSpanEventDroppedAttributeCount[K](), nil
+	default:
+		return nil, ctxerror.New(path.Name(), path.String(), Name, DocRef)
+	}
+}
+
+func accessSpanEventTimeUnixNano[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetSpanEvent().Timestamp().AsTime().UnixNano(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newTimestamp, ok := val.(int64); ok {
+				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTimestamp)))
+			}
+			return nil
+		},
+	}
+}
+
+func accessSpanEventTime[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetSpanEvent().Timestamp().AsTime(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newTimestamp, ok := val.(time.Time); ok {
+				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(newTimestamp))
+			}
+			return nil
+		},
+	}
+}
+
+func accessSpanEventName[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetSpanEvent().Name(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newName, ok := val.(string); ok {
+				tCtx.GetSpanEvent().SetName(newName)
+			}
+			return nil
+		},
+	}
+}
+
+func accessSpanEventAttributes[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return tCtx.GetSpanEvent().Attributes(), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if attrs, ok := val.(pcommon.Map); ok {
+				attrs.CopyTo(tCtx.GetSpanEvent().Attributes())
+			}
+			return nil
+		},
+	}
+}
+
+func accessSpanEventAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(ctx context.Context, tCtx K) (any, error) {
+			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key)
+		},
+		Setter: func(ctx context.Context, tCtx K, val any) error {
+			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key, val)
+		},
+	}
+}
+
+func accessSpanEventDroppedAttributeCount[K Context]() ottl.StandardGetSetter[K] {
+	return ottl.StandardGetSetter[K]{
+		Getter: func(_ context.Context, tCtx K) (any, error) {
+			return int64(tCtx.GetSpanEvent().DroppedAttributesCount()), nil
+		},
+		Setter: func(_ context.Context, tCtx K, val any) error {
+			if newCount, ok := val.(int64); ok {
+				tCtx.GetSpanEvent().SetDroppedAttributesCount(uint32(newCount))
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
@@ -1,0 +1,481 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ctxspanevent_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxspanevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+)
+
+var spanID2 = [8]byte{8, 7, 6, 5, 4, 3, 2, 1}
+
+func TestPathGetSetter(t *testing.T) {
+	refSpanEvent := createTelemetry()
+
+	newAttrs := pcommon.NewMap()
+	newAttrs.PutStr("hello", "world")
+
+	newCache := pcommon.NewMap()
+	newCache.PutStr("temp", "value")
+
+	newEvents := ptrace.NewSpanEventSlice()
+	newEvents.AppendEmpty().SetName("new event")
+
+	newLinks := ptrace.NewSpanLinkSlice()
+	newLinks.AppendEmpty().SetSpanID(spanID2)
+
+	newStatus := ptrace.NewStatus()
+	newStatus.SetMessage("new status")
+
+	newPMap := pcommon.NewMap()
+	pMap2 := newPMap.PutEmptyMap("k2")
+	pMap2.PutStr("k1", "string")
+
+	newMap := make(map[string]any)
+	newMap2 := make(map[string]any)
+	newMap2["k1"] = "string"
+	newMap["k2"] = newMap2
+
+	tests := []struct {
+		name              string
+		path              ottl.Path[*testContext]
+		orig              any
+		newVal            any
+		expectSetterError bool
+		modified          func(spanEvent ptrace.SpanEvent)
+	}{
+		{
+			name: "span event time",
+			path: &pathtest.Path[*testContext]{
+				N: "time",
+			},
+			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "name",
+			path: &pathtest.Path[*testContext]{
+				N: "name",
+			},
+			orig:   "bear",
+			newVal: "cat",
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.SetName("cat")
+			},
+		},
+		{
+			name: "time_unix_nano",
+			path: &pathtest.Path[*testContext]{
+				N: "time_unix_nano",
+			},
+			orig:   int64(100_000_000),
+			newVal: int64(200_000_000),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
+			},
+		},
+		{
+			name: "attributes",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refSpanEvent.Attributes(),
+			newVal: newAttrs,
+			modified: func(spanEvent ptrace.SpanEvent) {
+				newAttrs.CopyTo(spanEvent.Attributes())
+			},
+		},
+		{
+			name: "attributes string",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("str"),
+					},
+				},
+			},
+			orig:   "val",
+			newVal: "newVal",
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutStr("str", "newVal")
+			},
+		},
+		{
+			name: "attributes bool",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("bool"),
+					},
+				},
+			},
+			orig:   true,
+			newVal: false,
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutBool("bool", false)
+			},
+		},
+		{
+			name: "attributes int",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("int"),
+					},
+				},
+			},
+			orig:   int64(10),
+			newVal: int64(20),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutInt("int", 20)
+			},
+		},
+		{
+			name: "attributes float",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("double"),
+					},
+				},
+			},
+			orig:   float64(1.2),
+			newVal: float64(2.4),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutDouble("double", 2.4)
+			},
+		},
+		{
+			name: "attributes bytes",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("bytes"),
+					},
+				},
+			},
+			orig:   []byte{1, 3, 2},
+			newVal: []byte{2, 3, 4},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
+			},
+		},
+		{
+			name: "attributes array string",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("arr_str"),
+					},
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpanEvent.Attributes().Get("arr_str")
+				return val.Slice()
+			}(),
+			newVal: []string{"new"},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
+			},
+		},
+		{
+			name: "attributes array bool",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("arr_bool"),
+					},
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpanEvent.Attributes().Get("arr_bool")
+				return val.Slice()
+			}(),
+			newVal: []bool{false},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
+			},
+		},
+		{
+			name: "attributes array int",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("arr_int"),
+					},
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpanEvent.Attributes().Get("arr_int")
+				return val.Slice()
+			}(),
+			newVal: []int64{20},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
+			},
+		},
+		{
+			name: "attributes array float",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("arr_float"),
+					},
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpanEvent.Attributes().Get("arr_float")
+				return val.Slice()
+			}(),
+			newVal: []float64{2.0},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
+			},
+		},
+		{
+			name: "attributes array bytes",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("arr_bytes"),
+					},
+				},
+			},
+			orig: func() pcommon.Slice {
+				val, _ := refSpanEvent.Attributes().Get("arr_bytes")
+				return val.Slice()
+			}(),
+			newVal: [][]byte{{9, 6, 4}},
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
+			},
+		},
+		{
+			name: "attributes pcommon.Map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("pMap"),
+					},
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpanEvent.Attributes().Get("pMap")
+				return val.Map()
+			}(),
+			newVal: newPMap,
+			modified: func(spanEvent ptrace.SpanEvent) {
+				m := spanEvent.Attributes().PutEmptyMap("pMap")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes map[string]any",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("map"),
+					},
+				},
+			},
+			orig: func() pcommon.Map {
+				val, _ := refSpanEvent.Attributes().Get("map")
+				return val.Map()
+			}(),
+			newVal: newMap,
+			modified: func(spanEvent ptrace.SpanEvent) {
+				m := spanEvent.Attributes().PutEmptyMap("map")
+				m2 := m.PutEmptyMap("k2")
+				m2.PutStr("k1", "string")
+			},
+		},
+		{
+			name: "attributes nested",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("slice"),
+					},
+					&pathtest.Key[*testContext]{
+						I: ottltest.Intp(0),
+					},
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("map"),
+					},
+				},
+			},
+			orig: func() string {
+				val, _ := refSpanEvent.Attributes().Get("slice")
+				val, _ = val.Slice().At(0).Map().Get("map")
+				return val.Str()
+			}(),
+			newVal: "new",
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
+			},
+		},
+		{
+			name: "attributes nested new values",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
+						S: ottltest.Strp("new"),
+					},
+					&pathtest.Key[*testContext]{
+						I: ottltest.Intp(2),
+					},
+					&pathtest.Key[*testContext]{
+						I: ottltest.Intp(0),
+					},
+				},
+			},
+			orig: func() any {
+				return nil
+			}(),
+			newVal: "new",
+			modified: func(spanEvent ptrace.SpanEvent) {
+				s := spanEvent.Attributes().PutEmptySlice("new")
+				s.AppendEmpty()
+				s.AppendEmpty()
+				s.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("new")
+			},
+		},
+		{
+			name: "dropped_attributes_count",
+			path: &pathtest.Path[*testContext]{
+				N: "dropped_attributes_count",
+			},
+			orig:   int64(10),
+			newVal: int64(20),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				spanEvent.SetDroppedAttributesCount(20)
+			},
+		},
+	}
+	// Copy all tests cases and sets the path.Context value to the generated ones.
+	// It ensures all exiting field access also work when the path context is set.
+	for _, tt := range slices.Clone(tests) {
+		testWithContext := tt
+		testWithContext.name = "with_path_context:" + tt.name
+		pathWithContext := *tt.path.(*pathtest.Path[*testContext])
+		pathWithContext.C = ctxspanevent.Name
+		testWithContext.path = ottl.Path[*testContext](&pathWithContext)
+		tests = append(tests, testWithContext)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessor, err := ctxspanevent.PathGetSetter(tt.path)
+			assert.NoError(t, err)
+
+			spanEvent := createTelemetry()
+
+			tCtx := newTestContext(spanEvent)
+
+			got, err := accessor.Get(context.Background(), tCtx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.orig, got)
+
+			err = accessor.Set(context.Background(), tCtx, tt.newVal)
+			if tt.expectSetterError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			exSpanEvent := createTelemetry()
+			tt.modified(exSpanEvent)
+			assert.Equal(t, exSpanEvent, spanEvent)
+		})
+	}
+}
+
+func createTelemetry() ptrace.SpanEvent {
+	spanEvent := ptrace.NewSpan().Events().AppendEmpty()
+
+	spanEvent.SetName("bear")
+	spanEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(100)))
+	spanEvent.SetDroppedAttributesCount(10)
+
+	spanEvent.Attributes().PutStr("str", "val")
+	spanEvent.Attributes().PutBool("bool", true)
+	spanEvent.Attributes().PutInt("int", 10)
+	spanEvent.Attributes().PutDouble("double", 1.2)
+	spanEvent.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{1, 3, 2})
+
+	arrStr := spanEvent.Attributes().PutEmptySlice("arr_str")
+	arrStr.AppendEmpty().SetStr("one")
+	arrStr.AppendEmpty().SetStr("two")
+
+	arrBool := spanEvent.Attributes().PutEmptySlice("arr_bool")
+	arrBool.AppendEmpty().SetBool(true)
+	arrBool.AppendEmpty().SetBool(false)
+
+	arrInt := spanEvent.Attributes().PutEmptySlice("arr_int")
+	arrInt.AppendEmpty().SetInt(2)
+	arrInt.AppendEmpty().SetInt(3)
+
+	arrFloat := spanEvent.Attributes().PutEmptySlice("arr_float")
+	arrFloat.AppendEmpty().SetDouble(1.0)
+	arrFloat.AppendEmpty().SetDouble(2.0)
+
+	arrBytes := spanEvent.Attributes().PutEmptySlice("arr_bytes")
+	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{1, 2, 3})
+	arrBytes.AppendEmpty().SetEmptyBytes().FromRaw([]byte{2, 3, 4})
+
+	pMap := spanEvent.Attributes().PutEmptyMap("pMap")
+	pMap.PutStr("original", "map")
+
+	m := spanEvent.Attributes().PutEmptyMap("map")
+	m.PutStr("original", "map")
+
+	s := spanEvent.Attributes().PutEmptySlice("slice")
+	s.AppendEmpty().SetEmptyMap().PutStr("map", "pass")
+
+	return spanEvent
+}
+
+type testContext struct {
+	spanEvent ptrace.SpanEvent
+}
+
+func (l *testContext) GetSpanEvent() ptrace.SpanEvent {
+	return l.spanEvent
+}
+
+func (l *testContext) GetEventIndex() (int64, error) {
+	return 1, nil
+}
+
+func newTestContext(spanEvent ptrace.SpanEvent) *testContext {
+	return &testContext{spanEvent: spanEvent}
+}

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -233,23 +232,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			return accessCache(), nil
 		}
 		return accessCacheKey(path.Keys()), nil
-	case "time_unix_nano":
-		return accessSpanEventTimeUnixNano(), nil
-	case "time":
-		return accessSpanEventTime(), nil
-	case "name":
-		return accessSpanEventName(), nil
-	case "attributes":
-		if path.Keys() == nil {
-			return accessSpanEventAttributes(), nil
-		}
-		return accessSpanEventAttributesKey(path.Keys()), nil
-	case "dropped_attributes_count":
-		return accessSpanEventDroppedAttributeCount(), nil
 	case "event_index":
 		return accessSpanEventIndex(), nil
 	default:
-		return nil, ctxerror.New(path.Name(), path.String(), ctxspanevent.Name, ctxspanevent.DocRef)
+		return ctxspanevent.PathGetSetter(path)
 	}
 }
 
@@ -291,87 +277,6 @@ func accessCacheKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[Tra
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
 			return ctxutil.SetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key, val)
-		},
-	}
-}
-
-func accessSpanEventTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
-			return tCtx.GetSpanEvent().Timestamp().AsTime().UnixNano(), nil
-		},
-		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
-			if newTimestamp, ok := val.(int64); ok {
-				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTimestamp)))
-			}
-			return nil
-		},
-	}
-}
-
-func accessSpanEventTime() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
-			return tCtx.GetSpanEvent().Timestamp().AsTime(), nil
-		},
-		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
-			if newTimestamp, ok := val.(time.Time); ok {
-				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(newTimestamp))
-			}
-			return nil
-		},
-	}
-}
-
-func accessSpanEventName() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
-			return tCtx.GetSpanEvent().Name(), nil
-		},
-		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
-			if newName, ok := val.(string); ok {
-				tCtx.GetSpanEvent().SetName(newName)
-			}
-			return nil
-		},
-	}
-}
-
-func accessSpanEventAttributes() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
-			return tCtx.GetSpanEvent().Attributes(), nil
-		},
-		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetSpanEvent().Attributes())
-			}
-			return nil
-		},
-	}
-}
-
-func accessSpanEventAttributesKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return ctxutil.GetMapValue[TransformContext](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key)
-		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return ctxutil.SetMapValue[TransformContext](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key, val)
-		},
-	}
-}
-
-func accessSpanEventDroppedAttributeCount() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
-			return int64(tCtx.GetSpanEvent().DroppedAttributesCount()), nil
-		},
-		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
-			if newCount, ok := val.(int64); ok {
-				tCtx.GetSpanEvent().SetDroppedAttributesCount(uint32(newCount))
-			}
-			return nil
 		},
 	}
 }


### PR DESCRIPTION
Follows pattern established in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38184

Note: this does not yet move `event_index` into ctxspanevent. This field seems to break the pattern so will require additional consideration of how to handle it. For now, it remains handled in the ottlspanevent package.