### PR TITLE
[chore] Fix wavefrontreceiver component ID

### DIFF
--- a/receiver/wavefrontreceiver/receiver.go
+++ b/receiver/wavefrontreceiver/receiver.go
@@ -55,7 +55,9 @@ func (r *metricsReceiver) Start(ctx context.Context, host component.Host) error 
 		},
 	}
 
-	carbonReceiver, err := fact.CreateMetrics(ctx, r.set, carbonCfg, r.nextConsumer)
+	set := r.set
+	set.ID = component.NewIDWithName(fact.Type(), r.set.ID.String())
+	carbonReceiver, err := fact.CreateMetrics(ctx, set, carbonCfg, r.nextConsumer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes contrib-tests for core, as a new validation fails when creating a carbon receiver with the wavefront receiver receiver settings.

Currently, tests fail with:
```
=== Failed
=== FAIL: . TestComponentLifecycle/metrics-lifecycle (0.00s)
    generated_component_test.go:63: 
        	Error Trace:	/tmp/contrib/receiver/wavefrontreceiver/generated_component_test.go:63
        	Error:      	Received unexpected error:
        	            	component type mismatch: component ID "wavefront/50a66f9b-48cc-4338-9701-fd51487c5ecc" does not have type "carbon"
        	Test:       	TestComponentLifecycle/metrics-lifecycle

=== FAIL: . TestComponentLifecycle (0.00s)

=== FAIL: . Test_wavefrontreceiver_EndToEnd (0.00s)
    receiver_test.go:38: 
        	Error Trace:	/tmp/contrib/receiver/wavefrontreceiver/receiver_test.go:38
        	Error:      	Received unexpected error:
        	            	component type mismatch: component ID "wavefront/03ee0cef-57a4-4444-b7e2-18bdc84c22cc" does not have type "carbon"
        	Test:       	Test_wavefrontreceiver_EndToEnd

=== FAIL: . TestComponentLifecycle/metrics-lifecycle (re-run 1) (0.00s)
    generated_component_test.go:63: 
        	Error Trace:	/tmp/contrib/receiver/wavefrontreceiver/generated_component_test.go:63
        	Error:      	Received unexpected error:
        	            	component type mismatch: component ID "wavefront/b873a78a-6cc5-4dc2-9859-fc28142a28af" does not have type "carbon"
        	Test:       	TestComponentLifecycle/metrics-lifecycle

make[3]: *** [../../Makefile.Common:102: test] Error 1
make[2]: *** [Makefile:231: receiver/wavefrontreceiver] Error 2
make[1]: *** [Makefile:149: gotest] Error 2
make: *** [Makefile:278: check-contrib] Error 2
=== FAIL: . TestComponentLifecycle (re-run 1) (0.00s)

=== FAIL: . Test_wavefrontreceiver_EndToEnd (re-run 1) (0.00s)
    receiver_test.go:38: 
        	Error Trace:	/tmp/contrib/receiver/wavefrontreceiver/receiver_test.go:38
        	Error:      	Received unexpected error:
        	            	component type mismatch: component ID "wavefront/99cf9fcc-e9dc-438e-a41a-52b2c2c1f9f8" does not have type "carbon"
        	Test:       	Test_wavefrontreceiver_EndToEnd
```

See https://github.com/open-telemetry/opentelemetry-collector/actions/runs/13596976480/job/38016127009?pr=12528