### PR TITLE
kafkatopicsobserver: use configkafka.ClientConfig

### DIFF
--- a/.chloggen/kafkatopicsobserver-embed-clientconfig.yaml
+++ b/.chloggen/kafkatopicsobserver-embed-clientconfig.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/observer/kafakatopicsobserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add support for client_id and metadata config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38411]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The kafkatopicsobserver is now using the common configkafka package,
+  which brings support for client_id and metadata configuration.
+  This also means that protocol_version is no longer required, and a
+  default version will be used like in other Kafka-related components.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/observer/kafkatopicsobserver/README.md
+++ b/extension/observer/kafkatopicsobserver/README.md
@@ -19,13 +19,15 @@ provided regex. If any change in available topics matching the regex is detected
 
 The following settings are required:
 
-- `protocol_version` (no default): Kafka protocol version e.g. 2.0.0
+- `topic_regex` regex pattern of the topic name to subscribe to.
 
 The following settings can be optionally configured:
 
 - `brokers` (default = localhost:9092): The list of kafka brokers
 - `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup
-- `topic_regex` regex pattern of the topic name to subscribe to.
+- `protocol_version` (default = 2.1.0): Kafka protocol version e.g. 2.0.0
+- `client_id` (default = "otel-collector"): The client ID to configure the Kafka client with.
+- `topics_sync_interval` (default 5s)
 - `auth`
     - `plain_text`
         - `username`: The username to use.
@@ -56,3 +58,8 @@ The following settings can be optionally configured:
         - `config_file`: Path to Kerberos configuration. i.e /etc/krb5.conf
         - `keytab_file`: Path to keytab file. i.e /etc/security/kafka.keytab
         - `disable_fast_negotiation`: Disable PA-FX-FAST negotiation (Pre-Authentication Framework - Fast). Some common Kerberos implementations do not support PA-FX-FAST negotiation. This is set to `false` by default.
+- `metadata`
+  - `full` (default = true): Whether to maintain a full set of metadata. When disabled, the client does not make the initial request to broker at the startup.
+  - `retry`
+    - `max` (default = 3): The number of retries to get metadata
+    - `backoff` (default = 250ms): How long to wait between metadata retries

--- a/extension/observer/kafkatopicsobserver/config.go
+++ b/extension/observer/kafkatopicsobserver/config.go
@@ -14,27 +14,12 @@ import (
 
 // Config defines configuration for docker observer
 type Config struct {
-	// The list of kafka brokers (default localhost:9092)
-	Brokers []string `mapstructure:"brokers"`
-	// ResolveCanonicalBootstrapServersOnly makes Sarama do a DNS lookup for
-	// each of the provided brokers. It will then do a PTR lookup for each
-	// returned IP, and that set of names becomes the broker list. This can be
-	// required in SASL environments.
-	ResolveCanonicalBootstrapServersOnly bool `mapstructure:"resolve_canonical_bootstrap_servers_only"`
-	// Kafka protocol version
-	ProtocolVersion    string                           `mapstructure:"protocol_version"`
-	Authentication     configkafka.AuthenticationConfig `mapstructure:"auth"`
-	TopicRegex         string                           `mapstructure:"topic_regex"`
-	TopicsSyncInterval time.Duration                    `mapstructure:"topics_sync_interval"`
+	configkafka.ClientConfig `mapstructure:",squash"`
+	TopicRegex               string        `mapstructure:"topic_regex"`
+	TopicsSyncInterval       time.Duration `mapstructure:"topics_sync_interval"`
 }
 
 func (config *Config) Validate() (errs error) {
-	if len(config.Brokers) == 0 {
-		errs = multierr.Append(errs, fmt.Errorf("brokers list must be specified"))
-	}
-	if len(config.ProtocolVersion) == 0 {
-		errs = multierr.Append(errs, fmt.Errorf("protocol_version must be specified"))
-	}
 	if len(config.TopicRegex) == 0 {
 		errs = multierr.Append(errs, fmt.Errorf("topic_regex must be specified"))
 	}

--- a/extension/observer/kafkatopicsobserver/factory.go
+++ b/extension/observer/kafkatopicsobserver/factory.go
@@ -11,10 +11,11 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/configkafka"
 )
 
 const (
-	defaultBroker             = "localhost:9092"
 	defaultTopicsSyncInterval = 5 * time.Second
 )
 
@@ -30,7 +31,7 @@ func NewFactory() extension.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Brokers:            []string{defaultBroker},
+		ClientConfig:       configkafka.NewDefaultClientConfig(),
 		TopicsSyncInterval: defaultTopicsSyncInterval,
 	}
 }
@@ -41,5 +42,5 @@ func createExtension(
 	cfg component.Config,
 ) (extension.Extension, error) {
 	config := cfg.(*Config)
-	return newObserver(settings.Logger, config)
+	return newObserver(settings.Logger, config, kafka.NewSaramaClusterAdminClient)
 }


### PR DESCRIPTION
#### Description

Remove the duplicated client config from the Config struct, and embed configkafka.ClientConfig. Remove the duplicated cluster admin client creation code, and use kafka.NewSaramaClientConfig.

As a result of this change:
 - protocol_version config is no longer required, it has a default like the other Kafka components do
 - client_id config is now supported, and defaults to "otel-collector"
 - metadata config is now supported
 - validation of client config has been removed from this package, since it's covered by validation in the configkafka types

#### Link to tracking issue

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38411

#### Testing

Ran the unit tests.

#### Documentation

Updated README.