### PR TITLE
set start timestamp

### DIFF
--- a/.chloggen/set-start-timestamp.yaml
+++ b/.chloggen/set-start-timestamp.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: prometheusremotewritereceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: 'Set start timestamp for datapoint attributes'
+note: Use Created Timestamps to populate Datapoint's StartTimeUnixNano
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [37277]

--- a/.chloggen/set-start-timestamp.yaml
+++ b/.chloggen/set-start-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewritereciever
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Set start timestamp for datapoint attributes'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37277]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/set-start-timestamp.yaml
+++ b/.chloggen/set-start-timestamp.yaml
@@ -4,7 +4,7 @@
 change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: prometheusremotewritereciever
+component: prometheusremotewritereceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: 'Set start timestamp for datapoint attributes'

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -301,12 +301,11 @@ func parseJobAndInstance(dest pcommon.Map, job, instance string) {
 }
 
 // addNumberDatapoints adds the labels to the datapoints attributes.
-// TODO: We're still not handling the StartTimestamp.
 func addNumberDatapoints(datapoints pmetric.NumberDataPointSlice, ls labels.Labels, ts writev2.TimeSeries) {
 	// Add samples from the timeseries
 	for _, sample := range ts.Samples {
 		dp := datapoints.AppendEmpty()
-
+		dp.SetStartTimestamp(pcommon.Timestamp(ts.CreatedTimestamp * int64(time.Millisecond)))
 		// Set timestamp in nanoseconds (Prometheus uses milliseconds)
 		dp.SetTimestamp(pcommon.Timestamp(sample.Timestamp * int64(time.Millisecond)))
 		dp.SetDoubleValue(sample.Value)

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -31,19 +31,22 @@ var writeV2RequestFixture = &writev2.Request{
 	Symbols: []string{"", "__name__", "test_metric1", "job", "service-x/test", "instance", "107cn001", "d", "e", "foo", "bar", "f", "g", "h", "i", "Test gauge for test purposes", "Maybe op/sec who knows (:", "Test counter for test purposes"},
 	Timeseries: []writev2.TimeSeries{
 		{
-			Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-			LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // Symbolized writeRequestFixture.Timeseries[0].Labels
-			Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+			Metadata:         writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+			LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // Symbolized writeRequestFixture.Timeseries[0].Labels
+			Samples:          []writev2.Sample{{Value: 1, Timestamp: 1}},
+			CreatedTimestamp: 1,
 		},
 		{
-			Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-			LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // Same series as first. Should use the same resource metrics.
-			Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
+			Metadata:         writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+			LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, // Same series as first. Should use the same resource metrics.
+			Samples:          []writev2.Sample{{Value: 2, Timestamp: 2}},
+			CreatedTimestamp: 2,
 		},
 		{
-			Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-			LabelsRefs: []uint32{1, 2, 3, 9, 5, 10, 7, 8, 9, 10}, // This series has different label values for job and instance.
-			Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
+			Metadata:         writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+			LabelsRefs:       []uint32{1, 2, 3, 9, 5, 10, 7, 8, 9, 10}, // This series has different label values for job and instance.
+			Samples:          []writev2.Sample{{Value: 2, Timestamp: 2}},
+			CreatedTimestamp: 2,
 		},
 	},
 }
@@ -197,12 +200,14 @@ func TestTranslateV2(t *testing.T) {
 				dp1.SetDoubleValue(1.0)
 				dp1.Attributes().PutStr("d", "e")
 				dp1.Attributes().PutStr("foo", "bar")
+				dp1.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
 
 				dp2 := metrics1.Gauge().DataPoints().AppendEmpty()
 				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
 				dp2.SetDoubleValue(2.0)
 				dp2.Attributes().PutStr("d", "e")
 				dp2.Attributes().PutStr("foo", "bar")
+				dp2.SetStartTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
 
 				rm2 := expected.ResourceMetrics().AppendEmpty()
 				rmAttributes2 := rm2.Resource().Attributes()
@@ -221,6 +226,7 @@ func TestTranslateV2(t *testing.T) {
 				dp3.SetDoubleValue(2.0)
 				dp3.Attributes().PutStr("d", "e")
 				dp3.Attributes().PutStr("foo", "bar")
+				dp3.SetStartTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
 
 				return expected
 			}(),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR belongs to part of the Linux foundation mentee program.
Here we are setting the start timestamp for data point attributes

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes part of [#37277](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37277)

