### PR TITLE
[receiver/vcenter] Add safety checks around any usage of nullable vm references

### DIFF
--- a/receiver/vcenterreceiver/resources.go
+++ b/receiver/vcenterreceiver/resources.go
@@ -115,7 +115,7 @@ func (v *vcenterMetricScraper) createVMResourceBuilder(
 	}
 	rb.SetVcenterHostName(hs.Name)
 
-	if vm.Config.Template {
+	if vm.Config != nil && vm.Config.Template {
 		rb.SetVcenterVMTemplateName(vm.Name)
 		rb.SetVcenterVMTemplateID(vm.Config.InstanceUuid)
 
@@ -123,7 +123,11 @@ func (v *vcenterMetricScraper) createVMResourceBuilder(
 	}
 
 	rb.SetVcenterVMName(vm.Name)
-	rb.SetVcenterVMID(vm.Config.InstanceUuid)
+	if vm.Config != nil {
+		rb.SetVcenterVMID(vm.Config.InstanceUuid)
+	} else {
+		rb.SetVcenterVMID("unknown")
+	}
 
 	if rp == nil {
 		return nil, fmt.Errorf("no Resource Pool found for VM: %s", vm.Name)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
I see at least one panic is reported around the vcenter receiver's access of nullable fields when the VM has been orphaned. I do not have a test environment to validate these changes so they are in draft until I find a way to validate. I'll add chlog, tests, etc once I have had the opportunity to validate.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34343
