### PR TITLE
Revert "fix(deps): update module github.com/elastic/go-docappender/v2 to v2.7.0"

### DIFF
--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/elastic/go-docappender/v2 v2.7.0
+	github.com/elastic/go-docappender/v2 v2.6.1
 	github.com/elastic/go-elasticsearch/v8 v8.17.1
 	github.com/elastic/go-structform v0.0.12
 	github.com/klauspost/compress v1.18.0

--- a/exporter/elasticsearchexporter/go.sum
+++ b/exporter/elasticsearchexporter/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/elastic-transport-go/v8 v8.6.1 h1:h2jQRqH6eLGiBSN4eZbQnJLtL4bC5b4lfVFRjw2R4e4=
 github.com/elastic/elastic-transport-go/v8 v8.6.1/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/go-docappender/v2 v2.7.0 h1:7zlhkeaZxnYij9N37mOx4DapswZtkmHe2SnI3w+MJzA=
-github.com/elastic/go-docappender/v2 v2.7.0/go.mod h1:xoTA2/HUjnIgF7acxxjfYaT7KE3nFhBQ5ZkmN0edE5o=
+github.com/elastic/go-docappender/v2 v2.6.1 h1:dl9dcRL390RTf5M5sb4bhpy4E+RJzC6NKoeTbF/hFY0=
+github.com/elastic/go-docappender/v2 v2.6.1/go.mod h1:NbNXsxNCnWEPmYeAqEkgdzk6SFOaw7c75wX2+RWEIZk=
 github.com/elastic/go-elasticsearch/v8 v8.17.1 h1:bOXChDoCMB4TIwwGqKd031U8OXssmWLT3UrAr9EGs3Q=
 github.com/elastic/go-elasticsearch/v8 v8.17.1/go.mod h1:MVJCtL+gJJ7x5jFeUmA20O7rvipX8GcQmo5iBcmaJn4=
 github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTRArYs=

--- a/exporter/elasticsearchexporter/integrationtest/go.mod
+++ b/exporter/elasticsearchexporter/integrationtest/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasti
 go 1.23.7
 
 require (
-	github.com/elastic/go-docappender/v2 v2.7.0
+	github.com/elastic/go-docappender/v2 v2.6.1
 	github.com/gorilla/mux v1.8.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.122.0

--- a/exporter/elasticsearchexporter/integrationtest/go.sum
+++ b/exporter/elasticsearchexporter/integrationtest/go.sum
@@ -38,8 +38,8 @@ github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elastic/elastic-transport-go/v8 v8.6.1 h1:h2jQRqH6eLGiBSN4eZbQnJLtL4bC5b4lfVFRjw2R4e4=
 github.com/elastic/elastic-transport-go/v8 v8.6.1/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/go-docappender/v2 v2.7.0 h1:7zlhkeaZxnYij9N37mOx4DapswZtkmHe2SnI3w+MJzA=
-github.com/elastic/go-docappender/v2 v2.7.0/go.mod h1:xoTA2/HUjnIgF7acxxjfYaT7KE3nFhBQ5ZkmN0edE5o=
+github.com/elastic/go-docappender/v2 v2.6.1 h1:dl9dcRL390RTf5M5sb4bhpy4E+RJzC6NKoeTbF/hFY0=
+github.com/elastic/go-docappender/v2 v2.6.1/go.mod h1:NbNXsxNCnWEPmYeAqEkgdzk6SFOaw7c75wX2+RWEIZk=
 github.com/elastic/go-elasticsearch/v8 v8.17.1 h1:bOXChDoCMB4TIwwGqKd031U8OXssmWLT3UrAr9EGs3Q=
 github.com/elastic/go-elasticsearch/v8 v8.17.1/go.mod h1:MVJCtL+gJJ7x5jFeUmA20O7rvipX8GcQmo5iBcmaJn4=
 github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTRArYs=


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#38743