### PR TITLE
[chore] unexport MockServer, used only in component

### DIFF
--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -277,15 +277,13 @@ func TestAlertManagerTracesExporterNoErrors(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-type (
-	MockServer struct {
-		mockserver            *httptest.Server // this means MockServer aggregates 'httptest.Server', but can it's more like inheritance in C++
-		fooCalledSuccessfully bool             // this is false by default
-	}
-)
+type mockServer struct {
+	mockserver            *httptest.Server // this means mockServer aggregates 'httptest.Server', but can it's more like inheritance in C++
+	fooCalledSuccessfully bool             // this is false by default
+}
 
-func newMockServer(t *testing.T) *MockServer {
-	mock := MockServer{
+func newMockServer(t *testing.T) *mockServer {
+	mock := mockServer{
 		fooCalledSuccessfully: false,
 	}
 


### PR DESCRIPTION
Just an API change for a test struct that should not be exported.