### PR TITLE
[chore] Promote atoulme to Maintainer

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,7 +11,6 @@ useAssigneeGroups: true
 assigneeGroups:
   approvers_maintainers:
     # Approvers
-    - atoulme
     # - ChrsMark on leave
     - crobert-1
     # - dashpole on leave
@@ -21,6 +20,7 @@ assigneeGroups:
     - fatsheep9146
     # Maintainers
     - andrzej-stencel
+    - atoulme
     - bogdandrutu
     - codeboten
     - djaglowski

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Emeritus Triagers:
 
 Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs/open-telemetry/teams/collector-contrib-approvers)):
 
-- [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Christos Markou](https://github.com/ChrsMark), Elastic (on leave)
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google (on leave)
@@ -108,6 +107,7 @@ Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/o
 
 - [Alex Boten](https://github.com/codeboten), Honeycomb
 - [Andrzej Stencel](https://github.com/andrzej-stencel), Elastic
+- [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Bogdan Drutu](https://github.com/bogdandrutu), Snowflake
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk


### PR DESCRIPTION
@atoulme has been a very active approver in Collector Contrib for a long time, showing great judgement and dedication to the project. His experience in Open Source projects has helped him lead Contrib through many process and technical improvements.

PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Aatoulme+
PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Aatoulme+
Issues created: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+author%3Aatoulme+
Issues commented: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+commenter%3Aatoulme+
Commits: https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?author=atoulme&since=2023-05-31&until=now

For these reasons we'd like to promote atoulme to Maintainer.