### PR TITLE
[chore][CI/CD] Always run windows tests for receiver/sqlserver PRs

### DIFF
--- a/.github/workflows/scripts/add-codeowners-to-pr.sh
+++ b/.github/workflows/scripts/add-codeowners-to-pr.sh
@@ -104,6 +104,10 @@ main () {
         done
     done
 
+    if [[ $LABELS =~ "receiver/sqlserver" ]]; then
+      LABELS+=",Run Windows"
+    fi
+
     if [[ -n "${LABELS}" ]]; then
         echo "Adding labels: ${LABELS}"
         gh pr edit "${PR}" --add-label "${LABELS}" || echo "Failed to add labels"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The SQL Server receiver heavily depends on Windows functionality, and every change should be tested on Windows. Failing tests are often hit as a result of forgetting to add the `Run Windows` label.

I'm sure there's a better way to do this logic that would allow for adding more components to the list of components that require `Run Windows`, so I'm happy to hear feedback.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Flakiness introduced because we forgot to add the `Run Windows` label in just the last couple of days:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38813
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38842

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested the regex matching, it worked with `receiver/sqlserver` as exact match, in the middle of a string, beginning of string, end of string, and not in string.