### PR TITLE
[receiver/statsdreceiver] add ability to customize socket permissions when transport is unixgram (#37807)

### DIFF
--- a/.chloggen/feat_37807_statsdreceiver_flexibility-socket-permissions.yaml
+++ b/.chloggen/feat_37807_statsdreceiver_flexibility-socket-permissions.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: statsdreceiver
+note: Add new config to customize socket permissions when transport is set to `unixgram`.
+issues:
+  - 37807
+
+subtext:
+change_logs: [user]

--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -27,6 +27,8 @@ The Following settings are optional:
 
 - `transport` (default = `udp`): Protocol used by the StatsD server. Currently supported transports can be found in [this file](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/statsdreceiver/internal/transport/transport.go).
 
+- `socket_permissions` (default = `0622`): When transport is set to `unixgram`, can be used to customize permissions of the binded socket. 
+
 - `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
 - `enable_metric_type: true`(default value is false): Enable the statsd receiver to be able to emit the metric type(gauge, counter, timer(in the future), histogram(in the future)) as a label.

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -6,6 +6,7 @@ package statsdreceiver // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/lightstep/go-expohisto/structure"
@@ -24,6 +25,8 @@ type Config struct {
 	EnableSimpleTags        bool                             `mapstructure:"enable_simple_tags"`
 	IsMonotonicCounter      bool                             `mapstructure:"is_monotonic_counter"`
 	TimerHistogramMapping   []protocol.TimerHistogramMapping `mapstructure:"timer_histogram_mapping"`
+	// Will only be used when transport set to 'unixgram'.
+	SocketPermissions os.FileMode `mapstructure:"socket_permissions"`
 }
 
 func (c *Config) Validate() error {

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -42,6 +42,7 @@ func TestLoadConfig(t *testing.T) {
 					Endpoint:  "localhost:12345",
 					Transport: confignet.TransportTypeUDP6,
 				},
+				SocketPermissions:   0o622,
 				AggregationInterval: 70 * time.Second,
 				TimerHistogramMapping: []protocol.TimerHistogramMapping{
 					{

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -5,6 +5,7 @@ package statsdreceiver // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -21,6 +22,7 @@ const (
 	defaultAggregationInterval = 60 * time.Second
 	defaultEnableMetricType    = false
 	defaultIsMonotonicCounter  = false
+	defaultSocketPermissions   = os.FileMode(0o622)
 )
 
 var defaultTimerHistogramMapping = []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}, {StatsdType: "distribution", ObserverType: "gauge"}}
@@ -44,6 +46,7 @@ func createDefaultConfig() component.Config {
 		EnableMetricType:      defaultEnableMetricType,
 		IsMonotonicCounter:    defaultIsMonotonicCounter,
 		TimerHistogramMapping: defaultTimerHistogramMapping,
+		SocketPermissions:     defaultSocketPermissions,
 	}
 }
 

--- a/receiver/statsdreceiver/internal/transport/uds_server_test.go
+++ b/receiver/statsdreceiver/internal/transport/uds_server_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build linux
+
+package transport
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewUDSServer_ListenPacketFailure(t *testing.T) {
+	invalidPath := "/invalid_path/test_socket"
+
+	server, err := NewUDSServer("unixgram", invalidPath, 0o622)
+
+	assert.Error(t, err)
+	assert.Nil(t, server)
+	assert.Contains(t, err.Error(), "starting to listen")
+}
+
+func Test_UDSServer_Close(t *testing.T) {
+	socketPath := "/tmp/test_socket_close"
+	defer os.Remove(socketPath)
+
+	server, err := NewUDSServer("unixgram", socketPath, 0o622)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	_, err = os.Stat(socketPath)
+	require.NoError(t, err)
+
+	err = server.Close()
+	assert.NoError(t, err)
+
+	_, err = os.Stat(socketPath)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func Test_NewUDSServer_AppliesChmod(t *testing.T) {
+	socketPath := "/tmp/test_socket_chmod"
+	defer os.Remove(socketPath) // Cleanup after test
+
+	expectedPermissions := os.FileMode(0o622)
+
+	server, err := NewUDSServer("unixgram", socketPath, expectedPermissions)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+
+	fileInfo, err := os.Stat(socketPath)
+	require.NoError(t, err)
+
+	actualPermissions := fileInfo.Mode().Perm()
+	assert.Equal(t, expectedPermissions, actualPermissions, "Expected file permissions to be set correctly")
+
+	server.Close()
+}

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -92,7 +92,7 @@ func buildTransportServer(config Config) (transport.Server, error) {
 	case transport.TCP, transport.TCP4, transport.TCP6:
 		return transport.NewTCPServer(trans, config.NetAddr.Endpoint)
 	case transport.UDS:
-		return transport.NewUDSServer(trans, config.NetAddr.Endpoint)
+		return transport.NewUDSServer(trans, config.NetAddr.Endpoint, config.SocketPermissions)
 	}
 
 	return nil, fmt.Errorf("unsupported transport %q", string(config.NetAddr.Transport))

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -99,6 +99,7 @@ func Test_statsdreceiver_EndToEnd(t *testing.T) {
 						Endpoint:  defaultBindEndpoint,
 						Transport: confignet.TransportTypeUDP,
 					},
+					SocketPermissions:   defaultSocketPermissions,
 					AggregationInterval: 4 * time.Second,
 				}
 			},
@@ -117,6 +118,7 @@ func Test_statsdreceiver_EndToEnd(t *testing.T) {
 						Endpoint:  "/tmp/statsd_test.sock",
 						Transport: confignet.TransportTypeUnixgram,
 					},
+					SocketPermissions:   defaultSocketPermissions,
 					AggregationInterval: 4 * time.Second,
 				}
 			},


### PR DESCRIPTION
#### Description

This PR introduces a new configuration key `socket_permissions` used when `transport: unixgram` to control permissions of the bind socket.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37807

#### Testing

Unit tests

#### Documentation

Readme updated with new configuration
