### PR TITLE
Revert "Introduce issuegenerator to open issues when tests fail on main (#38177)"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -648,27 +648,3 @@ jobs:
                 return
               }
             }
-
-  flakytests-generate-issues:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
-    needs: [unittest-matrix]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          pattern: test-results-*
-          path: ./internal/tools/testresults/
-      - name: Install Tools
-        run: make install-tools
-      - name: Generate Issues
-        run: |
-          # We want to start by generating issues of a single component
-          # As we mature the usage of issuegenerator, we can extend it to
-          # generate issues for multiple components.
-          #
-          # We'll start with the hostmetricsreceiver.
-          mkdir -p ./internal/tools/testresults/hostmetricsreceiver
-          mv ./internal/tools/testresults/github.com-open-telemetry-opentelemetry-collector-contrib-receiver-hostmetricsreceiver-junit.xml ./internal/tools/testresults/hostmetricsreceiver/
-          ./tools/issuegenerator -path ./internal/tools/testresults/hostmetricsreceiver/


### PR DESCRIPTION
This reverts commit b072b17b4871d7403f746f621eb1ae6f1537d901.

When introducing the previous commit to main, we noticed the steps are not well connected. For some reason that we're still investigating the JUnit artifacts aren't uploaded and the last step that depends on them always fail.