### PR TITLE
[chore](prometheusreceiver): use type and unit as identifier in tests

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_honor_timestamp_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_honor_timestamp_test.go
@@ -204,10 +204,11 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 	assert.Equal(t, 9, metricsCount(m1))
 
 	wantAttributes := td.attributes
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -215,10 +216,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareDoubleValue(19),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -236,10 +240,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -248,10 +255,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareHistogram(2500, 5000, []float64{0.05, 0.5, 1}, []uint64{1000, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -260,7 +270,9 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareSummary(1000, 5000, [][]float64{{0.01, 1}, {0.9, 5}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-honorTimestamp-1", wantAttributes, m1, e1)
 
@@ -268,10 +280,11 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 	// m1 has 4 metrics + 5 internal scraper metrics
 	assert.Equal(t, 9, metricsCount(m2))
 
-	e2 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e2 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -279,10 +292,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareDoubleValue(18),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -300,10 +316,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -312,10 +331,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareHistogram(2400, 4950, []float64{0.05, 0.5, 1}, []uint64{900, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -324,7 +346,9 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareSummary(900, 4980, [][]float64{{0.01, 1}, {0.9, 6}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-honorTimestamp-2", wantAttributes, m2, e2)
 
@@ -332,10 +356,11 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 	// m1 has 4 metrics + 5 internal scraper metrics
 	assert.Equal(t, 9, metricsCount(m3))
 
-	e3 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e3 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -343,10 +368,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareDoubleValue(19),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -364,10 +392,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -376,10 +407,13 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareHistogram(2500, 5000, []float64{0.05, 0.5, 1}, []uint64{1000, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -388,7 +422,9 @@ func verifyHonorTimeStampsTrue(t *testing.T, td *testData, resourceMetrics []pme
 						compareSummary(1000, 5000, [][]float64{{0.01, 1}, {0.9, 5}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-honorTimestamp-3", wantAttributes, m3, e3)
 }
@@ -404,10 +440,11 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -415,10 +452,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareDoubleValue(19),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -436,10 +476,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -448,10 +491,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareHistogram(2500, 5000, []float64{0.05, 0.5, 1}, []uint64{1000, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -460,7 +506,9 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareSummary(1000, 5000, [][]float64{{0.01, 1}, {0.9, 5}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-honorTimestamp-1", wantAttributes, m1, e1)
 
@@ -470,10 +518,11 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 
 	metricsScrape2 := m2.ScopeMetrics().At(0).Metrics()
 	ts2 := getTS(metricsScrape2)
-	e2 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e2 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -481,10 +530,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareDoubleValue(18),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -502,10 +554,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -514,10 +569,13 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareHistogram(2400, 4950, []float64{0.05, 0.5, 1}, []uint64{900, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -526,7 +584,9 @@ func verifyHonorTimeStampsFalse(t *testing.T, td *testData, resourceMetrics []pm
 						compareSummary(900, 4980, [][]float64{{0.01, 1}, {0.9, 6}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-honorTimestamp-2", wantAttributes, m2, e2)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -43,10 +43,11 @@ func verifyExternalLabels(t *testing.T, td *testData, rms []pmetric.ResourceMetr
 	wantAttributes := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
-	doCompare(t, "scrape-externalLabels", wantAttributes, rms[0], []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	doCompare(t, "scrape-externalLabels", wantAttributes, rms[0], []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -55,7 +56,9 @@ func verifyExternalLabels(t *testing.T, td *testData, rms []pmetric.ResourceMetr
 						compareAttributes(map[string]string{"key": "value"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	})
 }
 
@@ -74,10 +77,11 @@ func verifyLabelLimitTarget1(t *testing.T, td *testData, rms []pmetric.ResourceM
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
 
-	doCompare(t, "scrape-labelLimit", want, rms[0], []testExpectation{
-		assertMetricPresent("test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	doCompare(t, "scrape-labelLimit", want, rms[0], []metricExpectation{
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -87,7 +91,8 @@ func verifyLabelLimitTarget1(t *testing.T, td *testData, rms []pmetric.ResourceM
 					},
 				},
 			},
-		),
+			nil,
+		},
 	})
 }
 
@@ -166,10 +171,11 @@ func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
 
-	e1 := []testExpectation{
-		assertMetricPresent("test_counter0",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"test_counter0",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -179,10 +185,13 @@ func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 						compareAttributes(map[string]string{"label1": "value1", "label2": "value2"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -191,10 +200,13 @@ func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 						compareAttributes(map[string]string{"label1": "value1", "label2": "value2"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_histogram0",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_histogram0",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -204,10 +216,13 @@ func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 						compareHistogramAttributes(map[string]string{"label1": "value1", "label2": "value2"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_summary0",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_summary0",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -217,7 +232,9 @@ func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 						compareSummaryAttributes(map[string]string{"label1": "value1", "label2": "value2"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-label-config-test", want, rms[0], e1)
 }
@@ -333,10 +350,11 @@ func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.Res
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
 
-	e1 := []testExpectation{
-		assertMetricPresent("test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -345,10 +363,13 @@ func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.Res
 						compareAttributes(map[string]string{"id": "1"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_counter0",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_counter0",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -357,10 +378,13 @@ func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.Res
 						compareAttributes(map[string]string{"id": "1"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_histogram0",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_histogram0",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -370,10 +394,13 @@ func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.Res
 						compareHistogramAttributes(map[string]string{"id": "1"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_summary0",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_summary0",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -383,7 +410,9 @@ func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.Res
 						compareSummaryAttributes(map[string]string{"id": "1"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-empty-label-values-1", want, rms[0], e1)
 }
@@ -408,10 +437,11 @@ func verifyEmptyLabelValuesTarget2(t *testing.T, td *testData, rms []pmetric.Res
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
 
-	e1 := []testExpectation{
-		assertMetricPresent("test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -427,10 +457,13 @@ func verifyEmptyLabelValuesTarget2(t *testing.T, td *testData, rms []pmetric.Res
 						compareAttributes(map[string]string{"id": "2", "testLabel": "foobar"}),
 					},
 				},
-			}),
-		assertMetricPresent("test_counter0",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"test_counter0",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -446,7 +479,9 @@ func verifyEmptyLabelValuesTarget2(t *testing.T, td *testData, rms []pmetric.Res
 						compareAttributes(map[string]string{"id": "2", "testLabel": "foobar"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-empty-label-values-2", want, rms[0], e1)
 }
@@ -484,10 +519,11 @@ func verifyHonorLabelsFalse(t *testing.T, td *testData, rms []pmetric.ResourceMe
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
 
-	doCompare(t, "honor_labels_false", want, rms[0], []testExpectation{
-		assertMetricPresent("test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	doCompare(t, "honor_labels_false", want, rms[0], []metricExpectation{
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -497,7 +533,9 @@ func verifyHonorLabelsFalse(t *testing.T, td *testData, rms []pmetric.ResourceMe
 						compareAttributes(map[string]string{"exported_job": "honor_labels_test", "exported_instance": "hostname:8080", "testLabel": "value1"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	})
 }
 
@@ -519,11 +557,11 @@ func verifyEmptyLabelsTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
 
-	e1 := []testExpectation{
-		assertMetricPresent(
+	e1 := []metricExpectation{
+		{
 			"test_gauge0",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -533,11 +571,12 @@ func verifyEmptyLabelsTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 					},
 				},
 			},
-		),
-		assertMetricPresent(
+			nil,
+		},
+		{
 			"test_counter0",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -547,7 +586,8 @@ func verifyEmptyLabelsTarget1(t *testing.T, td *testData, rms []pmetric.Resource
 					},
 				},
 			},
-		),
+			nil,
+		},
 	}
 	doCompare(t, "scrape-empty-labels-1", want, rms[0], e1)
 }
@@ -617,23 +657,28 @@ func verifyHonorLabelsTrue(t *testing.T, td *testData, rms []pmetric.ResourceMet
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
 
 	// check the scrape metrics of the resource created from the scrape config
-	doCompare(t, "honor_labels_true", expectedScrapeConfigAttributes, scrapeConfigResourceMetrics, []testExpectation{})
+	doCompare(t, "honor_labels_true", expectedScrapeConfigAttributes, scrapeConfigResourceMetrics, nil)
 
 	// assert that the gauge metric has been retrieved correctly. This resource only contains the gauge and no scrape metrics,
 	// so we directly check the gauge metric without the scrape metrics
 	assertExpectedAttributes(t, expectedResourceAttributes, resourceMetric)
-	assertMetricPresent("test_gauge0",
-		compareMetricType(pmetric.MetricTypeGauge),
-		compareMetricUnit(""),
-		[]dataPointExpectation{
-			{
-				numberPointComparator: []numberPointComparator{
-					compareTimestamp(ts1),
-					compareDoubleValue(1),
-					compareAttributes(map[string]string{"testLabel": "value1"}),
+	assertExpectedMetrics(t, []metricExpectation{
+		{
+			"test_gauge0",
+			pmetric.MetricTypeGauge,
+			"",
+			[]dataPointExpectation{
+				{
+					numberPointComparator: []numberPointComparator{
+						compareTimestamp(ts1),
+						compareDoubleValue(1),
+						compareAttributes(map[string]string{"testLabel": "value1"}),
+					},
 				},
 			},
-		})(t, resourceMetric)
+			nil,
+		},
+	}, resourceMetric, false, true)
 }
 
 func TestHonorLabelsTrueConfig(t *testing.T) {
@@ -715,18 +760,23 @@ func verifyRelabelJobInstance(t *testing.T, td *testData, rms []pmetric.Resource
 	// are not included in this resourceMetric, which only contains the relabeled
 	// metrics
 	assertExpectedAttributes(t, wantAttributes, rms[0])
-	assertMetricPresent("jvm_memory_bytes_used",
-		compareMetricType(pmetric.MetricTypeGauge),
-		compareMetricUnit(""),
-		[]dataPointExpectation{
-			{
-				numberPointComparator: []numberPointComparator{
-					compareTimestamp(ts1),
-					compareDoubleValue(100),
-					compareAttributes(map[string]string{"area": "heap"}),
+	assertExpectedMetrics(t, []metricExpectation{
+		{
+			"jvm_memory_bytes_used",
+			pmetric.MetricTypeGauge,
+			"",
+			[]dataPointExpectation{
+				{
+					numberPointComparator: []numberPointComparator{
+						compareTimestamp(ts1),
+						compareDoubleValue(100),
+						compareAttributes(map[string]string{"area": "heap"}),
+					},
 				},
 			},
-		})(t, rms[0])
+			nil,
+		},
+	}, rms[0], false, true)
 }
 
 const targetResourceAttsInTargetInfo = `
@@ -762,10 +812,11 @@ func verifyTargetInfoResourceAttributes(t *testing.T, td *testData, rms []pmetri
 
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
-	doCompare(t, "relabel-job-instance", wantAttributes, rms[0], []testExpectation{
-		assertMetricPresent("jvm_memory_bytes_used",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	doCompare(t, "relabel-job-instance", wantAttributes, rms[0], []metricExpectation{
+		{
+			"jvm_memory_bytes_used",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -774,7 +825,9 @@ func verifyTargetInfoResourceAttributes(t *testing.T, td *testData, rms []pmetri
 						compareAttributes(map[string]string{"area": "heap"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	})
 }
 

--- a/receiver/prometheusreceiver/metrics_receiver_metric_name_normalize_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_metric_name_normalize_test.go
@@ -60,10 +60,11 @@ func verifyNormalizeMetric(t *testing.T, td *testData, resourceMetrics []pmetric
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("http_connected",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"http_connected",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -79,10 +80,13 @@ func verifyNormalizeMetric(t *testing.T, td *testData, resourceMetrics []pmetric
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
-		assertMetricPresent("foo_gauge_total",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"foo_gauge_total",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -98,10 +102,13 @@ func verifyNormalizeMetric(t *testing.T, td *testData, resourceMetrics []pmetric
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_connection_duration",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit("s"),
+			},
+			nil,
+		},
+		{
+			"http_connection_duration",
+			pmetric.MetricTypeSum,
+			"s",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -117,10 +124,13 @@ func verifyNormalizeMetric(t *testing.T, td *testData, resourceMetrics []pmetric
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
-		assertMetricPresent("foo_gauge",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit("s"),
+			},
+			nil,
+		},
+		{
+			"foo_gauge",
+			pmetric.MetricTypeGauge,
+			"s",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -136,7 +146,9 @@ func verifyNormalizeMetric(t *testing.T, td *testData, resourceMetrics []pmetric
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompareNormalized(t, "scrape-metricNormalize-1", wantAttributes, m1, e1, true)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_non_numerical_test.go
@@ -90,10 +90,11 @@ func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric 
 	wantAttributes := td.attributes // should want attribute be part of complete target or each scrape?
 	metrics1 := resourceMetric.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -101,10 +102,13 @@ func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric 
 						compareDoubleValue(19),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -122,10 +126,13 @@ func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric 
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -134,10 +141,13 @@ func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric 
 						compareHistogram(2500, 5000, []float64{0.05, 0.5, 1}, []uint64{1000, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -146,7 +156,9 @@ func verifyStaleNaNsSuccessfulScrape(t *testing.T, td *testData, resourceMetric 
 						compareSummary(1000, 5000, [][]float64{{0.01, 1}, {0.9, 5}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, fmt.Sprintf("validScrape-scrape-%d", iteration), wantAttributes, resourceMetric, e1)
 }
@@ -160,10 +172,11 @@ func verifyStaleNaNsFailedScrape(t *testing.T, td *testData, resourceMetric pmet
 
 	metrics1 := resourceMetric.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -171,10 +184,13 @@ func verifyStaleNaNsFailedScrape(t *testing.T, td *testData, resourceMetric pmet
 						assertNumberPointFlagNoRecordedValue(),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -190,10 +206,13 @@ func verifyStaleNaNsFailedScrape(t *testing.T, td *testData, resourceMetric pmet
 						assertNumberPointFlagNoRecordedValue(),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -202,10 +221,13 @@ func verifyStaleNaNsFailedScrape(t *testing.T, td *testData, resourceMetric pmet
 						assertHistogramPointFlagNoRecordedValue(),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -214,7 +236,9 @@ func verifyStaleNaNsFailedScrape(t *testing.T, td *testData, resourceMetric pmet
 						assertSummaryPointFlagNoRecordedValue(),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, fmt.Sprintf("failedScrape-scrape-%d", iteration), wantAttributes, resourceMetric, e1)
 }
@@ -264,10 +288,11 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -275,10 +300,13 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 						assertNormalNan(),
 					},
 				},
-			}),
-		assertMetricPresent("redis_connected_clients",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"redis_connected_clients",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -287,10 +315,13 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 						assertNormalNan(),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -303,7 +334,9 @@ func verifyNormalNaNs(t *testing.T, td *testData, resourceMetrics []pmetric.Reso
 						}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-NormalNaN-1", wantAttributes, m1, e1)
 }
@@ -354,10 +387,11 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -365,10 +399,13 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 						compareDoubleValue(math.Inf(1)),
 					},
 				},
-			}),
-		assertMetricPresent("redis_connected_clients",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"redis_connected_clients",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -377,10 +414,13 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 						compareDoubleValue(math.Inf(-1)),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -390,10 +430,13 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 						compareAttributes(map[string]string{"method": "post", "code": "200"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -402,7 +445,9 @@ func verifyInfValues(t *testing.T, td *testData, resourceMetrics []pmetric.Resou
 						compareSummary(1000, 5000, [][]float64{{0.01, math.Inf(1)}, {0.9, math.Inf(1)}, {0.99, math.Inf(1)}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-InfValues-1", wantAttributes, m1, e1)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -240,10 +240,11 @@ func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pme
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("foo",
-			compareMetricIsMonotonic(false),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"foo",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -259,10 +260,13 @@ func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pme
 						compareAttributes(map[string]string{"entity": "replica", "name": "prettiername", "version": "8.1.9"}),
 					},
 				},
-			}),
-		assertMetricPresent("bar",
+			},
 			compareMetricIsMonotonic(false),
-			compareMetricUnit(""),
+		},
+		{
+			"bar",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -306,7 +310,9 @@ func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pme
 						compareAttributes(map[string]string{"entity": "replica", "foo": "ccc"}),
 					},
 				},
-			}),
+			},
+			compareMetricIsMonotonic(false),
+		},
 	}
 	doCompare(t, "scrape-infostatesetmetrics-1", wantAttributes, m1, e1)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
@@ -30,19 +30,21 @@ foo_gauge_total{method="get",port="6380"} 13
 
 // TestReportExtraScrapeMetrics validates 3 extra scrape metrics are reported when flag is set to true.
 func TestReportExtraScrapeMetrics(t *testing.T) {
-	targets := []*testData{
-		{
+	target := func(reportExtraScrapeMetrics bool) *testData {
+		return &testData{
 			name: "target1",
 			pages: []mockPrometheusResponse{
 				{code: 200, data: metricSet, useOpenMetrics: true},
 			},
 			normalizedName: false,
-			validateFunc:   verifyMetrics,
-		},
+			validateFunc: func(t *testing.T, td *testData, result []pmetric.ResourceMetrics) {
+				verifyMetrics(t, td, result, reportExtraScrapeMetrics)
+			},
+		}
 	}
 
-	testScraperMetrics(t, targets, false) // extraScrapeMetrics flag is false
-	testScraperMetrics(t, targets, true)  // extraScrapeMetrics flag is true
+	testScraperMetrics(t, []*testData{target(false)}, false) // extraScrapeMetrics flag is false
+	testScraperMetrics(t, []*testData{target(true)}, true)   // extraScrapeMetrics flag is true
 }
 
 // starts prometheus receiver with custom config, retrieves metrics from MetricsSink
@@ -110,7 +112,7 @@ func testScraperMetrics(t *testing.T, targets []*testData, reportExtraScrapeMetr
 	}
 }
 
-func verifyMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
+func verifyMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics, reportExtraScrapeMetrics bool) {
 	verifyNumValidScrapeResults(t, td, resourceMetrics)
 	m1 := resourceMetrics[0]
 
@@ -118,10 +120,11 @@ func verifyMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("http_connected_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"http_connected_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -137,10 +140,13 @@ func verifyMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
-		assertMetricPresent("foo_gauge_total",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"foo_gauge_total",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -156,7 +162,36 @@ func verifyMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "get", "port": "6380"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
+
+	if reportExtraScrapeMetrics {
+		e1 = append(e1, []metricExpectation{
+			{
+				"scrape_body_size_bytes",
+				pmetric.MetricTypeGauge,
+				"",
+				nil,
+				nil,
+			},
+			{
+				"scrape_sample_limit",
+				pmetric.MetricTypeGauge,
+				"",
+				nil,
+				nil,
+			},
+			{
+				"scrape_timeout_seconds",
+				pmetric.MetricTypeGauge,
+				"",
+				nil,
+				nil,
+			},
+		}...)
+	}
+
 	doCompare(t, "scrape-reportExtraScrapeMetrics-1", wantAttributes, m1, e1)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -128,10 +128,11 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -139,10 +140,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(19),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -160,10 +164,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -172,10 +179,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(2500, 5000, []float64{0.05, 0.5, 1}, []uint64{1000, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -184,7 +194,9 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(1000, 5000, [][]float64{{0.01, 1}, {0.9, 5}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape1", wantAttributes, m1, e1)
 
@@ -194,10 +206,11 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape2 := m2.ScopeMetrics().At(0).Metrics()
 	ts2 := getTS(metricsScrape2)
-	e2 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e2 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -205,10 +218,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(18),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -226,10 +242,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -239,10 +258,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(2600, 5050, []float64{0.05, 0.5, 1}, []uint64{1100, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -252,7 +274,9 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(1001, 5002, [][]float64{{0.01, 1}, {0.9, 6}, {0.99, 8}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape2", wantAttributes, m2, e2)
 
@@ -261,10 +285,11 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 	assert.Equal(t, 9, metricsCount(m3))
 	metricsScrape3 := m3.ScopeMetrics().At(0).Metrics()
 	ts3 := getTS(metricsScrape3)
-	e3 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e3 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -272,10 +297,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -295,10 +323,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -308,10 +339,13 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(2400, 4900, []float64{0.05, 0.5, 1}, []uint64{900, 500, 500, 500}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -321,7 +355,9 @@ func verifyTarget1(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(900, 4900, [][]float64{{0.01, 1}, {0.9, 4}, {0.99, 6}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape3", wantAttributes, m3, e3)
 }
@@ -526,10 +562,11 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -537,10 +574,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(18),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -558,10 +598,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(50, 25, []float64{1}, []uint64{30, 20}),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -579,10 +622,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -600,7 +646,9 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(400, 180, [][]float64{{0.5, 35}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape1", wantAttributes, m1, e1)
 
@@ -610,10 +658,11 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape2 := m2.ScopeMetrics().At(0).Metrics()
 	ts2 := getTS(metricsScrape2)
-	e2 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e2 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -621,10 +670,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -650,10 +702,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(60, 30, []float64{1}, []uint64{35, 25}),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -679,10 +734,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -708,7 +766,9 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(410, 190, [][]float64{{0.5, 45}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape2", wantAttributes, m2, e2)
 
@@ -718,10 +778,11 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape3 := m3.ScopeMetrics().At(0).Metrics()
 	ts3 := getTS(metricsScrape3)
-	e3 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e3 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -729,10 +790,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -758,10 +822,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(60, 30, []float64{1}, []uint64{35, 25}),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -787,10 +854,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -816,7 +886,9 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(420, 200, [][]float64{{0.5, 55}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape3", wantAttributes, m3, e3)
 
@@ -826,10 +898,11 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape4 := m4.ScopeMetrics().At(0).Metrics()
 	ts4 := getTS(metricsScrape4)
-	e4 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e4 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -837,10 +910,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -866,10 +942,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(59, 29, []float64{1}, []uint64{34, 25}),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -895,10 +974,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -924,7 +1006,9 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(419, 199, [][]float64{{0.5, 54}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape4", wantAttributes, m4, e4)
 
@@ -934,10 +1018,11 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape5 := m5.ScopeMetrics().At(0).Metrics()
 	ts5 := getTS(metricsScrape5)
-	e5 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e5 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -945,10 +1030,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -974,10 +1062,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(59, 29, []float64{1}, []uint64{34, 25}),
 					},
 				},
-			}),
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1003,10 +1094,13 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -1032,7 +1126,9 @@ func verifyTarget2(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(429, 209, [][]float64{{0.5, 64}}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape5", wantAttributes, m5, e5)
 }
@@ -1128,10 +1224,11 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1139,10 +1236,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(18),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -1151,10 +1251,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(13003, 50000, []float64{0.2, 0.5, 1}, []uint64{10000, 1000, 1001, 1002}),
 					},
 				},
-			}),
-		assertMetricPresent("corrupted_hist",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"corrupted_hist",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -1163,10 +1266,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(10, 100, nil, []uint64{10}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -1184,7 +1290,9 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(50, 100, [][]float64{}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape1", wantAttributes, m1, e1)
 
@@ -1194,10 +1302,11 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metricsScrape2 := m2.ScopeMetrics().At(0).Metrics()
 	ts2 := getTS(metricsScrape2)
-	e2 := []testExpectation{
-		assertMetricPresent("go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e2 := []metricExpectation{
+		{
+			"go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1205,10 +1314,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(16),
 					},
 				},
-			}),
-		assertMetricPresent("http_request_duration_seconds",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_request_duration_seconds",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -1217,10 +1329,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(14003, 50100, []float64{0.2, 0.5, 1}, []uint64{11000, 1000, 1001, 1002}),
 					},
 				},
-			}),
-		assertMetricPresent("corrupted_hist",
-			compareMetricType(pmetric.MetricTypeHistogram),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"corrupted_hist",
+			pmetric.MetricTypeHistogram,
+			"",
 			[]dataPointExpectation{
 				{
 					histogramPointComparator: []histogramPointComparator{
@@ -1229,10 +1344,13 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareHistogram(15, 101, nil, []uint64{15}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_seconds",
-			compareMetricType(pmetric.MetricTypeSummary),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_seconds",
+			pmetric.MetricTypeSummary,
+			"",
 			[]dataPointExpectation{
 				{
 					summaryPointComparator: []summaryPointComparator{
@@ -1250,7 +1368,9 @@ func verifyTarget3(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareSummary(55, 101, [][]float64{}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape2", wantAttributes, m2, e2)
 }
@@ -1266,10 +1386,11 @@ func verifyTarget4(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("foo",
-			compareMetricIsMonotonic(true),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"foo",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1277,10 +1398,13 @@ func verifyTarget4(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(0),
 					},
 				},
-			}),
-		assertMetricPresent("foo_total",
+			},
 			compareMetricIsMonotonic(true),
-			compareMetricUnit(""),
+		},
+		{
+			"foo_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1288,7 +1412,9 @@ func verifyTarget4(t *testing.T, td *testData, resourceMetrics []pmetric.Resourc
 						compareDoubleValue(1.0),
 					},
 				},
-			}),
+			},
+			compareMetricIsMonotonic(true),
+		},
 	}
 	doCompare(t, "scrape-infostatesetmetrics-1", wantAttributes, m1, e1)
 }
@@ -1522,10 +1648,11 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"http_requests_total",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1541,10 +1668,13 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 						compareAttributes(map[string]string{"method": "post", "code": "400"}),
 					},
 				},
-			}),
-		assertMetricPresent("redis_connected_clients",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"redis_connected_clients",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -1560,7 +1690,9 @@ func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.
 						compareAttributes(map[string]string{"name": "rough-snowflake-web", "port": "6381"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-untypedMetric-1", wantAttributes, m1, e1)
 }

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -115,10 +115,11 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("foo",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"foo",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -134,11 +135,14 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 						compareAttributes(map[string]string{"method": "post", "port": "6380"}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 		// renaming config converts any metric type to untyped metric, which then gets converted to gauge double type by metric builder
-		assertMetricPresent("http_requests_total",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+		{
+			"http_requests_total",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -154,8 +158,9 @@ func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.Re
 						compareAttributes(map[string]string{"method": "post", "port": "6381"}),
 					},
 				},
-			}),
-		assertMetricAbsent("rpc_duration_total"),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-metricRename-1", wantAttributes, m1, e1)
 }
@@ -171,10 +176,11 @@ func verifyRenameMetricKeepAction(t *testing.T, td *testData, resourceMetrics []
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("rpc_duration_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"rpc_duration_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -191,10 +197,9 @@ func verifyRenameMetricKeepAction(t *testing.T, td *testData, resourceMetrics []
 						compareAttributes(map[string]string{"method": "post", "port": "6381"}),
 					},
 				},
-			}),
-		assertMetricAbsent("http_go_threads"),
-		assertMetricAbsent("http_connected_total"),
-		assertMetricAbsent("redis_http_requests_total"),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-metricRenameKeepAction-1", wantAttributes, m1, e1)
 }
@@ -278,10 +283,11 @@ func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.Res
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("http_go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"http_go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -290,10 +296,13 @@ func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.Res
 						compareAttributes(map[string]string{"foo": "bar"}),
 					},
 				},
-			}),
-		assertMetricPresent("http_connected_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_connected_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -302,10 +311,13 @@ func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.Res
 						compareAttributes(map[string]string{"foo": "bar", "status": "ok"}),
 					},
 				},
-			}),
-		assertMetricPresent("redis_http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"redis_http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -323,10 +335,13 @@ func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.Res
 						compareAttributes(map[string]string{"exported_job": "sample-app", "statusCode": "200", "foo": "bar"}),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -345,7 +360,9 @@ func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.Res
 						}),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-labelRename-1", wantAttributes, m1, e1)
 }
@@ -386,10 +403,11 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 
 	metrics1 := m1.ScopeMetrics().At(0).Metrics()
 	ts1 := getTS(metrics1)
-	e1 := []testExpectation{
-		assertMetricPresent("http_go_threads",
-			compareMetricType(pmetric.MetricTypeGauge),
-			compareMetricUnit(""),
+	e1 := []metricExpectation{
+		{
+			"http_go_threads",
+			pmetric.MetricTypeGauge,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -398,10 +416,13 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 						assertAttributesAbsent(),
 					},
 				},
-			}),
-		assertMetricPresent("http_connected_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"http_connected_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -410,10 +431,13 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 						assertAttributesAbsent(),
 					},
 				},
-			}),
-		assertMetricPresent("redis_http_requests_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"redis_http_requests_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -429,10 +453,13 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 						assertAttributesAbsent(),
 					},
 				},
-			}),
-		assertMetricPresent("rpc_duration_total",
-			compareMetricType(pmetric.MetricTypeSum),
-			compareMetricUnit(""),
+			},
+			nil,
+		},
+		{
+			"rpc_duration_total",
+			pmetric.MetricTypeSum,
+			"",
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
@@ -448,7 +475,9 @@ func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []p
 						assertAttributesAbsent(),
 					},
 				},
-			}),
+			},
+			nil,
+		},
 	}
 	doCompare(t, "scrape-LabelRenameKeepAction-1", wantAttributes, m1, e1)
 }

--- a/receiver/prometheusreceiver/metricsreceiver_api_server_test.go
+++ b/receiver/prometheusreceiver/metricsreceiver_api_server_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
@@ -46,7 +47,9 @@ func TestPrometheusAPIServer(t *testing.T) {
 				{code: 200, data: metricSet, useOpenMetrics: false},
 			},
 			normalizedName: false,
-			validateFunc:   verifyMetrics,
+			validateFunc: func(t *testing.T, td *testData, result []pmetric.ResourceMetrics) {
+				verifyMetrics(t, td, result, false)
+			},
 		},
 	}
 


### PR DESCRIPTION
I'd like to fix a technical dept from #28663 where the Prometheus receiver didn't allow receiving both classic and native histogram for the same metric name. To test the implementation, the assertions must not assume that the metric name alone is identifying in OpenTelemetry.

No new tests added, I just refactored to make name+type+unit the identifier.

Also I made it implicit that `doCompare` fails on metrics that were not expected - excluding the 5 scrape metrics. This means that `assertMetricAbsent` is not needed anymore.

