### PR TITLE
[receiver/sqlserver] fix failing windows unit test caused by line ending 

### DIFF
--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -106,6 +106,7 @@ func TestQueryTextAndPlanQueryContents(t *testing.T) {
 
 			actual, err := tt.getQuery(tt.instanceName, tt.maxQuerySampleCount, tt.lookbackTime)
 			require.NoError(t, err)
+			actual = strings.ReplaceAll(actual, "\r\n", "\n")
 			require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
 		})
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38813 Basically the line ending is different when testing in linux and windows 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
