### PR TITLE
update metric_calculator_test to work on arm

### DIFF
--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -269,11 +269,10 @@ func TestSweep(t *testing.T) {
 	}()
 
 	for i := 1; i <= 2; i++ {
-		sweepTime := <-sweepEvent
-		tickTime := time.Since(start) + mwe.ttl*time.Duration(i)
+		<-sweepEvent
+		clockTime := time.Since(start)
 		require.False(t, closed.Load())
-		assert.LessOrEqual(t, mwe.ttl, tickTime)
-		assert.LessOrEqual(t, time.Since(sweepTime), mwe.ttl)
+		assert.LessOrEqual(t, mwe.ttl*time.Duration(i), clockTime)
 	}
 	require.NoError(t, mwe.Shutdown())
 	for range sweepEvent { //nolint:revive


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Update the metric_calculator_test's TestSweep to not test the behavior of the internal go timer in a way that causes arm tests to fail.

On linked issue, I added these comments to the existing test to describe the existing behavior, this PR drops the last assert and causes the existing assert to check that the passed clock time is greater than the expected amount of TTLs, which appears to be the original intent. 
```
for i := 1; i <= 2; i++ {
	// sweepTime is the time that the internal ticker _expected_ to tick, may not be close (1ms) to the current time
	sweepTime := <-sweepEvent
	// tickTime is the time since test start plus the # of expected ticks
	tickTime := time.Since(start) + mwe.ttl*time.Duration(i)
	require.False(t, closed.Load())
	// This is asserting that the ttl is less than or equal to the time since the start captured before the mwe.sweep function was called,
	// so it's asserting that time consumed until now is greater than one ttl. Should probably be ttl * i, and tickTime should just be time.Since(start)
	assert.LessOrEqual(t, mwe.ttl, tickTime)
	// This is asserting that the time since the _expected_ current tick time is less than or equal to the ttl.
	// This is just testing if the internal timer got to schedule its tick well, and isn't late? This is go runtime behavior, not MWE behavior.
	assert.LessOrEqual(t, time.Since(sweepTime), mwe.ttl)
}
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38205
Relevant to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38204
