### PR TITLE
Avoid embedding the QueueConfig, avoids potential conflicts

### DIFF
--- a/.chloggen/queueconfig.yaml
+++ b/.chloggen/queueconfig.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stefexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid embedding the QueueConfig, avoids potential conflicts
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38887]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/faroexporter/config.go
+++ b/exporter/faroexporter/config.go
@@ -16,9 +16,9 @@ import (
 
 // Config defines configuration settings for the Faro exporter.
 type Config struct {
-	confighttp.ClientConfig    `mapstructure:",squash"`
-	exporterhelper.QueueConfig `mapstructure:"sending_queue"`
-	RetryConfig                configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	confighttp.ClientConfig `mapstructure:",squash"`
+	QueueConfig             exporterhelper.QueueConfig `mapstructure:"sending_queue"`
+	RetryConfig             configretry.BackOffConfig  `mapstructure:"retry_on_failure"`
 }
 
 var (

--- a/exporter/stefexporter/config.go
+++ b/exporter/stefexporter/config.go
@@ -20,8 +20,8 @@ import (
 // Config defines configuration for logging exporter.
 type Config struct {
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	exporterhelper.QueueConfig   `mapstructure:"sending_queue"`
-	RetryConfig                  configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	QueueConfig                  exporterhelper.QueueConfig `mapstructure:"sending_queue"`
+	RetryConfig                  configretry.BackOffConfig  `mapstructure:"retry_on_failure"`
 	configgrpc.ClientConfig      `mapstructure:",squash"`
 }
 


### PR DESCRIPTION
This fixes a bug if we add same variable names as in RetryConfig will conflict with QueueConfig even though by the yaml they are allowed.