### PR TITLE
[receiver/github] fix step parent span id

### DIFF
--- a/.chloggen/gh-trace-fix.yaml
+++ b/.chloggen/gh-trace-fix.yaml
@@ -10,7 +10,7 @@ component: githubreceiver
 note: Fixes a bug where Job Step Spans did not have the correct Parent SpanID.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [38647]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/gh-trace-fix.yaml
+++ b/.chloggen/gh-trace-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: githubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where Job Step Spans did not have the correct Parent SpanID.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/githubreceiver/trace_event_handling.go
+++ b/receiver/githubreceiver/trace_event_handling.go
@@ -214,7 +214,7 @@ func (gtr *githubTracesReceiver) createParentSpan(
 
 	span.Status().SetMessage(event.GetWorkflowJob().GetConclusion())
 
-	return parentSpanID, nil
+	return jobSpanID, nil
 }
 
 // newJobSpanId creates a deterministic Job Span ID based on the provided runID,


### PR DESCRIPTION
#### Description

Steps were associated with the wrong Parent SpanID. This fixes this by using the Job SpanID as the Parent SpanID for workflow job steps.
