### PR TITLE
[receiver/mysql] Mention MariaDB support in README.md

### DIFF
--- a/receiver/mysqlreceiver/README.md
+++ b/receiver/mysqlreceiver/README.md
@@ -20,9 +20,7 @@ There are also optional metrics that you must specify in your configuration to c
 
 ## Prerequisites
 
-This receiver supports MySQL version 8.0.
-
-MariaDB version 10.11 and later also work but features specific to MySQL 8.0 (e.g. the X protocol) will not work.
+This receiver supports MySQL version 8.0 and MariaDB 10.11.
 
 Collecting most metrics requires the ability to execute `SHOW GLOBAL STATUS`.
 

--- a/receiver/mysqlreceiver/README.md
+++ b/receiver/mysqlreceiver/README.md
@@ -20,7 +20,9 @@ There are also optional metrics that you must specify in your configuration to c
 
 ## Prerequisites
 
-This receiver supports MySQL version 8.0
+This receiver supports MySQL version 8.0.
+
+MariaDB version 10.11 and later also work but features specific to MySQL 8.0 (e.g. the X protocol) will not work.
 
 Collecting most metrics requires the ability to execute `SHOW GLOBAL STATUS`.
 


### PR DESCRIPTION
The receiver specifically looks for MariaDB in the version string in a handful of places and it appears to also be tested (#37840) against MariaDB 10.11 and MariaDB 11.6. Thus mentioning that it supports MariaDB as well would be good.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This mentions that MariaDB also works with the mysqlreceiver.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested by running the mysqlreceiver locally with MariaDB 11.4 and MariaDB 10.11. The source code already appears to test at least two versions of MariaDB.

<!--Describe the documentation added.-->
#### Documentation
This is a documentation fix.

<!--Please delete paragraphs that you did not use before submitting.-->
