### PR TITLE
fix(hostmetricsreceiver): Remove expectations in tests of arm missing metrics

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -53,6 +53,7 @@ var allMetrics = []string{
 	"system.network.io",
 	"system.network.packets",
 	"system.paging.operations",
+	"system.paging.usage",
 }
 
 var resourceMetrics = []string{
@@ -138,9 +139,6 @@ func assertIncludesExpectedMetrics(t *testing.T, got pmetric.Metrics) {
 
 	// verify the expected list of metrics returned (os/arch dependent)
 	expectedMetrics := allMetrics
-	if !(runtime.GOOS == "linux" && runtime.GOARCH == "arm64") {
-		expectedMetrics = append(expectedMetrics, "system.paging.usage")
-	}
 
 	expectedMetrics = append(expectedMetrics, systemSpecificMetrics[runtime.GOOS]...)
 	assert.Equal(t, len(expectedMetrics), len(returnedMetrics))

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
@@ -83,11 +83,6 @@ func TestScrape(t *testing.T) {
 				expectedMetrics = 3
 			}
 
-			// linux + ARM runner has no swap
-			if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
-				expectedMetrics = 2
-			}
-
 			assert.Equal(t, expectedMetrics, md.MetricCount())
 
 			startIndex := 0
@@ -102,12 +97,10 @@ func TestScrape(t *testing.T) {
 			internal.AssertSameTimeStampForMetrics(t, metrics, 0, metrics.Len()-2)
 			startIndex++
 
-			if !(runtime.GOOS == "linux" && runtime.GOARCH == "arm64") {
-				assertPagingUsageMetricValid(t, metrics.At(startIndex))
-				internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
-				startIndex++
-				assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
-			}
+			assertPagingUsageMetricValid(t, metrics.At(startIndex))
+			internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
+			startIndex++
+			assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
It seems the tests expecations are based on old github runners, validating that assumption...

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38206
Fixes http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37936

<!--Please delete paragraphs that you did not use before submitting.-->
