### PR TITLE
[chore][receiver/azuremonitorreceiver] fix: azure resources are never cleaned because we take subID instead of resID

### DIFF
--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -281,7 +281,7 @@ func (s *azureScraper) getResources(ctx context.Context, subscriptionID string) 
 	}
 
 	existingResources := map[string]void{}
-	for id := range s.resources {
+	for id := range s.resources[subscriptionID] {
 		existingResources[id] = void{}
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is a fix of regression introduced here #37167. 
We are using this little map to cleanup Azure resources that are not anymore discovered. In this case resources are now stored by subcriptions so ``resources`` should be changed to ``resources[subID]`` to have existing resources.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
