### PR TITLE
[spanmetricconnector] README.md: fix default metric name prefix

### DIFF
--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -31,20 +31,20 @@ dimensions, including Errors. Multiple metrics can be aggregated if, for instanc
 a user wishes to view call counts just on `service.name` and `span.name`.
 
 ```
-calls{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
+traces.span.metrics.calls{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
 ```
 
 **Error** counts are computed from the Request counts which have an `Error` Status Code metric dimension.
 
 ```
-calls{service.name="shipping",span.name="get_shipping/{shippingId},span.kind="SERVER",status.code="Error"}
+traces.span.metrics.calls{service.name="shipping",span.name="get_shipping/{shippingId},span.kind="SERVER",status.code="Error"}
 ```
 
 **Duration** is computed from the difference between the span start and end times and inserted into the
 relevant duration histogram time bucket for each unique set dimensions.
 
 ```
-duration{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
+traces.span.metrics.duration{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
 ```
 
 Each metric will have _at least_ the following dimensions because they are common


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update README.md, fix default metric name prefix to `traces.span.metrics`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

This is a documentation PR