### PR TITLE
[chore][exporter/elasticsearch] docs: otel mapping mode requires ES 8.12+

### DIFF
--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -177,6 +177,8 @@ See below for a description of each mapping mode.
 
 #### OTel mapping mode
 
+Requires Elasticsearch 8.12 or above.
+
 In `otel` mapping mode, the Elasticsearch Exporter stores documents in Elastic's preferred
 "OTel-native" schema. In this mapping mode, documents use the original attribute names and
 closely follows the event structure from the OTLP events.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update docs to mention that otel mapping mode requires Elasticsearch 8.12+ because of require_data_stream.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37283

