### PR TITLE
fix(redisreceiver): Collect redis keyspace metrics even if dbs are nonsequential

### DIFF
--- a/.chloggen/redis-collect-nonsequential-keyspace.yaml
+++ b/.chloggen/redis-collect-nonsequential-keyspace.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Collect keyspace metrics even if reported dbs are nonsequential
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38135]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If a redis instance has no activity on a db, the db number is not reported in the keyspace metrics.
+  This change ensures that the keyspace metrics are collected even if the reported dbs have gaps.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -137,11 +137,11 @@ func (rs *redisScraper) recordCommonMetrics(ts pcommon.Timestamp, inf info) {
 // recordKeyspaceMetrics records metrics from 'keyspace' Redis info key-value pairs,
 // e.g. "db0: keys=1,expires=2,avg_ttl=3".
 func (rs *redisScraper) recordKeyspaceMetrics(ts pcommon.Timestamp, inf info) {
-	for db := 0; db < redisMaxDbs; db++ {
+	for db := range redisMaxDbs {
 		key := "db" + strconv.Itoa(db)
 		str, ok := inf[key]
 		if !ok {
-			break
+			continue
 		}
 		keyspace, parsingError := parseKeyspaceString(db, str)
 		if parsingError != nil {

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -27,9 +27,9 @@ func TestRedisRunnable(t *testing.T) {
 	require.NoError(t, err)
 	md, err := runner.ScrapeMetrics(context.Background())
 	require.NoError(t, err)
-	// + 6 because there are two keyspace entries each of which has three metrics
+	// + 9 because there are three keyspace entries each of which has three metrics
 	// -2 because maxmemory and slave_repl_offset is by default disabled, so recorder is there, but there won't be data point
-	assert.Equal(t, len(rs.dataPointRecorders())+6-2, md.DataPointCount())
+	assert.Equal(t, len(rs.dataPointRecorders())+9-2, md.DataPointCount())
 	rm := md.ResourceMetrics().At(0)
 	ilm := rm.ScopeMetrics().At(0)
 	il := ilm.Scope()

--- a/receiver/redisreceiver/redis_svc_test.go
+++ b/receiver/redisreceiver/redis_svc_test.go
@@ -17,6 +17,6 @@ func TestParser(t *testing.T) {
 	s := newFakeAPIParser()
 	info, err := s.info()
 	require.NoError(t, err)
-	require.Len(t, info, 130)
+	require.Len(t, info, 131)
 	require.Equal(t, "1.24", info["allocator_frag_ratio"]) // spot check
 }

--- a/receiver/redisreceiver/testdata/info.txt
+++ b/receiver/redisreceiver/testdata/info.txt
@@ -140,6 +140,7 @@ cluster_enabled:0
 # Keyspace
 db0:keys=1,expires=2,avg_ttl=3
 db1:keys=4,expires=5,avg_ttl=6
+db3:keys=5,expires=10,avg_ttl=85
 
 # Commandstats
 cmdstat_ssubscribe:calls=0,usec=0,usec_per_call=0.00,rejected_calls=3,failed_calls=0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
As described in the issue, if a redis DB is inactive it will not report keyspace metrics, and if a user has nonsequential dbs in use the metrics will not all be captured.

This PR resolves the issue by continuing on a missing DB instead of breaking. The maximum number of dbs is 15, so a few extra loop iterations shouldn't be a significant performance affect.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38135

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added case to the unit tests.

<!--Please delete paragraphs that you did not use before submitting.-->
