### PR TITLE
[DO NOT MERGE] Test Run Windows label add

### DIFF
--- a/receiver/sqlserverreceiver/README.md
+++ b/receiver/sqlserverreceiver/README.md
@@ -110,3 +110,5 @@ SQL Server docker users may run into an issue that the collector fails to parse 
 references:
 1. https://pkg.go.dev/crypto/x509#ParseCertificate
 2. https://github.com/microsoft/mssql-docker/issues/895
+
+NO-OP


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This is to test https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38863 to ensure the `Run Windows` label is added every time the `receiver/sqlserver` label is added.