### PR TITLE
[draft] Scoped-tests using the default make target

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,6 @@
 
 go.sum linguist-generated=true
 
-# To avoid lint or diff reporting files due to different line endings
-eol=lf
+# To avoid git status and other tools reporting files due to different line endings
+# normalize the line endings to LF
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 
 go.sum linguist-generated=true
 
+# To avoid lint or diff reporting files due to different line endings
+eol=lf

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -24,20 +24,32 @@ jobs:
         shell: bash
         id: changes
         run: |
+          echo -e "00 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
 
           go_sources=$(echo "$changed_files" | grep .go$ | xargs)
-          echo "go_sources=$go_sources"
+          echo -e "go_sources=\n$go_sources\n***************"
           if [[ -n "$go_sources" ]]; then
-            echo "go_sources=$go_sources" >> $GITHUB_OUTPUT
+            {
+              echo 'go_sources<<EOF'
+              echo $go_sources
+              echo EOF
+            } >> $GITHUB_OUTPUT
           fi
+
+          echo -e "01 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
 
           go_tests=$(echo "$changed_files" | grep _test.go$ | xargs)
-          echo "go_tests=$go_tests"
+          echo -e "go_tests=\n$go_tests\n***************"
           if [[ -n "$go_tests" ]]; then
-            echo "go_tests=$go_tests" >> $GITHUB_OUTPUT
+            {
+              echo 'go_tests<<EOF'
+              echo $go_tests
+              echo EOF
+            } >> $GITHUB_OUTPUT
           fi
 
+          echo -e "02 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
   scoped-tests:
     needs: changedfiles
     if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -10,6 +10,8 @@ jobs:
   changedfiles:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
       go_sources: ${{ steps.changed-source.outputs.go_sources }}
       go_tests: ${{ steps.changed-test.outputs.go_tests }}

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -20,21 +20,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed files
+      - name: Get changed source files
         shell: bash
         id: changed-source
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .go$ | xargs)
-          echo $files
-          echo "go_sources=$files" >> $GITHUB_OUTPUT
+          if [[ -n "$files" ]]; then
+            echo "go_sources=$files" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Get changed files
+      - name: Get changed test files
         shell: bash
         id: changed-test
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep _test.go$ | xargs)
-          echo $files
-          echo "go_tests=$files" >> $GITHUB_OUTPUT
+          if [[ -n "$files" ]]; then
+            echo "go_tests=$files" >> $GITHUB_OUTPUT
+          fi
 
   scoped-tests:
     needs: changedfiles

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -19,19 +19,21 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+
       - name: Get changed files
         shell: bash
         id: changed-source
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .go$ | xargs)
-
+          echo $files
           echo "go_sources=$files" >> $GITHUB_OUTPUT
+
       - name: Get changed files
         shell: bash
         id: changed-test
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep _test.go$ | xargs)
-
+          echo $files
           echo "go_tests=$files" >> $GITHUB_OUTPUT
 
   scoped-tests:

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
 
-          go_sources=$(echo "$changed_files" | grep .go$  || true | xargs)
+          go_sources=$(echo "$changed_files" | grep .go$ | grep -v -E .*_test\.go$ | xargs)
           if [[ -n "$go_sources" ]]; then
             {
               echo 'go_sources<<EOF'
@@ -35,7 +35,7 @@ jobs:
             } >> $GITHUB_OUTPUT
           fi
 
-          go_tests=$(echo "$changed_files" | grep _test.go$ || true | xargs)
+          go_tests=$(echo "$changed_files" | grep -E .*_test.go$ | xargs)
           if [[ -n "$go_tests" ]]; then
             {
               echo 'go_tests<<EOF'

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -13,29 +13,29 @@ jobs:
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
-      go_sources: ${{ steps.changed-source.outputs.go_sources }}
-      go_tests: ${{ steps.changed-test.outputs.go_tests }}
+      go_sources: ${{ steps.changes.outputs.go_sources }}
+      go_tests: ${{ steps.changes.outputs.go_tests }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
-      - name: Get changed source files
+      - name: Get changes
         shell: bash
-        id: changed-source
+        id: changes
         run: |
-          files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .go$ | xargs)
-          if [[ -n "$files" ]]; then
-            echo "go_sources=$files" >> $GITHUB_OUTPUT
+          changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
+
+          go_sources=$(echo "$changed_files" | grep .go$ | xargs)
+          echo "go_sources=$go_sources"
+          if [[ -n "$go_sources" ]]; then
+            echo "go_sources=$go_sources" >> $GITHUB_OUTPUT
           fi
 
-      - name: Get changed test files
-        shell: bash
-        id: changed-test
-        run: |
-          files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep _test.go$ | xargs)
-          if [[ -n "$files" ]]; then
-            echo "go_tests=$files" >> $GITHUB_OUTPUT
+          go_tests=$(echo "$changed_files" | grep _test.go$ | xargs)
+          echo "go_tests=$go_tests"
+          if [[ -n "$go_tests" ]]; then
+            echo "go_tests=$go_tests" >> $GITHUB_OUTPUT
           fi
 
   scoped-tests:

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -24,11 +24,9 @@ jobs:
         shell: bash
         id: changes
         run: |
-          echo -e "00 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
 
           go_sources=$(echo "$changed_files" | grep .go$  || true | xargs)
-          echo -e "go_sources=\n$go_sources\n***************"
           if [[ -n "$go_sources" ]]; then
             {
               echo 'go_sources<<EOF'
@@ -37,10 +35,7 @@ jobs:
             } >> $GITHUB_OUTPUT
           fi
 
-          echo -e "01 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
-
           go_tests=$(echo "$changed_files" | grep _test.go$ || true | xargs)
