### PR TITLE
[chore] skip TestSyslogComplementaryRFC3164

### DIFF
--- a/testbed/tests/syslog_integration_test.go
+++ b/testbed/tests/syslog_integration_test.go
@@ -67,6 +67,7 @@ func TestSyslogComplementaryRFC5424(t *testing.T) {
 }
 
 func TestSyslogComplementaryRFC3164(t *testing.T) {
+	t.Skip("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38238")
 	expectedData := []expectedDataType{
 		{
 			message:        "<34>Oct 11 2023 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8",


### PR DESCRIPTION
#### Description
Skip TestSyslogComplementaryRFC3164, it has been broken for quite a while

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38238
