### PR TITLE
[cmd/opampsupervisor] Support http endpoint

### DIFF
--- a/.chloggen/opampsupervisor-http-client.yaml
+++ b/.chloggen/opampsupervisor-http-client.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support HTTP endpoint for opampsupervisor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/opampsupervisor-http-client.yaml
+++ b/.chloggen/opampsupervisor-http-client.yaml
@@ -10,7 +10,7 @@ component: opampsupervisor
 note: Support HTTP endpoint for opampsupervisor
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [38654]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1177,6 +1177,20 @@ func TestSupervisorOpAMPConnectionSettings(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond, "Collector did not connect to new OpAMP server")
 }
 
+func TestSupervisorOpAMPWithHTTPEndpoint(t *testing.T) {
+	initialServer := newOpAMPServer(
+		t,
+		defaultConnectingHandler,
+		types.ConnectionCallbacks{})
+
+	s := newSupervisor(t, "http", map[string]string{"url": initialServer.addr})
+
+	require.Nil(t, s.Start())
+	defer s.Shutdown()
+
+	waitForSupervisorConnection(initialServer.supervisorConnected, true)
+}
+
 func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 	// Create a temporary directory to store the test config file.
 	tempDir := t.TempDir()

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1178,10 +1178,15 @@ func TestSupervisorOpAMPConnectionSettings(t *testing.T) {
 }
 
 func TestSupervisorOpAMPWithHTTPEndpoint(t *testing.T) {
+	connected := atomic.Bool{}
 	initialServer := newOpAMPServer(
 		t,
 		defaultConnectingHandler,
-		types.ConnectionCallbacks{})
+		types.ConnectionCallbacks{
+			OnConnected: func(ctx context.Context, conn types.Connection) {
+				connected.Store(true)
+			},
+		})
 
 	s := newSupervisor(t, "http", map[string]string{"url": initialServer.addr})
 
@@ -1189,6 +1194,7 @@ func TestSupervisorOpAMPWithHTTPEndpoint(t *testing.T) {
 	defer s.Shutdown()
 
 	waitForSupervisorConnection(initialServer.supervisorConnected, true)
+	require.True(t, connected.Load(), "Supervisor failed to connect")
 }
 
 func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -116,7 +116,7 @@ func newUnstartedOpAMPServer(t *testing.T, connectingCallback onConnectingFuncFa
 			onConnectionCloseFunc(conn)
 		}
 	}
-	handler, _, err := s.Attach(server.Settings{
+	handler, connContext, err := s.Attach(server.Settings{
 		Callbacks: types.Callbacks{
 			OnConnecting: connectingCallback(callbacks),
 		},
@@ -125,6 +125,7 @@ func newUnstartedOpAMPServer(t *testing.T, connectingCallback onConnectingFuncFa
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/opamp", handler)
 	httpSrv := httptest.NewUnstartedServer(mux)
+	httpSrv.Config.ConnContext = connContext
 
 	shutdown := func() {
 		if !didShutdown.Load() {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -553,7 +553,7 @@ func (s *Supervisor) startOpAMPClient() error {
 	case "http", "https":
 		s.opampClient = client.NewHTTP(logger)
 	default:
-		return fmt.Errorf("unsupported scheme in server endpoint: %s", parsedURL.Scheme)
+		return fmt.Errorf("unsupported scheme in server endpoint: %q", parsedURL.Scheme)
 	}
 
 	s.telemetrySettings.Logger.Debug("Connecting to OpAMP server...", zap.String("endpoint", s.config.Server.Endpoint), zap.Any("headers", s.config.Server.Headers))

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -534,8 +534,6 @@ func (s *Supervisor) startOpAMP() error {
 }
 
 func (s *Supervisor) startOpAMPClient() error {
-	s.opampClient = client.NewWebSocket(newLoggerFromZap(s.telemetrySettings.Logger, "opamp-client"))
-
 	// determine if we need to load a TLS config or not
 	var tlsConfig *tls.Config
 	parsedURL, err := url.Parse(s.config.Server.Endpoint)
@@ -547,6 +545,15 @@ func (s *Supervisor) startOpAMPClient() error {
 		if err != nil {
 			return err
 		}
+	}
+	logger := newLoggerFromZap(s.telemetrySettings.Logger, "opamp-client")
+	switch parsedURL.Scheme {
+	case "ws", "wss":
+		s.opampClient = client.NewWebSocket(logger)
+	case "http", "https":
+		s.opampClient = client.NewHTTP(logger)
+	default:
+		return fmt.Errorf("unsupported scheme in server endpoint: %s", parsedURL.Scheme)
 	}
 
 	s.telemetrySettings.Logger.Debug("Connecting to OpAMP server...", zap.String("endpoint", s.config.Server.Endpoint), zap.Any("headers", s.config.Server.Headers))

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_http.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_http.yaml
@@ -1,0 +1,18 @@
+server:
+  endpoint: http://{{.url}}/v1/opamp
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+  accepts_restart_command: true
+
+storage:
+  directory: '{{.storage_dir}}'
+
+agent:
+  executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}


### PR DESCRIPTION
#### Description
- Prev closed PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36157
- [cmd/opampsupervisor] OpAMP supports http & websocket both.:
  - > OpAMP Client implementations may choose to support either plain HTTP or WebSocket transport, depending on their needs.
  - ref. https://opentelemetry.io/docs/specs/opamp/#communication-model

  - Already opampsupervisor code considers http in the configuration, but there is no code to use http client until now.:
    - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8dd2b7b00f9307bde95d4391d290f59aa901f219/cmd/opampsupervisor/supervisor/config/config.go#L139
