### PR TITLE
[chore][pkg/ottl] Move scope and resource PathGetSetters to internal ctx packages

### DIFF
--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -430,7 +430,7 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 
 			numberDataPoint := createNumberDataPoint(tt.valueType)
 
-			ctx := newContext(numberDataPoint)
+			ctx := newTestContext(numberDataPoint)
 
 			got, err := accessor.Get(context.Background(), ctx)
 			assert.NoError(t, err)
@@ -896,7 +896,7 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 			histogramDataPoint := createHistogramDataPointTelemetry()
 
-			ctx := newContext(histogramDataPoint)
+			ctx := newTestContext(histogramDataPoint)
 
 			got, err := accessor.Get(context.Background(), ctx)
 			assert.NoError(t, err)
@@ -1446,7 +1446,7 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 			expoHistogramDataPoint := createExpoHistogramDataPointTelemetry()
 
-			ctx := newContext(expoHistogramDataPoint)
+			ctx := newTestContext(expoHistogramDataPoint)
 
 			got, err := accessor.Get(context.Background(), ctx)
 			assert.NoError(t, err)
@@ -1896,7 +1896,7 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 			summaryDataPoint := createSummaryDataPointTelemetry()
 
-			ctx := newContext(summaryDataPoint)
+			ctx := newTestContext(summaryDataPoint)
 
 			got, err := accessor.Get(context.Background(), ctx)
 			assert.NoError(t, err)
@@ -1984,6 +1984,6 @@ func (m *testContext) GetDataPoint() any {
 	return m.dataPoint
 }
 
