### PR TITLE
[chore] Allow OTTL pdata Map setters to take raw map

### DIFF
--- a/pkg/ottl/contexts/internal/ctxcache/cache.go
+++ b/pkg/ottl/contexts/internal/ctxcache/cache.go
@@ -30,6 +30,12 @@ func accessCache[K any](cacheGetter func(K) pcommon.Map) ottl.StandardGetSetter[
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(cacheGetter(tCtx))
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := cacheGetter(tCtx).FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxcache/cache.go
+++ b/pkg/ottl/contexts/internal/ctxcache/cache.go
@@ -27,16 +27,7 @@ func accessCache[K any](cacheGetter func(K) pcommon.Map) ottl.StandardGetSetter[
 			return cacheGetter(tCtx), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if m, ok := val.(pcommon.Map); ok {
-				m.CopyTo(cacheGetter(tCtx))
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := cacheGetter(tCtx).FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(cacheGetter(tCtx), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxcache/cache_test.go
+++ b/pkg/ottl/contexts/internal/ctxcache/cache_test.go
@@ -89,6 +89,26 @@ func Test_PathExpressionParser(t *testing.T) {
 		require.NotEqual(t, cache, val)
 	})
 
+	t.Run("modify entire cache raw", func(t *testing.T) {
+		path := &pathtest.Path[testContext]{
+			N: "cache",
+		}
+
+		getter, err := parser(path)
+		require.NoError(t, err)
+
+		newCache := pcommon.NewMap()
+		newCache.PutStr("new_key", "new_value")
+
+		err = getter.Set(context.Background(), ctx, newCache.AsRaw())
+		require.NoError(t, err)
+
+		val, ok := ctx.cache.Get("new_key")
+		assert.True(t, ok)
+		assert.Equal(t, "new_value", val.Str())
+		require.NotEqual(t, cache, val)
+	})
+
 	t.Run("modify specific cache key", func(t *testing.T) {
 		path := &pathtest.Path[testContext]{
 			N: "cache",

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -104,45 +104,13 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 		Setter: func(_ context.Context, tCtx K, val any) error {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
-				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes())
-				}
-				if m, ok := val.(map[string]any); ok {
-					err := tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes().FromRaw(m)
-					if err != nil {
-						return err
-					}
-				}
+				return ctxutil.SetMap(tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), val)
 			case pmetric.HistogramDataPoint:
-				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes())
-				}
-				if m, ok := val.(map[string]any); ok {
-					err := tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes().FromRaw(m)
-					if err != nil {
-						return err
-					}
-				}
+				return ctxutil.SetMap(tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes(), val)
 			case pmetric.ExponentialHistogramDataPoint:
-				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes())
-				}
-				if m, ok := val.(map[string]any); ok {
-					err := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes().FromRaw(m)
-					if err != nil {
-						return err
-					}
-				}
+				return ctxutil.SetMap(tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes(), val)
 			case pmetric.SummaryDataPoint:
-				if attrs, ok := val.(pcommon.Map); ok {
-					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes())
-				}
-				if m, ok := val.(map[string]any); ok {
-					err := tCtx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes().FromRaw(m)
-					if err != nil {
-						return err
-					}
-				}
+				return ctxutil.SetMap(tCtx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes(), val)
 			}
 			return nil
 		},

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -107,17 +107,41 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 				if attrs, ok := val.(pcommon.Map); ok {
 					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes())
 				}
+				if m, ok := val.(map[string]any); ok {
+					err := tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes().FromRaw(m)
+					if err != nil {
+						return err
+					}
+				}
 			case pmetric.HistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
 					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes())
+				}
+				if m, ok := val.(map[string]any); ok {
+					err := tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Attributes().FromRaw(m)
+					if err != nil {
+						return err
+					}
 				}
 			case pmetric.ExponentialHistogramDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
 					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes())
 				}
+				if m, ok := val.(map[string]any); ok {
+					err := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint).Attributes().FromRaw(m)
+					if err != nil {
+						return err
+					}
+				}
 			case pmetric.SummaryDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
 					attrs.CopyTo(tCtx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes())
