### PR TITLE
[chore] internal/kafka: introduce kafkatest package

### DIFF
--- a/exporter/kafkaexporter/go.sum
+++ b/exporter/kafkaexporter/go.sum
@@ -138,6 +138,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
+github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327 h1:E2rCVOpwEnB6F0cUpwPNyzfRYfHee0IfHbUVSB5rH6I=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/extension/observer/kafkatopicsobserver/go.sum
+++ b/extension/observer/kafkatopicsobserver/go.sum
@@ -121,6 +121,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
+github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327 h1:E2rCVOpwEnB6F0cUpwPNyzfRYfHee0IfHbUVSB5rH6I=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -5,16 +5,29 @@ package kafka // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/configkafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
 )
+
+func init() {
+	// Disable the go-metrics registry, as there's a goroutine
+	// leak in the Sarama code that uses it.
+	metrics.UseNilMetrics = true
+}
 
 func TestNewSaramaClientConfig(t *testing.T) {
 	for name, tt := range map[string]struct {
@@ -107,4 +120,137 @@ func TestNewSaramaClientConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewSaramaClient(t *testing.T) {
+	_, clientConfig := kafkatest.NewCluster(t)
+	client, err := NewSaramaClient(context.Background(), clientConfig)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, client.Close()) }()
+}
+
+func TestNewSaramaClient_SASL(t *testing.T) {
+	_, clientConfig := kafkatest.NewCluster(t,
+		kfake.EnableSASL(),
+		kfake.Superuser("PLAIN", "plain_user", "plain_password"),
+		kfake.Superuser("SCRAM-SHA-256", "scramsha256_user", "scramsha256_password"),
+		kfake.Superuser("SCRAM-SHA-512", "scramsha512_user", "scramsha512_password"),
+	)
+
+	tryConnect := func(mechanism, username, password string) error {
+		clientConfig := clientConfig // copy
+		clientConfig.Authentication.SASL = &configkafka.SASLConfig{
+			Mechanism: mechanism,
+			Username:  username,
+			Password:  password,
+			Version:   1, // kfake only supports version 1
+		}
+		client, err := NewSaramaClient(context.Background(), clientConfig)
+		if err != nil {
+			return err
+		}
+		return client.Close()
+	}
+
+	type testcase struct {
+		mechanism string
+		username  string
+		password  string
+		expecErr  bool
+	}
+
+	for name, tt := range map[string]testcase{
+		"PLAIN": {
+			mechanism: "PLAIN",
+			username:  "plain_user",
+			password:  "plain_password",
+		},
+		"SCRAM-SHA-256": {
+			mechanism: "SCRAM-SHA-256",
+			username:  "scramsha256_user",
+			password:  "scramsha256_password",
+		},
+		"SCRAM-SHA-512": {
+			mechanism: "SCRAM-SHA-512",
+			username:  "scramsha512_user",
+			password:  "scramsha512_password",
+		},
+		"invalid_PLAIN": {
+			mechanism: "PLAIN",
+			username:  "scramsha256_user",
+			password:  "scramsha256_password",
+			expecErr:  true,
+		},
+		"invalid_SCRAM-SHA-256": {
+			mechanism: "SCRAM-SHA-256",
+			username:  "scramsha512_user",
+			password:  "scramsha512_password",
+			expecErr:  true,
+		},
+		"invalid_SCRAM-SHA-512": {
+			mechanism: "SCRAM-SHA-512",
+			username:  "scramsha256_user",
+			password:  "scramsha256_password",
+			expecErr:  true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := tryConnect(tt.mechanism, tt.username, tt.password)
+			if tt.expecErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewSaramaClient_TLS(t *testing.T) {
+	// We create an httptest.Server just so we can get its TLS configuration.
+	httpServer := httptest.NewTLSServer(http.NewServeMux())
+	defer httpServer.Close()
+	serverTLS := httpServer.TLS
+	caCert := httpServer.Certificate() // self-signed
+
+	_, clientConfig := kafkatest.NewCluster(t, kfake.TLS(serverTLS))
+	tryConnect := func(cfg *configtls.ClientConfig) error {
+		clientConfig := clientConfig // copy
+		clientConfig.Authentication.TLS = cfg
+		client, err := NewSaramaClient(context.Background(), clientConfig)
+		if err != nil {
+			return err
+		}
+		return client.Close()
+	}
+
+	t.Run("tls_valid_ca", func(t *testing.T) {
+		t.Parallel()
+		tlsConfig := configtls.NewDefaultClientConfig()
+		tlsConfig.CAPem = configopaque.String(
+			pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw}),
+		)
+		assert.NoError(t, tryConnect(&tlsConfig))
+	})
+
+	t.Run("tls_insecure_skip_verify", func(t *testing.T) {
+		t.Parallel()
+		tlsConfig := configtls.NewDefaultClientConfig()
+		tlsConfig.InsecureSkipVerify = true
+		require.NoError(t, tryConnect(&tlsConfig))
+	})
+
+	t.Run("tls_unknown_ca", func(t *testing.T) {
+		t.Parallel()
+		config := configtls.NewDefaultClientConfig()
+		err := tryConnect(&config)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "x509: certificate signed by unknown authority")
+	})
+
+	t.Run("plaintext", func(t *testing.T) {
+		t.Parallel()
+		// Should fail because the server expects TLS.
+		require.Error(t, tryConnect(nil))
+	})
 }

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -126,7 +126,7 @@ func TestNewSaramaClient(t *testing.T) {
 	_, clientConfig := kafkatest.NewCluster(t)
 	client, err := NewSaramaClient(context.Background(), clientConfig)
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, client.Close()) }()
+	assert.NoError(t, client.Close())
 }
 
 func TestNewSaramaClient_SASL(t *testing.T) {

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -24,8 +24,12 @@ import (
 )
 
 func init() {
-	// Disable the go-metrics registry, as there's a goroutine
-	// leak in the Sarama code that uses it.
+	// Disable the go-metrics registry, as there's a goroutine leak in the Sarama
+	// code that uses it. See this stale issue: https://github.com/IBM/sarama/issues/1321
+	//
+	// Sarama docs suggest setting UseNilMetrics to true to disable metrics if they
+	// are not needed, which is the case here. We only disable in tests to avoid
+	// affecting other components that rely on go-metrics.
 	metrics.UseNilMetrics = true
 }
 

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -7,9 +7,12 @@ require (
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.62
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/stretchr/testify v1.10.0
+	github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327
 	github.com/xdg-go/scram v1.1.2
 	go.opentelemetry.io/collector/component v1.28.2-0.20250319144947-41a9ea7f7402
+	go.opentelemetry.io/collector/config/configopaque v1.28.2-0.20250319144947-41a9ea7f7402
 	go.opentelemetry.io/collector/config/configtls v1.28.2-0.20250319144947-41a9ea7f7402
 	go.opentelemetry.io/collector/confmap v1.28.2-0.20250319144947-41a9ea7f7402
 	go.opentelemetry.io/collector/confmap/xconfmap v0.122.2-0.20250319144947-41a9ea7f7402
@@ -54,10 +57,10 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/twmb/franz-go v1.18.1 // indirect
+	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.28.2-0.20250319144947-41a9ea7f7402 // indirect
 	go.opentelemetry.io/collector/featuregate v1.28.2-0.20250319144947-41a9ea7f7402 // indirect
 	go.opentelemetry.io/collector/pdata v1.28.2-0.20250319144947-41a9ea7f7402 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/internal/kafka/go.sum
+++ b/internal/kafka/go.sum
@@ -118,6 +118,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
+github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327 h1:E2rCVOpwEnB6F0cUpwPNyzfRYfHee0IfHbUVSB5rH6I=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/internal/kafka/kafkatest/cluster.go
+++ b/internal/kafka/kafkatest/cluster.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkatest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/kafkatest"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka/configkafka"
+)
+
+// NewCluster returns a fake Kafka cluster and configkafka.ClientConfig
+// with the default configuration, and brokers set to the cluster addresses.
+func NewCluster(tb testing.TB, opts ...kfake.Opt) (*kfake.Cluster, configkafka.ClientConfig) {
+	cluster, err := kfake.NewCluster(opts...)
+	require.NoError(tb, err)
+	tb.Cleanup(cluster.Close)
+
+	cfg := configkafka.NewDefaultClientConfig()
+	cfg.Brokers = cluster.ListenAddrs()
+	return cluster, cfg
+}

--- a/receiver/kafkametricsreceiver/go.sum
+++ b/receiver/kafkametricsreceiver/go.sum
@@ -130,6 +130,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
+github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327 h1:E2rCVOpwEnB6F0cUpwPNyzfRYfHee0IfHbUVSB5rH6I=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=

--- a/receiver/kafkareceiver/go.sum
+++ b/receiver/kafkareceiver/go.sum
@@ -142,6 +142,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/twmb/franz-go v1.18.1 h1:D75xxCDyvTqBSiImFx2lkPduE39jz1vaD7+FNc+vMkc=
+github.com/twmb/franz-go v1.18.1/go.mod h1:Uzo77TarcLTUZeLuGq+9lNpSkfZI+JErv7YJhlDjs9M=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327 h1:E2rCVOpwEnB6F0cUpwPNyzfRYfHee0IfHbUVSB5rH6I=
+github.com/twmb/franz-go/pkg/kfake v0.0.0-20250320172111-35ab5e5f5327/go.mod h1:zCgWGv7Rg9B70WV6T+tUbifRJnx60gGTFU/U4xZpyUA=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0 h1:JojYUph2TKAau6SBtErXpXGC7E3gg4vGZMv9xFU/B6M=
+github.com/twmb/franz-go/pkg/kmsg v1.9.0/go.mod h1:CMbfazviCyY6HM0SXuG5t9vOwYDHRCSrJJyBAe5paqg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2 h1:FHX5I5B4i4hKRVRBCFRxq1iQRej7WO3hhBuJf+UUySY=


### PR DESCRIPTION
#### Description

This package will hold test-related code for Kafka components.

Initially, the package provides a single function for creating a fake Kafka cluster using franz-go's kfake, along with a configkafka.ClientConfig for connecting to it. We use this in new tests for NewSaramaClient.

#### Link to tracking issue

N/A

#### Testing

N/A, only adding test code.

#### Documentation

N/A