### PR TITLE
[exporter/prometheusremotewrite] remove `export_created_metric`

### DIFF
--- a/.chloggen/remove_export_created_metric.yaml
+++ b/.chloggen/remove_export_created_metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `export_created_metric` config option
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35003]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -59,10 +59,6 @@ The following settings can be optionally configured:
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `target_info`: customize `target_info` metric
   - `enabled` (default = true): If `enabled` is `true`, a `target_info` metric will be generated for each resource metric (see https://github.com/open-telemetry/opentelemetry-specification/pull/2381).
-- `export_created_metric`: `WARNING` Deprecated and planned for removal in v0.116.0. See [related issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35003) for more information. 
-  - `enabled` (default = false): If `enabled` is `true`, a `_created` metric is
-    exported for Summary, Histogram, and Monotonic Sum metric points if
-    `StartTimeUnixNano` is set.
 - `max_batch_size_bytes` (default = `3000000` -> `~2.861 mb`): Maximum size of a batch of
   samples to be sent to the remote write endpoint. If the batch size is larger
   than this value, it will be split into multiple batches.

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -47,11 +47,6 @@ type Config struct {
 	// TargetInfo allows customizing the target_info metric
 	TargetInfo *TargetInfo `mapstructure:"target_info,omitempty"`
 
-	// CreatedMetric allows customizing creation of _created metrics
-	// Deprecated[0.114.0]: The feature doesn't provide the expected behavior. Use Prometheus remote-write v2 to enable sending Created Timestamps.
-	// This feature is planned to be removed in v0.116.0
-	CreatedMetric *CreatedMetric `mapstructure:"export_created_metric,omitempty"`
-
 	// AddMetricSuffixes controls whether unit and type suffixes are added to metrics on export
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
 
@@ -109,11 +104,6 @@ func (cfg *Config) Validate() error {
 	if cfg.TargetInfo == nil {
 		cfg.TargetInfo = &TargetInfo{
 			Enabled: true,
-		}
-	}
-	if cfg.CreatedMetric == nil {
-		cfg.CreatedMetric = &CreatedMetric{
-			Enabled: false,
 		}
 	}
 	if cfg.MaxBatchSizeBytes < 0 {

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -81,7 +81,6 @@ func TestLoadConfig(t *testing.T) {
 				TargetInfo: &TargetInfo{
 					Enabled: true,
 				},
-				CreatedMetric: &CreatedMetric{Enabled: true},
 			},
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -158,19 +158,14 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 		retrySettings:     cfg.BackOffConfig,
 		retryOnHTTP429:    retryOn429FeatureGate.IsEnabled(),
 		exporterSettings: prometheusremotewrite.Settings{
-			Namespace:           cfg.Namespace,
-			ExternalLabels:      sanitizedLabels,
-			DisableTargetInfo:   !cfg.TargetInfo.Enabled,
-			ExportCreatedMetric: cfg.CreatedMetric.Enabled,
-			AddMetricSuffixes:   cfg.AddMetricSuffixes,
-			SendMetadata:        cfg.SendMetadata,
+			Namespace:         cfg.Namespace,
+			ExternalLabels:    sanitizedLabels,
+			DisableTargetInfo: !cfg.TargetInfo.Enabled,
+			AddMetricSuffixes: cfg.AddMetricSuffixes,
+			SendMetadata:      cfg.SendMetadata,
 		},
 		telemetry:      telemetry,
 		batchStatePool: sync.Pool{New: func() any { return newBatchTimeServicesState() }},
-	}
-
-	if prwe.exporterSettings.ExportCreatedMetric {
-		prwe.settings.Logger.Warn("export_created_metric is deprecated and will be removed in a future release")
 	}
 
 	prwe.wal = newWAL(cfg.WAL, prwe.export)

--- a/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
@@ -109,9 +109,6 @@ func Test_PushMetricsConcurrent(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		CreatedMetric: &CreatedMetric{
-			Enabled: false,
-		},
 		BackOffConfig: retrySettings,
 	}
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -56,9 +56,6 @@ func Test_NewPRWExporter(t *testing.T) {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		CreatedMetric: &CreatedMetric{
-			Enabled: false,
-		},
 	}
 	buildInfo := component.BuildInfo{
 		Description: "OpenTelemetry Collector",
@@ -151,9 +148,6 @@ func Test_Start(t *testing.T) {
 		ExternalLabels:    map[string]string{},
 		TargetInfo: &TargetInfo{
 			Enabled: true,
-		},
-		CreatedMetric: &CreatedMetric{
-			Enabled: false,
 		},
 	}
 	buildInfo := component.BuildInfo{
@@ -497,7 +491,7 @@ func Test_PushMetrics(t *testing.T) {
 			name:               "intSum_case",
 			metrics:            intSumBatch,
 			reqTestFunc:        checkFunc,
-			expectedTimeSeries: 4,
+			expectedTimeSeries: 2,
 			httpResponseCode:   http.StatusAccepted,
 		},
 		{
@@ -719,9 +713,6 @@ func Test_PushMetrics(t *testing.T) {
 						MaxBatchSizeBytes: 3000000,
 						RemoteWriteQueue:  RemoteWriteQueue{NumConsumers: 1},
 						TargetInfo: &TargetInfo{
-							Enabled: true,
-						},
-						CreatedMetric: &CreatedMetric{
 							Enabled: true,
 						},
 						BackOffConfig: retrySettings,
@@ -947,9 +938,6 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		},
 		TargetInfo: &TargetInfo{
 			Enabled: true,
-		},
-		CreatedMetric: &CreatedMetric{
-			Enabled: false,
 		},
 	}
 
@@ -1309,7 +1297,6 @@ func benchmarkPushMetrics(b *testing.B, numMetrics, numConsumers int) {
 		RemoteWriteQueue:  RemoteWriteQueue{NumConsumers: numConsumers},
 		BackOffConfig:     retrySettings,
 		TargetInfo:        &TargetInfo{Enabled: true},
-		CreatedMetric:     &CreatedMetric{Enabled: false},
 	}
 	exporter, err := newPRWExporter(cfg, set)
 	require.NoError(b, err)

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -116,8 +116,5 @@ func createDefaultConfig() component.Config {
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
-		CreatedMetric: &CreatedMetric{
-			Enabled: false,
-		},
 	}
 }

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -21,8 +21,6 @@ prometheusremotewrite/2:
     key2: value2
   resource_to_telemetry_conversion:
     enabled: true
-  export_created_metric:
-    enabled: true
   remote_write_queue:
     queue_size: 2000
     num_consumers: 10

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -166,8 +166,7 @@ func TestExportWithWALEnabled(t *testing.T) {
 		WAL: &WALConfig{
 			Directory: t.TempDir(),
 		},
-		TargetInfo:    &TargetInfo{},    // Declared just to avoid nil pointer dereference.
-		CreatedMetric: &CreatedMetric{}, // Declared just to avoid nil pointer dereference.
+		TargetInfo: &TargetInfo{}, // Declared just to avoid nil pointer dereference.
 	}
 	buildInfo := component.BuildInfo{
 		Description: "OpenTelemetry Collector",

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -285,12 +285,6 @@ func (c *prometheusConverter) addHistogramDataPoints(dataPoints pmetric.Histogra
 
 		bucketBounds = append(bucketBounds, bucketBoundsData{ts: ts, bound: math.Inf(1)})
 		c.addExemplars(pt, bucketBounds)
-
-		startTimestamp := pt.StartTimestamp()
-		if settings.ExportCreatedMetric && startTimestamp != 0 && !exportCreatedMetricGate.IsEnabled() {
-			labels := createLabels(baseName+createdSuffix, baseLabels)
-			c.addTimeSeriesIfNeeded(labels, startTimestamp, pt.Timestamp())
-		}
 	}
 }
 
@@ -443,12 +437,6 @@ func (c *prometheusConverter) addSummaryDataPoints(dataPoints pmetric.SummaryDat
 			qtlabels := createLabels(baseName, baseLabels, quantileStr, percentileStr)
 			c.addSample(quantile, qtlabels)
 		}
-
-		startTimestamp := pt.StartTimestamp()
-		if settings.ExportCreatedMetric && startTimestamp != 0 && !exportCreatedMetricGate.IsEnabled() {
-			createdLabels := createLabels(baseName+createdSuffix, baseLabels)
-			c.addTimeSeriesIfNeeded(createdLabels, startTimestamp, pt.Timestamp())
-		}
 	}
 }
 
@@ -503,22 +491,6 @@ func (c *prometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*promp
 	}
 	c.unique[h] = ts
 	return ts, true
-}
-
-// addTimeSeriesIfNeeded adds a corresponding time series if it doesn't already exist.
-// If the time series doesn't already exist, it gets added with startTimestamp for its value and timestamp for its timestamp,
-// both converted to milliseconds.
-func (c *prometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
-	ts, created := c.getOrCreateTimeSeries(lbls)
-	if created {
-		ts.Samples = []prompb.Sample{
-			{
-				// convert ns to ms
-				Value:     float64(convertTimeStamp(startTimestamp)),
-				Timestamp: convertTimeStamp(timestamp),
-			},
-		}
-	}
 }
 
 // addResourceTargetInfo converts the resource to the target info metric.

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -862,9 +862,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 			converter.addSummaryDataPoints(
 				metric.Summary().DataPoints(),
 				pcommon.NewResource(),
-				Settings{
-					ExportCreatedMetric: true,
-				},
+				Settings{},
 				metric.Name(),
 			)
 
@@ -1004,9 +1002,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 			converter.addHistogramDataPoints(
 				metric.Histogram().DataPoints(),
 				pcommon.NewResource(),
-				Settings{
-					ExportCreatedMetric: true,
-				},
+				Settings{},
 				metric.Name(),
 			)
 

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -18,12 +18,11 @@ import (
 )
 
 type Settings struct {
-	Namespace           string
-	ExternalLabels      map[string]string
-	DisableTargetInfo   bool
-	ExportCreatedMetric bool
-	AddMetricSuffixes   bool
-	SendMetadata        bool
+	Namespace         string
+	ExternalLabels    map[string]string
+	DisableTargetInfo bool
+	AddMetricSuffixes bool
+	SendMetadata      bool
 }
 
 // FromMetrics converts pmetric.Metrics to Prometheus remote write format.

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_v2.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_v2.go
@@ -137,7 +137,3 @@ func (c *prometheusConverterV2) addSample(sample *writev2.Sample, lbls []prompb.
 	}
 	c.unique[timeSeriesSignature(lbls)] = &ts
 }