+				}
+				if m, ok := val.(map[string]any); ok {
+					err := tCtx.GetDataPoint().(pmetric.SummaryDataPoint).Attributes().FromRaw(m)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			return nil

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint_test.go
@@ -143,6 +143,17 @@ func TestPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refNumberDataPoint.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(datapoint pmetric.NumberDataPoint) {
+				_ = datapoint.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
@@ -606,6 +617,17 @@ func TestPathGetSetter_HistogramDataPoint(t *testing.T) {
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.HistogramDataPoint) {
 				newAttrs.CopyTo(datapoint.Attributes())
+			},
+		},
+		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refHistogramDataPoint.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(datapoint pmetric.HistogramDataPoint) {
+				_ = datapoint.Attributes().FromRaw(newAttrs.AsRaw())
 			},
 		},
 		{
@@ -1159,6 +1181,17 @@ func TestPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refExpoHistogramDataPoint.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(datapoint pmetric.ExponentialHistogramDataPoint) {
+				_ = datapoint.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",
@@ -1606,6 +1639,17 @@ func TestPathGetSetter_SummaryDataPoint(t *testing.T) {
 			newVal: newAttrs,
 			modified: func(datapoint pmetric.SummaryDataPoint) {
 				newAttrs.CopyTo(datapoint.Attributes())
+			},
+		},
+		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refSummaryDataPoint.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(datapoint pmetric.SummaryDataPoint) {
+				_ = datapoint.Attributes().FromRaw(newAttrs.AsRaw())
 			},
 		},
 		{

--- a/pkg/ottl/contexts/internal/ctxlog/log.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log.go
@@ -9,13 +9,14 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/plog"
 )
 
 func PathGetSetter[K Context](path ottl.Path[K]) (ottl.GetSetter[K], error) {

--- a/pkg/ottl/contexts/internal/ctxlog/log.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log.go
@@ -9,14 +9,13 @@ import (
 	"fmt"
 	"time"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/plog"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcommon"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 )
 
 func PathGetSetter[K Context](path ottl.Path[K]) (ottl.GetSetter[K], error) {
@@ -222,16 +221,7 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetLogRecord().Attributes(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetLogRecord().Attributes())
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := tCtx.GetLogRecord().Attributes().FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(tCtx.GetLogRecord().Attributes(), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxlog/log.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log.go
@@ -225,6 +225,12 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetLogRecord().Attributes())
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := tCtx.GetLogRecord().Attributes().FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxlog/log_test.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log_test.go
@@ -244,6 +244,17 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refLog.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(log plog.LogRecord) {
+				_ = log.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes.key",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",

--- a/pkg/ottl/contexts/internal/ctxresource/resource.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource.go
@@ -6,8 +6,6 @@ package ctxresource // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
@@ -41,16 +39,7 @@ func accessResourceAttributes[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetResource().Attributes(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetResource().Attributes())
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := tCtx.GetResource().Attributes().FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(tCtx.GetResource().Attributes(), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxresource/resource.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource.go
@@ -44,6 +44,12 @@ func accessResourceAttributes[K Context]() ottl.StandardGetSetter[K] {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetResource().Attributes())
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := tCtx.GetResource().Attributes().FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxresource/resource_test.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource_test.go
@@ -55,6 +55,17 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refResource.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(resource pcommon.Resource) {
+				_ = resource.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",

--- a/pkg/ottl/contexts/internal/ctxscope/scope.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope.go
@@ -6,8 +6,6 @@ package ctxscope // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxcache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
@@ -46,16 +44,7 @@ func accessInstrumentationScopeAttributes[K Context]() ottl.StandardGetSetter[K]
 			return tCtx.GetInstrumentationScope().Attributes(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetInstrumentationScope().Attributes())
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := tCtx.GetInstrumentationScope().Attributes().FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(tCtx.GetInstrumentationScope().Attributes(), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxscope/scope.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope.go
@@ -49,6 +49,12 @@ func accessInstrumentationScopeAttributes[K Context]() ottl.StandardGetSetter[K]
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetInstrumentationScope().Attributes())
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := tCtx.GetInstrumentationScope().Attributes().FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxscope/scope_test.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope_test.go
@@ -76,6 +76,17 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refIS.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(is pcommon.InstrumentationScope) {
+				_ = is.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",

--- a/pkg/ottl/contexts/internal/ctxspan/span.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span.go
@@ -421,16 +421,7 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetSpan().Attributes(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetSpan().Attributes())
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := tCtx.GetSpan().Attributes().FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(tCtx.GetSpan().Attributes(), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxspan/span.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span.go
@@ -424,6 +424,12 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetSpan().Attributes())
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := tCtx.GetSpan().Attributes().FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxspan/span_test.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span_test.go
@@ -235,6 +235,17 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refSpan.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(span ptrace.Span) {
+				_ = span.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
@@ -85,16 +85,7 @@ func accessSpanEventAttributes[K Context]() ottl.StandardGetSetter[K] {
 			return tCtx.GetSpanEvent().Attributes(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if attrs, ok := val.(pcommon.Map); ok {
-				attrs.CopyTo(tCtx.GetSpanEvent().Attributes())
-			}
-			if m, ok := val.(map[string]any); ok {
-				err := tCtx.GetSpanEvent().Attributes().FromRaw(m)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
+			return ctxutil.SetMap(tCtx.GetSpanEvent().Attributes(), val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
@@ -88,6 +88,12 @@ func accessSpanEventAttributes[K Context]() ottl.StandardGetSetter[K] {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetSpanEvent().Attributes())
 			}
+			if m, ok := val.(map[string]any); ok {
+				err := tCtx.GetSpanEvent().Attributes().FromRaw(m)
+				if err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
@@ -101,6 +101,17 @@ func TestPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "attributes raw map",
+			path: &pathtest.Path[*testContext]{
+				N: "attributes",
+			},
+			orig:   refSpanEvent.Attributes(),
+			newVal: newAttrs.AsRaw(),
+			modified: func(spanEvent ptrace.SpanEvent) {
+				_ = spanEvent.Attributes().FromRaw(newAttrs.AsRaw())
+			},
+		},
+		{
 			name: "attributes string",
 			path: &pathtest.Path[*testContext]{
 				N: "attributes",

--- a/pkg/ottl/contexts/internal/ctxutil/map.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map.go
@@ -79,3 +79,14 @@ func FetchValueFromExpression[K any, T int64 | string](ctx context.Context, tCtx
 	}
 	return &resVal, nil
 }
+
+func SetMap(target pcommon.Map, val any) error {
+	if cm, ok := val.(pcommon.Map); ok {
+		cm.CopyTo(target)
+		return nil
+	}
+	if rm, ok := val.(map[string]any); ok {
+		return target.FromRaw(rm)
+	}
+	return nil
+}


### PR DESCRIPTION
#### Description

To be consistent, we should try treating raw maps and pcommon.Map the same. Updates all the setters that were expecting a pcommon.Map to also allow a raw map to set the value

#### Testing

unit tests