### PR TITLE
Enhancement: Add path to Splunk errors

### DIFF
--- a/.chloggen/msg_signalfx-exporter-include-endpoint-in-error.yaml
+++ b/.chloggen/msg_signalfx-exporter-include-endpoint-in-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Errors will now include the URL that it was trying to access
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 39026 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/.chloggen/msg_splunk-hec-include-endpoint-in-error.yaml
+++ b/.chloggen/msg_splunk-hec-include-endpoint-in-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Errors will now include the URL that it was trying to access
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 39026 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -122,7 +123,7 @@ func TestConsumeMetrics(t *testing.T) {
 		wantErr              bool
 		wantPermanentErr     bool
 		wantThrottleErr      bool
-		expectedErrorMsg     string
+		wantStatusCode       int
 	}{
 		{
 			name:             "happy_path",
@@ -135,7 +136,7 @@ func TestConsumeMetrics(t *testing.T) {
 			httpResponseCode:     http.StatusForbidden,
 			numDroppedTimeSeries: 1,
 			wantErr:              true,
-			expectedErrorMsg:     "HTTP 403 \"Forbidden\"",
+			wantStatusCode:       403,
 		},
 		{
 			name:                 "response_bad_request",
@@ -143,7 +144,7 @@ func TestConsumeMetrics(t *testing.T) {
 			httpResponseCode:     http.StatusBadRequest,
 			numDroppedTimeSeries: 1,
 			wantPermanentErr:     true,
-			expectedErrorMsg:     "Permanent error: \"HTTP/1.1 400 Bad Request",
+			wantStatusCode:       400,
 		},
 		{
 			name:                 "response_throttle",
@@ -151,6 +152,7 @@ func TestConsumeMetrics(t *testing.T) {
 			httpResponseCode:     http.StatusTooManyRequests,
 			numDroppedTimeSeries: 1,
 			wantThrottleErr:      true,
+			wantStatusCode:       429,
 		},
 		{
 			name:                 "response_throttle_with_header",
@@ -159,6 +161,7 @@ func TestConsumeMetrics(t *testing.T) {
 			httpResponseCode:     http.StatusServiceUnavailable,
 			numDroppedTimeSeries: 1,
 			wantThrottleErr:      true,
+			wantStatusCode:       503,
 		},
 		{
 			name:             "large_batch",
@@ -207,25 +210,30 @@ func TestConsumeMetrics(t *testing.T) {
 				converter: c,
 			}
 
+			errMsg := fmt.Sprintf("HTTP %q %d %q",
+				serverURL.JoinPath("/v2/datapoint").String(),
+				tt.wantStatusCode,
+				http.StatusText(tt.wantStatusCode),
+			)
+
 			numDroppedTimeSeries, err := dpClient.pushMetricsData(context.Background(), tt.md)
 			assert.Equal(t, tt.numDroppedTimeSeries, numDroppedTimeSeries)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.EqualError(t, err, tt.expectedErrorMsg)
+				assert.EqualError(t, err, errMsg)
 				return
 			}
 
 			if tt.wantPermanentErr {
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
-				assert.True(t, strings.HasPrefix(err.Error(), tt.expectedErrorMsg))
-				assert.ErrorContains(t, err, "response content")
+				assert.ErrorContains(t, err, errMsg)
 				return
 			}
 
 			if tt.wantThrottleErr {
-				expected := fmt.Errorf("HTTP %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
+				expected := errors.New(errMsg)
 				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
 				assert.EqualValues(t, expected, err)
 				return
@@ -1892,8 +1900,8 @@ func TestConsumeMixedMetrics(t *testing.T) {
 		wantErr               bool
 		wantPermanentErr      bool
 		wantThrottleErr       bool
-		expectedErrorMsg      string
 		wantPartialMetricsErr bool
+		wantStatusCode        int
 	}{
 		{
 			name:                 "happy_path",
@@ -1912,7 +1920,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			sfxHTTPResponseCode:  http.StatusForbidden,
 			numDroppedTimeSeries: 1,
 			wantErr:              true,
-			expectedErrorMsg:     "HTTP 403 \"Forbidden\"",
+			wantStatusCode:       403,
 		},
 		{
 			name:                 "response_forbidden_otlp",
@@ -1920,7 +1928,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			otlpHTTPResponseCode: http.StatusForbidden,
 			numDroppedTimeSeries: 2,
 			wantErr:              true,
-			expectedErrorMsg:     "HTTP 403 \"Forbidden\"",
+			wantStatusCode:       403,
 		},
 		{
 			name:                 "response_forbidden_mixed",
@@ -1929,7 +1937,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			otlpHTTPResponseCode: http.StatusForbidden,
 			numDroppedTimeSeries: 2,
 			wantErr:              true,
-			expectedErrorMsg:     "HTTP 403 \"Forbidden\"",
+			wantStatusCode:       403,
 		},
 		{
 			name:                 "response_bad_request_sfx",
@@ -1937,7 +1945,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			sfxHTTPResponseCode:  http.StatusBadRequest,
 			numDroppedTimeSeries: 1,
 			wantPermanentErr:     true,
-			expectedErrorMsg:     "Permanent error: \"HTTP/1.1 400 Bad Request",
+			wantStatusCode:       400,
 		},
 		{
 			name:                 "response_bad_request_otlp",
@@ -1945,7 +1953,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			otlpHTTPResponseCode: http.StatusBadRequest,
 			numDroppedTimeSeries: 2,
 			wantPermanentErr:     true,
-			expectedErrorMsg:     "Permanent error: \"HTTP/1.1 400 Bad Request",
+			wantStatusCode:       400,
 		},
 		{
 			name:                 "response_bad_request_mixed",
@@ -1954,7 +1962,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			otlpHTTPResponseCode: http.StatusBadRequest,
 			numDroppedTimeSeries: 2,
 			wantPermanentErr:     true,
-			expectedErrorMsg:     "Permanent error: \"HTTP/1.1 400 Bad Request",
+			wantStatusCode:       400,
 		},
 		{
 			name:                 "response_throttle_sfx",
@@ -1962,6 +1970,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			sfxHTTPResponseCode:  http.StatusTooManyRequests,
 			numDroppedTimeSeries: 1,
 			wantThrottleErr:      true,
+			wantStatusCode:       429,
 		},
 		{
 			name:                  "response_throttle_mixed",
@@ -1971,6 +1980,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries:  2,
 			wantThrottleErr:       true,
 			wantPartialMetricsErr: true,
+			wantStatusCode:        429,
 		},
 		{
 			name:                  "response_throttle_otlp",
@@ -1979,6 +1989,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries:  2,
 			wantThrottleErr:       true,
 			wantPartialMetricsErr: true,
+			wantStatusCode:        429,
 		},
 		{
 			name:                 "response_throttle_with_header_sfx",
@@ -1987,6 +1998,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			sfxHTTPResponseCode:  http.StatusServiceUnavailable,
 			numDroppedTimeSeries: 1,
 			wantThrottleErr:      true,
+			wantStatusCode:       503,
 		},
 		{
 			name:                  "response_throttle_with_header_otlp",
@@ -1996,6 +2008,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries:  2,
 			wantThrottleErr:       true,
 			wantPartialMetricsErr: true,
+			wantStatusCode:        503,
 		},
 		{
 			name:                  "response_throttle_with_header_mixed",
@@ -2006,6 +2019,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries:  2,
 			wantThrottleErr:       true,
 			wantPartialMetricsErr: true,
+			wantStatusCode:        503,
 		},
 		{
 			name:                 "large_batch",
@@ -2065,31 +2079,37 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries, err := sfxClient.pushMetricsData(context.Background(), tt.md)
 			assert.Equal(t, tt.numDroppedTimeSeries, numDroppedTimeSeries)
 
+			errMsg := fmt.Sprintf("HTTP %q %d %q",
+				serverURL.JoinPath("/v2/datapoint").String(),
+				tt.wantStatusCode,
+				http.StatusText(tt.wantStatusCode),
+			)
+
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.EqualError(t, err, tt.expectedErrorMsg)
+				assert.EqualError(t, err, errMsg)
 				return
 			}
 
 			if tt.wantPermanentErr {
+				errMsg = "Permanent error: " + errMsg
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
-				assert.True(t, strings.HasPrefix(err.Error(), tt.expectedErrorMsg))
-				assert.ErrorContains(t, err, "response content")
+				assert.EqualError(t, err, errMsg)
 				return
 			}
 
 			if tt.wantThrottleErr {
 				if tt.wantPartialMetricsErr {
 					partialMetrics, _ := utils.GetHistograms(smallBatch)
-					throttleErr := fmt.Errorf("HTTP %d %q", tt.otlpHTTPResponseCode, http.StatusText(tt.otlpHTTPResponseCode))
+					throttleErr := errors.New(errMsg)
 					throttleErr = exporterhelper.NewThrottleRetry(throttleErr, time.Duration(tt.retryAfter)*time.Second)
 					testErr := consumererror.NewMetrics(throttleErr, partialMetrics)
 					assert.EqualValues(t, testErr, err)
 					return
 				}
 
-				expected := fmt.Errorf("HTTP %d %q", tt.sfxHTTPResponseCode, http.StatusText(tt.sfxHTTPResponseCode))
+				expected := errors.New(errMsg)
 				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
 				assert.EqualValues(t, expected, err)
 				return

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -210,8 +210,7 @@ func TestConsumeMetrics(t *testing.T) {
 				converter: c,
 			}
 
-			errMsg := fmt.Sprintf("HTTP %q %d %q",
-				serverURL.JoinPath("/v2/datapoint").String(),
+			errMsg := fmt.Sprintf("HTTP \"/v2/datapoint\" %d %q",
 				tt.wantStatusCode,
 				http.StatusText(tt.wantStatusCode),
 			)
@@ -2079,8 +2078,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			numDroppedTimeSeries, err := sfxClient.pushMetricsData(context.Background(), tt.md)
 			assert.Equal(t, tt.numDroppedTimeSeries, numDroppedTimeSeries)
 
-			errMsg := fmt.Sprintf("HTTP %q %d %q",
-				serverURL.JoinPath("/v2/datapoint").String(),
+			errMsg := fmt.Sprintf("HTTP \"/v2/datapoint\" %d %q",
 				tt.wantStatusCode,
 				http.StatusText(tt.wantStatusCode),
 			)

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -9,7 +9,6 @@ require (
 	go.opentelemetry.io/collector/pdata v1.29.0
 	go.opentelemetry.io/collector/semconv v0.123.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.11.0
 )
 
 require (
@@ -47,6 +46,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -24,7 +24,7 @@ func HandleHTTPCode(resp *http.Response) error {
 
 	err := fmt.Errorf(
 		"HTTP %q %d %q",
-		resp.Request.URL.String(),
+		resp.Request.URL.Path,
 		resp.StatusCode,
 		http.StatusText(resp.StatusCode),
 	)

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -25,7 +25,8 @@ func HandleHTTPCode(resp *http.Response) error {
 	}
 
 	err := fmt.Errorf(
-		"HTTP %d %q",
+		"HTTP %q %d %q",
+		resp.Request.URL.String(),
 		resp.StatusCode,
 		http.StatusText(resp.StatusCode))
 

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -18,7 +18,7 @@ const HeaderRetryAfter = "Retry-After"
 // HandleHTTPCode handles an http response and returns the right type of error in case of a failure.
 func HandleHTTPCode(resp *http.Response) error {
 	// Splunk accepts all 2XX codes.
-	if resp.StatusCode/100 == 2 {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}
 

--- a/internal/splunk/httprequest_test.go
+++ b/internal/splunk/httprequest_test.go
@@ -55,7 +55,7 @@ func TestConsumeMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := &http.Response{
 				Request: &http.Request{
-					URL: &url.URL{Scheme: "http", Host: "splunk.com"},
+					URL: &url.URL{Scheme: "http", Host: "splunk.com", Path: "/endpoint"},
 				},
 				StatusCode: tt.httpResponseCode,
 			}
@@ -78,7 +78,7 @@ func TestConsumeMetrics(t *testing.T) {
 			}
 
 			if tt.wantThrottleErr {
-				expected := fmt.Errorf("HTTP \"http://splunk.com\" %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
+				expected := fmt.Errorf("HTTP \"/endpoint\" %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
 				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
 				assert.EqualValues(t, expected, err)
 				return

--- a/internal/splunk/httprequest_test.go
+++ b/internal/splunk/httprequest_test.go
@@ -6,6 +6,7 @@ package splunk
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"testing"
 	"time"
@@ -53,6 +54,9 @@ func TestConsumeMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := &http.Response{
+				Request: &http.Request{
+					URL: &url.URL{Scheme: "http", Host: "splunk.com"},
+				},
 				StatusCode: tt.httpResponseCode,
 			}
 			if tt.retryAfter != 0 {
@@ -74,7 +78,7 @@ func TestConsumeMetrics(t *testing.T) {
 			}
 
 			if tt.wantThrottleErr {
-				expected := fmt.Errorf("HTTP %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
+				expected := fmt.Errorf("HTTP \"http://splunk.com\" %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
 				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
 				assert.EqualValues(t, expected, err)
 				return


### PR DESCRIPTION
#### Description

To help clarify what endpoint is being used within the collector once errors are being reported, this makes it apparent to all which is the impacted endpoint.

#### Link to tracking issue
Tracked externally

#### Testing

Updated existing tests.

#### Documentation

No user facing changes made, no additional documentation required.
