### PR TITLE
[reciever/prometheusremotewritereceiver] add help ref

### DIFF
--- a/.chloggen/metric-help-ref.yaml
+++ b/.chloggen/metric-help-ref.yaml
@@ -10,7 +10,7 @@ component: prometheusremotewritereciever
 note: 'Add help ref attribute to metric'
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [37791]
+issues: [37277]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/metric-help-ref.yaml
+++ b/.chloggen/metric-help-ref.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewritereciever
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Add help ref attribute to metric'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -174,6 +174,19 @@ func TestTranslateV2(t *testing.T) {
 			expectError: "unit ref 3 is out of bounds of symbolsTable",
 		},
 		{
+			name: "HelpRef bigger than symbols length",
+			request: &writev2.Request{
+				Symbols: []string{"", "__name__", "test"},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, HelpRef: 3},
+						LabelsRefs: []uint32{1, 2},
+					},
+				},
+			},
+			expectError: "help ref 3 is out of bounds of symbolsTable",
+		},
+		{
 			name:    "valid request",
 			request: writeV2RequestFixture,
 			expectedMetrics: func() pmetric.Metrics {

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -191,6 +191,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics1 := sm1.Metrics().AppendEmpty()
 				metrics1.SetName("test_metric1")
 				metrics1.SetUnit("")
+				metrics1.SetDescription("")
 
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -215,6 +216,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics2 := sm2.Metrics().AppendEmpty()
 				metrics2.SetName("test_metric1")
 				metrics2.SetUnit("")
+				metrics2.SetDescription("")
 
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
@@ -273,6 +275,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics1 := sm1.Metrics().AppendEmpty()
 				metrics1.SetName("test_metric")
 				metrics1.SetUnit("")
+				metrics1.SetDescription("")
 
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -290,6 +293,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics2 := sm2.Metrics().AppendEmpty()
 				metrics2.SetName("test_metric")
 				metrics2.SetUnit("")
+				metrics1.SetDescription("")
 
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
@@ -314,21 +318,27 @@ func TestTranslateV2(t *testing.T) {
 					"foo", "bar", // 13, 14
 					"f", "g", // 15, 16
 					"seconds", "milliseconds", // 17, 18
+					"small desc", "longer description", // 19, 20
 				},
 				Timeseries: []writev2.TimeSeries{
+					// The only difference between ts 0 and 1 is the value assigned in the HelpRef. According to the spec
+					// Ref: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model,
+					// the HelpRef(description) field is not considered an identifying property.
+					// This means that if you have two metrics with the same name, unit, scope, and resource attributes but different description values, they are still considered to be the same
+					// But, between them, the longer description should be used.
 					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 17},
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 17, HelpRef: 19},
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 						Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
 					},
 					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 17},
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 17, HelpRef: 20},
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
 						Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
 					},
 					{
 						// Unit changed, so it should be a different metric.
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 18},
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE, UnitRef: 18, HelpRef: 19},
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14},
 						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
 					},
@@ -352,6 +362,8 @@ func TestTranslateV2(t *testing.T) {
 				metrics1 := sm1.Metrics().AppendEmpty()
 				metrics1.SetName("test_metric")
 				metrics1.SetUnit("seconds")
+				metrics1.SetDescription("longer description")
+
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 				dp1.SetDoubleValue(1.0)
@@ -365,6 +377,8 @@ func TestTranslateV2(t *testing.T) {
 				metrics2 := sm1.Metrics().AppendEmpty()
 				metrics2.SetName("test_metric")
 				metrics2.SetUnit("milliseconds")
+				metrics2.SetDescription("small desc")
+
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
 				dp3.SetDoubleValue(3.0)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR belongs to part of the Linux foundation mentee program.
Here we are adding the help ref attribute to metric following the rules described [here](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes part of [#37277](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277)

