### PR TITLE
#38291: feat: add CCache

### DIFF
--- a/internal/kafka/authentication.go
+++ b/internal/kafka/authentication.go
@@ -68,10 +68,12 @@ type KerberosConfig struct {
 	ServiceName     string `mapstructure:"service_name"`
 	Realm           string `mapstructure:"realm"`
 	UseKeyTab       bool   `mapstructure:"use_keytab"`
+	UseCCache       bool   `mapstructure:"use_ccache"`
 	Username        string `mapstructure:"username"`
 	Password        string `mapstructure:"password" json:"-"`
 	ConfigPath      string `mapstructure:"config_file"`
 	KeyTabPath      string `mapstructure:"keytab_file"`
+	CCachePath      string `mapstructure:"ccache_file"`
 	DisablePAFXFAST bool   `mapstructure:"disable_fast_negotiation"`
 }
 
@@ -169,6 +171,9 @@ func configureKerberos(config KerberosConfig, saramaConfig *sarama.Config) {
 	if config.UseKeyTab {
 		saramaConfig.Net.SASL.GSSAPI.KeyTabPath = config.KeyTabPath
 		saramaConfig.Net.SASL.GSSAPI.AuthType = sarama.KRB5_KEYTAB_AUTH
+	} else if config.UseCCache {
+		saramaConfig.Net.SASL.GSSAPI.CCachePath = config.CCachePath
+		saramaConfig.Net.SASL.GSSAPI.AuthType = sarama.KRB5_CCACHE_AUTH
 	} else {
 		saramaConfig.Net.SASL.GSSAPI.AuthType = sarama.KRB5_USER_AUTH
 		saramaConfig.Net.SASL.GSSAPI.Password = config.Password


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

* Support Kerberos credential cache by adding `use_ccache` and `ccache_file` config parameters.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38291 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Manually teseted by sending to a Kerberized Kafka broker with the following config.

```yaml
exporters:
  kafka:
    protocol_version: 7.6.0
    topic: otelcol
    partition_traces_by_id: true
    brokers:
      - my_broker_host_name:9092
    auth:
      kerberos:
        service_name: 'myservice'
        realm: 'MY.REALM'
        # use credential cache
        use_ccache: true
        ccache_file: '/tmp/krb5cc_12345'
        username: 'foo'
        config_file: '/etc/krb5.conf'
        disable_fast_negotiation: true
```

<!--Describe the documentation added.-->
#### Documentation
   * `use_ccache` (bool) : if this is `true` and `use_keytab` is `false`/not-specified, OTELCOL connects to the brokers using Kerberos ccache
   * `ccache_file` (string): path to the credential cache file
   
<!--Please delete paragraphs that you did not use before submitting.-->
#### License Information

A copyright notice may be inserted here, if appropriate, as discussed in Section
5B below THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE
LICENSE, V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT 
https://www.apache.org/licenses/LICENSE-2.0. THIS SOFTWARE IS LICENSED BY THE 
COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF 
NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY 
EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY 
OTHER REQUIRED LICENSE TERMS.