### PR TITLE
[chore] Add axw to awsfirehosereceiver codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -211,7 +211,7 @@ receiver/apachesparkreceiver/                                    @open-telemetry
 receiver/awscloudwatchreceiver/                                  @open-telemetry/collector-contrib-approvers @schmikei
 receiver/awscontainerinsightreceiver/                            @open-telemetry/collector-contrib-approvers @Aneurysm9 @pxaws
 receiver/awsecscontainermetricsreceiver/                         @open-telemetry/collector-contrib-approvers @Aneurysm9
-receiver/awsfirehosereceiver/                                    @open-telemetry/collector-contrib-approvers @Aneurysm9
+receiver/awsfirehosereceiver/                                    @open-telemetry/collector-contrib-approvers @Aneurysm9 @axw
 receiver/awss3receiver/                                          @open-telemetry/collector-contrib-approvers @atoulme @adcharre
 receiver/awsxrayreceiver/                                        @open-telemetry/collector-contrib-approvers @wangzlei @srprash
 receiver/azureblobreceiver/                                      @open-telemetry/collector-contrib-approvers @eedorenko @mx-psi

--- a/receiver/awsfirehosereceiver/README.md
+++ b/receiver/awsfirehosereceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: metrics, logs   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fawsfirehose%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fawsfirehose) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fawsfirehose%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fawsfirehose) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@axw](https://www.github.com/axw) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/awsfirehosereceiver/metadata.yaml
+++ b/receiver/awsfirehosereceiver/metadata.yaml
@@ -6,7 +6,7 @@ status:
     alpha: [metrics, logs]
   distributions: [contrib]
   codeowners:
-    active: [Aneurysm9]
+    active: [Aneurysm9, axw]
 
 tests:
   config:


### PR DESCRIPTION
#### Description

I would like to become a codeowner of the awsfirehosereceiver. Elastic (where I work) intends to use this receiver heavily, and I would like to:
 - help spread out the maintenance load
 - ensure we have a path to progressing beyond the current Alpha stability

Assuming https://github.com/open-telemetry/opentelemetry-collector/pull/11864 goes through, it will be necessary to have multiple codeowners to progress to Beta and preferable to have codeowners from multiple employers, which is the case for @Aneurysm9 (AWS) and me (Elastic).

Relevant changes:
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37111 (superseded by #37361)
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37262
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37361
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38388 (will extract from awsfirehosereceiver)
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38445

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A