### PR TITLE
[extension/opampextension] Report `service.namespace` from BuildInfo

### DIFF
--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -79,3 +79,5 @@ replace go.opentelemetry.io/collector/extension/extensionauth => go.opentelemetr
 replace go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest => go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.0.0-20250226024140-8099e51f9a77
 
 replace go.opentelemetry.io/collector/service/hostcapabilities => go.opentelemetry.io/collector/service/hostcapabilities v0.0.0-20250226024140-8099e51f9a77
+
+replace go.opentelemetry.io/collector/component => github.com/observIQ/opentelemetry-collector/component v0.0.0-20250227184409-742e731ecbde

--- a/extension/opampextension/go.sum
+++ b/extension/opampextension/go.sum
@@ -44,6 +44,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/observIQ/opentelemetry-collector/component v0.0.0-20250227184409-742e731ecbde h1:VlvEpcBMW1OlpNYEUsBaLVjMzFXOfdJF7YLT8diMEqU=
+github.com/observIQ/opentelemetry-collector/component v0.0.0-20250227184409-742e731ecbde/go.mod h1:Ya5O+5NWG9XdhJPnOVhKtBrNXHN3hweQbB98HH4KPNU=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/open-telemetry/opamp-go v0.18.0 h1:sNHsrBvGU2CMxCB1TRJXncDARrmxDEebx8dsEIawqA4=
@@ -71,8 +73,6 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
-go.opentelemetry.io/collector/component v0.120.1-0.20250226024140-8099e51f9a77 h1:yz63enLYYcZkHQ+5GZKL2YUf1fqrwb0OKBQMdIRMF48=
-go.opentelemetry.io/collector/component v0.120.1-0.20250226024140-8099e51f9a77/go.mod h1:Ya5O+5NWG9XdhJPnOVhKtBrNXHN3hweQbB98HH4KPNU=
 go.opentelemetry.io/collector/component/componentstatus v0.120.1-0.20250226024140-8099e51f9a77 h1:VqZscK/gQc2thbK/FIoLX5ZPvxq/Tufo3FDWFKFf0l8=
 go.opentelemetry.io/collector/component/componentstatus v0.120.1-0.20250226024140-8099e51f9a77/go.mod h1:kbuAEddxvcyjGLXGmys3nckAj4jTGC0IqDIEXAOr3Ag=
 go.opentelemetry.io/collector/component/componenttest v0.120.1-0.20250226024140-8099e51f9a77 h1:acRutss2nHDMMJBG1rgNq/Gc0QvntS4ERonMxqsAyN8=

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -34,11 +34,12 @@ import (
 func TestNewOpampAgent(t *testing.T) {
 	cfg := createDefaultConfig()
 	set := extensiontest.NewNopSettings(extensiontest.NopType)
-	set.BuildInfo = component.BuildInfo{Version: "test version", Command: "otelcoltest"}
+	set.BuildInfo = component.BuildInfo{Version: "test version", Command: "otelcoltest", Namespace: "opentelemetry-test"}
 	o, err := newOpampAgent(cfg.(*Config), set)
 	assert.NoError(t, err)
 	assert.Equal(t, "otelcoltest", o.agentType)
 	assert.Equal(t, "test version", o.agentVersion)
+	assert.Equal(t, "opentelemetry-test", o.agentNamespace)
 	assert.NotEmpty(t, o.instanceID.String())
 	assert.True(t, o.capabilities.ReportsEffectiveConfig)
 	assert.True(t, o.capabilities.ReportsHealth)
@@ -54,10 +55,12 @@ func TestNewOpampAgentAttributes(t *testing.T) {
 	set.Resource.Attributes().PutStr(semconv.AttributeServiceName, "otelcol-distro")
 	set.Resource.Attributes().PutStr(semconv.AttributeServiceVersion, "distro.0")
 	set.Resource.Attributes().PutStr(semconv.AttributeServiceInstanceID, "f8999bc1-4c9b-4619-9bae-7f009d2411ec")
+	set.Resource.Attributes().PutStr(semconv.AttributeServiceNamespace, "opentelemetry-test")
 	o, err := newOpampAgent(cfg.(*Config), set)
 	assert.NoError(t, err)
 	assert.Equal(t, "otelcol-distro", o.agentType)
 	assert.Equal(t, "distro.0", o.agentVersion)
+	assert.Equal(t, "opentelemetry-test", o.agentNamespace)
 	assert.Equal(t, "f8999bc1-4c9b-4619-9bae-7f009d2411ec", o.instanceID.String())
 	assert.NoError(t, o.Shutdown(context.Background()))
 }
@@ -70,6 +73,7 @@ func TestCreateAgentDescription(t *testing.T) {
 	serviceName := "otelcol-distrot"
 	serviceVersion := "distro.0"
 	serviceInstanceUUID := "f8999bc1-4c9b-4619-9bae-7f009d2411ec"
+	serviceNamespace := "opentelemetry-test"
 
 	testCases := []struct {
 		name string
@@ -85,6 +89,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue(semconv.AttributeServiceInstanceID, serviceInstanceUUID),
 					stringKeyValue(semconv.AttributeServiceName, serviceName),
 					stringKeyValue(semconv.AttributeServiceVersion, serviceVersion),
+					stringKeyValue(semconv.AttributeServiceNamespace, serviceNamespace),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					stringKeyValue(semconv.AttributeHostArch, runtime.GOARCH),
@@ -107,6 +112,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue(semconv.AttributeServiceInstanceID, serviceInstanceUUID),
 					stringKeyValue(semconv.AttributeServiceName, serviceName),
 					stringKeyValue(semconv.AttributeServiceVersion, serviceVersion),
+					stringKeyValue(semconv.AttributeServiceNamespace, serviceNamespace),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					stringKeyValue("env", "prod"),
@@ -130,6 +136,7 @@ func TestCreateAgentDescription(t *testing.T) {
 					stringKeyValue(semconv.AttributeServiceInstanceID, serviceInstanceUUID),
 					stringKeyValue(semconv.AttributeServiceName, serviceName),
 					stringKeyValue(semconv.AttributeServiceVersion, serviceVersion),
+					stringKeyValue(semconv.AttributeServiceNamespace, serviceNamespace),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					stringKeyValue(semconv.AttributeHostArch, runtime.GOARCH),
@@ -150,6 +157,7 @@ func TestCreateAgentDescription(t *testing.T) {
 			set.Resource.Attributes().PutStr(semconv.AttributeServiceName, serviceName)
 			set.Resource.Attributes().PutStr(semconv.AttributeServiceVersion, serviceVersion)
 			set.Resource.Attributes().PutStr(semconv.AttributeServiceInstanceID, serviceInstanceUUID)
+			set.Resource.Attributes().PutStr(semconv.AttributeServiceNamespace, serviceNamespace)
 
 			o, err := newOpampAgent(cfg, set)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Report the semantic convention `service.namespace` as an IdentifyingAttribute in the AgentDescription message, as specified [here](https://opentelemetry.io/docs/specs/opamp/#agentdescription-message).

Currently blocked by this [PR](https://github.com/open-telemetry/opentelemetry-collector/pull/12508) until merged. Then replace statement will be removed.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
