### PR TITLE
[exporter/azuremonitor] Support span links in Azure Monitor exporter

### DIFF
--- a/.chloggen/35855.yaml
+++ b/.chloggen/35855.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support span links for traces for azure monitor exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35855]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -109,6 +109,8 @@ The exact mapping can be found in [trace_to_envelope.go](trace_to_envelope.go).
 
 All attributes are also mapped to custom properties if they are booleans or strings and to custom measurements if they are ints or doubles.
 
+All links are mapped to property `_MS.links` with JSON array string.
+
 #### Span Events
 
 Span events are optionally saved to the Application Insights `traces` table.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Support exporting span links. All links are mapped to property `_MS.links` with JSON array string for traces.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35855 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1. added unit tests
2. validated e2e test.
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/90d76b02-fc19-47c5-86bb-9e98c00c9ef5" />

<!--Describe the documentation added.-->
#### Documentation

Added in `README.md`.

<!--Please delete paragraphs that you did not use before submitting.-->