-          echo -e "go_tests=\n$go_tests\n***************"
           if [[ -n "$go_tests" ]]; then
             {
               echo 'go_tests<<EOF'
@@ -49,7 +44,6 @@ jobs:
             } >> $GITHUB_OUTPUT
           fi
 
-          echo -e "02 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
   scoped-tests:
     needs: changedfiles
     if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -18,12 +18,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get changed files
+        shell: bash
         id: changed-source
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .go$ | xargs)
 
           echo "go_sources=$files" >> $GITHUB_OUTPUT
       - name: Get changed files
+        shell: bash
         id: changed-test
         run: |
           files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep _test.go$ | xargs)

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -24,13 +24,25 @@ jobs:
         shell: bash
         id: changes
         run: |
-          changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
+          changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | tr '\n' ' ')
 
           go_sources=$(echo "$changed_files" | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
-          echo "go_sources=$go_sources" >> $GITHUB_OUTPUT
+          if [[ -n "$go_sources" ]]; then
+            {
+              echo 'go_sources<<EOF'
+              echo $go_sources
+              echo EOF
+            } >> $GITHUB_OUTPUT
+          fi
 
           go_tests=$(echo "$changed_files" | grep -E '.*_test\.go$' || true)
-          echo "go_tests=$go_tests" >> $GITHUB_OUTPUT
+          if [[ -n "$go_tests" ]]; then
+            {
+              echo 'go_tests<<EOF'
+              echo $go_tests
+              echo EOF
+            } >> $GITHUB_OUTPUT
+          fi
 
   scoped-tests:
     needs: changedfiles

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -81,4 +81,4 @@ jobs:
         env:
           CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
         run: |
-          make for-affected-components CMD="make test"
+          make for-affected-components CMD="make"

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -26,23 +26,11 @@ jobs:
         run: |
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
 
-          go_sources=$(echo "$changed_files" | grep .go$ | grep -v -E .*_test\.go$ | xargs)
-          if [[ -n "$go_sources" ]]; then
-            {
-              echo 'go_sources<<EOF'
-              echo $go_sources
-              echo EOF
-            } >> $GITHUB_OUTPUT
-          fi
+          go_sources=$(echo "$changed_files" | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
+          echo "go_sources=$go_sources" >> $GITHUB_OUTPUT
 
-          go_tests=$(echo "$changed_files" | grep -E .*_test.go$ | xargs)
-          if [[ -n "$go_tests" ]]; then
-            {
-              echo 'go_tests<<EOF'
-              echo $go_tests
-              echo EOF
-            } >> $GITHUB_OUTPUT
-          fi
+          go_tests=$(echo "$changed_files" | grep -E '.*_test\.go$' || true)
+          echo "go_tests=$go_tests" >> $GITHUB_OUTPUT
 
   scoped-tests:
     needs: changedfiles

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -27,7 +27,7 @@ jobs:
           echo -e "00 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
 
-          go_sources=$(echo "$changed_files" | grep .go$ | xargs)
+          go_sources=$(echo "$changed_files" | grep .go$  || true | xargs)
           echo -e "go_sources=\n$go_sources\n***************"
           if [[ -n "$go_sources" ]]; then
             {
@@ -39,7 +39,7 @@ jobs:
 
           echo -e "01 GITHUB_OUTPUT=\n$(cat $GITHUB_OUTPUT)\n***************"
 
-          go_tests=$(echo "$changed_files" | grep _test.go$ | xargs)
+          go_tests=$(echo "$changed_files" | grep _test.go$ || true | xargs)
           echo -e "go_tests=\n$go_tests\n***************"
           if [[ -n "$go_tests" ]]; then
             {

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -27,6 +27,8 @@ jobs:
           changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | tr '\n' ' ')
 
           go_sources=$(echo "$changed_files" | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
+          echo go_sources
+          echo $go_sources
           if [[ -n "$go_sources" ]]; then
             {
               echo 'go_sources<<EOF'
@@ -36,6 +38,8 @@ jobs:
           fi
 
           go_tests=$(echo "$changed_files" | grep -E '.*_test\.go$' || true)
+          echo go_tests
+          echo $go_tests
           if [[ -n "$go_tests" ]]; then
             {
               echo 'go_tests<<EOF'
@@ -46,7 +50,7 @@ jobs:
 
   scoped-tests:
     needs: changedfiles
-    if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
+    # if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/ottl/config.go
+++ b/pkg/ottl/config.go
@@ -10,6 +10,8 @@ import (
 
 type ErrorMode string
 
+// Useless comment just to test changes on scoped-tests
+
 const (
 	IgnoreError    ErrorMode = "ignore"
 	PropagateError ErrorMode = "propagate"

--- a/receiver/hostmetricsreceiver/hostmetrics_others.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_others.go
@@ -12,6 +12,7 @@ import (
 )
 
 func validateRootPath(rootPath string) error {
+	// Change just for testing purposes - to be removed.
 	if rootPath == "" {
 		return nil
 	}

--- a/receiver/hostmetricsreceiver/hostmetrics_others_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_others_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRootPathNotAllowedOnOS(t *testing.T) {
+	// Useless comment just to test changes on scoped-tests
 	assert.Error(t, validateRootPath("testdata"))
 }
 

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -74,6 +74,8 @@ var systemSpecificMetrics = map[string][]string{
 func TestGatherMetrics_EndToEnd(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 
+	// Useless comment just to test changes on scoped-tests
+
 	cfg := &Config{
 		ControllerConfig: scraperhelper.ControllerConfig{
 			CollectionInterval: 100 * time.Millisecond,


### PR DESCRIPTION
When scoped-tests workflow was created the default target was broken on Windows for various components and as such it was using the `test` target. Since then the default target was fixed on Windows, enabling the default target that includes lint, misspell, etc.