### PR TITLE
[chore] Cleanup for extensionauth.Server update

### DIFF
--- a/extension/basicauthextension/extension.go
+++ b/extension/basicauthextension/extension.go
@@ -32,7 +32,7 @@ func newClientAuthExtension(cfg *Config) *basicAuthClient {
 	return &basicAuthClient{clientAuth: cfg.ClientAuth}
 }
 
-func newServerAuthExtension(cfg *Config) (extensionauth.Server, error) {
+func newServerAuthExtension(cfg *Config) (*basicAuthServer, error) {
 	if cfg.Htpasswd == nil || (cfg.Htpasswd.File == "" && cfg.Htpasswd.Inline == "") {
 		return nil, errNoCredentialSource
 	}
@@ -42,7 +42,10 @@ func newServerAuthExtension(cfg *Config) (extensionauth.Server, error) {
 	}, nil
 }
 
-var _ extensionauth.Server = (*basicAuthServer)(nil)
+var (
+	_ extension.Extension  = (*basicAuthServer)(nil)
+	_ extensionauth.Server = (*basicAuthServer)(nil)
+)
 
 type basicAuthServer struct {
 	htpasswd  *HtpasswdSettings

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -20,11 +20,15 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.uber.org/zap"
 )
 
-var _ extensionauth.Server = (*oidcExtension)(nil)
+var (
+	_ extension.Extension  = (*oidcExtension)(nil)
+	_ extensionauth.Server = (*oidcExtension)(nil)
+)
 
 type oidcExtension struct {
 	cfg *Config

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -21,11 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensionauth"
 	"go.uber.org/zap"
 )
 
-func newTestExtension(t *testing.T, cfg *Config) extensionauth.Server {
+func newTestExtension(t *testing.T, cfg *Config) extension.Extension {
 	t.Helper()
 	return newExtension(cfg, zap.NewNop())
 }
@@ -58,15 +59,18 @@ func TestOIDCAuthenticationSucceeded(t *testing.T) {
 	token, err := oidcServer.token(payload)
 	require.NoError(t, err)
 
+	srvAuth, ok := p.(extensionauth.Server)
+	require.True(t, ok)
+
 	// test
-	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+	ctx, err := srvAuth.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 	// verify
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	// test, upper-case header
-	ctx, err = p.Authenticate(context.Background(), map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token)}})
+	ctx, err = srvAuth.Authenticate(context.Background(), map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 	// verify
 	assert.NoError(t, err)
@@ -206,10 +210,11 @@ func TestOIDCFailedToLoadIssuerCAFromPathInvalidContent(t *testing.T) {
 
 func TestOIDCInvalidAuthHeader(t *testing.T) {
 	// prepare
-	p := newTestExtension(t, &Config{
+	p, ok := newTestExtension(t, &Config{
 		Audience:  "some-audience",
 		IssuerURL: "http://example.com",
-	})
+	}).(extensionauth.Server)
+	require.True(t, ok)
 
 	// test
 	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"some-value"}})
@@ -221,10 +226,11 @@ func TestOIDCInvalidAuthHeader(t *testing.T) {
 
 func TestOIDCNotAuthenticated(t *testing.T) {
 	// prepare
-	p := newTestExtension(t, &Config{
+	p, ok := newTestExtension(t, &Config{
 		Audience:  "some-audience",
 		IssuerURL: "http://example.com",
-	})
+	}).(extensionauth.Server)
+	require.True(t, ok)
 
 	// test
 	ctx, err := p.Authenticate(context.Background(), make(map[string][]string))
@@ -266,8 +272,11 @@ func TestFailedToVerifyToken(t *testing.T) {
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
+	srvAuth, ok := p.(extensionauth.Server)
+	require.True(t, ok)
+
 	// test
-	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"Bearer some-token"}})
+	ctx, err := srvAuth.Authenticate(context.Background(), map[string][]string{"authorization": {"Bearer some-token"}})
 
 	// verify
 	assert.Error(t, err)
@@ -329,8 +338,11 @@ func TestFailedToGetGroupsClaimFromToken(t *testing.T) {
 			token, err := oidcServer.token(payload)
 			require.NoError(t, err)
 
+			srvAuth, ok := p.(extensionauth.Server)
+			require.True(t, ok)
+
 			// test
-			ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+			ctx, err := srvAuth.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 			// verify
 			assert.ErrorIs(t, err, tt.expectedError)

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/consumer v1.28.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.122.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.122.0
+	go.opentelemetry.io/collector/extension v1.28.0
 	go.opentelemetry.io/collector/extension/extensionauth v0.122.0
 	go.opentelemetry.io/collector/pdata v1.28.0
 	go.opentelemetry.io/collector/receiver v1.28.0
@@ -75,7 +76,6 @@ require (
 	go.opentelemetry.io/collector/config/configopaque v1.28.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.122.0 // indirect
 	go.opentelemetry.io/collector/exporter v0.122.0 // indirect
-	go.opentelemetry.io/collector/extension v1.28.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.28.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.122.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.122.0 // indirect

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/extension/extensionauth"
+	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
@@ -675,7 +675,7 @@ func (h *hostWithExtensions) GetExtensions() map[component.ID]component.Componen
 	return h.exts
 }
 
-func newTestAuthExtension(t *testing.T, authFunc func(ctx context.Context, hdrs map[string][]string) (context.Context, error)) extensionauth.Server {
+func newTestAuthExtension(t *testing.T, authFunc func(ctx context.Context, hdrs map[string][]string) (context.Context, error)) extension.Extension {
 	ctrl := gomock.NewController(t)
 	as := mock.NewMockServer(ctrl)
 	as.EXPECT().Authenticate(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(authFunc)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I intend to make `extensionauth.Server` independent of `extension.Extension` with open-telemetry/opentelemetry-collector/pull/12672. This means some changes in tests and such to make sure that we cast to the right interface when calling each method. This should have no visible impact to end users.