### PR TITLE
[chore] kafkareceiver: embed configkafka types

### DIFF
--- a/internal/kafka/configkafka/config.go
+++ b/internal/kafka/configkafka/config.go
@@ -99,7 +99,7 @@ func NewDefaultConsumerConfig() ConsumerConfig {
 		SessionTimeout:    10 * time.Second,
 		HeartbeatInterval: 3 * time.Second,
 		GroupID:           "otel-collector",
-		InitialOffset:     "latest",
+		InitialOffset:     LatestOffset,
 		AutoCommit: AutoCommitConfig{
 			Enable:   true,
 			Interval: time.Second,

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -19,13 +19,12 @@ Note that metrics and logs only support OTLP.
 
 ## Getting Started
 
-The following settings are required:
-
-- `protocol_version` (no default): Kafka protocol version e.g. 2.0.0
+There are no required settings.
 
 The following settings can be optionally configured:
 
-- `brokers` (default = localhost:9092): The list of kafka brokers
+- `brokers` (default = localhost:9092): The list of kafka brokers.
+- `protocol_version` (default = 2.1.0): Kafka protocol version.
 - `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to read from.
   Only one telemetry type may be used for a given topic.

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -4,21 +4,33 @@
 package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 
 import (
-	"time"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/configkafka"
 )
 
-type AutoCommit struct {
-	// Whether or not to auto-commit updated offsets back to the broker.
-	// (default enabled).
-	Enable bool `mapstructure:"enable"`
-	// How frequently to commit updated offsets. Ineffective unless
-	// auto-commit is enabled (default 1s)
-	Interval time.Duration `mapstructure:"interval"`
+var _ component.Config = (*Config)(nil)
+
+// Config defines configuration for Kafka receiver.
+type Config struct {
+	configkafka.ClientConfig   `mapstructure:",squash"`
+	configkafka.ConsumerConfig `mapstructure:",squash"`
+
+	// The name of the kafka topic to consume from (default "otlp_spans" for traces, "otlp_metrics" for metrics, "otlp_logs" for logs)
+	Topic string `mapstructure:"topic"`
+
+	// Encoding of the messages (default "otlp_proto")
+	Encoding string `mapstructure:"encoding"`
+
+	// Controls the way the messages are marked as consumed
+	MessageMarking MessageMarking `mapstructure:"message_marking"`
+
+	// Extract headers from kafka records
+	HeaderExtraction HeaderExtraction `mapstructure:"header_extraction"`
+
+	// In case of some errors returned by the next consumer, the receiver will wait and retry the failed message
+	ErrorBackOff configretry.BackOffConfig `mapstructure:"error_backoff"`
 }
 
 type MessageMarking struct {
@@ -35,68 +47,4 @@ type MessageMarking struct {
 type HeaderExtraction struct {
 	ExtractHeaders bool     `mapstructure:"extract_headers"`
 	Headers        []string `mapstructure:"headers"`
-}
-
-// Config defines configuration for Kafka receiver.
-type Config struct {
-	// The list of kafka brokers (default localhost:9092)
-	Brokers []string `mapstructure:"brokers"`
-	// ResolveCanonicalBootstrapServersOnly makes Sarama do a DNS lookup for
-	// each of the provided brokers. It will then do a PTR lookup for each
-	// returned IP, and that set of names becomes the broker list. This can be
-	// required in SASL environments.
-	ResolveCanonicalBootstrapServersOnly bool `mapstructure:"resolve_canonical_bootstrap_servers_only"`
-	// Kafka protocol version
-	ProtocolVersion string `mapstructure:"protocol_version"`
-	// Session interval for the Kafka consumer
-	SessionTimeout time.Duration `mapstructure:"session_timeout"`
-	// Heartbeat interval for the Kafka consumer
-	HeartbeatInterval time.Duration `mapstructure:"heartbeat_interval"`
-	// The name of the kafka topic to consume from (default "otlp_spans" for traces, "otlp_metrics" for metrics, "otlp_logs" for logs)
-	Topic string `mapstructure:"topic"`
-	// Encoding of the messages (default "otlp_proto")
-	Encoding string `mapstructure:"encoding"`
-	// The consumer group that receiver will be consuming messages from (default "otel-collector")
-	GroupID string `mapstructure:"group_id"`
-	// The consumer client ID that receiver will use (default "otel-collector")
-	ClientID string `mapstructure:"client_id"`
-	// The initial offset to use if no offset was previously committed.
-	// Must be `latest` or `earliest` (default "latest").
-	InitialOffset string `mapstructure:"initial_offset"`
-
-	// Metadata is the namespace for metadata management properties used by the
-	// Client, and shared by the Producer/Consumer.
-	Metadata configkafka.MetadataConfig `mapstructure:"metadata"`
-
-	Authentication configkafka.AuthenticationConfig `mapstructure:"auth"`
-
-	// Controls the auto-commit functionality
-	AutoCommit AutoCommit `mapstructure:"autocommit"`
-
-	// Controls the way the messages are marked as consumed
-	MessageMarking MessageMarking `mapstructure:"message_marking"`
-
-	// Extract headers from kafka records
-	HeaderExtraction HeaderExtraction `mapstructure:"header_extraction"`
-
-	// The minimum bytes per fetch from Kafka (default "1")
-	MinFetchSize int32 `mapstructure:"min_fetch_size"`
-	// The default bytes per fetch from Kafka (default "1048576")
-	DefaultFetchSize int32 `mapstructure:"default_fetch_size"`
-	// The maximum bytes per fetch from Kafka (default "0", no limit)
-	MaxFetchSize int32 `mapstructure:"max_fetch_size"`
-	// In case of some errors returned by the next consumer, the receiver will wait and retry the failed message
-	ErrorBackOff configretry.BackOffConfig `mapstructure:"error_backoff"`
-}
-
-const (
-	offsetLatest   string = "latest"
-	offsetEarliest string = "earliest"
-)
-
-var _ component.Config = (*Config)(nil)
-
-// Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
-	return nil
 }

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -18,28 +17,10 @@ import (
 )
 
 const (
-	defaultTracesTopic       = "otlp_spans"
-	defaultMetricsTopic      = "otlp_metrics"
-	defaultLogsTopic         = "otlp_logs"
-	defaultEncoding          = "otlp_proto"
-	defaultBroker            = "localhost:9092"
-	defaultClientID          = "otel-collector"
-	defaultGroupID           = defaultClientID
-	defaultInitialOffset     = offsetLatest
-	defaultSessionTimeout    = 10 * time.Second
-	defaultHeartbeatInterval = 3 * time.Second
-
-	// default from sarama.NewConfig()
-	defaultAutoCommitEnable = true
-	// default from sarama.NewConfig()
-	defaultAutoCommitInterval = 1 * time.Second
-
-	// default from sarama.NewConfig()
-	defaultMinFetchSize = int32(1)
-	// default from sarama.NewConfig()
-	defaultDefaultFetchSize = int32(1048576)
-	// default from sarama.NewConfig()
-	defaultMaxFetchSize = int32(0)
+	defaultTracesTopic  = "otlp_spans"
+	defaultMetricsTopic = "otlp_metrics"
+	defaultLogsTopic    = "otlp_logs"
+	defaultEncoding     = "otlp_proto"
 )
 
 var errUnrecognizedEncoding = errors.New("unrecognized encoding")
@@ -64,18 +45,9 @@ func NewFactory(options ...FactoryOption) receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Encoding:          defaultEncoding,
-		Brokers:           []string{defaultBroker},
-		ClientID:          defaultClientID,
-		GroupID:           defaultGroupID,
-		InitialOffset:     defaultInitialOffset,
-		SessionTimeout:    defaultSessionTimeout,
-		HeartbeatInterval: defaultHeartbeatInterval,
-		Metadata:          configkafka.NewDefaultMetadataConfig(),
-		AutoCommit: AutoCommit{
-			Enable:   defaultAutoCommitEnable,
-			Interval: defaultAutoCommitInterval,
-		},
+		ClientConfig:   configkafka.NewDefaultClientConfig(),
+		ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
+		Encoding:       defaultEncoding,
 		MessageMarking: MessageMarking{
 			After:   false,
 			OnError: false,
@@ -83,9 +55,6 @@ func createDefaultConfig() component.Config {
 		HeaderExtraction: HeaderExtraction{
 			ExtractHeaders: false,
 		},
-		MinFetchSize:     defaultMinFetchSize,
-		DefaultFetchSize: defaultDefaultFetchSize,
-		MaxFetchSize:     defaultMaxFetchSize,
 	}
 }
 

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/configkafka"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
 
@@ -24,15 +25,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.NotNil(t, cfg, "failed to create default config")
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
-	assert.Equal(t, []string{defaultBroker}, cfg.Brokers)
-	assert.Equal(t, defaultGroupID, cfg.GroupID)
-	assert.Equal(t, defaultClientID, cfg.ClientID)
-	assert.Equal(t, defaultInitialOffset, cfg.InitialOffset)
-	assert.Equal(t, defaultSessionTimeout, cfg.SessionTimeout)
-	assert.Equal(t, defaultHeartbeatInterval, cfg.HeartbeatInterval)
-	assert.Equal(t, defaultMinFetchSize, cfg.MinFetchSize)
-	assert.Equal(t, defaultDefaultFetchSize, cfg.DefaultFetchSize)
-	assert.Equal(t, defaultMaxFetchSize, cfg.MaxFetchSize)
+	assert.Equal(t, configkafka.NewDefaultClientConfig(), cfg.ClientConfig)
+	assert.Equal(t, configkafka.NewDefaultConsumerConfig(), cfg.ConsumerConfig)
 }
 
 func TestCreateTraces(t *testing.T) {

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -35,17 +35,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadatatest"
 )
 
-func TestNewTracesReceiver_version_err(t *testing.T) {
-	c := Config{
-		Encoding:        defaultEncoding,
-		ProtocolVersion: "none",
-	}
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-}
-
 func TestNewTracesReceiver_encoding_err(t *testing.T) {
 	c := createDefaultConfig().(*Config)
 	c.Encoding = "foo"
@@ -55,19 +44,6 @@ func TestNewTracesReceiver_encoding_err(t *testing.T) {
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
-}
-
-func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
-	c := Config{
-		InitialOffset: "foo",
-		Encoding:      defaultEncoding,
-	}
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	require.Error(t, err)
-	assert.EqualError(t, err, errInvalidInitialOffset.Error())
 }
 
 func TestTracesReceiverStart(t *testing.T) {
@@ -372,17 +348,6 @@ func TestTracesReceiver_encoding_extension(t *testing.T) {
 	}, 10*time.Second, time.Millisecond*100)
 }
 
-func TestNewMetricsReceiver_version_err(t *testing.T) {
-	c := Config{
-		Encoding:        defaultEncoding,
-		ProtocolVersion: "none",
-	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-}
-
 func TestNewMetricsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
@@ -392,19 +357,6 @@ func TestNewMetricsReceiver_encoding_err(t *testing.T) {
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
-}
-
-func TestNewMetricsReceiver_initial_offset_err(t *testing.T) {
-	c := Config{
-		InitialOffset: "foo",
-		Encoding:      defaultEncoding,
-	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	require.Error(t, err)
-	assert.EqualError(t, err, errInvalidInitialOffset.Error())
 }
 
 func TestMetricsReceiverStartConsume(t *testing.T) {
@@ -693,18 +645,6 @@ func TestMetricsReceiver_encoding_extension(t *testing.T) {
 	}, 10*time.Second, time.Millisecond*100)
 }
 
-func TestNewLogsReceiver_version_err(t *testing.T) {
-	c := Config{
-		Encoding:        defaultEncoding,
-		ProtocolVersion: "none",
-	}
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-}
-
 func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
@@ -715,19 +655,6 @@ func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
-}
-
-func TestNewLogsReceiver_initial_offset_err(t *testing.T) {
-	c := Config{
-		InitialOffset: "foo",
-		Encoding:      defaultEncoding,
-	}
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(metadata.Type), consumertest.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	require.Error(t, err)
-	assert.EqualError(t, err, errInvalidInitialOffset.Error())
 }
 
 func TestLogsReceiverStart(t *testing.T) {
@@ -1152,33 +1079,6 @@ func TestLogsReceiver_encoding_extension(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return logObserver.FilterField(zap.Error(expectedErr)).Len() > 0
 	}, 10*time.Second, time.Millisecond*100)
-}
-
-func TestToSaramaInitialOffset_earliest(t *testing.T) {
-	saramaInitialOffset, err := toSaramaInitialOffset(offsetEarliest)
-
-	require.NoError(t, err)
-	assert.Equal(t, sarama.OffsetOldest, saramaInitialOffset)
-}
-
-func TestToSaramaInitialOffset_latest(t *testing.T) {
-	saramaInitialOffset, err := toSaramaInitialOffset(offsetLatest)
-
-	require.NoError(t, err)
-	assert.Equal(t, sarama.OffsetNewest, saramaInitialOffset)
-}
-
-func TestToSaramaInitialOffset_default(t *testing.T) {
-	saramaInitialOffset, err := toSaramaInitialOffset("")
-
-	require.NoError(t, err)
-	assert.Equal(t, sarama.OffsetNewest, saramaInitialOffset)
-}
-
-func TestToSaramaInitialOffset_invalid(t *testing.T) {
-	_, err := toSaramaInitialOffset("other")
-
-	assert.Equal(t, err, errInvalidInitialOffset)
 }
 
 type testConsumerGroupClaim struct {

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -4,17 +4,8 @@ kafka:
     - "foo:123"
     - "bar:456"
   resolve_canonical_bootstrap_servers_only: true
-  client_id: otel-collector
-  group_id: otel-collector
-  auth:
-    tls:
-      ca_file: ca.pem
-      cert_file: cert.pem
-      key_file: key.pem
-  metadata:
-    retry:
-      max: 10
-      backoff: 5s
+  client_id: the_client_id
+  group_id: the_group_id
 kafka/logs:
   topic: logs
   session_timeout: 45s


### PR DESCRIPTION
#### Description

Use configkafka.ClientConfig and configkafka.ConsumerConfig, and the newly extracted consumer client. Redundant validation tests have been removed, as they are now covered by configkafka.

This is a non-functional change, as the config defaults do not change for this component. Nevertheless I have manually tested -- see Testing section below.

#### Link to tracking issue

Fixes #38411

#### Testing

Updated unit tests.

Manually tested against Redpanda:

`$ docker run --publish=9093:9093 --health-cmd "rpk cluster health | grep 'Healthy:.*true'" docker.redpanda.com/redpandadata/redpanda:v23.1.11 redpanda start --kafka-addr=internal://0.0.0.0:9092,external://0.0.0.0:9093 --smp=1 --memory=1G --mode=dev-container`

Ran the collector with `kafkametrics -> kafkaexporter -> Redpanda -> kafkareceiver -> debugexporter`:

```yaml
receivers:
  kafka:
    brokers: [localhost:9093]
  kafkametrics:
    brokers: [localhost:9093]
    collection_interval: 10s
    scrapers: [topics, consumers]

exporters:
  debug:
    verbosity: detailed
  kafka:
    brokers: [localhost:9093]

service:
  pipelines:
    metrics/kafka:
      receivers: [kafka]
      exporters: [debug]
    metrics:
      receivers: [kafkametrics]
      exporters: [kafka]
```

#### Documentation

Updated README to clarify that `protocol_version` is not required.