### PR TITLE
[exporter/elasticsearch] Fix getLocations()

### DIFF
--- a/.chloggen/elasticsearchexporter-getlocations.yaml
+++ b/.chloggen/elasticsearchexporter-getlocations.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes the getLocations() function.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38274]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter-getlocations.yaml
+++ b/.chloggen/elasticsearchexporter-getlocations.yaml
@@ -7,7 +7,8 @@ change_type: bug_fix
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fixes the getLocations() function.
+note: Fixes the getLocations() function. It only worked with a location start of 0, which is very unlikely when a
+profile contains more than one sample.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [38274]

--- a/.chloggen/elasticsearchexporter-getlocations.yaml
+++ b/.chloggen/elasticsearchexporter-getlocations.yaml
@@ -7,8 +7,8 @@ change_type: bug_fix
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fixes the getLocations() function. It only worked with a location start of 0, which is very unlikely when a
-profile contains more than one sample.
+note: Fixes the getLocations() function.
+  It only worked with a location start of 0, which is very unlikely when a profile contains more than one sample.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [38274]

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
@@ -389,23 +389,10 @@ func stackTraceID(frames []StackFrame) (string, error) {
 }
 
 func getLocations(profile pprofile.Profile, sample pprofile.Sample) []pprofile.Location {
-	if sample.LocationsLength() > 0 {
-		locations := make([]pprofile.Location, 0, sample.LocationsLength())
-
-		for i := int(sample.LocationsStartIndex()); i < int(sample.LocationsLength()); i++ {
-			if i < profile.LocationTable().Len() {
-				locations = append(locations, profile.LocationTable().At(i))
-			}
-		}
-		return locations
-	}
-
 	locations := make([]pprofile.Location, 0, sample.LocationsLength())
-	lastIndex := int(sample.LocationsStartIndex() + sample.LocationsLength())
+	lastIndex := min(int(sample.LocationsStartIndex()+sample.LocationsLength()), profile.LocationTable().Len())
 	for i := int(sample.LocationsStartIndex()); i < lastIndex; i++ {
-		if i < profile.LocationTable().Len() {
-			locations = append(locations, profile.LocationTable().At(i))
-		}
+		locations = append(locations, profile.LocationTable().At(i))
 	}
 	return locations
 }


### PR DESCRIPTION
Fixes `getLocations()`, random encounter when reading the code.

**Problem(s)**
1. The code block executed for `length > 0` is broken. It should loop from `start` to `start + length` but loops from `start` to `length`, which only works for `start == 0`.
2. The code block executed for `length == 0` contains a no-op loop.

**Solution**
Fix the code to work for all values of `length` and `start`.
Additionally, the PR moves the check `i < profile.LocationTable().Len()` out of the loop body.