### PR TITLE
[receiver/sqlserver] Ensure all enabled metrics are emitted

### DIFF
--- a/.chloggen/fix_sqlserver_query_check.yaml
+++ b/.chloggen/fix_sqlserver_query_check.yaml
@@ -10,7 +10,7 @@ component: receiver/sqlserver
 note: Ensure all enabled metrics are emitted
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [38839]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix_sqlserver_query_check.yaml
+++ b/.chloggen/fix_sqlserver_query_check.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure all enabled metrics are emitted
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -66,15 +66,7 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabaseIOQuery(cfg.InstanceName))
 	}
 
-	if cfg.MetricsBuilderConfig.Metrics.SqlserverBatchRequestRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverPageBufferCacheHitRatio.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledWriteRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverLockWaitRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverProcessesBlocked.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLCompilationRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverUserConnectionCount.Enabled {
+	if isPerfCounterQueryEnabled(&cfg.MetricsBuilderConfig.Metrics) {
 		queries = append(queries, getSQLServerPerformanceCounterQuery(cfg.InstanceName))
 	}
 
@@ -256,10 +248,52 @@ func setupLogsScrapers(params receiver.Settings, cfg *Config) ([]scraperhelper.C
 }
 
 func isDatabaseIOQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+
 	if metrics.SqlserverDatabaseLatency.Enabled ||
 		metrics.SqlserverDatabaseOperations.Enabled ||
 		metrics.SqlserverDatabaseIo.Enabled {
 		return true
 	}
+	return false
+}
+
+func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
+	if metrics == nil {
+		return false
+	}
+
+	if metrics.SqlserverBatchRequestRate.Enabled ||
+		metrics.SqlserverBatchSQLCompilationRate.Enabled ||
+		metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
+		metrics.SqlserverDatabaseBackupOrRestoreRate.Enabled ||
+		metrics.SqlserverDatabaseExecutionErrors.Enabled ||
+		metrics.SqlserverDatabaseFullScanRate.Enabled ||
+		metrics.SqlserverDatabaseTempdbSpace.Enabled ||
+		metrics.SqlserverDatabaseTempdbVersionStoreSize.Enabled ||
+		metrics.SqlserverDeadlockRate.Enabled ||
+		metrics.SqlserverIndexSearchRate.Enabled ||
+		metrics.SqlserverLockTimeoutRate.Enabled ||
+		metrics.SqlserverLockWaitRate.Enabled ||
+		metrics.SqlserverLoginRate.Enabled ||
+		metrics.SqlserverLogoutRate.Enabled ||
+		metrics.SqlserverMemoryGrantsPendingCount.Enabled ||
+		metrics.SqlserverMemoryUsage.Enabled ||
+		metrics.SqlserverPageBufferCacheFreeListStallsRate.Enabled ||
+		metrics.SqlserverPageBufferCacheHitRatio.Enabled ||
+		metrics.SqlserverPageLookupRate.Enabled ||
+		metrics.SqlserverProcessesBlocked.Enabled ||
+		metrics.SqlserverReplicaDataRate.Enabled ||
+		metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
+		metrics.SqlserverResourcePoolDiskThrottledWriteRate.Enabled ||
+		metrics.SqlserverTableCount.Enabled ||
+		metrics.SqlserverTransactionDelay.Enabled ||
+		metrics.SqlserverTransactionMirrorWriteRate.Enabled ||
+		metrics.SqlserverUserConnectionCount.Enabled {
+		return true
+	}
+
 	return false
 }

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -252,12 +252,9 @@ func isDatabaseIOQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	if metrics.SqlserverDatabaseLatency.Enabled ||
+	return metrics.SqlserverDatabaseLatency.Enabled ||
 		metrics.SqlserverDatabaseOperations.Enabled ||
-		metrics.SqlserverDatabaseIo.Enabled {
-		return true
-	}
-	return false
+		metrics.SqlserverDatabaseIo.Enabled
 }
 
 func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
@@ -265,7 +262,7 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		return false
 	}
 
-	if metrics.SqlserverBatchRequestRate.Enabled ||
+	return metrics.SqlserverBatchRequestRate.Enabled ||
 		metrics.SqlserverBatchSQLCompilationRate.Enabled ||
 		metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
 		metrics.SqlserverDatabaseBackupOrRestoreRate.Enabled ||
@@ -291,9 +288,5 @@ func isPerfCounterQueryEnabled(metrics *metadata.MetricsConfig) bool {
 		metrics.SqlserverTableCount.Enabled ||
 		metrics.SqlserverTransactionDelay.Enabled ||
 		metrics.SqlserverTransactionMirrorWriteRate.Enabled ||
-		metrics.SqlserverUserConnectionCount.Enabled {
-		return true
-	}
-
-	return false
+		metrics.SqlserverUserConnectionCount.Enabled
 }

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -5,6 +5,7 @@ package sqlserverreceiver
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
+	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver/internal/metadata"
 )
@@ -247,4 +249,20 @@ func TestNewCache(t *testing.T) {
 	require.NotNil(t, cache.Values())
 	cache = newCache(0)
 	require.NotNil(t, cache.Values())
+}
+
+func TestSetupQueries(t *testing.T) {
+	var metadata map[string]any
+
+	yamlFile, err := os.ReadFile("./metadata.yaml")
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(yamlFile, &metadata))
+	require.NotNil(t, metadata["metrics"])
+
+	metricsMetadata, ok := metadata["metrics"].(map[string]any)
+	require.True(t, ok)
+	require.Len(t, metricsMetadata, 45,
+		"Every time metrics are added or removed, the function `setupQueries` must "+
+			"be modified to properly account for the change. Please update `setupQueries` and then, "+
+			"and only then, update the expected metric count here.")
 }

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -136,7 +137,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.71.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When directly connecting to SQL Server, this receiver runs multiple queries to get enabled metrics. Each query is only run if one or more metric is enabled for that particular query. The bug here was that some metrics weren't properly being checked to see if they were enabled. This means that in some cases, if a subset of metrics were enabled, the query wouldn't be run, and the metrics wouldn't be recorded or emitted.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a test to ensure whenever new metrics are added, the `setupQueries` method gets changed as well. If we continue to hit more bugs with this we may want to just always run the queries, even if there's a slight performance hit.