### PR TITLE
[chore] .github: match components in reverse order in add-codeowners-to-pr script

### DIFF
--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -32,7 +32,7 @@ main () {
     AUTHOR=$(echo -n "${JSON}"| jq -r '.author.login')
     FILES=$(echo -n "${JSON}"| jq -r '.files[].path')
     REVIEW_LOGINS=$(echo -n "${JSON}"| jq -r '.latestReviews[].author.login')
-    COMPONENTS=$(bash "${CUR_DIRECTORY}/get-components.sh")
+    COMPONENTS=$(bash "${CUR_DIRECTORY}/get-components.sh" | tac) # Reversed so we visit subdirectories first
     REVIEWERS=""
     LABELS=""
     declare -A PROCESSED_COMPONENTS


### PR DESCRIPTION
#### Description

When a component matches a file, the file is removed from the set so it won't be processed again: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/62488e46e8872365f4fe51c272c73981e471e2e5/.github/workflows/scripts/add-codeowners-to-pr.sh#L68-L69

This means that if a file cannot match multiple components. For example, I am not getting assigned to [PRs](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38516) that modify `extension/encoding/awscloudwatchmetricstreamsencodingextension`, since all of its files will first match the `extension/encoding` component path.

In order to assign the correct PR owners for nested components, we need to make sure we process those components before their ancestors. Each group of components is already in lexicographical order, so we can just reverse the order.

#### Link to tracking issue

N/A

#### Testing

Verified by running `REPO=open-telemetry/opentelemetry-collector-contrib PR=38516 bash .github/workflows/scripts/add-codeowners-to-pr.sh` with the `gh` calls commented out.

#### Documentation

N/A