### PR TITLE
[receiver/sqlserver] Remove warning on resource attributes

### DIFF
--- a/.chloggen/remove_resourceattrs_warning.yaml
+++ b/.chloggen/remove_resourceattrs_warning.yaml
@@ -10,7 +10,7 @@ component: receiver/sqlserver
 note: Remove warning that `server.address` and `server.port` resource attributes will be enabled
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [38831]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/remove_resourceattrs_warning.yaml
+++ b/.chloggen/remove_resourceattrs_warning.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove warning that `server.address` and `server.port` resource attributes will be enabled
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/remove_resourceattrs_warning.yaml
+++ b/.chloggen/remove_resourceattrs_warning.yaml
@@ -15,7 +15,11 @@ issues: []
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  There is no intention of enabling these resource attributes by default,
+  this change is to simply remove the warning.
+  The `server.address` and `server.port` resource attributes were, and still are,
+  disabled by default.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -2538,12 +2538,6 @@ func WithStartTime(startTime pcommon.Timestamp) MetricBuilderOption {
 	})
 }
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...MetricBuilderOption) *MetricsBuilder {
-	if !mbc.ResourceAttributes.ServerAddress.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `server.address`: This attribute will be enabled by default starting in release v0.121.0.")
-	}
-	if !mbc.ResourceAttributes.ServerPort.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `server.port`: This attribute will be enabled by default starting in release v0.121.0.")
-	}
 	mb := &MetricsBuilder{
 		config:                                   mbc,
 		startTime:                                pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -62,14 +62,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			if tt.resAttrsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `server.address`: This attribute will be enabled by default starting in release v0.121.0.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if tt.resAttrsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `server.port`: This attribute will be enabled by default starting in release v0.121.0.", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
 
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -27,14 +27,10 @@ resource_attributes:
     description: Name of the database host.
     enabled: false
     type: string
-    warnings:
-      if_enabled_not_set: "This attribute will be enabled by default starting in release v0.121.0."
   server.port:
     description: Server port number.
     enabled: false
     type: int
-    warnings:
-      if_enabled_not_set: "This attribute will be enabled by default starting in release v0.121.0."
 
 attributes:
   page.operations:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The `server.address` and `server.port` resource attributes in the SQL Server receiver had warnings that they will be enabled by default in a future release. These resource attributes are being set by simply passing through config option values. The config options, `server` and `port`, are optional. Also, the SQL Server receiver supports scraping Windows Performance counters for metrics, which render these resource attributes meaningless. For these reasons, the resource attributes should continue to be disabled by default.

There may be some way to get these resource attributes from windows perf counters, but that is a separate work item that would be required before enabling. If that work gets done at some point we can revisit enabling these by default.

Related: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35183