### PR TITLE
[chore] fix Docker warning "FromAsCasing"

### DIFF
--- a/cmd/telemetrygen/Dockerfile
+++ b/cmd/telemetrygen/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM scratch

--- a/examples/demo/client/Dockerfile
+++ b/examples/demo/client/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-FROM golang:1.24 as build
+FROM golang:1.24 AS build
 WORKDIR /app/
 COPY . .
 RUN go env -w GOPROXY=direct

--- a/examples/demo/server/Dockerfile
+++ b/examples/demo/server/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-FROM golang:1.24 as build
+FROM golang:1.24 AS build
 WORKDIR /app/
 COPY . .
 RUN go env -w GOPROXY=direct

--- a/exporter/clickhouseexporter/example/Dockerfile
+++ b/exporter/clickhouseexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM golang:latest

--- a/exporter/loadbalancingexporter/example/Dockerfile
+++ b/exporter/loadbalancingexporter/example/Dockerfile
@@ -5,7 +5,7 @@ ADD . /src
 
 RUN make otelcontribcol
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM scratch

--- a/exporter/splunkhecexporter/example/Dockerfile
+++ b/exporter/splunkhecexporter/example/Dockerfile
@@ -5,7 +5,7 @@ ADD . /src
 
 RUN make otelcontribcol
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM scratch


### PR DESCRIPTION
Fixes [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/) warnings reported by Docker like:

```console
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)                                                                                                                                                                                                                                                                                                                                  ```