### PR TITLE
[chore] Fix SQLServer receiver test on Windows

### DIFF
--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -99,14 +99,12 @@ func TestQueryTextAndPlanQueryContents(t *testing.T) {
 
 	for _, tt := range queryTests {
 		t.Run(tt.name, func(t *testing.T) {
-			expectedBytes, err := os.ReadFile(path.Join("./testdata", tt.expectedQueryValFilename))
+			expected, err := os.ReadFile(path.Join("./testdata", tt.expectedQueryValFilename))
 			require.NoError(t, err)
-			// Replace all will fix newlines when testing on Windows
-			expected := strings.ReplaceAll(string(expectedBytes), "\r\n", "\n")
 
 			actual, err := tt.getQuery(tt.instanceName, tt.maxQuerySampleCount, tt.lookbackTime)
 			require.NoError(t, err)
-			require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
+			require.Equal(t, strings.TrimSpace(string(expected)), strings.TrimSpace(actual))
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Removing the unnecessary `\r\n` replacement since the new query uses file template-based formatting.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38813 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
