### PR TITLE
[chore] Update container operator docs

### DIFF
--- a/pkg/stanza/docs/operators/container.md
+++ b/pkg/stanza/docs/operators/container.md
@@ -37,7 +37,7 @@ will produce the following k8s metadata:
       "k8s.pod.uid":                 "49cc7c1fd3702c40b2686ea7486091d6",
       "k8s.container.name":          "kube-controller",
       "k8s.container.restart_count": "1",
-      "k8s.namespace.name":          "some"
+      "k8s.namespace.name":          "some-ns"
     }
   }
 }


### PR DESCRIPTION
Fixing a documentation mismatch: The namespace in the example file path is `some-ns`, but the extracted metadata is `some`.
