### PR TITLE
[chore][ping-codeowners-on-new-issue] Process issue even if code owner filed

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -47,8 +47,8 @@ for COMPONENT in ${BODY_COMPONENTS}; do
   COMPONENT=${COMPONENT//,/}
   
   CODEOWNERS=$(COMPONENT="${COMPONENT}" "${CUR_DIRECTORY}/get-codeowners.sh" || true)
-  
-  if [[ -n "${CODEOWNERS}" && ! ("${CODEOWNERS}" =~ ${OPENER}) ]]; then
+
+  if [[ -n "${CODEOWNERS}" ]]; then
     if [[ -v PINGED_COMPONENTS["${COMPONENT}"] ]]; then
       continue
     fi


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently when a code owner files an issue the component's label is not added and the code owners are not pinged. This changes functionality so that even if a code owner files an issue, the component label is added and the code owners are pinged. I investigated this as a result of [confusion because of the existing behavior](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38672#issuecomment-2730517521).

Note: If the component is included in the title the label will be properly added to the component even before this change.

Pros for this change:
- Labels are added automatically
- Other code owners (for the case of >1 code owner for a component) are notified of a new issue against their component.

Cons for this change:
- It might result in noise for the code owner who is filing issues, especially if they're filing in bulk.

Alternatives:
- We could at least add the label even if a code owner filed the issue.
- We could try to remove the filing code owner's handle from the ping message so they don't get pinged, and add a case for not pinging code owners if the user filing is the only code owner.

Related:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33437
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30136