### PR TITLE
[chore] prevent unkeyed literal initialization

### DIFF
--- a/extension/encoding/avrologencodingextension/config.go
+++ b/extension/encoding/avrologencodingextension/config.go
@@ -9,6 +9,8 @@ var errNoSchema = errors.New("no schema provided")
 
 type Config struct {
 	Schema string `mapstructure:"schema"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {

--- a/extension/encoding/googlecloudlogentryencodingextension/config.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	HandleJSONPayloadAs HandleAs `mapstructure:"handle_json_payload_as"`
 	// Controls how the proto payload of the [LogEntry]  is parsed into the body.
 	HandleProtoPayloadAs HandleAs `mapstructure:"handle_proto_payload_as"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (config *Config) Validate() error {

--- a/extension/encoding/jaegerencodingextension/config.go
+++ b/extension/encoding/jaegerencodingextension/config.go
@@ -15,6 +15,8 @@ const (
 
 type Config struct {
 	Protocol JaegerProtocol `mapstructure:"protocol"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {

--- a/extension/encoding/jsonlogencodingextension/config.go
+++ b/extension/encoding/jsonlogencodingextension/config.go
@@ -15,6 +15,8 @@ const (
 type Config struct {
 	// Export raw log string instead of log wrapper
 	Mode JSONEncodingMode `mapstructure:"mode,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {

--- a/extension/encoding/otlpencodingextension/config.go
+++ b/extension/encoding/otlpencodingextension/config.go
@@ -12,6 +12,8 @@ var _ xconfmap.Validator = (*Config)(nil)
 
 type Config struct {
 	Protocol string `mapstructure:"protocol"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {

--- a/extension/encoding/textencodingextension/config.go
+++ b/extension/encoding/textencodingextension/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Encoding              string `mapstructure:"encoding"`
 	MarshalingSeparator   string `mapstructure:"marshaling_separator"`
 	UnmarshalingSeparator string `mapstructure:"unmarshaling_separator"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {

--- a/extension/encoding/zipkinencodingextension/config.go
+++ b/extension/encoding/zipkinencodingextension/config.go
@@ -14,6 +14,8 @@ var _ xconfmap.Validator = (*Config)(nil)
 type Config struct {
 	Protocol string `mapstructure:"protocol"`
 	Version  string `mapstructure:"version"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
Adds an unexported field to Config structs to avoid unkeyed literal initialization. See https://github.com/open-telemetry/opentelemetry-collector/issues/12363 for motivation.