### PR TITLE
[confmap/provider/s3provider] Remove duplicate check for scheme

### DIFF
--- a/confmap/provider/s3provider/provider.go
+++ b/confmap/provider/s3provider/provider.go
@@ -57,10 +57,6 @@ func newWithSettings(_ confmap.ProviderSettings) confmap.Provider {
 }
 
 func (fmp *provider) Retrieve(ctx context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
-	if !strings.HasPrefix(uri, schemeName+":") {
-		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemeName)
-	}
-
 	// initialize the s3 client in the first call of Retrieve
 	if fmp.client == nil {
 		cfg, err := config.LoadDefaultConfig(context.Background())

--- a/confmap/provider/s3provider/provider_test.go
+++ b/confmap/provider/s3provider/provider_test.go
@@ -77,6 +77,7 @@ func TestURIs(t *testing.T) {
 		{"No bucket", "s3://s3.region.amazonaws.com/key", "", "", "", false},
 		{"No region", "s3://some-bucket.s3..amazonaws.com/key", "", "", "", false},
 		{"Test malformed uri", "s3://some-bucket.s3.us-west-2.amazonaws.com/key%", "", "", "", false},
+		{"Unsupported scheme", "https://google.com", "", "", "", false},
 		{"Valid bucket", "s3://bucket.name-here.s3.us-west-2.amazonaws.com/key", "bucket.name-here", "us-west-2", "key", true},
 	}
 
@@ -92,13 +93,6 @@ func TestURIs(t *testing.T) {
 			require.NoError(t, fp.Shutdown(context.Background()))
 		})
 	}
-}
-
-func TestUnsupportedScheme(t *testing.T) {
-	fp := newTestProvider("./testdata/otel-config.yaml")
-	_, err := fp.Retrieve(context.Background(), "https://google.com", nil)
-	assert.Error(t, err)
-	assert.NoError(t, fp.Shutdown(context.Background()))
 }
 
 func TestNonExistent(t *testing.T) {


### PR DESCRIPTION
#### Description
This was already being checked by the S3 URI regular expression evaluation/parsing.

#### Testing
I refactored the previously existing `Unsupported scheme` unit test into `TestURIs`