### PR TITLE
[chore] Fix check-links action

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -16,6 +16,8 @@ jobs:
     name: changed files
     runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
       files: ${{ steps.changes.outputs.files }}
     steps:


### PR DESCRIPTION
Check links were broken for some time since the action is missing an environment variable.

This one I didn't test directly as I did for #38931 I will check later if this is enough to fix it.