### PR TITLE
exporter/prometheus: Migrate to centralized translator package

### DIFF
--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	prometheustranslator "github.com/ArthurSens/otlp-prometheus-translator"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
@@ -18,8 +19,6 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.25.0"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
-
-	prometheustranslator "github.com/ArthurSens/otlp-prometheus-translator"
 )
 
 var separatorString = string([]byte{model.SeparatorByte})

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -146,26 +146,23 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 }
 
 func getTranslatorMetricType(metric pmetric.Metric) prometheustranslator.MetricType {
-	var translatorMetricType prometheustranslator.MetricType
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
-		translatorMetricType = prometheustranslator.MetricTypeGauge
+		return prometheustranslator.MetricTypeGauge
 	case pmetric.MetricTypeSum:
 		if metric.Sum().IsMonotonic() {
-			translatorMetricType = prometheustranslator.MetricTypeMonotonicCounter
-		} else {
-			translatorMetricType = prometheustranslator.MetricTypeNonMonotonicCounter
+			return prometheustranslator.MetricTypeMonotonicCounter
 		}
+		return prometheustranslator.MetricTypeNonMonotonicCounter
 	case pmetric.MetricTypeHistogram:
-		translatorMetricType = prometheustranslator.MetricTypeHistogram
+		return prometheustranslator.MetricTypeHistogram
 	case pmetric.MetricTypeExponentialHistogram:
-		translatorMetricType = prometheustranslator.MetricTypeExponentialHistogram
+		return prometheustranslator.MetricTypeExponentialHistogram
 	case pmetric.MetricTypeSummary:
-		translatorMetricType = prometheustranslator.MetricTypeSummary
+		return prometheustranslator.MetricTypeSummary
 	default:
-		translatorMetricType = prometheustranslator.MetricTypeUnknown
+		return prometheustranslator.MetricTypeUnknown
 	}
-	return translatorMetricType
 }
 
 func (c *collector) convertGauge(metric pmetric.Metric, resourceAttrs pcommon.Map) (prometheus.Metric, error) {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	prometheustranslator "github.com/ArthurSens/otlp-prometheus-translator"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	io_prometheus_client "github.com/prometheus/client_model/go"
@@ -20,8 +21,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	prometheustranslator "github.com/ArthurSens/otlp-prometheus-translator"
 )
 
 type mockAccumulator struct {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+	prometheustranslator "github.com/ArthurSens/otlp-prometheus-translator"
 )
 
 type mockAccumulator struct {

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -3,9 +3,9 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/promet
 go 1.23.0
 
 require (
+	github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.121.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.121.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.121.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.121.0
 	github.com/prometheus/client_golang v1.21.1
 	github.com/prometheus/client_model v0.6.1
@@ -129,6 +129,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.121.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.121.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/ovh/go-ovh v1.6.0 // indirect

--- a/exporter/prometheusexporter/go.sum
+++ b/exporter/prometheusexporter/go.sum
@@ -37,6 +37,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139 h1:MfsvSjnczEX7esNT7XaJTyUHRoqtpfjS8Bp6p/5DJd8=
+github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139/go.mod h1:ckiRxFaOjQLjkKVGv4sLswjyI3B9Pnh0Wlf0MuFl/Ck=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -76,6 +76,7 @@ require (
 	cloud.google.com/go/auth v0.9.5 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.4 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
+	github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -37,6 +37,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139 h1:MfsvSjnczEX7esNT7XaJTyUHRoqtpfjS8Bp6p/5DJd8=
+github.com/ArthurSens/otlp-prometheus-translator v0.0.0-20250311183008-8babad3a8139/go.mod h1:ckiRxFaOjQLjkKVGv4sLswjyI3B9Pnh0Wlf0MuFl/Ck=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0 h1:tfLQ34V6F7tVSwoTf/4lH5sE0o6eCJuNDTmH09nDpbc=


### PR DESCRIPTION
#### Description
Similar to https://github.com/prometheus/prometheus/pull/16089/files

As discussed with multiple peers in the last couple of quarters(yes, quarters 😅), @ywwg and I started experiments to avoid duplicated code between Prometheus and OpenTelemetry-Collector for translating OTel to Prometheus metric and label names.

The experiments led to https://github.com/ArthurSens/otlp-prometheus-translator, but I'm very happy to move it somewhere else, like prometheus/common, or into a separate repository in the Prometheus org, where we can make other folks maintainers.


#### Motivation for the new module
* Avoid code variance between Prometheus and Collector.
* Allow other projects in the ecosystem to benefit(e.g. Thanos) from the package, without opentelemetry dependencies.

#### Goals

* Dependency-free so that it can be re-used by both Prometheus and OpenTelemetry-Collector
* Efficient: we can't bring regressions compared to the existing codebase.

#### Known variance from the original `pkg/translator/prometheus`

The Prometheus codebase completely ignores adding a namespace prefix, so adding it as an argument to BuildCompliantMetricName seemed unnecessary. The logic for adding a namespace prefix was rewritten here.


Opening as a draft to continue discussions! I think we want to ask/answer questions before committing.
