### PR TITLE
[receiver/cloudflare] Fix missing telemetry

### DIFF
--- a/.chloggen/fix-cloudflare-telemetry.yaml
+++ b/.chloggen/fix-cloudflare-telemetry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cloudflarereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add missing telemetry for Cloudflare receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38447]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -43,7 +43,6 @@ type logsReceiver struct {
 const secretHeaderName = "X-CF-Secret"
 
 func newLogsReceiver(params rcvr.Settings, cfg *Config, consumer consumer.Logs) (*logsReceiver, error) {
-
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             params.ID,
 		Transport:              "http",


### PR DESCRIPTION
#### Description
Added `receiverhelper.ObsReport` to create telemetry signals

#### Link to tracking issue
Fixes #38447 

#### Testing
Built docker image, deployed in GCP and configured Cloudflare Logpush to produce logs to endpoint. Exported telemetry signals and monitored result.

#### Documentation
