### PR TITLE
[receiver/awsfirehose] remove error logging on gzip.Reader type assertion failure due to nil value

### DIFF
--- a/.chloggen/fix-reader-type-assertion-log.yaml
+++ b/.chloggen/fix-reader-type-assertion-log.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsfirehosereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove error log when gzip reader type assertion fails due to nil value
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38352]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
@@ -53,10 +53,6 @@ func (u *Unmarshaler) UnmarshalLogs(compressedRecord []byte) (plog.Logs, error) 
 	var err error
 	r, ok := u.gzipPool.Get().(*gzip.Reader)
 	if !ok {
-		u.logger.Error(fmt.Sprintf("Expected *gzip.Reader, got %T", r))
-		// Fall through and create a new *gzip.Reader (r == nil)
-	}
-	if r == nil {
 		r, err = gzip.NewReader(bytes.NewReader(compressedRecord))
 	} else {
 		err = r.Reset(bytes.NewReader(compressedRecord))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixing a bug. 

We see a lot of error logs after upgrading `opentelemetry-collector-contrib` to 0.120.0:
```
Expected *gzip.Reader, got *gzip.Reader
```

The root cause is that the type assertion in the following code could return `ok=false` when `r` is `nil`. This could happen when the marshaller is instantiated and there's no value in `gzipPool` yet.

```
r, ok := u.gzipPool.Get().(*gzip.Reader)
if !ok {
  u.logger.Error(fmt.Sprintf("Expected *gzip.Reader, got %T", r))
  // Fall through and create a new *gzip.Reader (r == nil)
}
```

This PR removes the error log. Since we are instantiating the reader only in the line right below
```
r, err = gzip.NewReader(bytes.NewReader(compressedRecord))
```
I don't think checking the type assertion result and logging an error is really necessary.

