### PR TITLE
[chore] update nginx-prometheus-exporter dependency to v1.4.1

### DIFF
--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/nginxinc/nginx-prometheus-exporter v0.11.0
+	github.com/nginx/nginx-prometheus-exporter v1.4.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.122.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.122.0

--- a/receiver/nginxreceiver/go.sum
+++ b/receiver/nginxreceiver/go.sum
@@ -101,8 +101,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/nginxinc/nginx-prometheus-exporter v0.11.0 h1:21xjnqNgxtni2jDgAQ90bl15uDnrTreO9sIlu1YsX/U=
-github.com/nginxinc/nginx-prometheus-exporter v0.11.0/go.mod h1:GdyHnWAb8q8OW1Pssrrqbcqra0SH0Vn6UXICMmyWkw8=
+github.com/nginx/nginx-prometheus-exporter v1.4.1 h1:sqA5VYSs4Rx8pX/NIE37yZR0gNlH1WYVZHONe38a93k=
+github.com/nginx/nginx-prometheus-exporter v1.4.1/go.mod h1:TEU3FUxQKBvVgRkPyMuq9kclmUp/x0/ocr3K/8F7At8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This change has had a few previous attempts, mostly by renovate, which largely failed due to the rename of the upstream's org from `nginxinc` to `nginx`.

In addition, the function signature for the Nginx client initialization changed in v1 to no longer return an error. To account for that inspiration was taken from #31071 to move the client constructor to the `start` function.

This is my first attempt at contributing to this project, so please let me know if I need to adjust anything. Thank you.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
No open issues, but related to these previous PRs: #38545 #36999 #31272 #31071.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran tests via `make` locally.

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->