### PR TITLE
[chore] cache docker images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -379,6 +379,10 @@ jobs:
             ~/go/pkg/mod
             ./.tools
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@fb28c93772363301b8d0a6072ce850224b73f74e # 0.5.0
+        with:
+          key: docker-${{ matrix.group }}
       - name: Run Integration Tests
         run: make gointegration-test GROUP=${{ matrix.group }}
 


### PR DESCRIPTION
Try introducing a docker cache so we avoid hitting limits on Docker Hub.

Example:

https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13730940591/job/38407799262?pr=38466
```
=== FAIL: . TestObserverEmitsEndpointsIntegration (0.39s)
XXX: too many requests: &{AuthConfigs:map[[https://index.docker.io/v1/:{Username:](https://index.docker.io/v1/:%7BUsername:) Password: Auth:Z2l0aHViYWN0aW9uczozZDY0NzJiOS0zZDQ5LTRkMTctOWZjOS05MGQyNDI1ODA0M2I= Email: ServerAddress: IdentityToken: RegistryToken:}] HTTPHeaders:map[] PsFormat: ImagesFormat: NetworksFormat: PluginsFormat: VolumesFormat: StatsFormat: DetachKeys: CredentialsStore: CredentialHelpers:map[] Filename: ServiceInspectFormat: ServicesFormat: TasksFormat: SecretFormat: ConfigFormat: NodesFormat: PruneFilters:[] Proxies:map[] Experimental: StackOrchestrator: Kubernetes:<nil> CurrentContext: CLIPluginsExtraDirs:[] Aliases:map[]}    integration_test.go:40: 
        	Error Trace:	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/extension/observer/dockerobserver/integration_test.go:40
        	Error:      	Received unexpected error:
        	            	create container: Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
        	Test:       	TestObserverEmitsEndpointsIntegration
```