### PR TITLE
[chore] Auto-populate release notes

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -12,6 +12,8 @@ entries_dir: .chloggen
 # (Optional) Default: .chloggen/TEMPLATE.yaml
 template_yaml: .chloggen/TEMPLATE.yaml
 
+summary_template: .chloggen/summary.tmpl
+
 # The CHANGELOG file or files to which 'chloggen update' will write new entries
 # (Optional) Default filename: CHANGELOG.md
 change_logs:

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,70 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+#{{ $issue }}
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+<!-- previous-version -->

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -624,9 +624,13 @@ jobs:
       - name: Set Release Tag
         id: github_tag
         run: ./.github/workflows/scripts/set_release_tag.sh
+      - name: Prepare release notes
+        env:
+          RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}
+        run: ./.github/workflows/scripts/prepare-release-notes.sh
       - name: Create Github Release
         run: |
-          gh release create $RELEASE_TAG -t $RELEASE_TAG -n "The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-collector release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/$RELEASE_TAG), be sure to check the release notes there as well."
+          gh release create $RELEASE_TAG -t $RELEASE_TAG -F release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}

--- a/.github/workflows/scripts/prepare-release-notes.sh
+++ b/.github/workflows/scripts/prepare-release-notes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+touch release-notes.md
+echo "The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-collector release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/$RELEASE_TAG), be sure to check the release notes there as well." >> release-notes.md
+echo "" >> release-notes.md
+echo "## End User Changelog" >> release-notes.md
+
+awk '/<!-- next version -->/,/<!-- previous-version -->/' CHANGELOG.md > tmp-chlog.md # select changelog of latest version only
+sed '1,3d' tmp-chlog.md >> release-notes.md # delete first 3 lines of file
+
+echo "" >> release-notes.md
+echo "## API Changelog" >> release-notes.md
+
+awk '/<!-- next version -->/,/<!-- previous-version -->/' CHANGELOG-API.md > tmp-chlog-api.md # select changelog of latest version only
+sed '1,3d' tmp-chlog-api.md >> release-notes.md # delete first 3 lines of file


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR takes the [changes already made in the collector core repo](https://github.com/open-telemetry/opentelemetry-collector/pull/12644) and implements them here as well.

This PR changes the release workflow to autofill the release notes from `CHANGELOG.md` and `CHANGELOG-API.md` into the generated GH release.

It makes use of `awk` and `sed` to build the release notes step by step from the changelog files.
The [default chloggen template](https://github.com/open-telemetry/opentelemetry-go-build-tools/blob/c43cb0331ccdb9ff9b4a8862a3dce032147e615d/chloggen/internal/chlog/summary.tmpl) was added and a `<!--preview-version-->` tag was added to easily filter out the changelog of just the latest version.

Note: The list of unmaintained components at the top of the release notes is not auto-populated and still needs to be filled in by hand for now.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37703

<!--Describe what testing was performed and which tests were added.-->
#### Testing
1. Add `<!-- previous-version -->` below the changelogs for the latest version in `CHANGELOG.md` and `CHANGELOG_API.md`. (check example below)
2. run the new script `./.github/workflows/scripts/prepare-release-notes.sh`
3. Check that the produced `release-notes.md` file contains the correct output by comparing it against the latest published github release.

<details>
<summary>Example for changelog for testing this PR</summary>

```
# Changelog

Starting with version v0.83.0, this changelog includes only user-facing changes.
If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./CHANGELOG-API.md).

<!-- next version -->

## v0.122.0

### 🛑 Breaking changes 🛑

- some changes
- ...

<!-- previous-version -->						# <= add this comment in manually

## v0.121.0

### 🛑 Breaking changes 🛑
...
```
</details>

<!--Describe the documentation added.-->
#### Documentation
Follow-up: update release doc in collector core repo

<!--Please delete paragraphs that you did not use before submitting.-->