-
-// TODO: implement this function.
-func (c *prometheusConverterV2) addTimeSeriesIfNeeded(_ []prompb.Label, _ pcommon.Timestamp, _ pcommon.Timestamp) {
-}

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_v2_test.go
@@ -16,12 +16,11 @@ import (
 
 func TestFromMetricsV2(t *testing.T) {
 	settings := Settings{
-		Namespace:           "",
-		ExternalLabels:      nil,
-		DisableTargetInfo:   false,
-		ExportCreatedMetric: false,
-		AddMetricSuffixes:   false,
-		SendMetadata:        false,
+		Namespace:         "",
+		ExternalLabels:    nil,
+		DisableTargetInfo: false,
+		AddMetricSuffixes: false,
+		SendMetadata:      false,
 	}
 
 	ts := uint64(time.Now().UnixNano())

--- a/pkg/translator/prometheusremotewrite/number_data_points.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points.go
@@ -45,7 +45,7 @@ func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.Number
 }
 
 func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
-	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string,
+	resource pcommon.Resource, _ pmetric.Metric, settings Settings, name string,
 ) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -75,24 +75,6 @@ func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDa
 		if ts != nil {
 			exemplars := getPromExemplars[pmetric.NumberDataPoint](pt)
 			ts.Exemplars = append(ts.Exemplars, exemplars...)
-		}
-
-		// add created time series if needed
-		if settings.ExportCreatedMetric && metric.Sum().IsMonotonic() {
-			startTimestamp := pt.StartTimestamp()
-			if startTimestamp == 0 {
-				return
-			}
-
-			createdLabels := make([]prompb.Label, len(lbls))
-			copy(createdLabels, lbls)
-			for i, l := range createdLabels {
-				if l.Name == model.MetricNameLabel {
-					createdLabels[i].Value = name + createdSuffix
-					break
-				}
-			}
-			c.addTimeSeriesIfNeeded(createdLabels, startTimestamp, pt.Timestamp())
 		}
 	}
 }

