### PR TITLE
[chore] remove old dashboard link from github receiver readme

### DIFF
--- a/receiver/githubreceiver/README.md
+++ b/receiver/githubreceiver/README.md
@@ -71,7 +71,7 @@ receivers:
         scrapers:
             scraper:
                 metrics:
-                    vcs.repository.contributor.count:
+                    vcs.contributor.count:
                         enabled: true
                 github_org: myfancyorg
                 search_query: "org:myfancyorg topic:o11yalltheway" #Recommended optional query override, defaults to "{org,user}:<github_org>"
@@ -86,8 +86,6 @@ service:
             processors: []
             exporters: [...]
 ```
-
-A [Grafana Dashboard for metrics from this receiver is on the marketplace](https://grafana.com/grafana/dashboards/20976-engineering-effectiveness-metrics/).
 
 ### Scraping
 


### PR DESCRIPTION
#### Description

The readme included a dashboard that was out of date and hard to maintain. Opted for removing it based on discussion on community issue. Additionally found a typo on the readme that was fixed while there in the example config.

#### Link to tracking issue
Fixes #38435 