### PR TITLE
googlecloudexporter: add ability to write to custom MRs

### DIFF
--- a/.chloggen/custom-monitored-resources.yaml
+++ b/.chloggen/custom-monitored-resources.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a featuregate to support user defined mapping from OTel resources to Monitored Resources
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38102]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.26.1-0.20250303102058-a9bca17f1a4c
 	go.opentelemetry.io/collector/pdata v1.26.1-0.20250303102058-a9bca17f1a4c
 	go.uber.org/goleak v1.3.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422
 )
 
 require (
@@ -87,7 +88,6 @@ require (
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/api v0.216.0 // indirect
 	google.golang.org/genproto v0.0.0-20250106144421-5f5ef82da422 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250219182151-9fdb1cabc7b2 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect

--- a/exporter/googlecloudexporter/internal/resourcemapping/custommapping.go
+++ b/exporter/googlecloudexporter/internal/resourcemapping/custommapping.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcemapping // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter/internal/resourcemapping"
+
+import (
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+var (
+	mappingKey                   = "gcp.resource_type"
+	monitoredResourceLabelPrefix = "gcp."
+)
+
+// CustomMonitoredResourceMapping allows mapping from OTel resources to
+// Monitored Resources defined here:
+// https://cloud.google.com/monitoring/api/resources
+//
+// The monitored resource type is extracted from the `gcp.resource_type`
+// attribute. And the monitored resource labels are extracted from resource
+// attributes with the prefix `gcp.<monitored resource type>.`.
+func CustomMonitoredResourceMapping(r pcommon.Resource) *monitoredrespb.MonitoredResource {
+	var monitoredResourceType string
+	monitoredResourceLabels := make(map[string]string)
+	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+		if k == mappingKey {
+			monitoredResourceType = v.AsString()
+			return false
+		}
+		return true
+	})
+
+	if monitoredResourceType == "" {
+		return collector.DefaultConfig().MetricConfig.MapMonitoredResource(r)
+	}
+
+	prefix := monitoredResourceLabelPrefix + monitoredResourceType + "."
+	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+		// Extract the monitored resource label by separating it from the prefix.
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			monitoredResourceLabels[k[len(prefix):]] = v.AsString()
+		}
+		return true
+	})
+
+	return &monitoredrespb.MonitoredResource{
+		Type:   monitoredResourceType,
+		Labels: monitoredResourceLabels,
+	}
+}

--- a/exporter/googlecloudexporter/internal/resourcemapping/custommapping_test.go
+++ b/exporter/googlecloudexporter/internal/resourcemapping/custommapping_test.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package resourcemapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+)
+
+func TestCustomMonitoredResourceMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource pcommon.Resource
+		want     *monitoredrespb.MonitoredResource
+	}{
+		{
+			name: "Custom Monitored Resource",
+			resource: func() pcommon.Resource {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("gcp.resource_type", "custom_resource")
+				r.Attributes().PutStr("gcp.custom_resource.label1", "value1")
+				r.Attributes().PutStr("gcp.custom_resource.label2", "value2")
+				r.Attributes().PutStr("other.label", "otherValue")
+				return r
+			}(),
+			want: &monitoredrespb.MonitoredResource{
+				Type: "custom_resource",
+				Labels: map[string]string{
+					"label1": "value1",
+					"label2": "value2",
+				},
+			},
+		},
+		{
+			name: "No Custom Monitored Resource",
+			resource: func() pcommon.Resource {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("other.label", "otherValue")
+				return r
+			}(),
+			want: &monitoredrespb.MonitoredResource{
+				Type: "generic_node",
+				Labels: map[string]string{
+					"location":  "global",
+					"namespace": "",
+					"node_id":   "",
+				},
+			},
+		},
+		{
+			name: "Empty Custom Monitored Resource",
+			resource: func() pcommon.Resource {
+				r := pcommon.NewResource()
+				r.Attributes().PutStr("gcp.resource_type", "")
+				r.Attributes().PutStr("gcp..label1", "value1")
+				return r
+			}(),
+			want: &monitoredrespb.MonitoredResource{
+				Type: "generic_node",
+				Labels: map[string]string{
+					"location":  "global",
+					"namespace": "",
+					"node_id":   "",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CustomMonitoredResourceMapping(tt.resource)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change adds a featuregate that allows writing to custom monitored resources based on presence of the `gcp.resource_type` resource attribute.

The default mapping from OTel resources to MRs are used as a fallback.

To enable it, use the `exporter.googlecloud.CustomMonitoredResources` featuregate.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38102

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
