### PR TITLE
[chore] Fix addlicense and checklicense Makefile targets

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -86,8 +86,10 @@ BUILD_TYPE?=release
 # All source code and documents. Used in spell check.
 ALL_SRC_AND_DOC_CMD := find . -name "*.md" -o -name "*.go" -o -name "*.yaml" -not -path '*/third_party/*' -type f | sort
 
-
 ADDLICENSE_CMD := $(ADDLICENSE) -s=only -y "" -c "The OpenTelemetry Authors"
+
+# All source code and .sh files (evaluated when used)
+ALL_SRC_AND_SHELL = $(shell find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort)
 
 pwd:
 	@pwd
@@ -157,8 +159,7 @@ benchmark: $(GOTESTSUM)
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE)
-	ALL_SRC_AND_SHELL := find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
-	@ADDLICENSEOUT=$$(for f in $$($(ALL_SRC_AND_SHELL)); do \
+	@ADDLICENSEOUT=$$(for f in $(ALL_SRC_AND_SHELL); do \
 		`$(ADDLICENSE_CMD) "$$f" 2>&1`; \
 	done); \
 	if [ "$$ADDLICENSEOUT" ]; then \
@@ -171,8 +172,7 @@ addlicense: $(ADDLICENSE)
 
 .PHONY: checklicense
 checklicense: $(ADDLICENSE)
-  ALL_SRC_AND_SHELL := find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
-	@licRes=$$(for f in $$($(ALL_SRC_AND_SHELL)); do \
+	@licRes=$$(for f in $(ALL_SRC_AND_SHELL); do \
 		awk '/Copyright The OpenTelemetry Authors|generated|GENERATED/ && NR<=3 { found=1; next } END { if (!found) print FILENAME }' $$f; \
 		awk '/SPDX-License-Identifier: Apache-2.0|generated|GENERATED/ && NR<=4 { found=1; next } END { if (!found) print FILENAME }' $$f; \
 		$(ADDLICENSE_CMD) -check "$$f" 2>&1 || echo "$$f"; \

--- a/cmd/telemetrygen/pkg/metrics/aggregation_temporality.go
+++ b/cmd/telemetrygen/pkg/metrics/aggregation_temporality.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (

--- a/receiver/faroreceiver/config.go
+++ b/receiver/faroreceiver/config.go
@@ -1,3 +1,4 @@
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package faroreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver"

--- a/receiver/faroreceiver/reciever.go
+++ b/receiver/faroreceiver/reciever.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package faroreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver"
 
 import (

--- a/testbed/testbed/load_generator_test.go
+++ b/testbed/testbed/load_generator_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package testbed
 
 import (


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes the [checklicense](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile.Common#L174) target as it's using spaces instead of tabs, leading the checklicense target to skip the header's verifications as the variable is not properly working. The `addlicense` target is also printing the following errors, which is probably being caused by syntax currently used to try to set target-scoped variables:

```
ALL_SRC_AND_SHELL := find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
/bin/bash: ALL_SRC_AND_SHELL: command not found

```

<!--Please delete paragraphs that you did not use before submitting.-->
