### PR TITLE
[receiver/kafka][exporter/kafka] Do not expose programmatic API via NewFactory

### DIFF
--- a/.chloggen/implement_factory_api.yaml
+++ b/.chloggen/implement_factory_api.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kakfaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable exposing factory options programmatically on NewFactory.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/implement_factory_api_receiver.yaml
+++ b/.chloggen/implement_factory_api_receiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable exposing factory options programmatically on NewFactory.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -27,21 +27,14 @@ const (
 	defaultPartitionLogsByResourceAttributesEnabled = false
 )
 
-// FactoryOption applies changes to kafkaExporterFactory.
-type FactoryOption func(factory *kafkaExporterFactory)
-
 // NewFactory creates Kafka exporter factory.
-func NewFactory(options ...FactoryOption) exporter.Factory {
-	f := &kafkaExporterFactory{}
-	for _, o := range options {
-		o(f)
-	}
+func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		exporter.WithTraces(f.createTracesExporter, metadata.TracesStability),
-		exporter.WithMetrics(f.createMetricsExporter, metadata.MetricsStability),
-		exporter.WithLogs(f.createLogsExporter, metadata.LogsStability),
+		exporter.WithTraces(createTracesExporter, metadata.TracesStability),
+		exporter.WithMetrics(createMetricsExporter, metadata.MetricsStability),
+		exporter.WithLogs(createLogsExporter, metadata.LogsStability),
 	)
 }
 
@@ -60,9 +53,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-type kafkaExporterFactory struct{}
-
-func (f *kafkaExporterFactory) createTracesExporter(
+func createTracesExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,
@@ -90,7 +81,7 @@ func (f *kafkaExporterFactory) createTracesExporter(
 		exporterhelper.WithShutdown(exp.Close))
 }
 
-func (f *kafkaExporterFactory) createMetricsExporter(
+func createMetricsExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,
@@ -118,7 +109,7 @@ func (f *kafkaExporterFactory) createMetricsExporter(
 		exporterhelper.WithShutdown(exp.Close))
 }
 
-func (f *kafkaExporterFactory) createLogsExporter(
+func createLogsExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -44,21 +44,14 @@ const (
 
 var errUnrecognizedEncoding = errors.New("unrecognized encoding")
 
-// FactoryOption applies changes to kafkaExporterFactory.
-type FactoryOption func(factory *kafkaReceiverFactory)
-
 // NewFactory creates Kafka receiver factory.
-func NewFactory(options ...FactoryOption) receiver.Factory {
-	f := &kafkaReceiverFactory{}
-	for _, o := range options {
-		o(f)
-	}
+func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		receiver.WithTraces(f.createTracesReceiver, metadata.TracesStability),
-		receiver.WithMetrics(f.createMetricsReceiver, metadata.MetricsStability),
-		receiver.WithLogs(f.createLogsReceiver, metadata.LogsStability),
+		receiver.WithTraces(createTracesReceiver, metadata.TracesStability),
+		receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability),
+		receiver.WithLogs(createLogsReceiver, metadata.LogsStability),
 	)
 }
 
@@ -89,9 +82,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-type kafkaReceiverFactory struct{}
-
-func (f *kafkaReceiverFactory) createTracesReceiver(
+func createTracesReceiver(
 	_ context.Context,
 	set receiver.Settings,
 	cfg component.Config,
@@ -109,7 +100,7 @@ func (f *kafkaReceiverFactory) createTracesReceiver(
 	return r, nil
 }
 
-func (f *kafkaReceiverFactory) createMetricsReceiver(
+func createMetricsReceiver(
 	_ context.Context,
 	set receiver.Settings,
 	cfg component.Config,
@@ -127,7 +118,7 @@ func (f *kafkaReceiverFactory) createMetricsReceiver(
 	return r, nil
 }
 
-func (f *kafkaReceiverFactory) createLogsReceiver(
+func createLogsReceiver(
 	_ context.Context,
 	set receiver.Settings,
 	cfg component.Config,

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -39,8 +39,7 @@ func TestCreateTraces(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{}
-	r, err := f.createTracesReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
+	r, err := createTracesReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
@@ -78,8 +77,7 @@ func TestCreateMetrics(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{}
-	r, err := f.createMetricsReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
+	r, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
@@ -117,8 +115,7 @@ func TestCreateLogs(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{}
-	r, err := f.createLogsReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
+	r, err := createLogsReceiver(context.Background(), receivertest.NewNopSettings(metadata.Type), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))


### PR DESCRIPTION
#### Description
It seems suspect to offer a FactoryFunc func on both kafka receivers and exporters, when they don't offer any changes to the factory struct, given that it has no fields and no exposed functions that can be overridden.

This PR removes the vararg used by NewFactory for both components, bringing the API in line with what is expected of components. The change is considered a breaking change, however the API signature is the same if the vararg is not used. 
