### PR TITLE
chore: Refactor uses of attribute.Range() to use attributes.All() iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 - `awscloudwatchencodingextension`: Introduce new encoding extension for AWS CloudWatch Metric Streams (#37870)
 - `azureblobexporter`: implementation of azure blob exporter (#34319)
-- `faroreceiver`: Introduce a new receiver to recieve faro data (#19180)
+- `faroreceiver`: Introduce a new receiver to receive faro data (#19180)
 - `kafkatopicsobserver`: Change stability level of kafkatopicsobserver to alpha (#37665)
 - `datadogsemanticsprocessor`: Add datadogsemanticsprocessor, which transforms OpenTelemetry semantic conventions to Datadog semantic conventions (#35304)
 - `pprofreceiver`: Introduce a new receiver to report pprof profiles (#38260)

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -241,10 +241,9 @@ func initTelemetrySettings(logger *zap.Logger, cfg config.Telemetry) (telemetryS
 	// TODO currently we do not have the build info containing the version available to set semconv.AttributeServiceVersion
 
 	var attrs []telemetryconfig.AttributeNameValue
-	pcommonRes.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range pcommonRes.Attributes().All() {
 		attrs = append(attrs, telemetryconfig.AttributeNameValue{Name: k, Value: v.Str()})
-		return true
-	})
+	}
 
 	sch := semconv.SchemaURL
 

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -219,7 +219,7 @@ func verifyMetricLabels(tb testing.TB, dp metricDataPoint, seenMetricIDs map[met
 		exceptionTypeKey:    pcommon.NewValueStr("Exception"),
 		exceptionMessageKey: pcommon.NewValueStr("Exception message"),
 	}
-	dp.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range dp.Attributes().All() {
 		switch k {
 		case serviceNameKey:
 			mID.service = v.Str()
@@ -235,8 +235,7 @@ func verifyMetricLabels(tb testing.TB, dp metricDataPoint, seenMetricIDs map[met
 			assert.Equal(tb, wantDimensions[k], v)
 			delete(wantDimensions, k)
 		}
-		return true
-	})
+	}
 	assert.Empty(tb, wantDimensions, "Did not see all expected dimensions in metric. Missing: ", wantDimensions)
 
 	// Service/kind should be a unique metric.

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
@@ -28,7 +28,7 @@ func NewCollectorInstanceInfo(
 	set component.TelemetrySettings,
 ) *CollectorInstanceInfo {
 	var info CollectorInstanceInfo
-	set.Resource.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range set.Resource.Attributes().All() {
 		switch k {
 		case semconv.AttributeServiceInstanceID:
 			if str := v.Str(); str != "" {
@@ -46,8 +46,7 @@ func NewCollectorInstanceInfo(
 				info.size++
 			}
 		}
-		return true
-	})
+	}
 	return &info
 }
 

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -285,7 +285,7 @@ func verifyMetricLabels(tb testing.TB, dp metricDataPoint, seenMetricIDs map[met
 		notInSpanAttrName0:     pcommon.NewValueStr("defaultNotInSpanAttrVal"),
 		regionResourceAttrName: pcommon.NewValueStr(sampleRegion),
 	}
-	dp.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range dp.Attributes().All() {
 		switch k {
 		case serviceNameKey:
 			mID.service = v.Str()
@@ -301,8 +301,7 @@ func verifyMetricLabels(tb testing.TB, dp metricDataPoint, seenMetricIDs map[met
 			assert.Equal(tb, wantDimensions[k], v)
 			delete(wantDimensions, k)
 		}
-		return true
-	})
+	}
 	assert.Empty(tb, wantDimensions, "Did not see all expected dimensions in metric. Missing: ", wantDimensions)
 
 	// Service/name/kind should be a unique metric.

--- a/exporter/alertmanagerexporter/alertmanager_exporter.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter.go
@@ -96,10 +96,9 @@ func (s *alertmanagerExporter) extractEvents(td ptrace.Traces) []*alertmanagerEv
 
 func createAnnotations(event *alertmanagerEvent) model.LabelSet {
 	labelMap := make(model.LabelSet, event.spanEvent.Attributes().Len()+2)
-	event.spanEvent.Attributes().Range(func(key string, attr pcommon.Value) bool {
+	for key, attr := range event.spanEvent.Attributes().All() {
 		labelMap[model.LabelName(key)] = model.LabelValue(attr.AsString())
-		return true
-	})
+	}
 	labelMap["TraceID"] = model.LabelValue(event.traceID)
 	labelMap["SpanID"] = model.LabelValue(event.spanID)
 	return labelMap

--- a/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice.go
@@ -84,13 +84,12 @@ func resourceToLogContents(resource pcommon.Resource) []*sls.LogContent {
 	}
 
 	fields := map[string]any{}
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		if k == conventions.AttributeServiceName || k == conventions.AttributeHostName {
-			return true
+			continue
 		}
 		fields[k] = v.AsString()
-		return true
-	})
+	}
 	attributeBuffer, _ := json.Marshal(fields)
 	logContents[2] = &sls.LogContent{
 		Key:   proto.String(slsLogResource),
@@ -146,10 +145,9 @@ func mapLogRecordToLogService(lr plog.LogRecord,
 	})
 
 	fields := map[string]any{}
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		fields[k] = v.AsString()
-		return true
-	})
+	}
 	attributeBuffer, _ := json.Marshal(fields)
 	contentsBuffer = append(contentsBuffer, sls.LogContent{
 		Key:   proto.String(slsLogAttribute),

--- a/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
@@ -141,10 +141,9 @@ func newMetricLogFromRaw(
 
 func resourceToMetricLabels(labels *KeyValues, resource pcommon.Resource) {
 	attrs := resource.Attributes()
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		labels.Append(k, v.AsString())
-		return true
-	})
+	}
 }
 
 func numberMetricsToLogs(name string, data pmetric.NumberDataPointSlice, defaultLabels KeyValues) (logs []*sls.Log) {
@@ -152,10 +151,9 @@ func numberMetricsToLogs(name string, data pmetric.NumberDataPointSlice, default
 		dataPoint := data.At(i)
 		attributeMap := dataPoint.Attributes()
 		labels := defaultLabels.Clone()
-		attributeMap.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range attributeMap.All() {
 			labels.Append(k, v.AsString())
-			return true
-		})
+		}
 		switch dataPoint.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:
 			logs = append(logs,
@@ -183,10 +181,9 @@ func doubleHistogramMetricsToLogs(name string, data pmetric.HistogramDataPointSl
 		dataPoint := data.At(i)
 		attributeMap := dataPoint.Attributes()
 		labels := defaultLabels.Clone()
-		attributeMap.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range attributeMap.All() {
 			labels.Append(k, v.AsString())
-			return true
-		})
+		}
 		logs = append(logs, newMetricLogFromRaw(name+"_sum",
 			labels,
 			int64(dataPoint.Timestamp()),
@@ -230,10 +227,9 @@ func doubleSummaryMetricsToLogs(name string, data pmetric.SummaryDataPointSlice,
 		dataPoint := data.At(i)
 		attributeMap := dataPoint.Attributes()
 		labels := defaultLabels.Clone()
-		attributeMap.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range attributeMap.All() {
 			labels.Append(k, v.AsString())
-			return true
-		})
+		}
 		logs = append(logs, newMetricLogFromRaw(name+"_sum",
 			labels,
 			int64(dataPoint.Timestamp()),

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -253,9 +253,8 @@ func attrsValue(attrs pcommon.Map) map[string]any {
 		return nil
 	}
 	out := make(map[string]any, attrs.Len())
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		out[k] = v.AsRaw()
-		return true
-	})
+	}
 	return out
 }

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -509,10 +509,9 @@ func (dps summaryDataPointSlice) IsStaleNaNInf(i int) (bool, pcommon.Map) {
 // and optionally adds in the OTel instrumentation library name
 func createLabels(attributes pcommon.Map, instrLibName string) map[string]string {
 	labels := make(map[string]string, attributes.Len()+1)
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		labels[k] = v.AsString()
-		return true
-	})
+	}
 
 	// Add OTel instrumentation lib name as an additional label if it is defined
 	if instrLibName != "" {

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
@@ -103,10 +102,9 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pmetric.Metrics) e
 		rm := rms.At(i)
 		am := rm.Resource().Attributes()
 		if am.Len() > 0 {
-			am.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range am.All() {
 				labels[k] = v.Str()
-				return true
-			})
+			}
 		}
 	}
 	emf.config.logger.Debug("Start processing resource metrics", zap.Any("labels", labels))

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -165,9 +165,8 @@ func unixNanoToMilliseconds(timestamp pcommon.Timestamp) int64 {
 func attrMaptoStringMap(attrMap pcommon.Map) map[string]string {
 	strMap := make(map[string]string, attrMap.Len())
 
-	attrMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrMap.All() {
 		strMap[k] = v.AsString()
-		return true
-	})
+	}
 	return strMap
 }

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -57,7 +57,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	)
 
 	filtered := make(map[string]pcommon.Value)
-	resource.Attributes().Range(func(key string, value pcommon.Value) bool {
+	for key, value := range resource.Attributes().All() {
 		switch key {
 		case conventionsv112.AttributeCloudProvider:
 			cloud = value.Str()
@@ -112,8 +112,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		case conventionsv112.AttributeAWSLogGroupARNs:
 			logGroupArns = normalizeToSlice(value)
 		}
-		return true
-	})
+	}
 
 	if awsOperation, ok := attributes[awsxray.AWSOperationAttribute]; ok {
 		operation = awsOperation.Str()

--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -34,7 +34,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 	hasHTTPRequestURLAttributes := false
 	hasNetPeerAddr := false
 
-	span.Attributes().Range(func(key string, value pcommon.Value) bool {
+	for key, value := range span.Attributes().All() {
 		switch key {
 		case conventionsv112.AttributeHTTPMethod, conventions.AttributeHTTPRequestMethod:
 			info.Request.Method = awsxray.String(value.Str())
@@ -121,8 +121,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 		default:
 			filtered[key] = value
 		}
-		return true
-	})
+	}
 
 	if !hasNetPeerAddr && info.Request.ClientIP != nil {
 		info.Request.XForwardedFor = aws.Bool(true)

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -642,7 +642,7 @@ func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Re
 	}
 
 	if storeResource {
-		resource.Attributes().Range(func(key string, value pcommon.Value) bool {
+		for key, value := range resource.Attributes().All() {
 			key = "otel.resource." + key
 			annoVal := annotationValue(value)
 			indexed := indexAllAttrs || indexedKeys[key]
@@ -655,8 +655,7 @@ func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Re
 					defaultMetadata[key] = metaVal
 				}
 			}
-			return true
-		})
+		}
 	}
 
 	if indexAllAttrs {

--- a/exporter/awsxrayexporter/internal/translator/span_links.go
+++ b/exporter/awsxrayexporter/internal/translator/span_links.go
@@ -4,7 +4,6 @@
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter/internal/translator"
 
 import (
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
@@ -29,10 +28,9 @@ func makeSpanLinks(links ptrace.SpanLinkSlice, skipTimestampValidation bool) ([]
 		if link.Attributes().Len() > 0 {
 			spanLinkData.Attributes = make(map[string]any)
 
-			link.Attributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range link.Attributes().All() {
 				spanLinkData.Attributes[k] = v.AsRaw()
-				return true
-			})
+			}
 		}
 
 		spanLinkDataArray = append(spanLinkDataArray, spanLinkData)

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -17,10 +17,9 @@ const (
 // Applies resource attributes values to data properties
 func applyResourcesToDataProperties(dataProperties map[string]string, resourceAttributes pcommon.Map) {
 	// Copy all the resource labels into the base data properties. Resource values are always strings
-	resourceAttributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range resourceAttributes.All() {
 		dataProperties[k] = v.Str()
-		return true
-	})
+	}
 }
 
 // Sets important ai.cloud.* tags on the envelope
