### PR TITLE
metricstarttimeprocessor: Use hash of resource attributes for StartimeCache

### DIFF
--- a/.chloggen/resource-hash.yaml
+++ b/.chloggen/resource-hash.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use a hash of resource attributes to cache start times for metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38286]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
@@ -5,6 +5,7 @@ package truereset
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,7 +13,8 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 
 var (
@@ -71,7 +73,7 @@ func TestGauge(t *testing.T) {
 			adjusted:    metrics(gaugeMetric(gauge1, doublePoint(k1v1k2v2, t3, t3, 55))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSum(t *testing.T) {
@@ -102,7 +104,7 @@ func TestSum(t *testing.T) {
 			adjusted:    metrics(sumMetric(sum1, doublePoint(k1v1k2v2, t3, t5, 72))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSumWithDifferentResources(t *testing.T) {
@@ -133,7 +135,7 @@ func TestSumWithDifferentResources(t *testing.T) {
 			adjusted:    metricsFromResourceMetrics(resourceMetrics("job1", "instance1", sumMetric(sum1, doublePoint(k1v1k2v2, t3, t5, 72))), resourceMetrics("job2", "instance2", sumMetric(sum2, doublePoint(k1v1k2v2, t5, t5, 10)))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSummaryNoCount(t *testing.T) {
@@ -160,7 +162,7 @@ func TestSummaryNoCount(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSummaryFlagNoRecordedValue(t *testing.T) {
@@ -177,7 +179,7 @@ func TestSummaryFlagNoRecordedValue(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSummary(t *testing.T) {
@@ -220,7 +222,7 @@ func TestSummary(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestHistogram(t *testing.T) {
@@ -243,7 +245,7 @@ func TestHistogram(t *testing.T) {
 			adjusted:    metrics(histogramMetric(histogram1, histogramPoint(k1v1k2v2, t3, t4, bounds0, []uint64{7, 4, 2, 12}))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestHistogramFlagNoRecordedValue(t *testing.T) {
@@ -260,7 +262,7 @@ func TestHistogramFlagNoRecordedValue(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -277,7 +279,7 @@ func TestHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 // In TestExponentHistogram we exclude negative buckets on purpose as they are
@@ -304,7 +306,7 @@ func TestExponentialHistogram(t *testing.T) {
 			adjusted:    metrics(exponentialHistogramMetric(histogram1, exponentialHistogramPoint(k1v1k2v2, t3, t4, 3, 1, 0, []uint64{}, -2, []uint64{7, 4, 2, 12}))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestExponentialHistogramFlagNoRecordedValue(t *testing.T) {
@@ -321,7 +323,7 @@ func TestExponentialHistogramFlagNoRecordedValue(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestExponentialHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -338,7 +340,7 @@ func TestExponentialHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSummaryFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -355,7 +357,7 @@ func TestSummaryFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestGaugeFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -372,7 +374,7 @@ func TestGaugeFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestSumFlagNoRecordedValueFirstObservation(t *testing.T) {
@@ -389,7 +391,7 @@ func TestSumFlagNoRecordedValueFirstObservation(t *testing.T) {
 		},
 	}
 
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestMultiMetrics(t *testing.T) {
@@ -453,7 +455,7 @@ func TestMultiMetrics(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestNewDataPointsAdded(t *testing.T) {
@@ -515,7 +517,7 @@ func TestNewDataPointsAdded(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestMultiTimeseries(t *testing.T) {
@@ -574,7 +576,7 @@ func TestMultiTimeseries(t *testing.T) {
 			),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestEmptyLabels(t *testing.T) {
@@ -600,7 +602,7 @@ func TestEmptyLabels(t *testing.T) {
 			adjusted:    metrics(sumMetric(sum1, doublePoint(k1vEmptyk2vEmptyk3vEmpty, t1, t3, 88))),
 		},
 	}
-	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), "job", "0", script)
+	runScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
 func TestTsGC(t *testing.T) {
@@ -656,16 +658,21 @@ func TestTsGC(t *testing.T) {
 
 	ma := NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute)
 
+	resourceAttr := "0"
+	resourceAttrs := pcommon.NewMap()
+	resourceAttrs.PutStr("0", resourceAttr)
+	resourceHash := pdatautil.MapHash(resourceAttrs)
+
 	// run round 1
-	runScript(t, ma, "job", "0", script1)
+	runScript(t, ma, script1, resourceAttr)
 	// gc the tsmap, unmarking all entries
-	ma.jobsMap.get("job", "0").gc()
+	ma.startTimeCache.get(resourceHash).gc()
 	// run round 2 - update metrics first timeseries only
-	runScript(t, ma, "job", "0", script2)
+	runScript(t, ma, script2, resourceAttr)
 	// gc the tsmap, collecting umarked entries
-	ma.jobsMap.get("job", "0").gc()
+	ma.startTimeCache.get(resourceHash).gc()
 	// run round 3 - verify that metrics second timeseries have been gc'd
-	runScript(t, ma, "job", "0", script3)
+	runScript(t, ma, script3, resourceAttr)
 }
 
 func TestJobGC(t *testing.T) {
@@ -717,19 +724,19 @@ func TestJobGC(t *testing.T) {
 	ma := NewAdjuster(componenttest.NewNopTelemetrySettings(), gcInterval)
 
 	// run job 1, round 1 - all entries marked
-	runScript(t, ma, "job1", "0", job1Script1)
+	runScript(t, ma, job1Script1, "0")
 	// sleep longer than gcInterval to enable job gc in the next run
 	time.Sleep(2 * gcInterval)
 	// run job 2, round1 - trigger job gc, unmarking all entries
-	runScript(t, ma, "job1", "1", job2Script1)
+	runScript(t, ma, job2Script1, "1")
 	// sleep longer than gcInterval to enable job gc in the next run
 	time.Sleep(2 * gcInterval)
 	// re-run job 2, round1 - trigger job gc, removing unmarked entries
-	runScript(t, ma, "job1", "1", job2Script1)
+	runScript(t, ma, job2Script1, "1")
 	// ensure that at least one jobsMap.gc() completed
-	ma.jobsMap.gc()
+	ma.startTimeCache.gc()
 	// run job 1, round 2 - verify that all job 1 timeseries have been gc'd
-	runScript(t, ma, "job1", "0", job1Script2)
+	runScript(t, ma, job1Script2, "0")
 }
 
 type metricsAdjusterTest struct {
@@ -738,7 +745,7 @@ type metricsAdjusterTest struct {
 	adjusted    pmetric.Metrics
 }
 
-func runScript(t *testing.T, ma *Adjuster, job, instance string, tests []*metricsAdjusterTest) {
+func runScript(t *testing.T, ma *Adjuster, tests []*metricsAdjusterTest, additionalResourceAttrs ...string) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			adjusted := pmetric.NewMetrics()
@@ -746,13 +753,8 @@ func runScript(t *testing.T, ma *Adjuster, job, instance string, tests []*metric
 			// Add the instance/job to the input metrics if they aren't already present.
 			for i := 0; i < adjusted.ResourceMetrics().Len(); i++ {
 				rm := adjusted.ResourceMetrics().At(i)
-				_, found := rm.Resource().Attributes().Get(semconv.AttributeServiceName)
-				if !found {
-					rm.Resource().Attributes().PutStr(semconv.AttributeServiceName, job)
-				}
-				_, found = rm.Resource().Attributes().Get(semconv.AttributeServiceInstanceID)
-				if !found {
-					rm.Resource().Attributes().PutStr(semconv.AttributeServiceInstanceID, instance)
+				for i, attr := range additionalResourceAttrs {
+					rm.Resource().Attributes().PutStr(fmt.Sprintf("%d", i), attr)
 				}
 			}
 			var err error
@@ -762,13 +764,8 @@ func runScript(t *testing.T, ma *Adjuster, job, instance string, tests []*metric
 			// Add the instance/job to the expected metrics as well if they aren't already present.
 			for i := 0; i < test.adjusted.ResourceMetrics().Len(); i++ {
 				rm := test.adjusted.ResourceMetrics().At(i)
-				_, found := rm.Resource().Attributes().Get(semconv.AttributeServiceName)
-				if !found {
-					rm.Resource().Attributes().PutStr(semconv.AttributeServiceName, job)
-				}
-				_, found = rm.Resource().Attributes().Get(semconv.AttributeServiceInstanceID)
-				if !found {
-					rm.Resource().Attributes().PutStr(semconv.AttributeServiceInstanceID, instance)
+				for i, attr := range additionalResourceAttrs {
+					rm.Resource().Attributes().PutStr(fmt.Sprintf("%d", i), attr)
 				}
 			}
 			assert.EqualValues(t, test.adjusted, adjusted)

--- a/processor/metricstarttimeprocessor/internal/truereset/start_time_cache.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/start_time_cache.go
@@ -15,34 +15,34 @@ import (
 
 // Notes on garbage collection (gc):
 //
-// Job-level gc:
-// The Prometheus receiver will likely execute in a long running service whose lifetime may exceed
-// the lifetimes of many of the jobs that it is collecting from. In order to keep the JobsMap from
-// leaking memory for entries of no-longer existing jobs, the JobsMap needs to remove entries that
+// Resource level gc:
+// The collector will likely execute in a long running service whose lifetime may exceed
+// the lifetimes of many of the jobs that it is collecting from. In order to keep the StartTimeCache from
+// leaking memory for entries of no-longer existing jobs, the StartTimeCache needs to remove entries that
 // haven't been accessed for a long period of time.
 //
 // Timeseries-level gc:
-// Some jobs that the Prometheus receiver is collecting from may export timeseries based on metrics
-// from other jobs (e.g. cAdvisor). In order to keep the timeseriesMap from leaking memory for entries
-// of no-longer existing jobs, the timeseriesMap for each job needs to remove entries that haven't
+// Some resources that the collector is collecting from may export timeseries based on metrics
+// from other resources (e.g. cAdvisor). In order to keep the timeseriesMap from leaking memory for entries
+// of no-longer existing resources, the timeseriesMap for each resource needs to remove entries that haven't
 // been accessed for a long period of time.
 //
 // The gc strategy uses a standard mark-and-sweep approach - each time a timeseriesMap is accessed,
 // it is marked. Similarly, each time a timeseriesInfo is accessed, it is also marked.
 //
-// At the end of each JobsMap.get(), if the last time the JobsMap was gc'd exceeds the 'gcInterval',
-// the JobsMap is locked and any timeseriesMaps that are unmarked are removed from the JobsMap
+// At the end of each StartTimeCache.get(), if the last time the StartTimeCache was gc'd exceeds the 'gcInterval',
+// the StartTimeCache is locked and any timeseriesMaps that are unmarked are removed from the StartTimeCache
 // otherwise the timeseriesMap is gc'd
 //
 // The gc for the timeseriesMap is straightforward - the map is locked and, for each timeseriesInfo
 // in the map, if it has not been marked, it is removed otherwise it is unmarked.
 //
 // Alternative Strategies
-// 1. If the job-level gc doesn't run often enough, or runs too often, a separate go routine can
-//    be spawned at JobMap creation time that gc's at periodic intervals. This approach potentially
+// 1. If the resource-level gc doesn't run often enough, or runs too often, a separate go routine can
+//    be spawned at StartTimeCache creation time that gc's at periodic intervals. This approach potentially
 //    adds more contention and latency to each scrape so the current approach is used. Note that
 //    the go routine will need to be cancelled upon Shutdown().
-// 2. If the gc of each timeseriesMap during the gc of the JobsMap causes too much contention,
+// 2. If the gc of each timeseriesMap during the gc of the StartTimeCache causes too much contention,
 //    the gc of timeseriesMaps can be moved to the end of MetricsAdjuster().AdjustMetricSlice(). This
 //    approach requires adding 'lastGC' Time and (potentially) a gcInterval duration to
 //    timeseriesMap so the current approach is used instead.
@@ -157,72 +157,71 @@ func newTimeseriesMap() *timeseriesMap {
 	return &timeseriesMap{mark: true, tsiMap: map[timeseriesKey]*timeseriesInfo{}}
 }
 
-// JobsMap maps from a job instance to a map of timeseries instances for the job.
-type JobsMap struct {
+// StartTimeCache maps from a resource to a map of timeseries instances for the resource.
+type StartTimeCache struct {
 	sync.RWMutex
 	// The mutex is used to protect access to the member fields. It is acquired for most of
 	// get() and also acquired by gc().
 
-	gcInterval time.Duration
-	lastGC     time.Time
-	jobsMap    map[string]*timeseriesMap
+	gcInterval  time.Duration
+	lastGC      time.Time
+	resourceMap map[[16]byte]*timeseriesMap
 }
 
-// NewJobsMap creates a new (empty) JobsMap.
-func NewJobsMap(gcInterval time.Duration) *JobsMap {
-	return &JobsMap{gcInterval: gcInterval, lastGC: time.Now(), jobsMap: make(map[string]*timeseriesMap)}
+// NewStartTimeCache creates a new (empty) JobsMap.
+func NewStartTimeCache(gcInterval time.Duration) *StartTimeCache {
+	return &StartTimeCache{gcInterval: gcInterval, lastGC: time.Now(), resourceMap: make(map[[16]byte]*timeseriesMap)}
 }
 
 // Remove jobs and timeseries that have aged out.
-func (jm *JobsMap) gc() {
-	jm.Lock()
-	defer jm.Unlock()
+func (c *StartTimeCache) gc() {
+	c.Lock()
+	defer c.Unlock()
 	// once the structure is locked, confirm that gc() is still necessary
-	if time.Since(jm.lastGC) > jm.gcInterval {
-		for sig, tsm := range jm.jobsMap {
+	if time.Since(c.lastGC) > c.gcInterval {
+		for sig, tsm := range c.resourceMap {
 			tsm.RLock()
 			tsmNotMarked := !tsm.mark
 			// take a read lock here, no need to get a full lock as we have a lock on the JobsMap
 			tsm.RUnlock()
 			if tsmNotMarked {
-				delete(jm.jobsMap, sig)
+				delete(c.resourceMap, sig)
 			} else {
 				// a full lock will be obtained in here, if required.
 				tsm.gc()
 			}
 		}
-		jm.lastGC = time.Now()
+		c.lastGC = time.Now()
 	}
 }
 
-func (jm *JobsMap) maybeGC() {
+func (c *StartTimeCache) maybeGC() {
 	// speculatively check if gc() is necessary, recheck once the structure is locked
-	jm.RLock()
-	defer jm.RUnlock()
-	if time.Since(jm.lastGC) > jm.gcInterval {
-		go jm.gc()
+	c.RLock()
+	defer c.RUnlock()
+	if time.Since(c.lastGC) > c.gcInterval {
+		go c.gc()
 	}
 }
 
-func (jm *JobsMap) get(job, instance string) *timeseriesMap {
-	sig := job + ":" + instance
+func (c *StartTimeCache) get(resourceHash [16]byte) *timeseriesMap {
 	// a read lock is taken here as we will not need to modify jobsMap if the target timeseriesMap is available.
-	jm.RLock()
-	tsm, ok := jm.jobsMap[sig]
-	jm.RUnlock()
-	defer jm.maybeGC()
+	c.RLock()
+	tsm, ok := c.resourceMap[resourceHash]
+	c.RUnlock()
+	defer c.maybeGC()
 	if ok {
 		return tsm
 	}
-	jm.Lock()
-	defer jm.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	// Now that we've got an exclusive lock, check once more to ensure an entry wasn't created in the interim
 	// and then create a new timeseriesMap if required.
-	tsm2, ok2 := jm.jobsMap[sig]
+	tsm2, ok2 := c.resourceMap[resourceHash]
 	if ok2 {
 		return tsm2
 	}
 	tsm2 = newTimeseriesMap()
-	jm.jobsMap[sig] = tsm2
+	c.resourceMap[resourceHash] = tsm2
 	return tsm2
 }


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This change decouples the processor from the prometheus receiver concepts. It uses a hash of all resource attributes for the `StartTimeCache` instead of the `job` and `instance` labels.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38286.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated unit tests.

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
