### PR TITLE
[chore] Promote edmocosta to Approver

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -16,6 +16,7 @@ assigneeGroups:
     - crobert-1
     # - dashpole on leave
     - dehaansa
+    - edmocosta
     - mwear
     - songy23
     - fatsheep9146

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 - [Christos Markou](https://github.com/ChrsMark), Elastic (on leave)
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google (on leave)
+- [Edmo Vamerlatti Costa](https://github.com/edmocosta), Elastic
 - [Matt Wear](https://github.com/mwear), Lightstep
 - [Sam DeHaan](https://github.com/dehaansa), Grafana Labs
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba


### PR DESCRIPTION
@edmocosta has been consistently contributing to the project and shown great judgement through his PRs submissions, reviews and triaging of issues. I'd especially like to call out his great work on OTTL over the last 6 months designing and implementing our context inference solution. For these reasons we'd like to promote him to Approver, where he'll be an even more effective member of the Otel community.

PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Aedmocosta+
PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Aedmocosta+
Issues created: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+author%3Aedmocosta+
Issues commented: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+commenter%3Aedmocosta+
Commits: https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?author=edmocosta&since=2023-05-31&until=now