### PR TITLE
[chore] receiver/elasticsearchreceiver: add note about coming native OTel instrumentation

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -15,6 +15,9 @@
 
 This receiver queries the Elasticsearch [node stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html), [cluster health](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html) and [index stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html) endpoints in order to scrape metrics from a running Elasticsearch cluster.
 
+Note: in the future, Elasticsearch will be instrumented with the OpenTelemetry Java SDK directly (https://github.com/elastic/elasticsearch/issues/109335).
+When this is complete, native OpenTelemetry metrics may be added for measuring cluster health, index statistics, and so on. Please subscribe to the linked issue to keep updated.
+
 ## Prerequisites
 
 This receiver supports Elasticsearch versions 7.9+


### PR DESCRIPTION
#### Description

Add a note about native OTel SDK instrumentation that will be coming to Elasticsearch in the future.

The initial scope of the linked issue is to replace Elasticsearch's use of the [Elastic APM Java Agent](https://www.elastic.co/guide/en/apm/agent/java/current/intro.html) with the [OpenTelemetry Java SDK](https://opentelemetry.io/docs/languages/java/), primarily for tracing and APM use cases.

Once this is completed, there will be an avenue for natively producing OpenTelemetry metrics related to cluster and node health, index statistics, etc. i.e. all the things this receiver covers.

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A