--- a/pkg/translator/prometheusremotewrite/number_data_points_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_test.go
@@ -149,20 +149,11 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_sum"},
 				}
-				createdLabels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_sum" + createdSuffix},
-				}
 				return map[uint64]*prompb.TimeSeries{
 					timeSeriesSignature(labels): {
 						Labels: labels,
 						Samples: []prompb.Sample{
 							{Value: 1, Timestamp: convertTimeStamp(ts)},
-						},
-					},
-					timeSeriesSignature(createdLabels): {
-						Labels: createdLabels,
-						Samples: []prompb.Sample{
-							{Value: float64(convertTimeStamp(ts)), Timestamp: convertTimeStamp(ts)},
 						},
 					},
 				}
@@ -232,7 +223,7 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 				metric.Sum().DataPoints(),
 				pcommon.NewResource(),
 				metric,
-				Settings{ExportCreatedMetric: true},
+				Settings{},
 				metric.Name(),
 			)
 

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/model/value"
-	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -49,7 +48,7 @@ func (c *prometheusConverterV2) addGaugeNumberDataPoints(dataPoints pmetric.Numb
 }
 
 func (c *prometheusConverterV2) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
-	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string,
+	resource pcommon.Resource, _ pmetric.Metric, settings Settings, name string,
 ) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -78,24 +77,6 @@ func (c *prometheusConverterV2) addSumNumberDataPoints(dataPoints pmetric.Number
 		}
 		// TODO: properly add exemplars to the TimeSeries
 		c.addSample(sample, lbls)
