### PR TITLE
[chore] tidy up examples

### DIFF
--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -19,9 +19,9 @@ OpenTelemetry Collectors deployed:
 - The OTel Collector then sends the data to the appropriate backend, in this demo
  Jaeger, Zipkin, and Prometheus;
 
-This demo uses `docker-compose` and by default runs against the
-`otel/opentelemetry-collector:0.67.0` image. To run the demo, switch
-to the `examples/demo` folder and run:
+This demo uses [Docker Compose](https://docs.docker.com/compose/) and by
+default runs against the most recent release of `otel/opentelemetry-collector`.
+To run the demo, switch to the `examples/demo` folder and run:
 
 ```shell
 docker compose up -d
@@ -42,12 +42,23 @@ To clean up any docker container from the demo run `docker-compose down` from
 the `examples/demo` folder.
 
 ### Using a Locally Built Image
+
 Developers interested in running a local build of the Collector need to build a
-docker image using the command below:
+Docker image using the command below:
 
 ```shell
 make docker-otelcontribcol
 ```
 
-And set an environment variable `OTELCOL_IMG` to `otelcontribcol` before
-launching the command `docker-compose up -d`.
+Then either modify `examples/demo/docker-compose.yml` to use the newly
+`otelcontribcol` image, or create another Compose file that will be merged
+with the base Compose file to override the image, like:
+
+```yaml
+services:
+  otel-collector:
+    image: otelcontribcol
+```
+
+For more on merging Compose files, see
+https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/#how-to-merge-multiple-compose-files

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -29,9 +29,9 @@ docker compose up -d
 
 The demo exposes the following backends:
 
-- Jaeger at http://0.0.0.0:16686
-- Zipkin at http://0.0.0.0:9411
-- Prometheus at http://0.0.0.0:9090
+- Jaeger at `http://0.0.0.0:16686`
+- Zipkin at `http://0.0.0.0:9411`
+- Prometheus at `http://0.0.0.0:9090`
 
 Notes:
 

--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 services:
 
   # Jaeger

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Collector Demo
 
-This demo is a sample app to build the collector and exercise its kubernetes logs scrapping functionality.
+This demo is a sample app to build the collector and exercise its kubernetes logs scraping functionality.
 
 ## Build and Run
 


### PR DESCRIPTION
#### Description

- examples/demo: give correct instructions on how to use the otelcontribcol image. "OTELCOL_IMG" does nothing.
- examples/demo: remove the deprecated version from docker-compose.yaml
- examples/kubernetes: fix typo

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A