### PR TITLE
[receiver/tlscheck] add `tlscheck.x509.san` attribute

### DIFF
--- a/.chloggen/add_san.yaml
+++ b/.chloggen/add_san.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tlscheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add `tlscheck.x509.san` attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38872]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Subject Alternative Name records are stored as an array on the metric.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/tlscheckreceiver/documentation.md
+++ b/receiver/tlscheckreceiver/documentation.md
@@ -26,6 +26,7 @@ Time in seconds until certificate expiry, as specified by `NotAfter` field in th
 | ---- | ----------- | ------ |
 | tlscheck.x509.issuer | The entity that issued the certificate. | Any Str |
 | tlscheck.x509.cn | The commonName in the subject of the certificate. | Any Str |
+| tlscheck.x509.san | The Subject Alternative Name of the certificate. | Any Slice |
 
 ## Resource Attributes
 

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
@@ -27,7 +27,7 @@ func (m *metricTlscheckTimeLeft) init() {
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricTlscheckTimeLeft) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string) {
+func (m *metricTlscheckTimeLeft) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string, tlscheckX509SanAttributeValue []any) {
 	if !m.config.Enabled {
 		return
 	}
@@ -37,6 +37,7 @@ func (m *metricTlscheckTimeLeft) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("tlscheck.x509.issuer", tlscheckX509IssuerAttributeValue)
 	dp.Attributes().PutStr("tlscheck.x509.cn", tlscheckX509CnAttributeValue)
+	dp.Attributes().PutEmptySlice("tlscheck.x509.san").FromRaw(tlscheckX509SanAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -212,8 +213,8 @@ func (mb *MetricsBuilder) Emit(options ...ResourceMetricsOption) pmetric.Metrics
 }
 
 // RecordTlscheckTimeLeftDataPoint adds a data point to tlscheck.time_left metric.
-func (mb *MetricsBuilder) RecordTlscheckTimeLeftDataPoint(ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string) {
-	mb.metricTlscheckTimeLeft.recordDataPoint(mb.startTime, ts, val, tlscheckX509IssuerAttributeValue, tlscheckX509CnAttributeValue)
+func (mb *MetricsBuilder) RecordTlscheckTimeLeftDataPoint(ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string, tlscheckX509SanAttributeValue []any) {
+	mb.metricTlscheckTimeLeft.recordDataPoint(mb.startTime, ts, val, tlscheckX509IssuerAttributeValue, tlscheckX509CnAttributeValue, tlscheckX509SanAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
@@ -70,7 +70,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordTlscheckTimeLeftDataPoint(ts, 1, "tlscheck.x509.issuer-val", "tlscheck.x509.cn-val")
+			mb.RecordTlscheckTimeLeftDataPoint(ts, 1, "tlscheck.x509.issuer-val", "tlscheck.x509.cn-val", []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"})
 
 			rb := mb.NewResourceBuilder()
 			rb.SetTlscheckEndpoint("tlscheck.endpoint-val")
@@ -114,6 +114,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok = dp.Attributes().Get("tlscheck.x509.cn")
 					assert.True(t, ok)
 					assert.EqualValues(t, "tlscheck.x509.cn-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("tlscheck.x509.san")
+					assert.True(t, ok)
+					assert.EqualValues(t, []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"}, attrVal.Slice().AsRaw())
 				}
 			}
 		})

--- a/receiver/tlscheckreceiver/metadata.yaml
+++ b/receiver/tlscheckreceiver/metadata.yaml
@@ -23,6 +23,10 @@ attributes:
     enabled: true
     description: The commonName in the subject of the certificate.
     type: string
+  tlscheck.x509.san:
+    enabled: false
+    description: The Subject Alternative Name of the certificate.
+    type: slice
 
 metrics:
   tlscheck.time_left:
@@ -31,4 +35,4 @@ metrics:
     gauge:
       value_type: int
     unit: "s"
-    attributes: [tlscheck.x509.issuer, tlscheck.x509.cn]
+    attributes: [tlscheck.x509.issuer, tlscheck.x509.cn, tlscheck.x509.san]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Subject Alternative Name records are stored as an array on the metric.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38872

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Basic testing.

<!--Describe the documentation added.-->
#### Documentation
Generated docs.

<!--Please delete paragraphs that you did not use before submitting.-->
