### PR TITLE
kafka: deprecate redundant auth.plain_text

### DIFF
--- a/.chloggen/kafka-deprecate-plaintext-kafkaexporter.yaml
+++ b/.chloggen/kafka-deprecate-plaintext-kafkaexporter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `auth.plain_text` configuration. Use `auth.sasl` with mechanism set to PLAIN instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38883]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/kafka-deprecate-plaintext-kafkametricsreceiver.yaml
+++ b/.chloggen/kafka-deprecate-plaintext-kafkametricsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkametricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `auth.plain_text` configuration. Use `auth.sasl` with mechanism set to PLAIN instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38883]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/kafka-deprecate-plaintext-kafkareceiver.yaml
+++ b/.chloggen/kafka-deprecate-plaintext-kafkareceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `auth.plain_text` configuration. Use `auth.sasl` with mechanism set to PLAIN instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38883]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/kafka-deprecate-plaintext-kafkatopicsobserver.yaml
+++ b/.chloggen/kafka-deprecate-plaintext-kafkatopicsobserver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkatopicsobserverextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate `auth.plain_text` configuration. Use `auth.sasl` with mechanism set to PLAIN instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38883]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -40,7 +40,7 @@ The following settings can be optionally configured:
 - `partition_metrics_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka.
 - `partition_logs_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka.
 - `auth`
-  - `plain_text`
+  - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)
     - `username`: The username to use.
     - `password`: The password to use
   - `sasl`

--- a/extension/observer/kafkatopicsobserver/README.md
+++ b/extension/observer/kafkatopicsobserver/README.md
@@ -29,7 +29,7 @@ The following settings can be optionally configured:
 - `client_id` (default = "otel-collector"): The client ID to configure the Kafka client with.
 - `topics_sync_interval` (default 5s)
 - `auth`
-    - `plain_text`
+    - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)
         - `username`: The username to use.
         - `password`: The password to use
     - `sasl`

--- a/internal/kafka/configkafka/config.go
+++ b/internal/kafka/configkafka/config.go
@@ -260,6 +260,9 @@ func NewDefaultMetadataConfig() MetadataConfig {
 
 // AuthenticationConfig defines authentication-related configuration.
 type AuthenticationConfig struct {
+	// PlainText is an alias for SASL/PLAIN authentication.
+	//
+	// Deprecated [v0.123.0]: use SASL with Mechanism set to PLAIN instead.
 	PlainText *PlainTextConfig        `mapstructure:"plain_text"`
 	SASL      *SASLConfig             `mapstructure:"sasl"`
 	TLS       *configtls.ClientConfig `mapstructure:"tls"`

--- a/receiver/kafkametricsreceiver/README.md
+++ b/receiver/kafkametricsreceiver/README.md
@@ -44,9 +44,15 @@ Optional Settings (with defaults):
 - `collection_interval` (default = 1m): frequency of metric collection/scraping.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `auth` (default none)
-    - `plain_text`
+    - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)
         - `username`: The username to use.
         - `password`: The password to use
+    - `sasl`
+        - `username`: The username to use.
+        - `password`: The password to use.
+        - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM, AWS_MSK_IAM_OAUTHBEARER or PLAIN)
+        - `aws_msk.region`: AWS Region in case of AWS_MSK_IAM or AWS_MSK_IAM_OAUTHBEARER mechanism
+        - `aws_msk.broker_addr`: MSK Broker address in case of AWS_MSK_IAM mechanism
     - `tls`
         - `ca_file`: path to the CA cert. For a client this verifies the server certificate. Should only be used
           if `insecure` is set to true.

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -50,12 +50,12 @@ The following settings can be optionally configured:
 - `default_fetch_size` (default = `1048576`): The default number of message bytes to fetch in a request, defaults to 1MB.
 - `max_fetch_size` (default = `0`): The maximum number of message bytes to fetch in a request, defaults to unlimited.
 - `auth`
-  - `plain_text`
+  - `plain_text` (Deprecated in v0.123.0: use sasl with mechanism set to PLAIN instead.)
     - `username`: The username to use.
     - `password`: The password to use
   - `sasl`
     - `username`: The username to use.
-    - `password`: The password to use
+    - `password`: The password to use.
     - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM, AWS_MSK_IAM_OAUTHBEARER or PLAIN)
     - `aws_msk.region`: AWS Region in case of AWS_MSK_IAM or AWS_MSK_IAM_OAUTHBEARER mechanism
     - `aws_msk.broker_addr`: MSK Broker address in case of AWS_MSK_IAM mechanism


### PR DESCRIPTION
#### Description

If `auth.plain_text` is configured, internally SASL/PLAIN is configured.

This config is redundant and makes things harder to understand: as a user, should I configure auth.plain_text, or auth.sasl with mechanism PLAIN? If I set plain_text I can't specify the SASL protocol version, why not?

So let's simplify, at the expense of slightly more verbose, but more explicit, configuration. Instead of configuring:

```yaml
auth:
  plain_text:
    username: alice
    password: bob
```

... you should configure this instead:

```yaml
auth:
  sasl:
    mechanism: PLAIN
    username: alice
    password: bob
```

#### Link to tracking issue

None

#### Testing

N/A

#### Documentation

Updated READMEs.