### PR TITLE
[extension/ecsobserver] Fix missing task tags retrieval

### DIFF
--- a/.chloggen/fix-ecsobserver-task-tags.yaml
+++ b/.chloggen/fix-ecsobserver-task-tags.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: ecsobserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed ecs task tags not being included in metadata labels
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -168,6 +168,9 @@ func (f *taskFetcher) getDiscoverableTasks(ctx context.Context) ([]*ecs.Task, er
 		descRes, err := svc.DescribeTasksWithContext(ctx, &ecs.DescribeTasksInput{
 			Cluster: cluster,
 			Tasks:   listRes.TaskArns,
+			Include: []*string{
+				aws.String("TAGS"),
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("ecs.DescribeTasks failed: %w", err)


### PR DESCRIPTION
#### Description
The `ecsobserver` extension is not complying with the latest [ECS DescribeTask API specs](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html) as it does not define the introduced `Include: ["TAGS"]` option.

This causes the `ecsobserver` to not render the `__meta_ecs_task_tags_*` labels on scraping since the Task Tags are not being included in the API response.

This is preventing us from enriching our metrics with Task Tags.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a test to validate that Task Tags are included in the response.
