### PR TITLE
[chore][ping code owners] Only get code owners for components

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -14,6 +14,12 @@ fi
 
 CUR_DIRECTORY=$(dirname "$0")
 COMPONENT=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt | head -n 1)
+# Some labels are unrelated to components. These labels do not have code owners,
+# e.g "os:windows", "priority:p1", and "chore"
+if [[ -z "${COMPONENT}" ]]; then
+    exit 0
+fi
+
 OWNERS=$(COMPONENT="${COMPONENT}" bash "${CUR_DIRECTORY}/get-codeowners.sh")
 
 if [[ -z "${OWNERS}" ]]; then


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
After checking the component labels file, `COMPONENT` may be empty if the label added is not for a component. This is a valid and acceptable state. If the label does not correspond to a component, code owners don't need to be pinged.

This is to fix the following [example failure](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13994662160/job/39186701459).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38622

Before the related PR the passed in component was checked to make sure it wasn't empty and passed directly to the `get-codeowners.sh` script, which fails if `COMPONENT` is empty, and returns an empty string successfully if the given label is not a component. After the change, `COMPONENT` is modified to potentially be empty, then passed to `get-codeowners.sh`. This is what caused the `1` return code.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested locally with the label `os:windows`. The script passes with the change, failed before.