### PR TITLE
[receiver/splunkhec] HEC metrics accepts empty string Event

### DIFF
--- a/.chloggen/38464.yaml
+++ b/.chloggen/38464.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enchancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: splunk hec receiver accepts metrics with empty string Event field
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38464]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/38464.yaml
+++ b/.chloggen/38464.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enchancement
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: splunkhecreceiver

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -66,7 +66,7 @@ type Event struct {
 
 // IsMetric returns true if the Splunk event is a metric.
 func (e *Event) IsMetric() bool {
-	return e.Event == HecEventMetricType || (e.Event == nil && len(e.GetMetricValues()) > 0)
+	return e.Event == HecEventMetricType || ((e.Event == nil || e.Event == "") && len(e.GetMetricValues()) > 0)
 }
 
 // checks if the field name matches the requirements for a metric datapoint field,

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -66,7 +66,7 @@ type Event struct {
 
 // IsMetric returns true if the Splunk event is a metric.
 func (e *Event) IsMetric() bool {
-	return e.Event == HecEventMetricType || ((e.Event == nil || e.Event == "") && len(e.GetMetricValues()) > 0)
+	return e.Event == HecEventMetricType || len(e.GetMetricValues()) > 0
 }
 
 // checks if the field name matches the requirements for a metric datapoint field,

--- a/internal/splunk/common_test.go
+++ b/internal/splunk/common_test.go
@@ -52,6 +52,22 @@ func TestIsMetric(t *testing.T) {
 		Event: "metric",
 	}
 	assert.True(t, metric.IsMetric())
+	metric = Event{
+		Event: "",
+		Fields: map[string]any{
+			"metric_name": "foo",
+			"_value":      123,
+		},
+	}
+	assert.True(t, metric.IsMetric())
+	metric = Event{
+		Event: "any value",
+		Fields: map[string]any{
+			"metric_name": "foo",
+			"_value":      123,
+		},
+	}
+	assert.True(t, metric.IsMetric())
 	arr := Event{
 		Event: []any{"foo", "bar"},
 	}

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -458,7 +458,6 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			events = append(events, &msg)
 		}
 	}
-	
 	resourceCustomizer := r.createResourceCustomizer(req)
 	if r.logsConsumer != nil && len(events) > 0 {
 		ld, err := splunkHecToLogData(r.settings.Logger, events, resourceCustomizer, r.config)

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -427,22 +427,13 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			return
 		}
 
-		if msg.Event == nil {
-			r.failRequest(resp, http.StatusBadRequest, eventRequiredRespBody, nil)
-			return
-		}
-
-		if msg.Event == "" {
-			r.failRequest(resp, http.StatusBadRequest, eventBlankRespBody, nil)
-			return
-		}
-
 		for _, v := range msg.Fields {
 			if !isFlatJSONField(v) {
 				r.failRequest(resp, http.StatusBadRequest, []byte(fmt.Sprintf(responseErrHandlingIndexedFields, len(events)+len(metricEvents))), nil)
 				return
 			}
 		}
+
 		if msg.IsMetric() {
 			if r.metricsConsumer == nil {
 				r.failRequest(resp, http.StatusBadRequest, errUnsupportedMetricEvent, err)
@@ -450,6 +441,16 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			}
 			metricEvents = append(metricEvents, &msg)
 		} else {
+			if msg.Event == nil {
+				r.failRequest(resp, http.StatusBadRequest, eventRequiredRespBody, nil)
+				return
+			}
+
+			if msg.Event == "" {
+				r.failRequest(resp, http.StatusBadRequest, eventBlankRespBody, nil)
+				return
+			}
+
 			if r.logsConsumer == nil {
 				r.failRequest(resp, http.StatusBadRequest, errUnsupportedLogEvent, err)
 				return
@@ -457,6 +458,7 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			events = append(events, &msg)
 		}
 	}
+	
 	resourceCustomizer := r.createResourceCustomizer(req)
 	if r.logsConsumer != nil && len(events) > 0 {
 		ld, err := splunkHecToLogData(r.settings.Logger, events, resourceCustomizer, r.config)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -760,6 +760,10 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			event: "",
 		},
 		{
+			name:  "any value event",
+			event: "some event",
+		},
+		{
 			name: "nil event",
 		},
 	}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -251,7 +251,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "metric_msg_accepted",
 			req: func() *http.Request {
-				msgBytes, err := json.Marshal(buildSplunkHecMetricsMsg(3, 4, 3))
+				msgBytes, err := json.Marshal(buildSplunkHecMetricsMsg("metric", 3, 4, 3))
 				require.NoError(t, err)
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
@@ -368,7 +368,7 @@ func Test_consumer_err(t *testing.T) {
 
 func Test_consumer_err_metrics(t *testing.T) {
 	currentTime := float64(time.Now().UnixNano()) / 1e6
-	splunkMsg := buildSplunkHecMetricsMsg(currentTime, 13, 2)
+	splunkMsg := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
 	assert.True(t, splunkMsg.IsMetric())
 	config := createDefaultConfig().(*Config)
 	config.Endpoint = "localhost:0" // Actually not creating the endpoint\
@@ -570,7 +570,7 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 			currentTime := float64(time.Now().UnixNano()) / 1e6
 			var splunkhecMsg *splunk.Event
 			if tt.metric {
-				splunkhecMsg = buildSplunkHecMetricsMsg(currentTime, 1.0, 3)
+				splunkhecMsg = buildSplunkHecMetricsMsg("metric", currentTime, 1.0, 3)
 			} else {
 				splunkhecMsg = buildSplunkHecMsg(currentTime, 3)
 			}
@@ -738,18 +738,29 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 		name       string
 		index      string
 		sourcetype string
+		event      string
 	}{
 		{
-			name: "No index, no source type",
+			name:  "No index, no source type",
+			event: "metric",
 		},
 		{
 			name:  "Index, no source type",
 			index: "myindex",
+			event: "metric",
 		},
 		{
 			name:       "Index and source type",
 			index:      "myindex",
 			sourcetype: "source:type",
+			event:      "metric",
+		},
+		{
+			name:  "empty event",
+			event: "",
+		},
+		{
+			name: "nil event",
 		},
 	}
 
@@ -786,7 +797,7 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			rcv.metricsConsumer = exporter
 
 			currentTime := float64(time.Now().UnixNano()) / 1e6
-			splunkhecMsg := buildSplunkHecMetricsMsg(currentTime, 42, 3)
+			splunkhecMsg := buildSplunkHecMetricsMsg(tt.event, currentTime, 42, 3)
 			splunkhecMsg.Index = tt.index
 			splunkhecMsg.SourceType = tt.sourcetype
 			msgBytes, _ := json.Marshal(splunkhecMsg)
@@ -834,10 +845,10 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 	}
 }
 
-func buildSplunkHecMetricsMsg(time float64, value int64, dimensions uint) *splunk.Event {
+func buildSplunkHecMetricsMsg(event any, time float64, value int64, dimensions uint) *splunk.Event {
 	ev := &splunk.Event{
 		Time:  time,
-		Event: "metric",
+		Event: event,
 		Fields: map[string]any{
 			"metric_name:foo": value,
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Splunk HEC metrics accepts metrics when `"event": ""`. This aligns with Splunk HEC behavior

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [38464](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38464)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
