### PR TITLE
hotfix: pin tj-actions/changed-files by SHA

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
         with:
           files_yaml: |
             md:

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get changed go files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
         with:
           files_yaml: |
             sources:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR pins the tj-actions/changed-files GitHub action to a SHA corresponding to a version that is not compromised. For details on the compromise, see:

https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
Compromised versions leak CI secrets, so this repo's CI secrets will need to be rotated.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Incident: https://dd.enterprise.slack.com/archives/C08HE4EL43H

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
