### PR TITLE
[chore] Fix a flaky prometheus test

### DIFF
--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go
@@ -4,6 +4,8 @@
 package prometheusremotewrite
 
 import (
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -24,25 +26,23 @@ func TestFromMetricsV2(t *testing.T) {
 
 	ts := uint64(time.Now().UnixNano())
 	payload := createExportRequest(5, 0, 1, 3, 0, pcommon.Timestamp(ts))
-	want := func() map[string]*writev2.TimeSeries {
-		return map[string]*writev2.TimeSeries{
-			"0": {
-				LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
-				Samples: []writev2.Sample{
-					{Timestamp: convertTimeStamp(pcommon.Timestamp(ts)), Value: 1.23},
-				},
+	want := []*writev2.TimeSeries{
+		{
+			LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			Samples: []writev2.Sample{
+				{Timestamp: convertTimeStamp(pcommon.Timestamp(ts)), Value: 1.23},
 			},
-			"1": {
-				LabelsRefs: []uint32{1, 9, 3, 4, 5, 6, 7, 8},
-				Samples: []writev2.Sample{
-					{Timestamp: convertTimeStamp(pcommon.Timestamp(ts)), Value: 1.23},
-				},
+		},
+		{
+			LabelsRefs: []uint32{1, 9, 3, 4, 5, 6, 7, 8},
+			Samples: []writev2.Sample{
+				{Timestamp: convertTimeStamp(pcommon.Timestamp(ts)), Value: 1.23},
 			},
-		}
+		},
 	}
 	wantedSymbols := []string{"", "series_name_2", "value-2", "series_name_3", "value-3", "__name__", "gauge_1", "series_name_1", "value-1", "sum_1"}
 	tsMap, symbolsTable, err := FromMetricsV2(payload.Metrics(), settings)
 	require.NoError(t, err)
-	require.Equal(t, want(), tsMap)
+	require.ElementsMatch(t, want, slices.Collect(maps.Values(tsMap)))
 	require.ElementsMatch(t, wantedSymbols, symbolsTable.Symbols())
 }


### PR DESCRIPTION
#### Description
Fix flaky TestFromMetricsV2. Previously the test depends on the element order in a map which is nondeterministic.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38556

#### Testing
Before:
```
% go test -run TestFromMetricsV2 -count 10000
--- FAIL: TestFromMetricsV2 (0.00s)
    metrics_to_prw_v2_test.go:46: 
        	Error Trace:	/Users/yang.song/go/src/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go:46
        	Error:      	Not equal: 
        	            	expected: map[string]*writev2.TimeSeries{"0":(*writev2.TimeSeries)(0x140002046c0), "1":(*writev2.TimeSeries)(0x14000204780)}
        	            	actual  : map[string]*writev2.TimeSeries{"0":(*writev2.TimeSeries)(0x14000176a80), "1":(*writev2.TimeSeries)(0x14000176b38)}        	            	
...
FAIL
exit status 1
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite	0.922s
```

After:
```
% go test -run TestFromMetricsV2 -count 10000
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite	0.608s
```
