### PR TITLE
[chore][pkg/ottl] Split package ctxutil

### DIFF
--- a/pkg/ottl/contexts/internal/ctxcommon/ids.go
+++ b/pkg/ottl/contexts/internal/ctxcommon/ids.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package ctxutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+package ctxcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 
 import (
 	"encoding/hex"

--- a/pkg/ottl/contexts/internal/ctxcommon/ids_test.go
+++ b/pkg/ottl/contexts/internal/ctxcommon/ids_test.go
@@ -1,14 +1,14 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package ctxutil_test
+package ctxcommon_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 )
 
 func TestParseSpanIDError(t *testing.T) {
@@ -30,7 +30,7 @@ func TestParseSpanIDError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ctxutil.ParseSpanID(tt.input)
+			_, err := ctxcommon.ParseSpanID(tt.input)
 			assert.EqualError(t, err, tt.wantErr)
 		})
 	}
@@ -55,7 +55,7 @@ func TestParseTraceIDError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ctxutil.ParseTraceID(tt.input)
+			_, err := ctxcommon.ParseTraceID(tt.input)
 			assert.EqualError(t, err, tt.wantErr)
 		})
 	}

--- a/pkg/ottl/contexts/internal/ctxcommon/schema.go
+++ b/pkg/ottl/contexts/internal/ctxcommon/schema.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-package ctxutil // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+package ctxcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 
 //revive:disable:var-naming The methods in this interface are defined by pdata types.
 type SchemaURLItem interface {

--- a/pkg/ottl/contexts/internal/ctxlog/log.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
@@ -290,7 +291,7 @@ func accessStringTraceID[K Context]() ottl.StandardGetSetter[K] {
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
-				id, err := ctxutil.ParseTraceID(str)
+				id, err := ctxcommon.ParseTraceID(str)
 				if err != nil {
 					return err
 				}
@@ -323,7 +324,7 @@ func accessStringSpanID[K Context]() ottl.StandardGetSetter[K] {
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
-				id, err := ctxutil.ParseSpanID(str)
+				id, err := ctxcommon.ParseSpanID(str)
 				if err != nil {
 					return err
 				}

--- a/pkg/ottl/contexts/internal/ctxresource/context.go
+++ b/pkg/ottl/contexts/internal/ctxresource/context.go
@@ -6,7 +6,7 @@ package ctxresource // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 )
 
 const (
@@ -16,5 +16,5 @@ const (
 
 type Context interface {
 	GetResource() pcommon.Resource
-	GetResourceSchemaURLItem() ctxutil.SchemaURLItem
+	GetResourceSchemaURLItem() ctxcommon.SchemaURLItem
 }

--- a/pkg/ottl/contexts/internal/ctxresource/resource_test.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource_test.go
@@ -12,8 +12,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
@@ -409,7 +409,7 @@ func (t *TestResourceSchemaURLItem) SetSchemaUrl(v string) {
 
 //revive:enable:var-naming
 
-func createResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func createResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return &TestResourceSchemaURLItem{
 		schemaURL: "schema_url",
 	}
@@ -417,14 +417,14 @@ func createResourceSchemaURLItem() ctxutil.SchemaURLItem {
 
 type testContext struct {
 	resource      pcommon.Resource
-	schemaURLItem ctxutil.SchemaURLItem
+	schemaURLItem ctxcommon.SchemaURLItem
 }
 
 func (r *testContext) GetResource() pcommon.Resource {
 	return r.resource
 }
 
-func (r *testContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (r *testContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return r.schemaURLItem
 }
 

--- a/pkg/ottl/contexts/internal/ctxscope/context.go
+++ b/pkg/ottl/contexts/internal/ctxscope/context.go
@@ -6,7 +6,7 @@ package ctxscope // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 )
 
 const (
@@ -17,5 +17,5 @@ const (
 
 type Context interface {
 	GetInstrumentationScope() pcommon.InstrumentationScope
-	GetScopeSchemaURLItem() ctxutil.SchemaURLItem
+	GetScopeSchemaURLItem() ctxcommon.SchemaURLItem
 }

--- a/pkg/ottl/contexts/internal/ctxscope/scope_test.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope_test.go
@@ -12,8 +12,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/pathtest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
@@ -445,7 +445,7 @@ func (t *TestSchemaURLItem) SetSchemaUrl(v string) {
 
 //revive:enable:var-naming
 
-func createSchemaURLItem() ctxutil.SchemaURLItem {
+func createSchemaURLItem() ctxcommon.SchemaURLItem {
 	return &TestSchemaURLItem{
 		schemaURL: "schema_url",
 	}
@@ -453,14 +453,14 @@ func createSchemaURLItem() ctxutil.SchemaURLItem {
 
 type testContext struct {
 	is            pcommon.InstrumentationScope
-	schemaURLItem ctxutil.SchemaURLItem
+	schemaURLItem ctxcommon.SchemaURLItem
 }
 
 func (r *testContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return r.is
 }
 
-func (r *testContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (r *testContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return r.schemaURLItem
 }
 

--- a/pkg/ottl/contexts/internal/ctxspan/span.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 )
@@ -139,7 +140,7 @@ func accessStringTraceID[K Context]() ottl.StandardGetSetter[K] {
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
-				id, err := ctxutil.ParseTraceID(str)
+				id, err := ctxcommon.ParseTraceID(str)
 				if err != nil {
 					return err
 				}
@@ -172,7 +173,7 @@ func accessStringSpanID[K Context]() ottl.StandardGetSetter[K] {
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
-				id, err := ctxutil.ParseSpanID(str)
+				id, err := ctxcommon.ParseSpanID(str)
 				if err != nil {
 					return err
 				}
@@ -257,7 +258,7 @@ func accessStringParentSpanID[K Context]() ottl.StandardGetSetter[K] {
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
-				id, err := ctxutil.ParseSpanID(str)
+				id, err := ctxcommon.ParseSpanID(str)
 				if err != nil {
 					return err
 				}

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxdatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
@@ -118,11 +119,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
@@ -112,11 +113,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeLogs
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceLogs
 }
 

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
@@ -87,11 +88,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
@@ -30,7 +31,7 @@ var (
 type TransformContext struct {
 	resource      pcommon.Resource
 	cache         pcommon.Map
-	schemaURLItem ctxutil.SchemaURLItem
+	schemaURLItem ctxcommon.SchemaURLItem
 }
 
 func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
@@ -43,7 +44,7 @@ type Option func(*ottl.Parser[TransformContext])
 
 type TransformContextOption func(*TransformContext)
 
-func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxutil.SchemaURLItem, options ...TransformContextOption) TransformContext {
+func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		resource:      resource,
 		cache:         pcommon.NewMap(),
@@ -72,7 +73,7 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
@@ -33,7 +34,7 @@ type TransformContext struct {
 	instrumentationScope pcommon.InstrumentationScope
 	resource             pcommon.Resource
 	cache                pcommon.Map
-	schemaURLItem        ctxutil.SchemaURLItem
+	schemaURLItem        ctxcommon.SchemaURLItem
 }
 
 func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
@@ -47,7 +48,7 @@ type Option func(*ottl.Parser[TransformContext])
 
 type TransformContextOption func(*TransformContext)
 
-func NewTransformContext(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, schemaURLItem ctxutil.SchemaURLItem, options ...TransformContextOption) TransformContext {
+func NewTransformContext(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		instrumentationScope: instrumentationScope,
 		resource:             resource,
@@ -81,11 +82,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
@@ -93,11 +94,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceSpans
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
@@ -113,11 +114,11 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 	return tCtx.cache
 }
 
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxutil.SchemaURLItem {
+func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resouceSpans
 }
 


### PR DESCRIPTION
This PR adds a `ctxcommon` package alongside `ctxutil`. I found while working on #38239 that circular dependencies became a problem. With this change, `ctxutil` is dedicated to generic accessors for different data types, while `ctxcommon` contains more specific functionality that is shared by multiple contexts. e.g. resource and scope share SchemaURL, logs and traces share trace/span ID parsing.