-
-		if settings.ExportCreatedMetric && metric.Sum().IsMonotonic() {
-			startTimestamp := pt.StartTimestamp()
-			if startTimestamp != 0 {
-				return
-			}
-
-			createdLabels := make([]prompb.Label, len(lbls))
-			copy(createdLabels, lbls)
-			for i, l := range createdLabels {
-				if l.Name == model.MetricNameLabel {
-					createdLabels[i].Value = name + createdSuffix
-					break
-				}
-			}
-			// TODO: implement this function.
-			c.addTimeSeriesIfNeeded(createdLabels, startTimestamp, pt.Timestamp())
-		}
 	}
 }
 

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
@@ -109,12 +109,10 @@ func TestPrometheusConverterV2_addGaugeNumberDataPoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
 			settings := Settings{
-				Namespace:           "",
-				ExternalLabels:      nil,
-				DisableTargetInfo:   false,
-				ExportCreatedMetric: false,
-				AddMetricSuffixes:   false,
-				SendMetadata:        false,
+				Namespace:         "",
+				ExternalLabels:    nil,
+				DisableTargetInfo: false,
+				SendMetadata:      false,
 			}
 			converter := newPrometheusConverterV2()
 			converter.addGaugeNumberDataPoints(metric.Gauge().DataPoints(), pcommon.NewResource(), settings, metric.Name())
@@ -158,12 +156,10 @@ func TestPrometheusConverterV2_addGaugeNumberDataPointsDuplicate(t *testing.T) {
 	}
 
 	settings := Settings{
-		Namespace:           "",
-		ExternalLabels:      nil,
-		DisableTargetInfo:   false,
-		ExportCreatedMetric: false,
-		AddMetricSuffixes:   false,
-		SendMetadata:        false,
+		Namespace:         "",
+		ExternalLabels:    nil,
+		DisableTargetInfo: false,
+		SendMetadata:      false,
 	}
 
 	converter := newPrometheusConverterV2()


### PR DESCRIPTION
#### Description
Removing `export_created_metric` per note in README.

See #35003  for reference.