@@ -63,8 +62,7 @@ func applyInstrumentationScopeValueToDataProperties(dataProperties map[string]st
 
 // Applies attributes as Application Insights properties
 func setAttributesAsProperties(attributeMap pcommon.Map, properties map[string]string) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributeMap.All() {
 		properties[k] = v.AsString()
-		return true
-	})
+	}
 }

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -553,13 +553,12 @@ func copyAndMapAttributes(
 	properties map[string]string,
 	mappingFunc func(k string, v pcommon.Value),
 ) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributeMap.All() {
 		setAttributeValueAsProperty(k, v, properties)
 		if mappingFunc != nil {
 			mappingFunc(k, v)
 		}
-		return true
-	})
+	}
 }
 
 // Copies all attributes to either properties or measurements without any kind of mapping to a known set of attributes

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -722,7 +722,7 @@ func assertAttributesCopiedToProperties(
 	attributeMap pcommon.Map,
 	properties map[string]string,
 ) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributeMap.All() {
 		p, exists := properties[k]
 		assert.True(t, exists)
 
@@ -736,8 +736,7 @@ func assertAttributesCopiedToProperties(
 		case pcommon.ValueTypeDouble:
 			assert.Equal(t, strconv.FormatFloat(v.Double(), 'f', -1, 64), p)
 		}
-		return true
-	})
+	}
 }
 
 /*

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -253,10 +253,9 @@ func newSample(dp pmetric.NumberDataPoint) BMCHelixOMSample {
 func extractResourceAttributes(resource pcommon.Resource) map[string]string {
 	attributes := make(map[string]string)
 
-	resource.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range resource.Attributes().All() {
 		attributes[k] = v.AsString()
-		return true
-	})
+	}
 
 	return attributes
 }

--- a/exporter/carbonexporter/metricdata_to_plaintext.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext.go
@@ -259,7 +259,7 @@ func buildPath(name string, attributes pcommon.Map) string {
 	defer writerPool.Put(buf)
 
 	buf.WriteString(name)
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		value := v.AsString()
 		if value == "" {
 			value = tagValueEmptyPlaceholder
@@ -268,8 +268,7 @@ func buildPath(name string, attributes pcommon.Map) string {
 		buf.WriteString(sanitizeTagKey(k))
 		buf.WriteString(tagKeyValueSeparator)
 		buf.WriteString(value)
-		return true
-	})
+	}
 
 	return buf.String()
 }

--- a/exporter/clickhouseexporter/internal/metrics_model.go
+++ b/exporter/clickhouseexporter/internal/metrics_model.go
@@ -170,9 +170,9 @@ func getValue(intValue int64, floatValue float64, dataType any) float64 {
 
 func AttributesToMap(attributes pcommon.Map) column.IterableOrderedMap {
 	return orderedmap.CollectN(func(yield func(string, string) bool) {
-		attributes.Range(func(k string, v pcommon.Value) bool {
-			return yield(k, v.AsString())
-		})
+		for k, v := range attributes.All() {
+			yield(k, v.AsString())
+		}
 	}, attributes.Len())
 }
 

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -562,10 +562,9 @@ func arrFromAttributes(aa pcommon.Slice) []Value {
 }
 
 func appendAttributeFields(fields []field, path string, am pcommon.Map) []field {
-	am.Range(func(k string, val pcommon.Value) bool {
+	for k, val := range am.All() {
 		fields = appendAttributeValue(fields, path, k, val)
-		return true
-	})
+	}
 	return fields
 }
 

--- a/exporter/elasticsearchexporter/internal/serializer/map.go
+++ b/exporter/elasticsearchexporter/internal/serializer/map.go
@@ -22,11 +22,10 @@ func Map(m pcommon.Map, buf *bytes.Buffer) {
 
 func writeMap(v *json.Visitor, m pcommon.Map, stringifyMapValues bool) {
 	_ = v.OnObjectStart(-1, structform.AnyType)
-	m.Range(func(k string, val pcommon.Value) bool {
+	for k, val := range m.All() {
 		_ = v.OnKey(k)
 		WriteValue(v, val, stringifyMapValues)
-		return true
-	})
+	}
 	_ = v.OnObjectFinished()
 }
 

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
@@ -423,8 +423,7 @@ func newHostMetadata(resource pcommon.Resource, scope pcommon.InstrumentationSco
 }
 
 func addEventHostData(data map[string]string, attrs pcommon.Map) {
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		data[k] = v.AsString()
-		return true
-	})
+	}
 }

--- a/exporter/elasticsearchexporter/metric_grouping.go
+++ b/exporter/elasticsearchexporter/metric_grouping.go
@@ -77,28 +77,24 @@ func (h otelDataPointHasher) hashDataPoint(resource pcommon.Resource, scope pcom
 // mapHashExcludeReservedAttrs is mapHash but ignoring some reserved attributes.
 // e.g. index is already considered during routing and DS attributes do not need to be considered in hashing
 func mapHashExcludeReservedAttrs(hasher hash.Hash, m pcommon.Map, extra ...string) {
-	m.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range m.All() {
 		switch k {
 		case elasticsearch.DataStreamType, elasticsearch.DataStreamDataset, elasticsearch.DataStreamNamespace:
-			return true
+			continue
 		}
 		if slices.Contains(extra, k) {
-			return true
+			continue
 		}
 		hasher.Write([]byte(k))
 		valueHash(hasher, v)
-
-		return true
-	})
+	}
 }
 
 func mapHash(hasher hash.Hash, m pcommon.Map) {
-	m.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range m.All() {
 		hasher.Write([]byte(k))
 		valueHash(hasher, v)
-
-		return true
-	})
+	}
 }
 
 func valueHash(h hash.Hash, v pcommon.Value) {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -459,25 +459,24 @@ func encodeAttributesECSMode(document *objmodel.Document, attrs pcommon.Map, con
 		return
 	}
 
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		// If ECS key is found for current k in conversion map, use it.
 		if ecsKey, exists := conversionMap[k]; exists {
 			if ecsKey == "" {
 				// Skip the conversion for this k.
-				return true
+				continue
 			}
 
 			document.AddAttribute(ecsKey, v)
 			if preserve := preserveMap[k]; preserve {
 				document.AddAttribute(k, v)
 			}
-			return true
+			continue
 		}
 
 		// Otherwise, add key at top level with attribute name as-is.
 		document.AddAttribute(k, v)
-		return true
-	})
+	}
 }
 
 func encodeLogAgentNameECSMode(document *objmodel.Document, resource pcommon.Resource) {

--- a/exporter/googlecloudexporter/internal/resourcemapping/custommapping.go
+++ b/exporter/googlecloudexporter/internal/resourcemapping/custommapping.go
@@ -24,26 +24,24 @@ var (
 func CustomMonitoredResourceMapping(r pcommon.Resource) *monitoredrespb.MonitoredResource {
 	var monitoredResourceType string
 	monitoredResourceLabels := make(map[string]string)
-	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range r.Attributes().All() {
 		if k == mappingKey {
 			monitoredResourceType = v.AsString()
-			return false
+			break
 		}
-		return true
-	})
+	}
 
 	if monitoredResourceType == "" {
 		return collector.DefaultConfig().MetricConfig.MapMonitoredResource(r)
 	}
 
 	prefix := monitoredResourceLabelPrefix + monitoredResourceType + "."
-	r.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range r.Attributes().All() {
 		// Extract the monitored resource label by separating it from the prefix.
 		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
 			monitoredResourceLabels[k[len(prefix):]] = v.AsString()
 		}
-		return true
-	})
+	}
 
 	return &monitoredrespb.MonitoredResource{
 		Type:   monitoredResourceType,

--- a/exporter/kineticaexporter/common.go
+++ b/exporter/kineticaexporter/common.go
@@ -633,7 +633,7 @@ func attributeValueToKineticaFieldValue(value pcommon.Value) (ValueTypePair, err
 //	@return map
 func otlpKeyValueListToMap(kvList pcommon.Map) map[string]any {
 	m := make(map[string]any, kvList.Len())
-	kvList.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range kvList.All() {
 		switch v.Type() {
 		case pcommon.ValueTypeStr:
 			m[k] = v.Str()
@@ -652,8 +652,7 @@ func otlpKeyValueListToMap(kvList pcommon.Map) map[string]any {
 		default:
 			m[k] = fmt.Sprintf("<invalid map value> %v", v)
 		}
-		return true
-	})
+	}
 	return m
 }
 

--- a/exporter/kineticaexporter/metrics_exporter.go
+++ b/exporter/kineticaexporter/metrics_exporter.go
@@ -419,7 +419,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 		kiSummaryRecord.summaryDatapoint = append(kiSummaryRecord.summaryDatapoint, *summaryDatapoint)
 
 		// Handle summary datapoint attribute
-		datapoint.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range datapoint.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Sum record attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -428,8 +428,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 				e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range datapointAttributes {
 			vtPair := datapointAttributes[key]
@@ -465,7 +464,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 	var resourceAttribute []SummaryResourceAttribute
 	resourceAttributes := make(map[string]ValueTypePair)
 
-	resAttr.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range resAttr.All() {
 		if k == "" {
 			e.logger.Debug("Resource attribute key is empty")
 		} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -474,8 +473,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 			e.logger.Debug("Invalid resource attribute value", zap.String("Error", err.Error()))
 			errs = append(errs, err)
 		}
-		return true
-	})
+	}
 
 	for key := range resourceAttributes {
 		vtPair := resourceAttributes[key]
@@ -495,7 +493,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 	scopeName := scopeInstr.Name()
 	scopeVersion := scopeInstr.Version()
 
-	scopeInstr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range scopeInstr.Attributes().All() {
 		if k == "" {
 			e.logger.Debug("Scope attribute key is empty")
 		} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -504,8 +502,7 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 			e.logger.Debug("Invalid scope attribute value", zap.String("Error", err.Error()))
 			errs = append(errs, err)
 		}
-		return true
-	})
+	}
 
 	for key := range scopeAttributes {
 		vtPair := scopeAttributes[key]
@@ -581,7 +578,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 		kiExpHistogramRecord.histogramDatapoint = append(kiExpHistogramRecord.histogramDatapoint, expHistogramDatapoint)
 
 		// Handle histogram datapoint attribute
-		datapoint.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range datapoint.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Sum record attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -590,8 +587,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 				e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range datapointAttributes {
 			vtPair := datapointAttributes[key]
@@ -625,7 +621,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 			kiExpHistogramRecord.exemplars = append(kiExpHistogramRecord.exemplars, sumDatapointExemplar)
 
 			// Handle Exemplar attribute
-			exemplar.FilteredAttributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range exemplar.FilteredAttributes().All() {
 				if k == "" {
 					e.logger.Debug("Sum record attribute key is empty")
 				} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -634,8 +630,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 					e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 					errs = append(errs, err)
 				}
-				return true
-			})
+			}
 
 			for key := range exemplarAttributes {
 				vtPair := exemplarAttributes[key]
@@ -682,7 +677,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 	var resourceAttribute []ExponentialHistogramResourceAttribute
 	resourceAttributes := make(map[string]ValueTypePair)
 
-	resAttr.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range resAttr.All() {
 		if k == "" {
 			e.logger.Debug("Resource attribute key is empty")
 		} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -691,8 +686,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 			e.logger.Debug("Invalid resource attribute value", zap.String("Error", err.Error()))
 			errs = append(errs, err)
 		}
-		return true
-	})
+	}
 
 	for key := range resourceAttributes {
 		vtPair := resourceAttributes[key]
@@ -712,7 +706,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 	scopeName := scopeInstr.Name()
 	scopeVersion := scopeInstr.Version()
 
-	scopeInstr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range scopeInstr.Attributes().All() {
 		if k == "" {
 			e.logger.Debug("Scope attribute key is empty")
 		} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -721,8 +715,7 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 			e.logger.Debug("Invalid scope attribute value", zap.String("Error", err.Error()))
 			errs = append(errs, err)
 		}
-		return true
-	})
+	}
 
 	for key := range scopeAttributes {
 		vtPair := scopeAttributes[key]
@@ -794,7 +787,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 		kiHistogramRecord.histogramDatapoint = append(kiHistogramRecord.histogramDatapoint, *histogramDatapoint)
 
 		// Handle histogram datapoint attribute
-		datapoint.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range datapoint.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Histogram record attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -803,8 +796,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 				e.logger.Debug("Invalid histogram record attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range datapointAttributes {
 			vtPair := datapointAttributes[key]
@@ -838,7 +830,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 			kiHistogramRecord.exemplars = append(kiHistogramRecord.exemplars, histogramDatapointExemplar)
 
 			// Handle Exemplar attribute
-			exemplar.FilteredAttributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range exemplar.FilteredAttributes().All() {
 				if k == "" {
 					e.logger.Debug("Histogram record attribute key is empty")
 				} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -847,8 +839,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 					e.logger.Debug("Invalid histogram record attribute value", zap.String("Error", err.Error()))
 					errs = append(errs, err)
 				}
-				return true
-			})
+			}
 
 			for key := range exemplarAttributes {
 				vtPair := exemplarAttributes[key]
@@ -895,7 +886,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 	resourceAttributes := make(map[string]ValueTypePair)
 
 	if resAttr.Len() > 0 {
-		resAttr.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range resAttr.All() {
 			if k == "" {
 				e.logger.Debug("Resource attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -904,8 +895,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 				e.logger.Debug("Invalid resource attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range resourceAttributes {
 			vtPair := resourceAttributes[key]
@@ -928,7 +918,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 	scopeVersion := scopeInstr.Version()
 
 	if scopeInstr.Attributes().Len() > 0 {
-		scopeInstr.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range scopeInstr.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Scope attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -937,8 +927,7 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 				e.logger.Debug("Invalid scope attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range scopeAttributes {
 			vtPair := scopeAttributes[key]
@@ -1011,7 +1000,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 		kiSumRecord.datapoint = append(kiSumRecord.datapoint, sumDatapoint)
 
 		// Handle Sum attribute
-		datapoint.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range datapoint.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Sum record attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1020,8 +1009,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 				e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range sumDatapointAttributes {
 			vtPair := sumDatapointAttributes[key]
@@ -1055,7 +1043,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 			kiSumRecord.exemplars = append(kiSumRecord.exemplars, sumDatapointExemplar)
 
 			// Handle Exemplar attribute
-			exemplar.FilteredAttributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range exemplar.FilteredAttributes().All() {
 				if k == "" {
 					e.logger.Debug("Sum record attribute key is empty")
 				} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1064,8 +1052,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 					e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 					errs = append(errs, err)
 				}
-				return true
-			})
+			}
 
 			for key := range exemplarAttributes {
 				vtPair := exemplarAttributes[key]
@@ -1090,7 +1077,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 	resourceAttributes := make(map[string]ValueTypePair)
 
 	if resAttr.Len() > 0 {
-		resAttr.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range resAttr.All() {
 			if k == "" {
 				e.logger.Debug("Resource attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1099,8 +1086,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 				e.logger.Debug("Invalid resource attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range resourceAttributes {
 			vtPair := resourceAttributes[key]
@@ -1123,7 +1109,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 	scopeVersion := scopeInstr.Version()
 
 	if scopeInstr.Attributes().Len() > 0 {
-		scopeInstr.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range scopeInstr.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Scope attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1132,8 +1118,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 				e.logger.Debug("Invalid scope attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range scopeAttributes {
 			vtPair := scopeAttributes[key]
@@ -1207,7 +1192,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 		}
 		kiGaugeRecord.datapoint = append(kiGaugeRecord.datapoint, gaugeDatapoint)
 
-		datapoint.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range datapoint.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Gauge record attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1216,8 +1201,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 				e.logger.Debug("Invalid gauge record attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		for key := range gaugeDatapointAttributes {
 			vtPair := gaugeDatapointAttributes[key]
@@ -1251,7 +1235,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 			kiGaugeRecord.exemplars = append(kiGaugeRecord.exemplars, gaugeDatapointExemplar)
 
 			// Handle Exemplar attribute
-			exemplar.FilteredAttributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range exemplar.FilteredAttributes().All() {
 				if k == "" {
 					e.logger.Debug("Sum record attribute key is empty")
 				} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1260,8 +1244,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 					e.logger.Debug("Invalid sum record attribute value", zap.String("Error", err.Error()))
 					errs = append(errs, err)
 				}
-				return true
-			})
+			}
 
 			for key := range exemplarAttributes {
 				vtPair := exemplarAttributes[key]
@@ -1288,7 +1271,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 	resourceAttributes := make(map[string]ValueTypePair)
 
 	if resAttr.Len() > 0 {
-		resAttr.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range resAttr.All() {
 			if k == "" {
 				e.logger.Debug("Resource attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1297,8 +1280,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 				e.logger.Debug("Invalid resource attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		e.logger.Debug("Resource Attributes to be added ->", zap.Any("Attributes", resourceAttributes))
 		for key := range resourceAttributes {
@@ -1328,7 +1310,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 	scopeVersion := scopeInstr.Version()
 
 	if scopeInstr.Attributes().Len() > 0 {
-		scopeInstr.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range scopeInstr.Attributes().All() {
 			if k == "" {
 				e.logger.Debug("Scope attribute key is empty")
 			} else if v, err := attributeValueToKineticaFieldValue(v); err == nil {
@@ -1337,8 +1319,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 				e.logger.Debug("Invalid scope attribute value", zap.String("Error", err.Error()))
 				errs = append(errs, err)
 			}
-			return true
-		})
+		}
 
 		e.logger.Debug("Scope Attributes to be added ->", zap.Any("Attributes", scopeAttributes))
 		for key := range scopeAttributes {

--- a/exporter/logicmonitorexporter/logs_exporter.go
+++ b/exporter/logicmonitorexporter/logs_exporter.go
@@ -76,18 +76,16 @@ func (e *logExporter) PushLogData(ctx context.Context, lg plog.Logs) error {
 				resourceMapperMap := make(map[string]any)
 				log := logs.At(k)
 
-				log.Attributes().Range(func(key string, value pcommon.Value) bool {
+				for key, value := range log.Attributes().All() {
 					logMetadataMap[key] = value.AsRaw()
-					return true
-				})
+				}
 
-				resourceLog.Resource().Attributes().Range(func(key string, value pcommon.Value) bool {
+				for key, value := range resourceLog.Resource().Attributes().All() {
 					if key == hostname {
 						resourceMapperMap[hostnameProperty] = value.AsRaw()
 					}
 					resourceMapperMap[key] = value.AsRaw()
-					return true
-				})
+				}
 
 				e.settings.Logger.Debug("Sending log data", zap.String("body", log.Body().Str()), zap.Any("resourcemap", resourceMapperMap), zap.Any("metadatamap", logMetadataMap))
 				payload = append(payload, translator.ConvertToLMLogInput(log.Body().AsRaw(), timestampFromLogRecord(log).String(), resourceMapperMap, logMetadataMap))

--- a/exporter/logzioexporter/jsonlog.go
+++ b/exporter/logzioexporter/jsonlog.go
@@ -28,10 +28,9 @@ func convertLogRecordToJSON(log plog.LogRecord, attributes pcommon.Map) map[stri
 	}
 
 	// Add merged attributed to each json log
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		jsonLog[k] = v.AsRaw()
-		return true
-	})
+	}
 
 	switch log.Body().Type() {
 	case pcommon.ValueTypeStr:

--- a/exporter/mezmoexporter/exporter.go
+++ b/exporter/mezmoexporter/exporter.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
 )
@@ -105,10 +104,9 @@ func (m *mezmoExporter) logDataToMezmo(ld plog.Logs) error {
 					attrs["span.id"] = hex.EncodeToString(spanID[:])
 				}
 
-				log.Attributes().Range(func(k string, v pcommon.Value) bool {
+				for k, v := range log.Attributes().All() {
 					attrs[k] = truncateString(v.Str(), maxMetaDataSize)
-					return true
-				})
+				}
 
 				s, _ := log.Attributes().Get("appname")
 				app := s.Str()

--- a/exporter/opensearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/opensearchexporter/internal/objmodel/objmodel.go
@@ -493,10 +493,9 @@ func arrFromAttributes(aa pcommon.Slice) []Value {
 }
 
 func appendAttributeFields(fields []field, path string, am pcommon.Map) []field {
-	am.Range(func(k string, val pcommon.Value) bool {
+	for k, val := range am.All() {
 		fields = appendAttributeValue(fields, path, k, val)
-		return true
-	})
+	}
 	return fields
 }
 

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -120,10 +120,9 @@ func responseAsError(item opensearchutil.BulkIndexerResponseItem) error {
 
 func attributesToMapString(attributes pcommon.Map) map[string]string {
 	m := make(map[string]string, attributes.Len())
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		m[k] = v.AsString()
-		return true
-	})
+	}
 	return m
 }
 

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -320,10 +320,9 @@ func timeseriesSignature(ilmName string, metric pmetric.Metric, attributes pcomm
 	b.WriteString("*" + ilmName)
 	b.WriteString("*" + metric.Name())
 	attrs := make([]string, 0, attributes.Len())
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		attrs = append(attrs, k+"*"+v.AsString())
-		return true
-	})
+	}
 	sort.Strings(attrs)
 	b.WriteString("*" + strings.Join(attrs, "*"))
 	if job, ok := extractJob(resourceAttrs); ok {

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -249,11 +249,10 @@ func TestAccumulateMetrics(t *testing.T) {
 
 			require.Equal(t, "test", v.scope.Name())
 			require.Equal(t, v.value.Type(), ilm2.Metrics().At(0).Type())
-			vLabels.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range vLabels.All() {
 				r, _ := m2Labels.Get(k)
 				require.Equal(t, r, v)
-				return true
-			})
+			}
 			require.Equal(t, m2Labels.Len(), vLabels.Len())
 			require.Equal(t, m2Value, vValue)
 			require.Equal(t, ts2.Unix(), vTS.Unix())
@@ -362,11 +361,10 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 			require.Equal(t, v.value.Type(), ilm.Metrics().At(0).Type())
 			require.Equal(t, v.value.Type(), ilm.Metrics().At(1).Type())
 
-			vLabels.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range vLabels.All() {
 				r, _ := mLabels.Get(k)
 				require.Equal(t, r, v)
-				return true
-			})
+			}
 			require.Equal(t, mLabels.Len(), vLabels.Len())
 			require.Equal(t, mValue, vValue)
 			require.Equal(t, dataPointValue1+dataPointValue2, vValue)

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -124,11 +124,10 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 	keys := make([]string, 0, attributes.Len()+2) // +2 for job and instance labels.
 	values := make([]string, 0, attributes.Len()+2)
 
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		keys = append(keys, prometheustranslator.NormalizeLabel(k))
 		values = append(values, v.AsString())
-		return true
-	})
+	}
 
 	if job, ok := extractJob(resourceAttrs); ok {
 		keys = append(keys, model.JobLabel)
@@ -348,16 +347,14 @@ func (c *collector) createTargetInfoMetrics(resourceAttrs []pcommon.Map) ([]prom
 			}
 		})
 
-		attributes.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range attributes.All() {
 			finalKey := prometheustranslator.NormalizeLabel(k)
 			if existingVal, ok := labels[finalKey]; ok {
 				labels[finalKey] = existingVal + ";" + v.AsString()
 			} else {
 				labels[finalKey] = v.AsString()
 			}
-
-			return true
-		})
+		}
 
 		// Map service.name + service.namespace to job
 		if job, ok := extractJob(rAttributes); ok {

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -359,10 +359,9 @@ func getSummaryMetric(name string, attributes pcommon.Map, ts uint64, sum float6
 	}
 	dp.SetCount(count)
 	dp.SetSum(sum)
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		v.CopyTo(dp.Attributes().PutEmpty(k))
-		return true
-	})
+	}
 
 	dp.SetTimestamp(pcommon.Timestamp(ts))
 

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -167,15 +167,14 @@ func convertEventsToSentryExceptions(eventList *[]*sentry.Event, events ptrace.S
 			continue
 		}
 		var exceptionMessage, exceptionType string
-		event.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range event.Attributes().All() {
 			switch k {
 			case conventions.AttributeExceptionMessage:
 				exceptionMessage = v.Str()
 			case conventions.AttributeExceptionType:
 				exceptionType = v.Str()
 			}
-			return true
-		})
+		}
 		if exceptionMessage == "" && exceptionType == "" {
 			// `At least one of the following sets of attributes is required:
 			// - exception.type
@@ -373,7 +372,7 @@ func generateTagsFromResource(resource pcommon.Resource) map[string]string {
 func generateTagsFromAttributes(attrs pcommon.Map) map[string]string {
 	tags := make(map[string]string)
 
-	attrs.Range(func(key string, attr pcommon.Value) bool {
+	for key, attr := range attrs.All() {
 		switch attr.Type() {
 		case pcommon.ValueTypeStr:
 			tags[key] = attr.Str()
@@ -388,8 +387,7 @@ func generateTagsFromAttributes(attrs pcommon.Map) map[string]string {
 		case pcommon.ValueTypeSlice:
 		case pcommon.ValueTypeBytes:
 		}
-		return true
-	})
+	}
 
 	return tags
 }

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -144,18 +144,17 @@ func resourceToDimensions(res pcommon.Resource) []*sfxpb.Dimension {
 		})
 	}
 
-	res.Attributes().Range(func(k string, val pcommon.Value) bool {
+	for k, val := range res.Attributes().All() {
 		// Never send the SignalFX token
 		if k == splunk.SFxAccessTokenLabel {
-			return true
+			continue
 		}
 
 		dims = append(dims, &sfxpb.Dimension{
 			Key:   k,
 			Value: val.AsString(),
 		})
-		return true
-	})
+	}
 
 	return dims
 }

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -85,7 +85,7 @@ func mapLogRecordToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, config *
 		fields[severityNumberKey] = lr.SeverityNumber()
 	}
 
-	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range res.Attributes().All() {
 		switch k {
 		case hostKey:
 			host = v.Str()
@@ -100,9 +100,8 @@ func mapLogRecordToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, config *
 		default:
 			mergeValue(fields, k, v.AsRaw())
 		}
-		return true
-	})
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	}
+	for k, v := range lr.Attributes().All() {
 		switch k {
 		case hostKey:
 			host = v.Str()
@@ -117,8 +116,7 @@ func mapLogRecordToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, config *
 		default:
 			mergeValue(fields, k, v.AsRaw())
 		}
-		return true
-	})
+	}
 
 	return &splunk.Event{
 		Time:       nanoTimestampToEpochMilliseconds(lr.Timestamp()),

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -62,7 +62,7 @@ func mapMetricToSplunkEvent(res pcommon.Resource, m pmetric.Metric, config *Conf
 	index := config.Index
 	commonFields := map[string]any{}
 
-	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range res.Attributes().All() {
 		switch k {
 		case hostKey:
 			host = v.Str()
@@ -77,8 +77,7 @@ func mapMetricToSplunkEvent(res pcommon.Resource, m pmetric.Metric, config *Conf
 		default:
 			commonFields[k] = v.AsString()
 		}
-		return true
-	})
+	}
 	metricFieldName := splunkMetricValue + ":" + m.Name()
 	//exhaustive:enforce
 	switch m.Type() {
@@ -247,10 +246,9 @@ func copyEventWithoutValues(event *splunk.Event) *splunk.Event {
 }
 
 func populateAttributes(fields map[string]any, attributeMap pcommon.Map) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributeMap.All() {
 		fields[k] = v.AsString()
-		return true
-	})
+	}
 }
 
 func cloneMap(fields map[string]any) map[string]any {

--- a/exporter/splunkhecexporter/tracedata_to_splunk.go
+++ b/exporter/splunkhecexporter/tracedata_to_splunk.go
@@ -58,7 +58,7 @@ func mapSpanToSplunkEvent(resource pcommon.Resource, span ptrace.Span, config *C
 	sourceType := config.SourceType
 	index := config.Index
 	commonFields := map[string]any{}
-	resource.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range resource.Attributes().All() {
 		switch k {
 		case hostKey:
 			host = v.Str()
@@ -73,8 +73,7 @@ func mapSpanToSplunkEvent(resource pcommon.Resource, span ptrace.Span, config *C
 		default:
 			commonFields[k] = v.AsString()
 		}
-		return true
-	})
+	}
 
 	se := &splunk.Event{
 		Time:       timestampToSecondsWithMillisecondPrecision(span.StartTimestamp()),

--- a/exporter/sumologicexporter/fields.go
+++ b/exporter/sumologicexporter/fields.go
@@ -35,19 +35,19 @@ func (f fields) string() string {
 
 	returnValue := make([]string, 0, f.orig.Len())
 
-	f.orig.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range f.orig.All() {
 		// Don't add source related attributes to fields as they are handled separately
 		// and are added to the payload either as special HTTP headers or as resources
 		// attributes.
 		if k == attributeKeySourceCategory || k == attributeKeySourceHost || k == attributeKeySourceName {
-			return true
+			continue
 		}
 
 		sv := v.AsString()
 
 		// Skip empty field
 		if len(sv) == 0 {
-			return true
+			continue
 		}
 
 		key := []byte(k)
@@ -64,8 +64,7 @@ func (f fields) string() string {
 			returnValue,
 			sb.String(),
 		)
-		return true
-	})
+	}
 	slices.Sort(returnValue)
 
 	return strings.Join(returnValue, ", ")

--- a/exporter/sumologicexporter/prometheus_formatter.go
+++ b/exporter/sumologicexporter/prometheus_formatter.go
@@ -53,14 +53,13 @@ func (f *prometheusFormatter) tags2String(attr pcommon.Map, labels pcommon.Map) 
 	mergedAttributes.EnsureCapacity(attrsPlusLabelsLen)
 
 	attr.CopyTo(mergedAttributes)
-	labels.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range labels.All() {
 		mergedAttributes.PutStr(k, v.AsString())
-		return true
-	})
+	}
 	length := mergedAttributes.Len()
 
 	returnValue := make([]string, 0, length)
-	mergedAttributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range mergedAttributes.All() {
 		key := f.sanitizeKeyBytes([]byte(k))
 		value := f.sanitizeValue(v.AsString())
 
@@ -68,8 +67,7 @@ func (f *prometheusFormatter) tags2String(attr pcommon.Map, labels pcommon.Map) 
 			returnValue,
 			formatKeyValuePair(key, value),
 		)
-		return true
-	})
+	}
 
 	return prometheusTags(stringsJoinAndSurround(returnValue, ",", "{", "}"))
 }
@@ -241,10 +239,9 @@ func (f *prometheusFormatter) mergeAttributes(attributes pcommon.Map, additional
 	mergedAttributes.EnsureCapacity(attributes.Len() + additionalAttributes.Len())
 
 	attributes.CopyTo(mergedAttributes)
-	additionalAttributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range additionalAttributes.All() {
 		v.CopyTo(mergedAttributes.PutEmpty(k))
-		return true
-	})
+	}
 	return mergedAttributes
 }
 

--- a/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice.go
+++ b/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice.go
@@ -73,13 +73,12 @@ func resourceToLogContents(resource pcommon.Resource) []*cls.Log_Content {
 	}
 
 	fields := map[string]any{}
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		if k == conventions.AttributeServiceName || k == conventions.AttributeHostName {
-			return true
+			continue
 		}
 		fields[k] = v.AsString()
-		return true
-	})
+	}
 	attributeBuffer, err := json.Marshal(fields)
 	if err != nil {
 		return nil
@@ -128,10 +127,9 @@ func mapLogRecordToLogService(lr plog.LogRecord,
 	clsLog.Contents = make([]*cls.Log_Content, 0, preAllocCount+len(resourceContents)+len(instrumentationLibraryContents))
 
 	fields := map[string]any{}
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		fields[k] = v.AsString()
-		return true
-	})
+	}
 	attributeBuffer, err := json.Marshal(fields)
 	if err != nil {
 		return nil

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -440,11 +440,10 @@ func getMatchingKeys(regexp *regexp.Regexp, attrs pcommon.Map) []string {
 		return keys
 	}
 
-	attrs.Range(func(k string, _ pcommon.Value) bool {
+	for k, _ := range attrs.All() {
 		if regexp.MatchString(k) {
 			keys = append(keys, k)
 		}
-		return true
-	})
+	}
 	return keys
 }

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -440,7 +440,7 @@ func getMatchingKeys(regexp *regexp.Regexp, attrs pcommon.Map) []string {
 		return keys
 	}
 
-	for k, _ := range attrs.All() {
+	for k := range attrs.All() {
 		if regexp.MatchString(k) {
 			keys = append(keys, k)
 		}

--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -331,9 +331,8 @@ func diffValues(
 
 func attrMapToString(m pcommon.Map) string {
 	out := ""
-	m.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range m.All() {
 		out += "[" + k + "=" + v.Str() + "]"
-		return true
-	})
+	}
 	return out
 }

--- a/pkg/golden/sort_metrics.go
+++ b/pkg/golden/sort_metrics.go
@@ -64,7 +64,7 @@ func sortMetrics(ms pmetric.Metrics) {
 func sortAttributeMap(mp pcommon.Map) {
 	tempMap := pcommon.NewMap()
 	keys := []string{}
-	for key, _ := range mp.All() {
+	for key := range mp.All() {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)

--- a/pkg/golden/sort_metrics.go
+++ b/pkg/golden/sort_metrics.go
@@ -64,10 +64,9 @@ func sortMetrics(ms pmetric.Metrics) {
 func sortAttributeMap(mp pcommon.Map) {
 	tempMap := pcommon.NewMap()
 	keys := []string{}
-	mp.Range(func(key string, _ pcommon.Value) bool {
+	for key, _ := range mp.All() {
 		keys = append(keys, key)
-		return true
-	})
+	}
 	sort.Strings(keys)
 	for _, k := range keys {
 		value, exists := mp.Get(k)
@@ -165,14 +164,12 @@ func compareMaps(a, b pcommon.Map) int {
 	}
 
 	var aKeys, bKeys []string
-	a.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range a.All() {
 		aKeys = append(aKeys, fmt.Sprintf("%s: %v", k, v.AsString()))
-		return true
-	})
-	b.Range(func(k string, v pcommon.Value) bool {
+	}
+	for k, v := range b.All() {
 		bKeys = append(bKeys, fmt.Sprintf("%s: %v", k, v.AsString()))
-		return true
-	})
+	}
 
 	for i := 0; i < len(aKeys); i++ {
 		if aKeys[i] != bKeys[i] {

--- a/pkg/golden/sort_metrics_test.go
+++ b/pkg/golden/sort_metrics_test.go
@@ -27,7 +27,7 @@ func TestSortAttributes(t *testing.T) {
 	// Verify the sorted keys
 	expectedKeys := []string{"age", "isStudent", "location", "name"}
 	actualKeys := []string{}
-	for key, _ := range mp.All() {
+	for key := range mp.All() {
 		actualKeys = append(actualKeys, key)
 	}
 

--- a/pkg/golden/sort_metrics_test.go
+++ b/pkg/golden/sort_metrics_test.go
@@ -27,10 +27,9 @@ func TestSortAttributes(t *testing.T) {
 	// Verify the sorted keys
 	expectedKeys := []string{"age", "isStudent", "location", "name"}
 	actualKeys := []string{}
-	mp.Range(func(key string, _ pcommon.Value) bool {
+	for key, _ := range mp.All() {
 		actualKeys = append(actualKeys, key)
-		return true
-	})
+	}
 
 	// Check if the keys are sorted correctly
 	if len(expectedKeys) != len(actualKeys) {

--- a/pkg/ottl/contexts/internal/logging/logging.go
+++ b/pkg/ottl/contexts/internal/logging/logging.go
@@ -45,7 +45,7 @@ type Map pcommon.Map
 func (m Map) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	mm := pcommon.Map(m)
 	var err error
-	mm.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range mm.All() {
 		switch v.Type() {
 		case pcommon.ValueTypeStr:
 			encoder.AddString(k, v.Str())
@@ -62,8 +62,7 @@ func (m Map) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 		case pcommon.ValueTypeBytes:
 			encoder.AddByteString(k, v.Bytes().AsRaw())
 		}
-		return true
-	})
+	}
 	return nil
 }
 

--- a/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
@@ -122,12 +122,11 @@ func Test_extractGrokPatterns_patterns(t *testing.T) {
 			expected := pcommon.NewMap()
 			tt.want(expected)
 
-			expected.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
@@ -122,7 +122,7 @@ func Test_extractGrokPatterns_patterns(t *testing.T) {
 			expected := pcommon.NewMap()
 			tt.want(expected)
 
-			for k, _ := range expected.All() {
+			for k := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)

--- a/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
@@ -57,7 +57,7 @@ func Test_extractPatterns(t *testing.T) {
 			tt.want(expected)
 
 			assert.Equal(t, expected.Len(), resultMap.Len())
-			for k, _ := range expected.All() {
+			for k := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)

--- a/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
@@ -57,12 +57,11 @@ func Test_extractPatterns(t *testing.T) {
 			tt.want(expected)
 
 			assert.Equal(t, expected.Len(), resultMap.Len())
-			expected.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_flatten.go
+++ b/pkg/ottl/ottlfuncs/func_flatten.go
@@ -88,9 +88,9 @@ func (f *flattenData) flattenMap(m pcommon.Map, prefix string, currentDepth int6
 	if len(prefix) > 0 {
 		prefix += "."
 	}
-	m.Range(func(k string, v pcommon.Value) bool {
-		return f.flattenValue(k, v, currentDepth, prefix)
-	})
+	for k, v := range m.All() {
+		f.flattenValue(k, v, currentDepth, prefix)
+	}
 }
 
 func (f *flattenData) flattenSlice(s pcommon.Slice, prefix string, currentDepth int64) {
@@ -99,7 +99,7 @@ func (f *flattenData) flattenSlice(s pcommon.Slice, prefix string, currentDepth 
 	}
 }
 
-func (f *flattenData) flattenValue(k string, v pcommon.Value, currentDepth int64, prefix string) bool {
+func (f *flattenData) flattenValue(k string, v pcommon.Value, currentDepth int64, prefix string) {
 	switch {
 	case v.Type() == pcommon.ValueTypeMap && currentDepth < f.maxDepth:
 		f.flattenMap(v.Map(), prefix+k, currentDepth+1)
@@ -127,7 +127,6 @@ func (f *flattenData) flattenValue(k string, v pcommon.Value, currentDepth int64
 			v.CopyTo(f.result.PutEmpty(key))
 		}
 	}
-	return true
 }
 
 func (f *flattenData) handleConflict(key string, v pcommon.Value) {

--- a/pkg/ottl/ottlfuncs/func_merge_maps.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
@@ -60,26 +58,23 @@ func mergeMaps[K any](target ottl.PMapGetter[K], source ottl.PMapGetter[K], stra
 		}
 		switch strategy {
 		case INSERT:
-			valueMap.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range valueMap.All() {
 				if _, ok := targetMap.Get(k); !ok {
 					tv := targetMap.PutEmpty(k)
 					v.CopyTo(tv)
 				}
-				return true
-			})
+			}
 		case UPDATE:
-			valueMap.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range valueMap.All() {
 				if tv, ok := targetMap.Get(k); ok {
 					v.CopyTo(tv)
 				}
-				return true
-			})
+			}
 		case UPSERT:
-			valueMap.Range(func(k string, v pcommon.Value) bool {
+			for k, v := range valueMap.All() {
 				tv := targetMap.PutEmpty(k)
 				v.CopyTo(tv)
-				return true
-			})
+			}
 		default:
 			return nil, fmt.Errorf("unknown strategy, %v", strategy)
 		}

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -172,12 +172,11 @@ func Test_ParseJSON(t *testing.T) {
 				expected := pcommon.NewMap()
 				tt.wantMap(expected)
 				assert.Equal(t, expected.Len(), resultMap.Len())
-				expected.Range(func(k string, _ pcommon.Value) bool {
+				for k, _ := range expected.All() {
 					ev, _ := expected.Get(k)
 					av, _ := resultMap.Get(k)
 					assert.Equal(t, ev, av)
-					return true
-				})
+				}
 			} else if tt.wantSlice != nil {
 				resultSlice, ok := result.(pcommon.Slice)
 				require.True(t, ok)

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -172,7 +172,7 @@ func Test_ParseJSON(t *testing.T) {
 				expected := pcommon.NewMap()
 				tt.wantMap(expected)
 				assert.Equal(t, expected.Len(), resultMap.Len())
-				for k, _ := range expected.All() {
+				for k := range expected.All() {
 					ev, _ := expected.Get(k)
 					av, _ := resultMap.Get(k)
 					assert.Equal(t, ev, av)

--- a/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
@@ -264,13 +264,12 @@ hello!!world  `, nil
 			assert.NoError(t, expected.FromRaw(tt.expected))
 
 			assert.Equal(t, expected.Len(), actual.Len())
-			expected.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, ok := actual.Get(k)
 				assert.True(t, ok)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
@@ -264,7 +264,7 @@ hello!!world  `, nil
 			assert.NoError(t, expected.FromRaw(tt.expected))
 
 			assert.Equal(t, expected.Len(), actual.Len())
-			for k, _ := range expected.All() {
+			for k := range expected.All() {
 				ev, _ := expected.Get(k)
 				av, ok := actual.Get(k)
 				assert.True(t, ok)

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -74,12 +74,11 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 				return nil, err
 			}
 		}
-		val.Range(func(_ string, value pcommon.Value) bool {
+		for _, value := range val.All() {
 			if value.Type() == pcommon.ValueTypeStr && glob.Match(value.Str()) {
 				value.SetStr(replacementVal)
 			}
-			return true
-		})
+		}
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_to_key_value_string.go
+++ b/pkg/ottl/ottlfuncs/func_to_key_value_string.go
@@ -81,13 +81,12 @@ func convertMapToKV(target pcommon.Map, delimiter string, pairDelimiter string, 
 		}
 
 		// Sort by keys
-		target.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range target.All() {
 			keyValues = append(keyValues, struct {
 				key string
 				val pcommon.Value
 			}{key: k, val: v})
-			return true
-		})
+		}
 		gosort.Slice(keyValues, func(i, j int) bool {
 			return keyValues[i].key < keyValues[j].key
 		})
@@ -97,10 +96,9 @@ func convertMapToKV(target pcommon.Map, delimiter string, pairDelimiter string, 
 			kvStrings = append(kvStrings, buildKVString(kv.key, kv.val, delimiter, pairDelimiter))
 		}
 	} else {
-		target.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range target.All() {
 			kvStrings = append(kvStrings, buildKVString(k, v, delimiter, pairDelimiter))
-			return true
-		})
+		}
 	}
 
 	return strings.Join(kvStrings, pairDelimiter)

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
@@ -44,13 +42,12 @@ func TruncateAll[K any](target ottl.PMapGetter[K], limit int64) (ottl.ExprFunc[K
 		if err != nil {
 			return nil, err
 		}
-		val.Range(func(_ string, value pcommon.Value) bool {
+		for _, value := range val.All() {
 			stringVal := value.Str()
 			if int64(len(stringVal)) > limit {
 				value.SetStr(stringVal[:limit])
 			}
-			return true
-		})
+		}
 		// TODO: Write log when truncation is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
 		return nil, nil

--- a/pkg/pdatautil/hash.go
+++ b/pkg/pdatautil/hash.go
@@ -130,10 +130,9 @@ func (hw *hashWriter) writeMapHash(m pcommon.Map) {
 	// on the first call due to it being cleared of any added keys at then end of the function.
 	nextIndex := len(hw.keysBuf)
 
-	m.Range(func(k string, _ pcommon.Value) bool {
+	for k, _ := range m.All() {
 		hw.keysBuf = append(hw.keysBuf, k)
-		return true
-	})
+	}
 
 	// Get only the newly added keys from the buffer by slicing the buffer from nextIndex to the end
 	workingKeySet := hw.keysBuf[nextIndex:]

--- a/pkg/pdatautil/hash.go
+++ b/pkg/pdatautil/hash.go
@@ -130,7 +130,7 @@ func (hw *hashWriter) writeMapHash(m pcommon.Map) {
 	// on the first call due to it being cleared of any added keys at then end of the function.
 	nextIndex := len(hw.keysBuf)
 
-	for k, _ := range m.All() {
+	for k := range m.All() {
 		hw.keysBuf = append(hw.keysBuf, k)
 	}
 

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -106,8 +106,7 @@ func addAttributesToExponentialHistogramDataPoints(ps pmetric.ExponentialHistogr
 
 func joinAttributeMaps(from, to pcommon.Map) {
 	to.EnsureCapacity(from.Len() + to.Len())
-	from.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range from.All() {
 		v.CopyTo(to.PutEmpty(k))
-		return true
-	})
+	}
 }

--- a/pkg/translator/jaeger/traces_to_jaegerproto.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto.go
@@ -97,13 +97,12 @@ func appendTagsFromResourceAttributes(dest []model.KeyValue, attrs pcommon.Map) 
 		return dest
 	}
 
-	attrs.Range(func(key string, attr pcommon.Value) bool {
+	for key, attr := range attrs.All() {
 		if key == conventions.AttributeServiceName {
-			return true
+			continue
 		}
 		dest = append(dest, attributeToJaegerProtoTag(key, attr))
-		return true
-	})
+	}
 	return dest
 }
 
@@ -111,10 +110,9 @@ func appendTagsFromAttributes(dest []model.KeyValue, attrs pcommon.Map) []model.
 	if attrs.Len() == 0 {
 		return dest
 	}
-	attrs.Range(func(key string, attr pcommon.Value) bool {
+	for key, attr := range attrs.All() {
 		dest = append(dest, attributeToJaegerProtoTag(key, attr))
-		return true
-	})
+	}
 	return dest
 }
 

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -98,16 +98,14 @@ func EncodeLogfmt(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrum
 		keyvals = keyvalsReplaceOrAppend(keyvals, "flags", lr.Flags())
 	}
 
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		keyvals = append(keyvals, valueToKeyvals(fmt.Sprintf("attribute_%s", k), v)...)
-		return true
-	})
+	}
 
-	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range res.Attributes().All() {
 		// todo handle maps, slices
 		keyvals = append(keyvals, valueToKeyvals(fmt.Sprintf("resource_%s", k), v)...)
-		return true
-	})
+	}
 
 	scopeName := scope.Name()
 	scopeVersion := scope.Version()
@@ -117,10 +115,9 @@ func EncodeLogfmt(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrum
 		if scopeVersion != "" {
 			keyvals = append(keyvals, "instrumentation_scope_version", scopeVersion)
 		}
-		scope.Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range scope.Attributes().All() {
 			keyvals = append(keyvals, valueToKeyvals(fmt.Sprintf("instrumentation_scope_attribute_%s", k), v)...)
-			return true
-		})
+		}
 	}
 
 	logfmtLine, err := logfmt.MarshalKeyvals(keyvals...)
@@ -178,10 +175,9 @@ func valueToKeyvals(key string, value pcommon.Value) []any {
 		if key != "" {
 			prefix = key + "_"
 		}
-		value.Map().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range value.Map().All() {
 			keyvals = append(keyvals, valueToKeyvals(prefix+k, v)...)
-			return true
-		})
+		}
 		return keyvals
 	case pcommon.ValueTypeSlice:
 		prefix := ""

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -149,7 +149,7 @@ func collectLabelKeysSummaryDataPoints(dhdp pmetric.SummaryDataPointSlice, keySe
 }
 
 func addLabelKeys(keySet map[string]struct{}, attributes pcommon.Map) {
-	for k, _ := range attributes.All() {
+	for k := range attributes.All() {
 		keySet[k] = struct{}{}
 	}
 }

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -149,10 +149,9 @@ func collectLabelKeysSummaryDataPoints(dhdp pmetric.SummaryDataPointSlice, keySe
 }
 
 func addLabelKeys(keySet map[string]struct{}, attributes pcommon.Map) {
-	attributes.Range(func(k string, _ pcommon.Value) bool {
+	for k, _ := range attributes.All() {
 		keySet[k] = struct{}{}
-		return true
-	})
+	}
 }
 
 func descriptorTypeToOC(metric pmetric.Metric, allNumberDataPointValueInt bool) ocmetrics.MetricDescriptor_Type {
@@ -374,10 +373,9 @@ func exemplarToOC(filteredLabels pcommon.Map, value float64, timestamp pcommon.T
 	var labels map[string]string
 	if filteredLabels.Len() != 0 {
 		labels = make(map[string]string, filteredLabels.Len())
-		filteredLabels.Range(func(k string, v pcommon.Value) bool {
+		for k, v := range filteredLabels.All() {
 			labels[k] = v.AsString()
-			return true
-		})
+		}
 	}
 
 	return &ocmetrics.DistributionValue_Exemplar{
@@ -401,7 +399,7 @@ func attributeValuesToOC(labels pcommon.Map, labelKeys *labelKeysAndType) []*ocm
 	}
 
 	// Visit all defined labels in the point and override defaults with actual values
-	labels.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range labels.All() {
 		// Find the appropriate label value that we need to update
 		keyIndex := labelKeys.keyIndices[k]
 		labelValue := labelValues[keyIndex]
@@ -409,8 +407,7 @@ func attributeValuesToOC(labels pcommon.Map, labelKeys *labelKeysAndType) []*ocm
 		// Update label value
 		labelValue.Value = v.AsString()
 		labelValue.HasValue = true
-		return true
-	})
+	}
 
 	return labelValues
 }

--- a/pkg/translator/opencensus/oc_to_resource_test.go
+++ b/pkg/translator/opencensus/oc_to_resource_test.go
@@ -37,13 +37,12 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	expectedAttrs.Range(func(k string, _ pcommon.Value) bool {
+	for k, _ := range expectedAttrs.All() {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 		if !strings.Contains(k, "-attr") {
 			ocNode.Attributes[k] = "this will be overridden 1"
 		}
-		return true
-	})
+	}
 	ocResource.Labels[occonventions.AttributeResourceType] = "this will be overridden 2"
 
 	// Convert again.

--- a/pkg/translator/opencensus/oc_to_resource_test.go
+++ b/pkg/translator/opencensus/oc_to_resource_test.go
@@ -37,7 +37,7 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	for k, _ := range expectedAttrs.All() {
+	for k := range expectedAttrs.All() {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 		if !strings.Contains(k, "-attr") {
 			ocNode.Attributes[k] = "this will be overridden 1"

--- a/pkg/translator/opencensus/resource_to_oc.go
+++ b/pkg/translator/opencensus/resource_to_oc.go
@@ -76,7 +76,7 @@ func internalResourceToOC(resource pcommon.Resource) (*occommon.Node, *ocresourc
 	ocNode := &occommon.Node{}
 	ocResource := &ocresource.Resource{}
 	labels := make(map[string]string, attrs.Len())
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		val := v.AsString()
 
 		switch k {
@@ -89,7 +89,7 @@ func internalResourceToOC(resource pcommon.Resource) (*occommon.Node, *ocresourc
 		case occonventions.AttributeProcessStartTime:
 			t, err := time.Parse(time.RFC3339Nano, val)
 			if err != nil {
-				return true
+				continue
 			}
 			ts := timestamppb.New(t)
 			getProcessIdentifier(ocNode).StartTimestamp = ts
@@ -112,8 +112,7 @@ func internalResourceToOC(resource pcommon.Resource) (*occommon.Node, *ocresourc
 			// Not a special attribute, put it into resource labels
 			labels[k] = val
 		}
-		return true
-	})
+	}
 	ocResource.Labels = labels
 
 	// If resource type is missing, try to infer it

--- a/pkg/translator/opencensus/resource_to_oc_test.go
+++ b/pkg/translator/opencensus/resource_to_oc_test.go
@@ -199,7 +199,7 @@ func TestResourceToOCAndBack(t *testing.T) {
 			// Remove opencensus resource type from actual. This will be added during translation.
 			actual.Attributes().Remove(occonventions.AttributeResourceType)
 			assert.Equal(t, expected.Attributes().Len(), actual.Attributes().Len())
-			expected.Attributes().Range(func(k string, v pcommon.Value) bool {
+			for k, v := range expected.Attributes().All() {
 				a, ok := actual.Attributes().Get(k)
 				assert.True(t, ok)
 				switch v.Type() {
@@ -214,8 +214,7 @@ func TestResourceToOCAndBack(t *testing.T) {
 				default:
 					assert.Equal(t, v, a)
 				}
-				return true
-			})
+			}
 		})
 	}
 }

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -102,10 +102,9 @@ func attributesMapToOCAttributeMap(attributes pcommon.Map) map[string]*octrace.A
 	}
 
 	ocAttributes := make(map[string]*octrace.AttributeValue, attributes.Len())
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		ocAttributes[k] = attributeValueToOC(v)
-		return true
-	})
+	}
 	return ocAttributes
 }
 

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -306,10 +306,9 @@ func getSummaryMetric(name string, attributes pcommon.Map, ts uint64, sum float6
 	}
 	dp.SetCount(count)
 	dp.SetSum(sum)
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		v.CopyTo(dp.Attributes().PutEmpty(k))
-		return true
-	})
+	}
 
 	dp.SetTimestamp(pcommon.Timestamp(ts))
 

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -265,13 +265,12 @@ func attributesToDimensions(attributes pcommon.Map, extraDims []*sfxpb.Dimension
 	}
 	dimensionsValue := make([]sfxpb.Dimension, attributes.Len())
 	pos := 0
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributes.All() {
 		dimensionsValue[pos].Key = k
 		dimensionsValue[pos].Value = v.AsString()
 		dimensions = append(dimensions, &dimensionsValue[pos])
 		pos++
-		return true
-	})
+	}
 	return dimensions
 }
 

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -238,10 +238,9 @@ func spanLinksToZipkinTags(links ptrace.SpanLinkSlice, zTags map[string]string) 
 
 func attributeMapToStringMap(attrMap pcommon.Map) map[string]string {
 	rawMap := make(map[string]string)
-	attrMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrMap.All() {
 		rawMap[k] = v.AsString()
-		return true
-	})
+	}
 	return rawMap
 }
 
@@ -262,10 +261,9 @@ func resourceToZipkinEndpointServiceNameAndAttributeMap(
 		return tracetranslator.ResourceNoServiceName, zTags
 	}
 
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		zTags[k] = v.AsString()
-		return true
-	})
+	}
 
 	serviceName = extractZipkinServiceName(zTags)
 	return serviceName, zTags

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -107,12 +107,11 @@ func testFilter(t *testing.T, mdType pmetric.MetricType, mvType pmetric.NumberDa
 }
 
 func assertFiltered(t *testing.T, lm pcommon.Map) {
-	lm.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lm.All() {
 		if k == filteredAttrKey {
 			require.NotEqual(t, v.AsRaw(), filteredAttrVal.AsRaw())
 		}
-		return true
-	})
+	}
 }
 
 func filterMetrics(t *testing.T, include []string, exclude []string, mds []pmetric.Metrics) []pmetric.Metrics {

--- a/processor/groupbyattrsprocessor/attribute_groups.go
+++ b/processor/groupbyattrsprocessor/attribute_groups.go
@@ -151,9 +151,8 @@ func matchingScopeMetrics(rm pmetric.ResourceMetrics, library pcommon.Instrument
 func buildReferenceResource(originResource pcommon.Resource, requiredAttributes pcommon.Map) pcommon.Resource {
 	referenceResource := pcommon.NewResource()
 	originResource.Attributes().CopyTo(referenceResource.Attributes())
-	requiredAttributes.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range requiredAttributes.All() {
 		v.CopyTo(referenceResource.Attributes().PutEmpty(k))
-		return true
-	})
+	}
 	return referenceResource
 }

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -160,7 +160,7 @@ func (gap *groupByAttrsProcessor) processMetrics(ctx context.Context, md pmetric
 }
 
 func deleteAttributes(attrsForRemoval, targetAttrs pcommon.Map) {
-	for key, _ := range attrsForRemoval.All() {
+	for key := range attrsForRemoval.All() {
 		targetAttrs.Remove(key)
 	}
 }

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -160,10 +160,9 @@ func (gap *groupByAttrsProcessor) processMetrics(ctx context.Context, md pmetric
 }
 
 func deleteAttributes(attrsForRemoval, targetAttrs pcommon.Map) {
-	attrsForRemoval.Range(func(key string, _ pcommon.Value) bool {
+	for key, _ := range attrsForRemoval.All() {
 		targetAttrs.Remove(key)
-		return true
-	})
+	}
 }
 
 // extractGroupingAttributes extracts the keys and values of the specified Attributes

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -183,12 +183,11 @@ func randFloat64Arr(size int) []float64 {
 }
 
 func assertResourceContainsAttributes(t *testing.T, resource pcommon.Resource, attributeMap pcommon.Map) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attributeMap.All() {
 		rv, found := resource.Attributes().Get(k)
 		assert.True(t, found)
 		assert.Equal(t, v, rv)
-		return true
-	})
+	}
 }
 
 // The "complex" use case has following input data:

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -146,7 +146,6 @@ func dataPointAttributesMatch(dp1, dp2 pmetric.NumberDataPoint) bool {
 	for key, dp1Val := range dp1.Attributes().All() {
 		dp1Val.Type()
 		if dp2Val, keyExists := dp2.Attributes().Get(key); keyExists && dp1Val.AsRaw() != dp2Val.AsRaw() {
-			attributesMatch = false
 			return false
 		}
 	}

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -6,7 +6,6 @@ package metricsgenerationprocessor // import "github.com/open-telemetry/opentele
 import (
 	"fmt"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
@@ -119,11 +118,10 @@ func generateMetricFromMatchingAttributes(metric1 pmetric.Metric, metric2 pmetri
 					metric1DP.CopyTo(newDP)
 					newDP.SetDoubleValue(val)
 
-					metric2DP.Attributes().Range(func(k string, v pcommon.Value) bool {
+					for k, v := range metric2DP.Attributes().All() {
 						v.CopyTo(newDP.Attributes().PutEmpty(k))
 						// Always return true to ensure iteration over all attributes
-						return true
-					})
+					}
 				}
 			}
 		}
@@ -145,14 +143,13 @@ func dataPointValue(dp pmetric.NumberDataPoint) float64 {
 
 func dataPointAttributesMatch(dp1, dp2 pmetric.NumberDataPoint) bool {
 	attributesMatch := true
-	dp1.Attributes().Range(func(key string, dp1Val pcommon.Value) bool {
+	for key, dp1Val := range dp1.Attributes().All() {
 		dp1Val.Type()
 		if dp2Val, keyExists := dp2.Attributes().Get(key); keyExists && dp1Val.AsRaw() != dp2Val.AsRaw() {
 			attributesMatch = false
 			return false
 		}
-		return true
-	})
+	}
 
 	return attributesMatch
 }

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
@@ -78,13 +78,12 @@ func (tsm *TimeseriesMap) Get(metric pmetric.Metric, kv pcommon.Map) (*Timeserie
 func getAttributesSignature(m pcommon.Map) AttributeHash {
 	// TODO(#38621): Investigate whether we should treat empty labels differently.
 	clearedMap := pcommon.NewMap()
-	m.Range(func(k string, attrValue pcommon.Value) bool {
+	for k, attrValue := range m.All() {
 		value := attrValue.Str()
 		if value != "" {
 			clearedMap.PutStr(k, value)
 		}
-		return true
-	})
+	}
 	return pdatautil.MapHash(clearedMap)
 }
 

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -385,10 +385,9 @@ func canBeCombined(metrics []pmetric.Metric) error {
 func metricAttributeKeys(metric pmetric.Metric) map[string]struct{} {
 	attrKeys := map[string]struct{}{}
 	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
-		attrs.Range(func(k string, _ pcommon.Value) bool {
+		for k, _ := range attrs.All() {
 			attrKeys[k] = struct{}{}
-			return true
-		})
+		}
 		return true
 	})
 	return attrKeys

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -385,7 +385,7 @@ func canBeCombined(metrics []pmetric.Metric) error {
 func metricAttributeKeys(metric pmetric.Metric) map[string]struct{} {
 	attrKeys := map[string]struct{}{}
 	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
-		for k, _ := range attrs.All() {
+		for k := range attrs.All() {
 			attrKeys[k] = struct{}{}
 		}
 		return true

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -116,13 +116,12 @@ func lessAttributes(a, b pcommon.Map) bool {
 	}
 
 	var res bool
-	a.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range a.All() {
 		bv, ok := b.Get(k)
 		if !ok || v.Str() < bv.Str() {
 			res = true
 			return false
 		}
-		return true
-	})
+	}
 	return res
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -119,8 +119,7 @@ func lessAttributes(a, b pcommon.Map) bool {
 	for k, v := range a.All() {
 		bv, ok := b.Get(k)
 		if !ok || v.Str() < bv.Str() {
-			res = true
-			return false
+			return true
 		}
 	}
 	return res

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -230,7 +230,7 @@ func MergeResource(to, from pcommon.Resource, overrideTo bool) {
 	}
 
 	toAttr := to.Attributes()
-	from.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range from.Attributes().All() {
 		if overrideTo {
 			v.CopyTo(toAttr.PutEmpty(k))
 		} else {
@@ -238,8 +238,7 @@ func MergeResource(to, from pcommon.Resource, overrideTo bool) {
 				v.CopyTo(toAttr.PutEmpty(k))
 			}
 		}
-		return true
-	})
+	}
 }
 
 func IsEmptyResource(res pcommon.Resource) bool {

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
@@ -204,11 +203,10 @@ func compareProfileAttributes(t *testing.T, expected pprofile.Profiles, got ppro
 		expectedResourceProfile := expected.ResourceProfiles().At(i)
 		gotResourceProfile := got.ResourceProfiles().At(i)
 
-		expectedResourceProfile.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
+		for k, v := range expectedResourceProfile.Resource().Attributes().All() {
 			get, ok := gotResourceProfile.Resource().Attributes().Get(k)
 			require.True(t, ok)
 			require.Equal(t, v, get)
-			return true
-		})
+		}
 	}
 }

--- a/processor/schemaprocessor/internal/migrate/attributes.go
+++ b/processor/schemaprocessor/internal/migrate/attributes.go
@@ -43,7 +43,7 @@ func (a *AttributeChangeSet) Do(ss StateSelector, attrs pcommon.Map) (errs error
 		updated = make(map[string]struct{})
 		results = pcommon.NewMap()
 	)
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range attrs.All() {
 		var (
 			key     string
 			matched bool
@@ -63,12 +63,11 @@ func (a *AttributeChangeSet) Do(ss StateSelector, attrs pcommon.Map) (errs error
 			//       entry's value, not the existing value.
 			if _, overridden := updated[k]; overridden {
 				errs = multierr.Append(errs, fmt.Errorf("value %q already exists", k))
-				return true
+				continue
 			}
 		}
 		v.CopyTo(results.PutEmpty(k))
-		return true
-	})
+	}
 	results.CopyTo(attrs)
 	return errs
 }

--- a/processor/sumologicprocessor/aggregate_attributes_processor.go
+++ b/processor/sumologicprocessor/aggregate_attributes_processor.go
@@ -121,7 +121,7 @@ func (proc *aggregateAttributesProcessor) processAttributes(attributes pcommon.M
 			newMap := pcommon.NewMap()
 			newMap.EnsureCapacity(attributes.Len())
 
-			attributes.Range(func(key string, value pcommon.Value) bool {
+			for key, value := range attributes.All() {
 				ok, trimmedKey := getNewKey(key, prefix)
 				if ok {
 					// TODO: Potential name conflict to resolve, eg.:
@@ -136,8 +136,7 @@ func (proc *aggregateAttributesProcessor) processAttributes(attributes pcommon.M
 				} else {
 					value.CopyTo(newMap.PutEmpty(key))
 				}
-				return true
-			})
+			}
 			newMap.CopyTo(attributes)
 		}
 

--- a/processor/sumologicprocessor/translate_attributes_processor.go
+++ b/processor/sumologicprocessor/translate_attributes_processor.go
@@ -87,7 +87,7 @@ func translateAttributes(attributes pcommon.Map) {
 	result := pcommon.NewMap()
 	result.EnsureCapacity(attributes.Len())
 
-	attributes.Range(func(otKey string, value pcommon.Value) bool {
+	for otKey, value := range attributes.All() {
 		if sumoKey, ok := attributeTranslations[otKey]; ok {
 			// Only insert if it doesn't exist yet to prevent overwriting.
 			// We have to do it this way since the final return value is not
@@ -106,8 +106,7 @@ func translateAttributes(attributes pcommon.Map) {
 				value.CopyTo(result.PutEmpty(otKey))
 			}
 		}
-		return true
-	})
+	}
 
 	result.CopyTo(attributes)
 }

--- a/processor/sumologicprocessor/translate_docker_metrics_processor.go
+++ b/processor/sumologicprocessor/translate_docker_metrics_processor.go
@@ -131,7 +131,7 @@ func translateDockerResourceAttributes(attributes pcommon.Map) {
 	result := pcommon.NewMap()
 	result.EnsureCapacity(attributes.Len())
 
-	attributes.Range(func(otKey string, value pcommon.Value) bool {
+	for otKey, value := range attributes.All() {
 		if sumoKey, ok := dockerResourceAttributeTranslations[otKey]; ok {
 			// Only insert if it doesn't exist yet to prevent overwriting.
 			// We have to do it this way since the final return value is not
@@ -150,8 +150,7 @@ func translateDockerResourceAttributes(attributes pcommon.Map) {
 				value.CopyTo(result.PutEmpty(otKey))
 			}
 		}
-		return true
-	})
+	}
 
 	result.CopyTo(attributes)
 }

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
@@ -26,10 +26,9 @@ func (acc *metricDataAccumulator) getMetricsData(containerStatsMap map[string]*C
 
 	for _, containerMetadata := range metadata.Containers {
 		containerResource := containerResource(containerMetadata, logger)
-		taskResource.Attributes().Range(func(k string, av pcommon.Value) bool {
+		for k, av := range taskResource.Attributes().All() {
 			av.CopyTo(containerResource.Attributes().PutEmpty(k))
-			return true
-		})
+		}
 
 		stats, ok := containerStatsMap[containerMetadata.DockerID]
 

--- a/receiver/datadogreceiver/internal/translator/tags_test.go
+++ b/receiver/datadogreceiver/internal/translator/tags_test.go
@@ -71,7 +71,7 @@ func TestGetMetricAttributes(t *testing.T) {
 			attrs := tagsToAttributes(c.tags, c.host, pool)
 
 			assert.Equal(t, c.expectedResourceAttrs.Len(), attrs.resource.Len())
-			for k, _ := range c.expectedResourceAttrs.All() {
+			for k := range c.expectedResourceAttrs.All() {
 				ev, _ := c.expectedResourceAttrs.Get(k)
 				av, ok := attrs.resource.Get(k)
 				assert.True(t, ok)
@@ -79,7 +79,7 @@ func TestGetMetricAttributes(t *testing.T) {
 			}
 
 			assert.Equal(t, c.expectedScopeAttrs.Len(), attrs.scope.Len())
-			for k, _ := range c.expectedScopeAttrs.All() {
+			for k := range c.expectedScopeAttrs.All() {
 				ev, _ := c.expectedScopeAttrs.Get(k)
 				av, ok := attrs.scope.Get(k)
 				assert.True(t, ok)
@@ -87,7 +87,7 @@ func TestGetMetricAttributes(t *testing.T) {
 			}
 
 			assert.Equal(t, c.expectedDpAttrs.Len(), attrs.dp.Len())
-			for k, _ := range c.expectedDpAttrs.All() {
+			for k := range c.expectedDpAttrs.All() {
 				ev, _ := c.expectedDpAttrs.Get(k)
 				av, ok := attrs.dp.Get(k)
 				assert.True(t, ok)

--- a/receiver/datadogreceiver/internal/translator/tags_test.go
+++ b/receiver/datadogreceiver/internal/translator/tags_test.go
@@ -71,31 +71,28 @@ func TestGetMetricAttributes(t *testing.T) {
 			attrs := tagsToAttributes(c.tags, c.host, pool)
 
 			assert.Equal(t, c.expectedResourceAttrs.Len(), attrs.resource.Len())
-			c.expectedResourceAttrs.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range c.expectedResourceAttrs.All() {
 				ev, _ := c.expectedResourceAttrs.Get(k)
 				av, ok := attrs.resource.Get(k)
 				assert.True(t, ok)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 
 			assert.Equal(t, c.expectedScopeAttrs.Len(), attrs.scope.Len())
-			c.expectedScopeAttrs.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range c.expectedScopeAttrs.All() {
 				ev, _ := c.expectedScopeAttrs.Get(k)
 				av, ok := attrs.scope.Get(k)
 				assert.True(t, ok)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 
 			assert.Equal(t, c.expectedDpAttrs.Len(), attrs.dp.Len())
-			c.expectedDpAttrs.Range(func(k string, _ pcommon.Value) bool {
+			for k, _ := range c.expectedDpAttrs.All() {
 				ev, _ := c.expectedDpAttrs.Get(k)
 				av, ok := attrs.dp.Get(k)
 				assert.True(t, ok)
 				assert.Equal(t, ev, av)
-				return true
-			})
+			}
 		})
 	}
 }

--- a/receiver/datadogreceiver/internal/translator/testutil.go
+++ b/receiver/datadogreceiver/internal/translator/testutil.go
@@ -24,13 +24,12 @@ func createMetricsTranslator() *MetricsTranslator {
 }
 
 func requireResourceAttributes(t *testing.T, attrs, expectedAttrs pcommon.Map) {
-	expectedAttrs.Range(func(k string, _ pcommon.Value) bool {
+	for k, _ := range expectedAttrs.All() {
 		ev, _ := expectedAttrs.Get(k)
 		av, ok := attrs.Get(k)
 		require.True(t, ok)
 		require.Equal(t, ev, av)
-		return true
-	})
+	}
 }
 
 //nolint:unparam

--- a/receiver/datadogreceiver/internal/translator/testutil.go
+++ b/receiver/datadogreceiver/internal/translator/testutil.go
@@ -24,7 +24,7 @@ func createMetricsTranslator() *MetricsTranslator {
 }
 
 func requireResourceAttributes(t *testing.T, attrs, expectedAttrs pcommon.Map) {
-	for k, _ := range expectedAttrs.All() {
+	for k := range expectedAttrs.All() {
 		ev, _ := expectedAttrs.Get(k)
 		av, ok := attrs.Get(k)
 		require.True(t, ok)

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
@@ -167,14 +167,12 @@ func TestLibHoneyEvent_ToPLogRecord(t *testing.T) {
 				assert.Equal(t, want.Body().AsString(), newLog.Body().AsString())
 
 				// Check each attribute has correct type and value
-				want.Attributes().Range(func(k string, v pcommon.Value) bool {
+				for k, v := range want.Attributes().All() {
 					got, ok := newLog.Attributes().Get(k)
 					assert.True(t, ok, "missing attribute %s", k)
 					assert.Equal(t, v.Type(), got.Type(), "wrong type for attribute %s", k)
 					assert.Equal(t, v, got, "wrong value for attribute %s", k)
-
-					return true
-				})
+				}
 
 				// Verify no extra attributes
 				assert.Equal(t, want.Attributes().Len(), newLog.Attributes().Len())
@@ -385,13 +383,12 @@ func TestToPTraceSpan(t *testing.T) {
 				assert.Equal(t, want.Status().Message(), span.Status().Message())
 
 				// Check attributes
-				want.Attributes().Range(func(k string, v pcommon.Value) bool {
+				for k, v := range want.Attributes().All() {
 					got, ok := span.Attributes().Get(k)
 					assert.True(t, ok, "missing attribute %s", k)
 					assert.Equal(t, v.Type(), got.Type(), "wrong type for attribute %s", k)
 					assert.Equal(t, v, got, "wrong value for attribute %s", k)
-					return true
-				})
+				}
 
 				// Verify no fewer attributes, extras are expected
 				assert.LessOrEqual(t, want.Attributes().Len(), span.Attributes().Len())

--- a/receiver/libhoneyreceiver/internal/parser/parser_test.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser_test.go
@@ -157,13 +157,12 @@ func TestToPdata(t *testing.T) {
 
 // Helper function to verify attributes
 func verifyAttributes(t *testing.T, expected, actual pcommon.Map) {
-	expected.Range(func(k string, v pcommon.Value) bool {
+	for k, v := range expected.All() {
 		got, ok := actual.Get(k)
 		assert.True(t, ok, "missing attribute %s", k)
 		assert.Equal(t, v.Type(), got.Type(), "wrong type for attribute %s", k)
 		assert.Equal(t, v, got, "wrong value for attribute %s", k)
-		return true
-	})
+	}
 }
 
 func TestAddSpanEventsToSpan(t *testing.T) {

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -128,13 +128,12 @@ func (tsm *timeseriesMap) get(metric pmetric.Metric, kv pcommon.Map) (*timeserie
 // Create a unique string signature for attributes values sorted by attribute keys.
 func getAttributesSignature(m pcommon.Map) [16]byte {
 	clearedMap := pcommon.NewMap()
-	m.Range(func(k string, attrValue pcommon.Value) bool {
+	for k, attrValue := range m.All() {
 		value := attrValue.Str()
 		if value != "" {
 			clearedMap.PutStr(k, value)
 		}
-		return true
-	})
+	}
 	return pdatautil.MapHash(clearedMap)
 }
 

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/scraper/scrapererror"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
@@ -554,14 +553,13 @@ func TestScrape(t *testing.T) {
 							expectedAttributeLen++
 						}
 						assert.Equal(t, expectedAttributeLen, dps.At(dpIdx).Attributes().Len())
-						dps.At(dpIdx).Attributes().Range(func(k string, v pcommon.Value) bool {
+						for k, v := range dps.At(dpIdx).Attributes().All() {
 							if k == instanceLabelName {
 								assert.Equal(t, val.InstanceName, v.Str())
 								return true
 							}
 							assert.Equal(t, counterCfg.MetricRep.Attributes[k], v.Str())
-							return true
-						})
+						}
 					}
 					curMetricsNum++
 				}

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -556,7 +556,7 @@ func TestScrape(t *testing.T) {
 						for k, v := range dps.At(dpIdx).Attributes().All() {
 							if k == instanceLabelName {
 								assert.Equal(t, val.InstanceName, v.Str())
-								return true
+								continue
 							}
 							assert.Equal(t, counterCfg.MetricRep.Attributes[k], v.Str())
 						}

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -103,7 +103,7 @@ func (f *FluentLogsForwarder) convertLogToMap(lr plog.LogRecord) map[string]stri
 		out["log"] = lr.Body().Str()
 	}
 
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		switch v.Type() {
 		case pcommon.ValueTypeStr:
 			out[k] = v.Str()
@@ -116,8 +116,7 @@ func (f *FluentLogsForwarder) convertLogToMap(lr plog.LogRecord) map[string]stri
 		default:
 			panic("missing case")
 		}
-		return true
-	})
+	}
 
 	return out
 }
@@ -128,7 +127,7 @@ func (f *FluentLogsForwarder) convertLogToJSON(lr plog.LogRecord) []byte {
 	}
 	rec["log"] = lr.Body().Str()
 
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		switch v.Type() {
 		case pcommon.ValueTypeStr:
 			rec[k] = v.Str()
@@ -141,8 +140,7 @@ func (f *FluentLogsForwarder) convertLogToJSON(lr plog.LogRecord) []byte {
 		default:
 			panic("missing case")
 		}
-		return true
-	})
+	}
 	b, err := json.Marshal(rec)
 	if err != nil {
 		panic("failed to write log: " + err.Error())

--- a/testbed/datasenders/k8s.go
+++ b/testbed/datasenders/k8s.go
@@ -108,7 +108,7 @@ func (f *FileLogK8sWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 		sb.WriteString(lr.Body().Str())
 	}
 
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		sb.WriteString(" ")
 		sb.WriteString(k)
 		sb.WriteString("=")
@@ -124,8 +124,7 @@ func (f *FileLogK8sWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 		default:
 			panic("missing case")
 		}
-		return true
-	})
+	}
 
 	return []byte(sb.String())
 }

--- a/testbed/datasenders/stanza.go
+++ b/testbed/datasenders/stanza.go
@@ -91,7 +91,7 @@ func (f *FileLogWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 		sb.WriteString(lr.Body().Str())
 	}
 
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		sb.WriteString(" ")
 		sb.WriteString(k)
 		sb.WriteString("=")
@@ -107,8 +107,7 @@ func (f *FileLogWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 		default:
 			panic("missing case")
 		}
-		return true
-	})
+	}
 
 	return []byte(sb.String())
 }

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
@@ -99,12 +98,11 @@ func (f *SyslogWriter) Send(lr plog.LogRecord) error {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", "span_id", lr.SpanID()))
 	}
 	sdid.WriteString(fmt.Sprintf("%s=\"%d\" ", "trace_flags", lr.Flags()))
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		if v.Str() != "" {
 			sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.Str()))
 		}
-		return true
-	})
+	}
 	msg := fmt.Sprintf("<166>1 %s 127.0.0.1 - - - [test@12345 %s] %s\n", ts, strings.TrimSpace(sdid.String()), lr.Body().Str())
 
 	f.buf = append(f.buf, msg)

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
@@ -94,10 +93,9 @@ func (f *TCPUDPWriter) Send(lr plog.LogRecord) error {
 	sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", "trace_id", traceutil.TraceIDToHexOrEmptyString(lr.TraceID())))
 	sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", "span_id", traceutil.SpanIDToHexOrEmptyString(lr.SpanID())))
 	sdid.WriteString(fmt.Sprintf("%s=\"%d\" ", "trace_flags", lr.Flags()))
-	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
+	for k, v := range lr.Attributes().All() {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.Str()))
-		return true
-	})
+	}
 	msg := fmt.Sprintf("<166> %s 127.0.0.1 - - - [%s] %s\n", ts, sdid.String(), lr.Body().Str())
 
 	f.buf = append(f.buf, msg)

--- a/testbed/mockdatasenders/mockdatadogagentexporter/traces_exporter.go
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/traces_exporter.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -63,10 +62,9 @@ func (dd *ddExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
 					Meta:     map[string]string{},
 					Type:     "custom",
 				}
-				span.Attributes().Range(func(k string, v pcommon.Value) bool {
+				for k, v := range span.Attributes().All() {
 					newSpan.GetMeta()[k] = v.AsString()
-					return true
-				})
+				}
 				var traceIDBytes [16]byte
 				var spanIDBytes [8]byte
 				var parentIDBytes [8]byte

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -468,7 +468,7 @@ func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
 				actualValue:   nil,
 			}
 			v.assertionFailures = append(v.assertionFailures, af)
-			return true
+			continue
 		}
 		switch sentVal.Type() {
 		case pcommon.ValueTypeMap:

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -457,7 +457,7 @@ func (v *CorrectnessTestValidator) diffSpanStatus(sentSpan ptrace.Span, recdSpan
 func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
 	sentAttrs pcommon.Map, recdAttrs pcommon.Map, fmtStr string,
 ) {
-	sentAttrs.Range(func(sentKey string, sentVal pcommon.Value) bool {
+	for sentKey, sentVal := range sentAttrs.All() {
 		recdVal, ok := recdAttrs.Get(sentKey)
 		if !ok {
 			af := &TraceAssertionFailure{
@@ -476,8 +476,7 @@ func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
 		default:
 			v.compareSimpleValues(spanName, sentVal, recdVal, fmtStr, sentKey)
 		}
-		return true
-	})
+	}
 }
 
 func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal pcommon.Value, recdVal pcommon.Value,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Update all uses of .Range from pdata types to use new .All() iterators, so the upstream deprecation can be re-added for next release. See https://github.com/open-telemetry/opentelemetry-collector/pull/12380
