### PR TITLE
[chore][ping-code-owners-on-new-issue] Fix variable reference

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -33,7 +33,7 @@ if [[ -n "${TITLE_COMPONENT}" && ! ("${TITLE_COMPONENT}" =~ " ") ]]; then
   if [[ -n "${CODEOWNERS}" ]]; then
     PING_LINES+="- ${TITLE_COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
-    LABEL_NAME=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
+    LABEL_NAME=$(awk -v path="${TITLE_COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
     if (( "${#LABEL_NAME}" <= 50 )); then
       LABELS+="${LABEL_NAME}"
     else


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Lately some `Ping code owners on a new issue` action runs have [been failing](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13972340605/job/39117145364) with the following error:
```
./.github/workflows/scripts/ping-codeowners-on-new-issue.sh: line 36: COMPONENT: unbound variable
```

This was because recently a variable reference was changed to the wrong variable name, view the diff of the related PR to see the context.

Related: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38622