### PR TITLE
[chore][ping code owners] Fix multiple matching components

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -13,7 +13,7 @@ if [[ -z "${COMPONENT:-}" || -z "${ISSUE:-}" ]]; then
 fi
 
 CUR_DIRECTORY=$(dirname "$0")
-COMPONENT=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt)
+COMPONENT=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt | head -n 1)
 OWNERS=$(COMPONENT="${COMPONENT}" bash "${CUR_DIRECTORY}/get-codeowners.sh")
 
 if [[ -z "${OWNERS}" ]]; then

--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -33,7 +33,7 @@ if [[ -n "${TITLE_COMPONENT}" && ! ("${TITLE_COMPONENT}" =~ " ") ]]; then
   if [[ -n "${CODEOWNERS}" ]]; then
     PING_LINES+="- ${TITLE_COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
-    LABEL_NAME=$(awk -v path="${TITLE_COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
+    LABEL_NAME=$(awk -v path="${TITLE_COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt | head -n 1)
     if (( "${#LABEL_NAME}" <= 50 )); then
       LABELS+="${LABEL_NAME}"
     else
@@ -55,7 +55,7 @@ for COMPONENT in ${BODY_COMPONENTS}; do
 
     PING_LINES+="- ${COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${COMPONENT}"]=1
-    LABEL_NAME=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
+    LABEL_NAME=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt | head -n 1)
     if (( "${#LABEL_NAME}" > 50 )); then
       echo "'${LABEL_NAME}' exceeds GitHub's 50-character limit on labels, skipping adding a label"
       continue


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The current `awk` expression will return all matches, so if a component label is a substring of another component label, the resulting label will be all matching labels appended to each other.

Example: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38780
The label wasn't originally added because the [found label was too long to add](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13938538170/job/39010977164). However, code owners were properly pinged. When I added the proper label, the [incorrect label name was detected](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38780#issuecomment-2737088985).

When searching the `.github/component_labels.txt` file, the label we want to add is the first match that we find. This is the **minimally matching label**, since the file is in alphabetical order. There may be a better `awk` way to implement this logic, but `head -n 1` returns the first matching line, if any are found in the given text.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38622

<!--Describe what testing was performed and which tests were added.-->
#### Testing
**Before:**
```
crobert$ ~/dev/contrib/first $ COMPONENT="receiver/hostmetrics"
crobert$ ~/dev/contrib/first $ awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt
receiver/hostmetricsreceiver
receiver/hostmetricsreceiver/internal/scraper/cpuscraper
receiver/hostmetricsreceiver/internal/scraper/diskscraper
receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
receiver/hostmetricsreceiver/internal/scraper/loadscraper
receiver/hostmetricsreceiver/internal/scraper/memoryscraper
receiver/hostmetricsreceiver/internal/scraper/networkscraper
receiver/hostmetricsreceiver/internal/scraper/pagingscraper
receiver/hostmetricsreceiver/internal/scraper/processesscraper
receiver/hostmetricsreceiver/internal/scraper/processscraper
receiver/hostmetricsreceiver/internal/scraper/systemscraper
crobert$ ~/dev/contrib/first $ COMPONENT="extension/encoding"
crobert$ ~/dev/contrib/first $ awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt
extension/encoding
extension/encoding/avrologencodingextension
extension/encoding/awscloudwatchmetricstreamsencodingextension
extension/encoding/awslogsencodingextension
extension/encoding/googlecloudlogentryencodingextension
extension/encoding/jaegerencodingextension
extension/encoding/jsonlogencodingextension
extension/encoding/otlpencodingextension
extension/encoding/skywalkingencodingextension
extension/encoding/textencodingextension
extension/encoding/zipkinencodingextension
```
**After:**
```
crobert$ ~/dev/contrib/first $ COMPONENT="receiver/hostmetrics"
crobert$ ~/dev/contrib/first $ awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt | head -n 1
receiver/hostmetricsreceiver
crobert$ ~/dev/contrib/first $ COMPONENT="extension/encoding"
crobert$ ~/dev/contrib/first $ awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt | head -n 1
extension/encoding