### PR TITLE
Add default values for resource_metrics_key_attributes and exclude changing resource attributes

### DIFF
--- a/.chloggen/21101.yaml
+++ b/.chloggen/21101.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix issue where `calls_total` metric could decrease over time due to unstable resource attributes being used in metric grouping"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [21101]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The connector now excludes unstable resource attributes (like process.pid) from metric grouping by default.
+  Users can explicitly configure which resource attributes to use via `resource_metrics_key_attributes`.
+  If nothing is configured, the connector will use a default set of resource attributes.
+
+  This feature is managed by the `connector.spanmetrics.defaultResourceMetricsKeyAttributes` feature gate.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -229,3 +229,28 @@ calls_total{span_name="/Address", service_name="shippingservice", span_kind="SPA
 For more example configuration covering various other use cases, please visit the [testdata directory](../../connector/spanmetricsconnector/testdata).
 
 [Connectors README]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md
+
+### Resource Metrics Key Attributes
+
+The connector provides two ways to control how resource attributes are used for metric grouping:
+
+1. Using the `resource_metrics_key_attributes` configuration:
+```yaml
+resource_metrics_key_attributes:
+  - service.name
+  - service.namespace
+  - telemetry.sdk.name
+  - telemetry.sdk.language
+```
+
+2. Using the feature gate `connector.spanmetrics.defaultResourceMetricsKeyAttributes`:
+   - When enabled: uses a default set of stable attributes and excludes attributes that commonly change between restarts.
+   - When disabled (default): uses all resource attributes for grouping, which may cause metric instability.
+
+> **Warning**: Using all resource attributes (default behavior) can cause counter metrics to reset or appear to decrease. This happens because changes in attributes like `process.pid` or `container.id` create new metric time series. To prevent this:
+> 1. Enable the feature gate, OR
+> 2. Configure `resource_metrics_key_attributes` with a stable set of attributes that uniquely identify your service
+
+Consider using the [resource detection processor](../../processor/resourcedetectionprocessor) or the [k8sattributes processor](../../processor/k8sattributesprocessor) to add appropriate labels.
+
+For more information about this feature, see [#21101](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21101).

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -19,11 +19,15 @@ import (
 )
 
 const (
-	DefaultNamespace               = "traces.span.metrics"
-	legacyMetricNamesFeatureGateID = "connector.spanmetrics.legacyMetricNames"
+	DefaultNamespace                          = "traces.span.metrics"
+	legacyMetricNamesFeatureGateID            = "connector.spanmetrics.legacyMetricNames"
+	defaultResourceMetricsKeyAttributesGateID = "connector.spanmetrics.defaultResourceMetricsKeyAttributes"
 )
 
-var legacyMetricNamesFeatureGate *featuregate.Gate
+var (
+	legacyMetricNamesFeatureGate            *featuregate.Gate
+	defaultResourceMetricsKeyAttributesGate *featuregate.Gate
+)
 
 func init() {
 	// TODO: Remove this feature gate when the legacy metric names are removed.
@@ -32,6 +36,13 @@ func init() {
 		featuregate.StageAlpha, // Alpha because we want it disabled by default.
 		featuregate.WithRegisterDescription("When enabled, connector uses legacy metric names."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33227"),
+	)
+
+	defaultResourceMetricsKeyAttributesGate = featuregate.GlobalRegistry().MustRegister(
+		defaultResourceMetricsKeyAttributesGateID,
+		featuregate.StageAlpha, // Alpha because we want it disabled by default.
+		featuregate.WithRegisterDescription("Controls whether to use default resource metrics key attributes and exclude attributes that change between restarts."),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21101"),
 	)
 }
 


### PR DESCRIPTION
#### Description
This PR fixes an issue where the `calls_total` metric in the spanmetrics connector could decrease over time, which violates Prometheus counter semantics. The problem occurred because the connector was using all resource attributes by default to generate metric keys, including "unstable" attributes like `process.pid` and `container.id` that change frequently.

The fix introduces:
1. A new feature gate `connector.spanmetrics.defaultResourceMetricsKeyAttributes` to control resource attribute handling
2. A default set of stable attributes when the feature gate is enabled

#### Link to tracking issue
Fixes #21101

#### Testing
Added new test cases in `connector_test.go`.