-func newContext(dataPoint any) *testContext {
+func newTestContext(dataPoint any) *testContext {
 	return &testContext{dataPoint: dataPoint}
 }

--- a/pkg/ottl/contexts/internal/ctxlog/log_test.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log_test.go
@@ -339,11 +339,11 @@ func TestPathGetSetter(t *testing.T) {
 
 			log := createTelemetry(tt.bodyType)
 
-			got, err := accessor.Get(context.Background(), newtestContext(log))
+			got, err := accessor.Get(context.Background(), newTestContext(log))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			err = accessor.Set(context.Background(), newtestContext(log), tt.newVal)
+			err = accessor.Set(context.Background(), newTestContext(log), tt.newVal)
 			assert.NoError(t, err)
 
 			expectedLog := createTelemetry(tt.bodyType)
@@ -424,6 +424,6 @@ func (l *testContext) GetLogRecord() plog.LogRecord {
 	return l.log
 }
 
-func newtestContext(log plog.LogRecord) *testContext {
+func newTestContext(log plog.LogRecord) *testContext {
 	return &testContext{log: log}
 }

--- a/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric_test.go
@@ -116,11 +116,11 @@ func TestPathGetSetter(t *testing.T) {
 
 			metric := createTelemetry()
 
-			got, err := accessor.Get(context.Background(), newContext(metric))
+			got, err := accessor.Get(context.Background(), newTestContext(metric))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			err = accessor.Set(context.Background(), newContext(metric), tt.newVal)
+			err = accessor.Set(context.Background(), newTestContext(metric), tt.newVal)
 			assert.NoError(t, err)
 
 			expectedMetric := createTelemetry()
@@ -149,6 +149,6 @@ func (m *testContext) GetMetric() pmetric.Metric {
 	return m.metric
 }
 
-func newContext(metric pmetric.Metric) *testContext {
+func newTestContext(metric pmetric.Metric) *testContext {
 	return &testContext{metric: metric}
 }

--- a/pkg/ottl/contexts/internal/ctxresource/context.go
+++ b/pkg/ottl/contexts/internal/ctxresource/context.go
@@ -3,7 +3,18 @@
 
 package ctxresource // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+)
+
 const (
 	Name   = "resource"
 	DocRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlresource"
 )
+
+type Context interface {
+	GetResource() pcommon.Resource
+	GetResourceSchemaURLItem() ctxutil.SchemaURLItem
+}

--- a/pkg/ottl/contexts/internal/ctxresource/resource.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+package ctxresource // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 
 import (
 	"context"
@@ -11,18 +11,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 )
 
-type ResourceContext interface {
-	GetResource() pcommon.Resource
-	GetResourceSchemaURLItem() SchemaURLItem
-}
-
-func ResourcePathGetSetter[K ResourceContext](lowerContext string, path ottl.Path[K]) (ottl.GetSetter[K], error) {
+func PathGetSetter[K Context](lowerContext string, path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return nil, ctxerror.New("nil", "nil", ctxresource.Name, ctxresource.DocRef)
+		return nil, ctxerror.New("nil", "nil", Name, DocRef)
 	}
 	switch path.Name() {
 	case "attributes":
@@ -37,11 +31,11 @@ func ResourcePathGetSetter[K ResourceContext](lowerContext string, path ottl.Pat
 	case "cache":
 		return nil, ctxcache.NewError(lowerContext, path.Context(), path.String())
 	default:
-		return nil, ctxerror.New(path.Name(), path.String(), ctxresource.Name, ctxresource.DocRef)
+		return nil, ctxerror.New(path.Name(), path.String(), Name, DocRef)
 	}
 }
 
-func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
+func accessResourceAttributes[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetResource().Attributes(), nil
@@ -55,7 +49,7 @@ func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessResourceAttributesKey[K ResourceContext](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
+func accessResourceAttributesKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
 			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetResource().Attributes(), keys)
@@ -66,7 +60,7 @@ func accessResourceAttributesKey[K ResourceContext](keys []ottl.Key[K]) ottl.Sta
 	}
 }
 
-func accessResourceDroppedAttributesCount[K ResourceContext]() ottl.StandardGetSetter[K] {
+func accessResourceDroppedAttributesCount[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetResource().DroppedAttributesCount()), nil
@@ -80,7 +74,7 @@ func accessResourceDroppedAttributesCount[K ResourceContext]() ottl.StandardGetS
 	}
 }
 
-func accessResourceSchemaURLItem[K ResourceContext]() ottl.StandardGetSetter[K] {
+func accessResourceSchemaURLItem[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetResourceSchemaURLItem().SchemaUrl(), nil

--- a/pkg/ottl/contexts/internal/ctxresource/resource_test.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package ctxresource_test
 
 import (
 	"context"
@@ -12,27 +12,29 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
-func TestResourcePathGetSetter(t *testing.T) {
+func TestPathGetSetter(t *testing.T) {
 	refResource := createResource()
 
-	refResourceContext := newResourceContext(refResource)
+	refResourceContext := newTestContext(refResource)
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[*resourceContext]
+		path     ottl.Path[*testContext]
 		orig     any
 		newVal   any
 		modified func(resource pcommon.Resource)
 	}{
 		{
 			name: "resource schema_url",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "schema_url",
 			},
 			orig:   refResourceContext.GetResourceSchemaURLItem().SchemaUrl(),
@@ -43,7 +45,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
 			orig:   refResource.Attributes(),
@@ -54,10 +56,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -70,10 +72,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -86,10 +88,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -102,10 +104,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -118,10 +120,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -134,10 +136,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_empty"),
 					},
 				},
@@ -153,10 +155,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -172,10 +174,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -191,10 +193,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -210,10 +212,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -229,10 +231,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -248,16 +250,16 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[*resourceContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[*resourceContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -274,16 +276,16 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*resourceContext]{
-					&pathtest.Key[*resourceContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[*resourceContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[*resourceContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -301,7 +303,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[*resourceContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -313,16 +315,16 @@ func TestResourcePathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := ResourcePathGetSetter[*resourceContext](tt.path.Context(), tt.path)
+			accessor, err := ctxresource.PathGetSetter[*testContext](tt.path.Context(), tt.path)
 			assert.NoError(t, err)
 
 			resource := createResource()
 
-			got, err := accessor.Get(context.Background(), newResourceContext(resource))
+			got, err := accessor.Get(context.Background(), newTestContext(resource))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			err = accessor.Set(context.Background(), newResourceContext(resource), tt.newVal)
+			err = accessor.Set(context.Background(), newTestContext(resource), tt.newVal)
 			assert.NoError(t, err)
 
 			expectedResource := createResource()
@@ -334,18 +336,18 @@ func TestResourcePathGetSetter(t *testing.T) {
 }
 
 func TestResourcePathGetSetterCacheAccessError(t *testing.T) {
-	path := &pathtest.Path[*resourceContext]{
+	path := &pathtest.Path[*testContext]{
 		N: "cache",
 		C: "resource",
-		KeySlice: []ottl.Key[*resourceContext]{
-			&pathtest.Key[*resourceContext]{
+		KeySlice: []ottl.Key[*testContext]{
+			&pathtest.Key[*testContext]{
 				S: ottltest.Strp("key"),
 			},
 		},
 		FullPath: "resource.cache[key]",
 	}
 
-	_, err := ResourcePathGetSetter[*resourceContext]("log", path)
+	_, err := ctxresource.PathGetSetter[*testContext]("log", path)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `replace "resource.cache[key]" with "log.cache[key]"`)
 }
@@ -407,25 +409,25 @@ func (t *TestResourceSchemaURLItem) SetSchemaUrl(v string) {
 
 //revive:enable:var-naming
 
-func createResourceSchemaURLItem() SchemaURLItem {
+func createResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return &TestResourceSchemaURLItem{
 		schemaURL: "schema_url",
 	}
 }
 
-type resourceContext struct {
+type testContext struct {
 	resource      pcommon.Resource
-	schemaURLItem SchemaURLItem
+	schemaURLItem ctxutil.SchemaURLItem
 }
 
-func (r *resourceContext) GetResource() pcommon.Resource {
+func (r *testContext) GetResource() pcommon.Resource {
 	return r.resource
 }
 
-func (r *resourceContext) GetResourceSchemaURLItem() SchemaURLItem {
+func (r *testContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return r.schemaURLItem
 }
 
-func newResourceContext(resource pcommon.Resource) *resourceContext {
-	return &resourceContext{resource: resource, schemaURLItem: createResourceSchemaURLItem()}
+func newTestContext(resource pcommon.Resource) *testContext {
+	return &testContext{resource: resource, schemaURLItem: createResourceSchemaURLItem()}
 }

--- a/pkg/ottl/contexts/internal/ctxscope/context.go
+++ b/pkg/ottl/contexts/internal/ctxscope/context.go
@@ -3,8 +3,19 @@
 
 package ctxscope // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+)
+
 const (
 	Name       = "scope"
 	LegacyName = "instrumentation_scope"
 	DocRef     = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlscope"
 )
+
+type Context interface {
+	GetInstrumentationScope() pcommon.InstrumentationScope
+	GetScopeSchemaURLItem() ctxutil.SchemaURLItem
+}

--- a/pkg/ottl/contexts/internal/ctxscope/scope.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+package ctxscope // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 
 import (
 	"context"
@@ -11,18 +11,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 )
 
-type InstrumentationScopeContext interface {
-	GetInstrumentationScope() pcommon.InstrumentationScope
-	GetScopeSchemaURLItem() SchemaURLItem
-}
-
-func ScopePathGetSetter[K InstrumentationScopeContext](lowerContext string, path ottl.Path[K]) (ottl.GetSetter[K], error) {
+func PathGetSetter[K Context](lowerContext string, path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return nil, ctxerror.New("nil", "nil", ctxscope.Name, ctxscope.DocRef)
+		return nil, ctxerror.New("nil", "nil", Name, DocRef)
 	}
 	switch path.Name() {
 	case "name":
@@ -42,11 +36,11 @@ func ScopePathGetSetter[K InstrumentationScopeContext](lowerContext string, path
 	case "cache":
 		return nil, ctxcache.NewError(lowerContext, path.Context(), path.String())
 	default:
-		return nil, ctxerror.New(path.Name(), path.String(), ctxscope.Name, ctxscope.DocRef)
+		return nil, ctxerror.New(path.Name(), path.String(), Name, DocRef)
 	}
 }
 
-func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeAttributes[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Attributes(), nil
@@ -60,7 +54,7 @@ func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.
 	}
 }
 
-func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeAttributesKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
 			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetInstrumentationScope().Attributes(), keys)
@@ -71,7 +65,7 @@ func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](keys
 	}
 }
 
-func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeName[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Name(), nil
@@ -85,7 +79,7 @@ func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.Standa
 	}
 }
 
-func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeVersion[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Version(), nil
@@ -99,7 +93,7 @@ func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.Sta
 	}
 }
 
-func accessInstrumentationScopeDroppedAttributesCount[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeDroppedAttributesCount[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetInstrumentationScope().DroppedAttributesCount()), nil
@@ -113,7 +107,7 @@ func accessInstrumentationScopeDroppedAttributesCount[K InstrumentationScopeCont
 	}
 }
 
-func accessInstrumentationScopeSchemaURLItem[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeSchemaURLItem[K Context]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetScopeSchemaURLItem().SchemaUrl(), nil

--- a/pkg/ottl/contexts/internal/ctxscope/scope_test.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package ctxscope_test
 
 import (
 	"context"
@@ -12,26 +12,28 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
-func TestScopePathGetSetter(t *testing.T) {
+func TestPathGetSetter(t *testing.T) {
 	refIS := createInstrumentationScope()
 
-	refISC := newInstrumentationScopeContext(refIS)
+	refISC := newTestContext(refIS)
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
 	tests := []struct {
 		name     string
-		path     ottl.Path[*instrumentationScopeContext]
+		path     ottl.Path[*testContext]
 		orig     any
 		newVal   any
 		modified func(is pcommon.InstrumentationScope)
 	}{
 		{
 			name: "instrumentation_scope name",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "name",
 			},
 			orig:   refIS.Name(),
@@ -42,7 +44,7 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope version",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "version",
 			},
 			orig:   refIS.Version(),
@@ -53,7 +55,7 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope schema_url",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "schema_url",
 			},
 			orig:   refISC.GetScopeSchemaURLItem().SchemaUrl(),
@@ -64,7 +66,7 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
 			},
 			orig:   refIS.Attributes(),
@@ -75,10 +77,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -91,7 +93,7 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -102,10 +104,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -118,10 +120,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -134,10 +136,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -150,10 +152,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -166,10 +168,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_empty"),
 					},
 				},
@@ -185,10 +187,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -205,10 +207,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -225,10 +227,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -245,10 +247,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -265,10 +267,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -285,16 +287,16 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[*instrumentationScopeContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[*instrumentationScopeContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -311,16 +313,16 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[*instrumentationScopeContext]{
-					&pathtest.Key[*instrumentationScopeContext]{
+				KeySlice: []ottl.Key[*testContext]{
+					&pathtest.Key[*testContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[*instrumentationScopeContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[*instrumentationScopeContext]{
+					&pathtest.Key[*testContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -338,7 +340,7 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "scope with context",
-			path: &pathtest.Path[*instrumentationScopeContext]{
+			path: &pathtest.Path[*testContext]{
 				C: "scope",
 				N: "name",
 			},
@@ -351,16 +353,16 @@ func TestScopePathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := ScopePathGetSetter[*instrumentationScopeContext](tt.path.Context(), tt.path)
+			accessor, err := ctxscope.PathGetSetter[*testContext](tt.path.Context(), tt.path)
 			assert.NoError(t, err)
 
 			is := createInstrumentationScope()
 
-			got, err := accessor.Get(context.Background(), newInstrumentationScopeContext(is))
+			got, err := accessor.Get(context.Background(), newTestContext(is))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			err = accessor.Set(context.Background(), newInstrumentationScopeContext(is), tt.newVal)
+			err = accessor.Set(context.Background(), newTestContext(is), tt.newVal)
 			assert.NoError(t, err)
 
 			expectedIS := createInstrumentationScope()
@@ -372,18 +374,18 @@ func TestScopePathGetSetter(t *testing.T) {
 }
 
 func TestScopePathGetSetterCacheAccessError(t *testing.T) {
-	path := &pathtest.Path[*instrumentationScopeContext]{
+	path := &pathtest.Path[*testContext]{
 		N: "cache",
 		C: "instrumentation_scope",
-		KeySlice: []ottl.Key[*instrumentationScopeContext]{
-			&pathtest.Key[*instrumentationScopeContext]{
+		KeySlice: []ottl.Key[*testContext]{
+			&pathtest.Key[*testContext]{
 				S: ottltest.Strp("key"),
 			},
 		},
 		FullPath: "instrumentation_scope.cache[key]",
 	}
 
-	_, err := ScopePathGetSetter[*instrumentationScopeContext]("metric", path)
+	_, err := ctxscope.PathGetSetter[*testContext]("metric", path)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `replace "instrumentation_scope.cache[key]" with "metric.cache[key]"`)
 }
@@ -443,25 +445,25 @@ func (t *TestSchemaURLItem) SetSchemaUrl(v string) {
 
 //revive:enable:var-naming
 
-func createSchemaURLItem() SchemaURLItem {
+func createSchemaURLItem() ctxutil.SchemaURLItem {
 	return &TestSchemaURLItem{
 		schemaURL: "schema_url",
 	}
 }
 
-type instrumentationScopeContext struct {
+type testContext struct {
 	is            pcommon.InstrumentationScope
-	schemaURLItem SchemaURLItem
+	schemaURLItem ctxutil.SchemaURLItem
 }
 
-func (r *instrumentationScopeContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (r *testContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return r.is
 }
 
-func (r *instrumentationScopeContext) GetScopeSchemaURLItem() SchemaURLItem {
+func (r *testContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return r.schemaURLItem
 }
 
-func newInstrumentationScopeContext(is pcommon.InstrumentationScope) *instrumentationScopeContext {
-	return &instrumentationScopeContext{is: is, schemaURLItem: createSchemaURLItem()}
+func newTestContext(is pcommon.InstrumentationScope) *testContext {
+	return &testContext{is: is, schemaURLItem: createSchemaURLItem()}
 }

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -611,11 +611,11 @@ func TestPathGetSetter(t *testing.T) {
 
 			span := createTelemetry()
 
-			got, err := accessor.Get(context.Background(), newSpanContext(span))
+			got, err := accessor.Get(context.Background(), newTestContext(span))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			err = accessor.Set(context.Background(), newSpanContext(span), tt.newVal)
+			err = accessor.Set(context.Background(), newTestContext(span), tt.newVal)
 			assert.NoError(t, err)
 
 			expectedSpan := createTelemetry()
@@ -706,6 +706,6 @@ func (r *testContext) GetSpan() ptrace.Span {
 	return r.span
 }
 
-func newSpanContext(span ptrace.Span) *testContext {
+func newTestContext(span ptrace.Span) *testContext {
 	return &testContext{span: span}
 }

--- a/pkg/ottl/contexts/internal/ctxutil/schema.go
+++ b/pkg/ottl/contexts/internal/ctxutil/schema.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+package ctxutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 
 //revive:disable:var-naming The methods in this interface are defined by pdata types.
 type SchemaURLItem interface {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxdatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
@@ -28,10 +27,10 @@ import (
 const ContextName = ctxdatapoint.Name
 
 var (
-	_ internal.ResourceContext             = (*TransformContext)(nil)
-	_ internal.InstrumentationScopeContext = (*TransformContext)(nil)
-	_ ctxmetric.Context                    = (*TransformContext)(nil)
-	_ zapcore.ObjectMarshaler              = (*TransformContext)(nil)
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ ctxscope.Context        = (*TransformContext)(nil)
+	_ ctxmetric.Context       = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
 )
 
 type TransformContext struct {
@@ -119,11 +118,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 
@@ -235,9 +234,9 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 func (pep *pathExpressionParser) parseHigherContextPath(context string, path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
 	switch context {
 	case ctxresource.Name:
-		return internal.ResourcePathGetSetter(ctxdatapoint.Name, path)
+		return ctxresource.PathGetSetter(ctxdatapoint.Name, path)
 	case ctxscope.LegacyName:
-		return internal.ScopePathGetSetter(ctxdatapoint.Name, path)
+		return ctxscope.PathGetSetter(ctxdatapoint.Name, path)
 	case ctxmetric.Name:
 		return ctxmetric.PathGetSetter(path)
 	default:

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
@@ -28,9 +27,9 @@ import (
 const ContextName = ctxlog.Name
 
 var (
-	_ internal.ResourceContext             = (*TransformContext)(nil)
-	_ internal.InstrumentationScopeContext = (*TransformContext)(nil)
-	_ zapcore.ObjectMarshaler              = (*TransformContext)(nil)
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ ctxscope.Context        = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
 )
 
 type TransformContext struct {
@@ -113,11 +112,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.scopeLogs
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.resourceLogs
 }
 
@@ -226,9 +225,9 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 func (pep *pathExpressionParser) parseHigherContextPath(context string, path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
 	switch context {
 	case ctxresource.Name:
-		return internal.ResourcePathGetSetter(ctxlog.Name, path)
+		return ctxresource.PathGetSetter(ctxlog.Name, path)
 	case ctxscope.LegacyName:
-		return internal.ScopePathGetSetter(ctxlog.Name, path)
+		return ctxscope.PathGetSetter(ctxlog.Name, path)
 	default:
 		var fullPath string
 		if path != nil {

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
@@ -24,9 +23,9 @@ import (
 const ContextName = ctxmetric.Name
 
 var (
-	_ internal.ResourceContext             = TransformContext{}
-	_ internal.InstrumentationScopeContext = TransformContext{}
-	_ ctxmetric.Context                    = TransformContext{}
+	_ ctxresource.Context = TransformContext{}
+	_ ctxscope.Context    = TransformContext{}
+	_ ctxmetric.Context   = TransformContext{}
 )
 
 type TransformContext struct {
@@ -88,11 +87,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 
@@ -201,9 +200,9 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 func (pep *pathExpressionParser) parseHigherContextPath(context string, path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
 	switch context {
 	case ctxresource.Name:
-		return internal.ResourcePathGetSetter(ctxmetric.Name, path)
+		return ctxresource.PathGetSetter(ctxmetric.Name, path)
 	case ctxscope.LegacyName:
-		return internal.ScopePathGetSetter(ctxmetric.Name, path)
+		return ctxscope.PathGetSetter(ctxmetric.Name, path)
 	default:
 		var fullPath string
 		if path != nil {

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
@@ -24,14 +23,14 @@ import (
 const ContextName = ctxresource.Name
 
 var (
-	_ internal.ResourceContext = (*TransformContext)(nil)
-	_ zapcore.ObjectMarshaler  = (*TransformContext)(nil)
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
 )
 
 type TransformContext struct {
 	resource      pcommon.Resource
 	cache         pcommon.Map
-	schemaURLItem internal.SchemaURLItem
+	schemaURLItem ctxutil.SchemaURLItem
 }
 
 func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
@@ -44,7 +43,7 @@ type Option func(*ottl.Parser[TransformContext])
 
 type TransformContextOption func(*TransformContext)
 
-func NewTransformContext(resource pcommon.Resource, schemaURLItem internal.SchemaURLItem, options ...TransformContextOption) TransformContext {
+func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxutil.SchemaURLItem, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		resource:      resource,
 		cache:         pcommon.NewMap(),
@@ -73,7 +72,7 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 
@@ -160,7 +159,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 		}
 		return accessCacheKey(path.Keys()), nil
 	default:
-		return internal.ResourcePathGetSetter[TransformContext](ContextName, path)
+		return ctxresource.PathGetSetter[TransformContext](ContextName, path)
 	}
 }
 

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
@@ -27,9 +26,10 @@ import (
 const ContextName = ctxspan.Name
 
 var (
-	_ internal.ResourceContext             = (*TransformContext)(nil)
-	_ internal.InstrumentationScopeContext = (*TransformContext)(nil)
-	_ zapcore.ObjectMarshaler              = (*TransformContext)(nil)
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ ctxscope.Context        = (*TransformContext)(nil)
+	_ ctxspan.Context         = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
 )
 
 type TransformContext struct {
@@ -93,11 +93,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.resourceSpans
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 
@@ -206,9 +206,9 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 func (pep *pathExpressionParser) parseHigherContextPath(context string, path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
 	switch context {
 	case ctxresource.Name:
-		return internal.ResourcePathGetSetter[TransformContext](ctxspan.Name, path)
+		return ctxresource.PathGetSetter[TransformContext](ctxspan.Name, path)
 	case ctxscope.LegacyName:
-		return internal.ScopePathGetSetter[TransformContext](ctxspan.Name, path)
+		return ctxscope.PathGetSetter[TransformContext](ctxspan.Name, path)
 	default:
 		var fullPath string
 		if path != nil {

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
@@ -28,9 +27,10 @@ import (
 const ContextName = ctxspanevent.Name
 
 var (
-	_ internal.ResourceContext             = (*TransformContext)(nil)
-	_ internal.InstrumentationScopeContext = (*TransformContext)(nil)
-	_ zapcore.ObjectMarshaler              = (*TransformContext)(nil)
+	_ ctxresource.Context     = (*TransformContext)(nil)
+	_ ctxscope.Context        = (*TransformContext)(nil)
+	_ ctxspan.Context         = (*TransformContext)(nil)
+	_ zapcore.ObjectMarshaler = (*TransformContext)(nil)
 )
 
 type TransformContext struct {
@@ -113,11 +113,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() internal.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
 	return tCtx.resouceSpans
 }
 
@@ -242,9 +242,9 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 func (pep *pathExpressionParser) parseHigherContextPath(context string, path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
 	switch context {
 	case ctxresource.Name:
-		return internal.ResourcePathGetSetter(ctxspanevent.Name, path)
+		return ctxresource.PathGetSetter(ctxspanevent.Name, path)
 	case ctxscope.LegacyName:
-		return internal.ScopePathGetSetter(ctxspanevent.Name, path)
+		return ctxscope.PathGetSetter(ctxspanevent.Name, path)
 	case ctxspan.Name:
 		return ctxspan.PathGetSetter(ctxspanevent.Name, path)
 	default:


### PR DESCRIPTION
Also normalizes the name of `newTestContext` across all internal context packages.