### PR TITLE
[processor/transform] Add support for profiles signal

### DIFF
--- a/.chloggen/profiles-transformprocessor.yaml
+++ b/.chloggen/profiles-transformprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add profiles support to transformprocessor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39009]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -11,7 +11,7 @@ import (
 )
 
 type DeleteKeyArguments[K any] struct {
-	Target ottl.PMapGetter[K]
+	Target ottl.PMapGetSetter[K]
 	Key    string
 }
 
@@ -29,13 +29,13 @@ func createDeleteKeyFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments
 	return deleteKey(args.Target, args.Key), nil
 }
 
-func deleteKey[K any](target ottl.PMapGetter[K], key string) ottl.ExprFunc[K] {
+func deleteKey[K any](target ottl.PMapGetSetter[K], key string) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
 		val.Remove(key)
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -15,7 +15,7 @@ import (
 )
 
 type DeleteMatchingKeysArguments[K any] struct {
-	Target  ottl.PMapGetter[K]
+	Target  ottl.PMapGetSetter[K]
 	Pattern string
 }
 
@@ -33,7 +33,7 @@ func createDeleteMatchingKeysFunction[K any](_ ottl.FunctionContext, oArgs ottl.
 	return deleteMatchingKeys(args.Target, args.Pattern)
 }
 
-func deleteMatchingKeys[K any](target ottl.PMapGetter[K], pattern string) (ottl.ExprFunc[K], error) {
+func deleteMatchingKeys[K any](target ottl.PMapGetSetter[K], pattern string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to delete_matching_keys is not a valid pattern: %w", err)
@@ -46,6 +46,6 @@ func deleteMatchingKeys[K any](target ottl.PMapGetter[K], pattern string) (ottl.
 		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			return compiledPattern.MatchString(key)
 		})
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_flatten.go
+++ b/pkg/ottl/ottlfuncs/func_flatten.go
@@ -16,7 +16,7 @@ import (
 )
 
 type FlattenArguments[K any] struct {
-	Target           ottl.PMapGetter[K]
+	Target           ottl.PMapGetSetter[K]
 	Prefix           ottl.Optional[string]
 	Depth            ottl.Optional[int64]
 	ResolveConflicts ottl.Optional[bool]
@@ -43,7 +43,7 @@ func createFlattenFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) 
 	return flatten(args.Target, args.Prefix, args.Depth, args.ResolveConflicts)
 }
 
-func flatten[K any](target ottl.PMapGetter[K], p ottl.Optional[string], d ottl.Optional[int64], c ottl.Optional[bool]) (ottl.ExprFunc[K], error) {
+func flatten[K any](target ottl.PMapGetSetter[K], p ottl.Optional[string], d ottl.Optional[int64], c ottl.Optional[bool]) (ottl.ExprFunc[K], error) {
 	depth := int64(math.MaxInt64)
 	if !d.IsEmpty() {
 		depth = d.Get()
@@ -72,7 +72,7 @@ func flatten[K any](target ottl.PMapGetter[K], p ottl.Optional[string], d ottl.O
 		flattenData.flattenMap(m, prefix, 0)
 		flattenData.result.MoveTo(m)
 
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, m)
 	}, nil
 }
 

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -13,7 +13,7 @@ import (
 )
 
 type KeepKeysArguments[K any] struct {
-	Target ottl.PMapGetter[K]
+	Target ottl.PMapGetSetter[K]
 	Keys   []string
 }
 
@@ -31,7 +31,7 @@ func createKeepKeysFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments)
 	return keepKeys(args.Target, args.Keys), nil
 }
 
-func keepKeys[K any](target ottl.PMapGetter[K], keys []string) ottl.ExprFunc[K] {
+func keepKeys[K any](target ottl.PMapGetSetter[K], keys []string) ottl.ExprFunc[K] {
 	keySet := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
 		keySet[key] = struct{}{}
@@ -49,6 +49,6 @@ func keepKeys[K any](target ottl.PMapGetter[K], keys []string) ottl.ExprFunc[K] 
 		if val.Len() == 0 {
 			val.Clear()
 		}
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -5,6 +5,7 @@ package ottlfuncs
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,15 +20,22 @@ func Test_keepKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
+	target := &ottl.StandardPMapGetSetter[pcommon.Map]{
+		Getter: func(_ context.Context, tCtx pcommon.Map) (pcommon.Map, error) {
 			return tCtx, nil
+		},
+		Setter: func(_ context.Context, tCtx pcommon.Map, m any) error {
+			if v, ok := m.(pcommon.Map); ok {
+				v.CopyTo(tCtx)
+				return nil
+			}
+			return errors.New("expected pcommon.Map")
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.PMapGetter[pcommon.Map]
+		target ottl.PMapGetSetter[pcommon.Map]
 		keys   []string
 		want   func(pcommon.Map)
 	}{
@@ -81,9 +89,12 @@ func Test_keepKeys(t *testing.T) {
 
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 
@@ -96,9 +107,12 @@ func Test_keepKeys_bad_input(t *testing.T) {
 }
 
 func Test_keepKeys_get_nil(t *testing.T) {
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/func_keep_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_matching_keys.go
@@ -14,7 +14,7 @@ import (
 )
 
 type KeepMatchingKeysArguments[K any] struct {
-	Target  ottl.PMapGetter[K]
+	Target  ottl.PMapGetSetter[K]
 	Pattern string
 }
 
@@ -32,7 +32,7 @@ func createKeepMatchingKeysFunction[K any](_ ottl.FunctionContext, oArgs ottl.Ar
 	return keepMatchingKeys(args.Target, args.Pattern)
 }
 
-func keepMatchingKeys[K any](target ottl.PMapGetter[K], pattern string) (ottl.ExprFunc[K], error) {
+func keepMatchingKeys[K any](target ottl.PMapGetSetter[K], pattern string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern provided to keep_matching_keys is not a valid pattern: %w", err)
@@ -47,6 +47,6 @@ func keepMatchingKeys[K any](target ottl.PMapGetter[K], pattern string) (ottl.Ex
 		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			return !compiledPattern.MatchString(key)
 		})
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -14,7 +14,7 @@ import (
 )
 
 type LimitArguments[K any] struct {
-	Target       ottl.PMapGetter[K]
+	Target       ottl.PMapGetSetter[K]
 	Limit        int64
 	PriorityKeys []string
 }
@@ -33,7 +33,7 @@ func createLimitFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (o
 	return limit(args.Target, args.Limit, args.PriorityKeys)
 }
 
-func limit[K any](target ottl.PMapGetter[K], limit int64, priorityKeys []string) (ottl.ExprFunc[K], error) {
+func limit[K any](target ottl.PMapGetSetter[K], limit int64, priorityKeys []string) (ottl.ExprFunc[K], error) {
 	if limit < 0 {
 		return nil, fmt.Errorf("invalid limit for limit function, %d cannot be negative", limit)
 	}
@@ -77,6 +77,6 @@ func limit[K any](target ottl.PMapGetter[K], limit int64, priorityKeys []string)
 		})
 		// TODO: Write log when limiting is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_merge_maps.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps.go
@@ -18,7 +18,7 @@ const (
 )
 
 type MergeMapsArguments[K any] struct {
-	Target   ottl.PMapGetter[K]
+	Target   ottl.PMapGetSetter[K]
 	Source   ottl.PMapGetter[K]
 	Strategy string
 }
@@ -43,7 +43,7 @@ func createMergeMapsFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments
 //	insert: Insert the value from `source` into `target` where the key does not already exist.
 //	update: Update the entry in `target` with the value from `source` where the key does exist
 //	upsert: Performs insert or update. Insert the value from `source` into `target` where the key does not already exist and update the entry in `target` with the value from `source` where the key does exist.
-func mergeMaps[K any](target ottl.PMapGetter[K], source ottl.PMapGetter[K], strategy string) (ottl.ExprFunc[K], error) {
+func mergeMaps[K any](target ottl.PMapGetSetter[K], source ottl.PMapGetter[K], strategy string) (ottl.ExprFunc[K], error) {
 	if strategy != INSERT && strategy != UPDATE && strategy != UPSERT {
 		return nil, fmt.Errorf("invalid value for strategy, %v, must be 'insert', 'update' or 'upsert'", strategy)
 	}
@@ -79,6 +79,6 @@ func mergeMaps[K any](target ottl.PMapGetter[K], source ottl.PMapGetter[K], stra
 		default:
 			return nil, fmt.Errorf("unknown strategy, %v", strategy)
 		}
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, targetMap)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -15,7 +15,7 @@ import (
 )
 
 type ReplaceAllMatchesArguments[K any] struct {
-	Target            ottl.PMapGetter[K]
+	Target            ottl.PMapGetSetter[K]
 	Pattern           string
 	Replacement       ottl.StringGetter[K]
 	Function          ottl.Optional[ottl.FunctionGetter[K]]
@@ -40,17 +40,18 @@ func createReplaceAllMatchesFunction[K any](_ ottl.FunctionContext, oArgs ottl.A
 	return replaceAllMatches(args.Target, args.Pattern, args.Replacement, args.Function, args.ReplacementFormat)
 }
 
-func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
+func replaceAllMatches[K any](target ottl.PMapGetSetter[K], pattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
-		var replacementVal string
 		if err != nil {
 			return nil, err
 		}
+
+		var replacementVal string
 		if fn.IsEmpty() {
 			replacementVal, err = replacement.Get(ctx, tCtx)
 			if err != nil {
@@ -75,11 +76,14 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 				return nil, err
 			}
 		}
-		for _, value := range val.All() {
+
+		updated := pcommon.NewMap()
+		val.CopyTo(updated)
+		for _, value := range updated.All() {
 			if value.Type() == pcommon.ValueTypeStr && glob.Match(value.Str()) {
 				value.SetStr(replacementVal)
 			}
 		}
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, updated)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -5,6 +5,7 @@ package ottlfuncs
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,15 +37,22 @@ func Test_replaceAllMatches(t *testing.T) {
 	}
 	optionalArg := ottl.NewTestingOptional[ottl.FunctionGetter[pcommon.Map]](ottlValue)
 
-	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
+	target := &ottl.StandardPMapGetSetter[pcommon.Map]{
+		Getter: func(_ context.Context, tCtx pcommon.Map) (pcommon.Map, error) {
 			return tCtx, nil
+		},
+		Setter: func(_ context.Context, tCtx pcommon.Map, m any) error {
+			if v, ok := m.(pcommon.Map); ok {
+				v.CopyTo(tCtx)
+				return nil
+			}
+			return errors.New("expected pcommon.Map")
 		},
 	}
 
 	tests := []struct {
 		name              string
-		target            ottl.PMapGetter[pcommon.Map]
+		target            ottl.PMapGetSetter[pcommon.Map]
 		pattern           string
 		replacement       ottl.StringGetter[pcommon.Map]
 		function          ottl.Optional[ottl.FunctionGetter[pcommon.Map]]
@@ -136,9 +144,8 @@ func Test_replaceAllMatches(t *testing.T) {
 			exprFunc, err := replaceAllMatches(tt.target, tt.pattern, tt.replacement, tt.function, tt.replacementFormat)
 			assert.NoError(t, err)
 
-			result, err := exprFunc(nil, scenarioMap)
+			_, err = exprFunc(nil, scenarioMap)
 			assert.NoError(t, err)
-			assert.Nil(t, result)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -150,9 +157,12 @@ func Test_replaceAllMatches(t *testing.T) {
 
 func Test_replaceAllMatches_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 	replacement := &ottl.StandardStringGetter[any]{
@@ -171,9 +181,12 @@ func Test_replaceAllMatches_bad_input(t *testing.T) {
 
 func Test_replaceAllMatches_bad_function_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 	replacement := &ottl.StandardStringGetter[any]{
@@ -195,9 +208,12 @@ func Test_replaceAllMatches_bad_function_input(t *testing.T) {
 
 func Test_replaceAllMatches_bad_function_result(t *testing.T) {
 	input := pcommon.NewValueInt(1)
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 	replacement := &ottl.StandardStringGetter[any]{
@@ -223,9 +239,12 @@ func Test_replaceAllMatches_bad_function_result(t *testing.T) {
 }
 
 func Test_replaceAllMatches_get_nil(t *testing.T) {
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, tCtx any) (any, error) {
-			return tCtx, nil
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
 	}
 	replacement := &ottl.StandardStringGetter[any]{

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -20,7 +20,7 @@ const (
 )
 
 type ReplaceAllPatternsArguments[K any] struct {
-	Target            ottl.PMapGetter[K]
+	Target            ottl.PMapGetSetter[K]
 	Mode              string
 	RegexPattern      string
 	Replacement       ottl.StringGetter[K]
@@ -42,7 +42,7 @@ func createReplaceAllPatternsFunction[K any](_ ottl.FunctionContext, oArgs ottl.
 	return replaceAllPatterns(args.Target, args.Mode, args.RegexPattern, args.Replacement, args.Function, args.ReplacementFormat)
 }
 
-func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
+func replaceAllPatterns[K any](target ottl.PMapGetSetter[K], mode string, regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_all_patterns is not a valid pattern: %w", err)
@@ -53,14 +53,16 @@ func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
-		var replacementVal string
 		if err != nil {
 			return nil, err
 		}
+
+		var replacementVal string
 		replacementVal, err = replacement.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
+
 		updated := pcommon.NewMap()
 		updated.EnsureCapacity(val.Len())
 	AttributeLoop:
@@ -98,7 +100,6 @@ func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 				}
 			}
 		}
-		updated.MoveTo(val)
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, updated)
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -12,7 +12,7 @@ import (
 )
 
 type TruncateAllArguments[K any] struct {
-	Target ottl.PMapGetter[K]
+	Target ottl.PMapGetSetter[K]
 	Limit  int64
 }
 
@@ -30,7 +30,7 @@ func createTruncateAllFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argumen
 	return TruncateAll(args.Target, args.Limit)
 }
 
-func TruncateAll[K any](target ottl.PMapGetter[K], limit int64) (ottl.ExprFunc[K], error) {
+func TruncateAll[K any](target ottl.PMapGetSetter[K], limit int64) (ottl.ExprFunc[K], error) {
 	if limit < 0 {
 		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limit)
 	}
@@ -51,6 +51,6 @@ func TruncateAll[K any](target ottl.PMapGetter[K], limit int64) (ottl.ExprFunc[K
 		}
 		// TODO: Write log when truncation is performed
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9730
-		return nil, nil
+		return nil, target.Set(ctx, tCtx, val)
 	}, nil
 }

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -46,7 +46,7 @@ transform:
   <trace|metric|log>_statements: []
 ```
 
-The Transform Processor's primary configuration section is broken down by signal (traces, metrics, and logs)
+The Transform Processor's primary configuration section is broken down by signal (traces, metrics, logs, and profiles)
 and allows you to configure a list of statements for the processor to execute. The list can be made of:
 
 - OTTL statements. This option will meet most user's needs. See [Basic Config](#basic-config) for more details.
@@ -54,11 +54,12 @@ and allows you to configure a list of statements for the processor to execute. T
 
 Within each `<signal_statements>` list, only certain OTTL Path prefixes can be used:
 
-| Signal            | Path Prefix Values                             |
-|-------------------|------------------------------------------------|
-| trace_statements  | `resource`, `scope`, `span`, and `spanevent`   |
-| metric_statements | `resource`, `scope`, `metric`, and `datapoint` |
-| log_statements    | `resource`, `scope`, and `log`                 |
+| Signal             | Path Prefix Values                             |
+|--------------------|------------------------------------------------|
+| trace_statements   | `resource`, `scope`, `span`, and `spanevent`   |
+| metric_statements  | `resource`, `scope`, `metric`, and `datapoint` |
+| log_statements     | `resource`, `scope`, and `log`                 |
+| profile_statements | `resource`, `scope`, and `profile`             |
 
 This means, for example, that you cannot use the Path `span.attributes` within the `log_statements` configuration section.
 

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -75,6 +75,21 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
+				ProfileStatements: []common.ContextStatements{
+					{
+						Context: "profile",
+						Statements: []string{
+							`set(original_payload_format, "bear") where attributes["http.path"] == "/animal"`,
+							`keep_keys(attributes, ["http.method", "http.path"])`,
+						},
+					},
+					{
+						Context: "resource",
+						Statements: []string{
+							`set(attributes["name"], "bear")`,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -108,6 +123,15 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
+				ProfileStatements: []common.ContextStatements{
+					{
+						Context:    "profile",
+						Conditions: []string{`attributes["http.path"] == "/animal"`},
+						Statements: []string{
+							`set(original_payload_format, "bear")`,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -122,8 +146,9 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
-				MetricStatements: []common.ContextStatements{},
-				LogStatements:    []common.ContextStatements{},
+				MetricStatements:  []common.ContextStatements{},
+				LogStatements:     []common.ContextStatements{},
+				ProfileStatements: []common.ContextStatements{},
 			},
 		},
 		{
@@ -143,6 +168,12 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "unknown_function_log"),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "bad_syntax_profile"),
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "unknown_function_profile"),
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "bad_syntax_multi_signal"),
@@ -174,6 +205,12 @@ func TestLoadConfig(t *testing.T) {
 						Statements: []string{`set(log.body, "bear") where log.attributes["http.path"] == "/animal"`},
 					},
 				},
+				ProfileStatements: []common.ContextStatements{
+					{
+						Context:    "profile",
+						Statements: []string{`set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"`},
+					},
+				},
 			},
 		},
 		{
@@ -200,6 +237,14 @@ func TestLoadConfig(t *testing.T) {
 					{
 						Statements: []string{
 							`set(log.body, "bear") where log.attributes["http.path"] == "/animal"`,
+							`set(resource.attributes["name"], "bear")`,
+						},
+					},
+				},
+				ProfileStatements: []common.ContextStatements{
+					{
+						Statements: []string{
+							`set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"`,
 							`set(resource.attributes["name"], "bear")`,
 						},
 					},
@@ -234,6 +279,14 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
+				ProfileStatements: []common.ContextStatements{
+					{
+						Statements: []string{
+							`set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"`,
+							`set(resource.attributes["name"], "bear")`,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -261,6 +314,16 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				LogStatements: []common.ContextStatements{
+					{
+						Statements: []string{`set(resource.attributes["name"], "propagate")`},
+						ErrorMode:  ottl.PropagateError,
+					},
+					{
+						Statements: []string{`set(resource.attributes["name"], "ignore")`},
+						ErrorMode:  "",
+					},
+				},
+				ProfileStatements: []common.ContextStatements{
 					{
 						Statements: []string{`set(resource.attributes["name"], "propagate")`},
 						ErrorMode:  ottl.PropagateError,

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -9,35 +9,41 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper"
+	"go.opentelemetry.io/collector/processor/xprocessor"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/profiles"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 func NewFactory() processor.Factory {
-	return processor.NewFactory(
+	return xprocessor.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		processor.WithLogs(createLogsProcessor, metadata.LogsStability),
-		processor.WithTraces(createTracesProcessor, metadata.TracesStability),
-		processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		xprocessor.WithLogs(createLogsProcessor, metadata.LogsStability),
+		xprocessor.WithTraces(createTracesProcessor, metadata.TracesStability),
+		xprocessor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
+		xprocessor.WithProfiles(createProfilesProcessor, metadata.ProfilesStability),
 	)
 }
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		ErrorMode:        ottl.PropagateError,
-		TraceStatements:  []common.ContextStatements{},
-		MetricStatements: []common.ContextStatements{},
-		LogStatements:    []common.ContextStatements{},
+		ErrorMode:         ottl.PropagateError,
+		TraceStatements:   []common.ContextStatements{},
+		MetricStatements:  []common.ContextStatements{},
+		LogStatements:     []common.ContextStatements{},
+		ProfileStatements: []common.ContextStatements{},
 	}
 }
 
@@ -103,4 +109,26 @@ func createMetricsProcessor(
 		nextConsumer,
 		proc.ProcessMetrics,
 		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func createProfilesProcessor(
+	ctx context.Context,
+	set processor.Settings,
+	cfg component.Config,
+	nextConsumer xconsumer.Profiles,
+) (xprocessor.Profiles, error) {
+	oCfg := cfg.(*Config)
+	oCfg.logger = set.Logger
+
+	proc, err := profiles.NewProcessor(oCfg.ProfileStatements, oCfg.ErrorMode, set.TelemetrySettings)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
+	}
+	return xprocessorhelper.NewProfiles(
+		ctx,
+		set,
+		cfg,
+		nextConsumer,
+		proc.ProcessProfiles,
+		xprocessorhelper.WithCapabilities(processorCapabilities))
 }

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -27,8 +27,12 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.126.1-0.20250515040533-97a6accbc082
 	go.opentelemetry.io/collector/confmap/xconfmap v0.126.1-0.20250515040533-97a6accbc082
 	go.opentelemetry.io/collector/consumer/consumertest v0.126.1-0.20250515040533-97a6accbc082
+	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1-0.20250515040533-97a6accbc082
+	go.opentelemetry.io/collector/pdata/pprofile v0.126.1-0.20250515040533-97a6accbc082
 	go.opentelemetry.io/collector/processor/processorhelper v0.126.1-0.20250515040533-97a6accbc082
+	go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1-0.20250515040533-97a6accbc082
 	go.opentelemetry.io/collector/processor/processortest v0.126.1-0.20250515040533-97a6accbc082
+	go.opentelemetry.io/collector/processor/xprocessor v0.126.1-0.20250515040533-97a6accbc082
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 )
 
@@ -67,12 +71,9 @@ require (
 	github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.126.1-0.20250515040533-97a6accbc082 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.1-0.20250515040533-97a6accbc082 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.126.1-0.20250515040533-97a6accbc082 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.1-0.20250515040533-97a6accbc082 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.126.1-0.20250515040533-97a6accbc082 // indirect
 	go.opentelemetry.io/collector/pipeline v0.126.1-0.20250515040533-97a6accbc082 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.1-0.20250515040533-97a6accbc082 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/log v0.11.0 // indirect
@@ -81,7 +82,7 @@ require (
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e // indirect
 	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/processor/transformprocessor/go.sum
+++ b/processor/transformprocessor/go.sum
@@ -126,6 +126,8 @@ go.opentelemetry.io/collector/processor v1.32.1-0.20250515040533-97a6accbc082 h1
 go.opentelemetry.io/collector/processor v1.32.1-0.20250515040533-97a6accbc082/go.mod h1:4j1uqeLh4QR4kbmL81Vc/VwNQmz5eZrmP+SfQ1DxxQs=
 go.opentelemetry.io/collector/processor/processorhelper v0.126.1-0.20250515040533-97a6accbc082 h1:VSIY/Q491yN+fI1rzcA61/uNcTeE/nz4Bd9+t8iBjCY=
 go.opentelemetry.io/collector/processor/processorhelper v0.126.1-0.20250515040533-97a6accbc082/go.mod h1:7eWyE5CMabClS24dPZzKx1RoICrHLJoZZgeL8mJL3dM=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1-0.20250515040533-97a6accbc082 h1:o8pN2WppnJICLW7BLKieSlp9C5GxSGAmhAFesi6eG1o=
+go.opentelemetry.io/collector/processor/processorhelper/xprocessorhelper v0.126.1-0.20250515040533-97a6accbc082/go.mod h1:248ActFrqGjayGJjgBOiyXZltMtp+3LRFeBslYauLx8=
 go.opentelemetry.io/collector/processor/processortest v0.126.1-0.20250515040533-97a6accbc082 h1:SY5y/D9znBMJtwI9+xYrLpi0lHnfs3XrnTG7G9+DMAA=
 go.opentelemetry.io/collector/processor/processortest v0.126.1-0.20250515040533-97a6accbc082/go.mod h1:OSP8iQDxn1vP71ChYQVSYYQ08s2r910G8eMOnMA7aiI=
 go.opentelemetry.io/collector/processor/xprocessor v0.126.1-0.20250515040533-97a6accbc082 h1:DHat8GOG8trWUxB4jSXklMnA3AA8fgn9D+TE+8SfO+Y=
@@ -237,8 +239,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a h1:51aaUVRocpvUOSQKM6Q7VuoaktNIaMCLuhZB6DKksq4=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a/go.mod h1:uRxBH1mhmO8PGhU89cMcHaXKZqO+OfakD8QQO0oYwlQ=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e h1:YA5lmSs3zc/5w+xsRcHqpETkaYyK63ivEPzNTcUUlSA=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
 google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=
 google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=

--- a/processor/transformprocessor/internal/common/config.go
+++ b/processor/transformprocessor/internal/common/config.go
@@ -22,12 +22,13 @@ const (
 	Metric    ContextID = "metric"
 	DataPoint ContextID = "datapoint"
 	Log       ContextID = "log"
+	Profile   ContextID = "profile"
 )
 
 func (c *ContextID) UnmarshalText(text []byte) error {
 	str := ContextID(strings.ToLower(string(text)))
 	switch str {
-	case Resource, Scope, Span, SpanEvent, Metric, DataPoint, Log:
+	case Resource, Scope, Span, SpanEvent, Metric, DataPoint, Log, Profile:
 		*c = str
 		return nil
 	default:

--- a/processor/transformprocessor/internal/common/profiles.go
+++ b/processor/transformprocessor/internal/common/profiles.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/expr"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
+)
+
+type ProfilesConsumer interface {
+	Context() ContextID
+	ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error
+}
+
+type profileStatements struct {
+	ottl.StatementSequence[ottlprofile.TransformContext]
+	expr.BoolExpr[ottlprofile.TransformContext]
+}
+
+func (l profileStatements) Context() ContextID {
+	return Profile
+}
+
+func (l profileStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error {
+	for i := 0; i < ld.ResourceProfiles().Len(); i++ {
+		rprofiles := ld.ResourceProfiles().At(i)
+		for j := 0; j < rprofiles.ScopeProfiles().Len(); j++ {
+			sprofiles := rprofiles.ScopeProfiles().At(j)
+			profiles := sprofiles.Profiles()
+			for k := 0; k < profiles.Len(); k++ {
+				tCtx := ottlprofile.NewTransformContext(profiles.At(k), sprofiles.Scope(), rprofiles.Resource(), sprofiles, rprofiles)
+				condition, err := l.Eval(ctx, tCtx)
+				if err != nil {
+					return err
+				}
+				if condition {
+					err := l.Execute(ctx, tCtx)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type ProfileParserCollection ottl.ParserCollection[ProfilesConsumer]
+
+type ProfileParserCollectionOption ottl.ParserCollectionOption[ProfilesConsumer]
+
+func WithProfileParser(functions map[string]ottl.Factory[ottlprofile.TransformContext]) ProfileParserCollectionOption {
+	return func(pc *ottl.ParserCollection[ProfilesConsumer]) error {
+		profileParser, err := ottlprofile.NewParser(functions, pc.Settings, ottlprofile.EnablePathContextNames())
+		if err != nil {
+			return err
+		}
+		return ottl.WithParserCollectionContext(ottlprofile.ContextName, &profileParser, ottl.WithStatementConverter(convertProfileStatements))(pc)
+	}
+}
+
+func WithProfileErrorMode(errorMode ottl.ErrorMode) ProfileParserCollectionOption {
+	return ProfileParserCollectionOption(ottl.WithParserCollectionErrorMode[ProfilesConsumer](errorMode))
+}
+
+func NewProfileParserCollection(settings component.TelemetrySettings, options ...ProfileParserCollectionOption) (*ProfileParserCollection, error) {
+	pcOptions := []ottl.ParserCollectionOption[ProfilesConsumer]{
+		withCommonContextParsers[ProfilesConsumer](),
+		ottl.EnableParserCollectionModifiedPathsLogging[ProfilesConsumer](true),
+	}
+
+	for _, option := range options {
+		pcOptions = append(pcOptions, ottl.ParserCollectionOption[ProfilesConsumer](option))
+	}
+
+	pc, err := ottl.NewParserCollection(settings, pcOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	ppc := ProfileParserCollection(*pc)
+	return &ppc, nil
+}
+
+func convertProfileStatements(pc *ottl.ParserCollection[ProfilesConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[ottlprofile.TransformContext]) (ProfilesConsumer, error) {
+	contextStatements, err := toContextStatements(statements)
+	if err != nil {
+		return nil, err
+	}
+	errorMode := pc.ErrorMode
+	if contextStatements.ErrorMode != "" {
+		errorMode = contextStatements.ErrorMode
+	}
+	var parserOptions []ottl.Option[ottlprofile.TransformContext]
+	if contextStatements.Context == "" {
+		parserOptions = append(parserOptions, ottlprofile.EnablePathContextNames())
+	}
+	globalExpr, errGlobalBoolExpr := parseGlobalExpr(filterottl.NewBoolExprForProfileWithOptions, contextStatements.Conditions, errorMode, pc.Settings, filterottl.StandardProfileFuncs(), parserOptions)
+	if errGlobalBoolExpr != nil {
+		return nil, errGlobalBoolExpr
+	}
+	lStatements := ottlprofile.NewStatementSequence(parsedStatements, pc.Settings, ottlprofile.WithStatementSequenceErrorMode(errorMode))
+	return profileStatements{lStatements, globalExpr}, nil
+}
+
+func (ppc *ProfileParserCollection) ParseContextStatements(contextStatements ContextStatements) (ProfilesConsumer, error) {
+	pc := ottl.ParserCollection[ProfilesConsumer](*ppc)
+	if contextStatements.Context != "" {
+		return pc.ParseStatementsWithContext(string(contextStatements.Context), contextStatements, true)
+	}
+	return pc.ParseStatements(contextStatements)
+}

--- a/processor/transformprocessor/internal/profiles/functions.go
+++ b/processor/transformprocessor/internal/profiles/functions.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profiles // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/profiles"
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+)
+
+func ProfileFunctions() map[string]ottl.Factory[ottlprofile.TransformContext] {
+	// No profiles-only functions yet.
+	return ottlfuncs.StandardFuncs[ottlprofile.TransformContext]()
+}

--- a/processor/transformprocessor/internal/profiles/functions_test.go
+++ b/processor/transformprocessor/internal/profiles/functions_test.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profiles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+)
+
+func Test_ProfileFunctions(t *testing.T) {
+	expected := ottlfuncs.StandardFuncs[ottlprofile.TransformContext]()
+	actual := ProfileFunctions()
+	require.Len(t, expected, len(actual))
+	for k := range actual {
+		assert.Contains(t, expected, k)
+	}
+}

--- a/processor/transformprocessor/internal/profiles/package_test.go
+++ b/processor/transformprocessor/internal/profiles/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profiles
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/processor/transformprocessor/internal/profiles/processor.go
+++ b/processor/transformprocessor/internal/profiles/processor.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profiles // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/profiles"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+)
+
+type Processor struct {
+	contexts []common.ProfilesConsumer
+	logger   *zap.Logger
+}
+
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings) (*Processor, error) {
+	pc, err := common.NewProfileParserCollection(settings, common.WithProfileParser(ProfileFunctions()), common.WithProfileErrorMode(errorMode))
+	if err != nil {
+		return nil, err
+	}
+
+	contexts := make([]common.ProfilesConsumer, len(contextStatements))
+	var errors error
+	for i, cs := range contextStatements {
+		context, err := pc.ParseContextStatements(cs)
+		if err != nil {
+			errors = multierr.Append(errors, err)
+		}
+		contexts[i] = context
+	}
+
+	if errors != nil {
+		return nil, errors
+	}
+
+	return &Processor{
+		contexts: contexts,
+		logger:   settings.Logger,
+	}, nil
+}
+
+func (p *Processor) ProcessProfiles(ctx context.Context, ld pprofile.Profiles) (pprofile.Profiles, error) {
+	for _, c := range p.contexts {
+		err := c.ConsumeProfiles(ctx, ld)
+		if err != nil {
+			p.logger.Error("failed processing profiles", zap.Error(err))
+			return ld, err
+		}
+	}
+	return ld, nil
+}

--- a/processor/transformprocessor/internal/profiles/processor_test.go
+++ b/processor/transformprocessor/internal/profiles/processor_test.go
@@ -1,0 +1,1321 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profiles
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pprofiletest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+)
+
+var (
+	TestProfileTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestProfileTimestamp = pcommon.NewTimestampFromTime(TestProfileTime)
+
+	TestObservedTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestObservedTimestamp = pcommon.NewTimestampFromTime(TestObservedTime)
+
+	profileID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+)
+
+func Test_ProcessProfiles_ResourceContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(attributes["test"], "pass")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
+			want: func(_ pprofile.Profiles) {
+			},
+		},
+		{
+			statement: `set(schema_url, "test_schema_url")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).SetSchemaUrl("test_schema_url")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_InferredResourceContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(resource.attributes["test"], "pass")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(resource.attributes["test"], "pass") where resource.attributes["host.name"] == "wrong"`,
+			want: func(_ pprofile.Profiles) {
+			},
+		},
+		{
+			statement: `set(resource.schema_url, "test_schema_url")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).SetSchemaUrl("test_schema_url")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_ScopeContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(attributes["test"], "pass") where name == "scope"`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where version == 2`,
+			want: func(_ pprofile.Profiles) {
+			},
+		},
+		{
+			statement: `set(schema_url, "test_schema_url")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).SetSchemaUrl("test_schema_url")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_InferredScopeContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(scope.attributes["test"], "pass") where scope.name == "scope"`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			statement: `set(scope.attributes["test"], "pass") where scope.version == 2`,
+			want: func(_ pprofile.Profiles) {
+			},
+		},
+		{
+			statement: `set(scope.schema_url, "test_schema_url")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).SetSchemaUrl("test_schema_url")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_ProfileContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(attributes["test"], "pass") where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where resource.attributes["host.name"] == "localhost"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			statement: `keep_keys(attributes, ["http.method"]) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				clearProfileAttributes(td, 0)
+				putProfileAttribute(t, td, 0, "http.method", "get")
+			},
+		},
+		{
+			statement: `set(original_payload_format, "json") where attributes["http.path"] == "/health"`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat("json")
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(1).SetOriginalPayloadFormat("json")
+			},
+		},
+		{
+			statement: `replace_pattern(attributes["http.method"], "get", "post")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "http.method", "post")
+				putProfileAttribute(t, td, 1, "http.method", "post")
+			},
+		},
+		{
+			statement: `replace_all_patterns(attributes, "value", "get", "post")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "http.method", "post")
+				putProfileAttribute(t, td, 1, "http.method", "post")
+			},
+		},
+		{
+			statement: `replace_all_patterns(attributes, "key", "http.url", "url")`,
+			want: func(td pprofile.Profiles) {
+				clearProfileAttributes(td, 0)
+				putProfileAttribute(t, td, 0, "http.method", "get")
+				putProfileAttribute(t, td, 0, "http.path", "/health")
+				putProfileAttribute(t, td, 0, "url", "http://localhost/health")
+				putProfileAttribute(t, td, 0, "flags", "A|B|C")
+				putProfileAttribute(t, td, 0, "total.string", "123456789")
+				clearProfileAttributes(td, 1)
+				putProfileAttribute(t, td, 1, "http.method", "get")
+				putProfileAttribute(t, td, 1, "http.path", "/health")
+				putProfileAttribute(t, td, 1, "url", "http://localhost/health")
+				putProfileAttribute(t, td, 1, "flags", "C|D")
+				putProfileAttribute(t, td, 1, "total.string", "345678")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where dropped_attributes_count == 1`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where profile_id == ProfileID(0x0102030405060708090a0b0c0d0e0f10)`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			statement: `set(attributes["test"], "pass") where IsMatch(original_payload_format, "operation[AC]")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+			},
+		},
+		{
+			statement: `delete_key(attributes, "http.url") where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				deleteProfileAttribute(td, 0, "http.url")
+			},
+		},
+		{
+			statement: `delete_matching_keys(attributes, "http.*t.*") where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				deleteProfileAttributeSequential(td, 0, "http.path")
+				deleteProfileAttributeSequential(td, 0, "http.method")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Concat([attributes["http.method"], attributes["http.url"]], ": ")) where original_payload_format == Concat(["operation", "A"], "")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "get: http://localhost/health")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Split(attributes["flags"], "|"))`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+				putProfileAttribute(t, td, 1, "test", []any{"C", "D"})
+			},
+		},
+		{
+			statement: `set(attributes["test"], Split(attributes["flags"], "|")) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+			},
+		},
+		{
+			statement: `set(attributes["test"], Split(attributes["not_exist"], "|"))`,
+			want:      func(_ pprofile.Profiles) {},
+		},
+		{
+			statement: `set(attributes["test"], Substring(attributes["total.string"], 3, 3))`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "456")
+				putProfileAttribute(t, td, 1, "test", "678")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Substring(attributes["total.string"], 3, 3)) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "456")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`,
+			want:      func(_ pprofile.Profiles) {},
+		},
+		{
+			statement: `set(attributes["test"], ["A", "B", "C"]) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+			},
+		},
+		{
+			statement: `set(attributes["test"], ConvertCase(original_payload_format, "lower")) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "operationa")
+			},
+		},
+		{
+			statement: `set(attributes["test"], ConvertCase(original_payload_format, "upper")) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "OPERATIONA")
+			},
+		},
+		{
+			statement: `set(attributes["test"], ConvertCase(original_payload_format, "snake")) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "operation_a")
+			},
+		},
+		{
+			statement: `set(attributes["test"], ConvertCase(original_payload_format, "camel")) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "OperationA")
+			},
+		},
+		{
+			statement: `merge_maps(attributes, ParseJSON("{\"json_test\":\"pass\"}"), "insert") where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "json_test", "pass")
+			},
+		},
+		{
+			statement: `limit(attributes, 0, []) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				clearProfileAttributes(td, 0)
+			},
+		},
+		{
+			statement: `set(attributes["test"], Log(1)) where original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", 0.0)
+			},
+		},
+		{
+			statement: `replace_match(profile.original_payload_format, "*", "12345")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat("12345")
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(1).SetOriginalPayloadFormat("12345")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "profile", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_InferredProfileContext(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      func(td pprofile.Profiles)
+	}{
+		{
+			statement: `set(profile.attributes["test"], "pass") where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], "pass") where resource.attributes["host.name"] == "localhost"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			statement: `keep_keys(profile.attributes, ["http.method"]) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				clearProfileAttributes(td, 0)
+				putProfileAttribute(t, td, 0, "http.method", "get")
+			},
+		},
+		{
+			statement: `set(profile.original_payload_format, "json") where profile.attributes["http.path"] == "/health"`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat("json")
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(1).SetOriginalPayloadFormat("json")
+			},
+		},
+		{
+			statement: `replace_pattern(profile.attributes["http.method"], "get", "post")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "http.method", "post")
+				putProfileAttribute(t, td, 1, "http.method", "post")
+			},
+		},
+		{
+			statement: `replace_all_patterns(profile.attributes, "value", "get", "post")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "http.method", "post")
+				putProfileAttribute(t, td, 1, "http.method", "post")
+			},
+		},
+		{
+			statement: `replace_all_patterns(profile.attributes, "key", "http.url", "url")`,
+			want: func(td pprofile.Profiles) {
+				clearProfileAttributes(td, 0)
+				putProfileAttribute(t, td, 0, "http.method", "get")
+				putProfileAttribute(t, td, 0, "http.path", "/health")
+				putProfileAttribute(t, td, 0, "url", "http://localhost/health")
+				putProfileAttribute(t, td, 0, "flags", "A|B|C")
+				putProfileAttribute(t, td, 0, "total.string", "123456789")
+				clearProfileAttributes(td, 1)
+				putProfileAttribute(t, td, 1, "http.method", "get")
+				putProfileAttribute(t, td, 1, "http.path", "/health")
+				putProfileAttribute(t, td, 1, "url", "http://localhost/health")
+				putProfileAttribute(t, td, 1, "flags", "C|D")
+				putProfileAttribute(t, td, 1, "total.string", "345678")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], "pass") where profile.dropped_attributes_count == 1`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], "pass") where IsMatch(profile.original_payload_format, "operation[AC]")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+			},
+		},
+		{
+			statement: `delete_key(profile.attributes, "http.url") where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				deleteProfileAttribute(td, 0, "http.url")
+			},
+		},
+		{
+			statement: `delete_matching_keys(profile.attributes, "http.*t.*") where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				deleteProfileAttributeSequential(td, 0, "http.path")
+				deleteProfileAttributeSequential(td, 0, "http.method")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Concat([profile.attributes["http.method"], profile.attributes["http.url"]], ": ")) where profile.original_payload_format == Concat(["operation", "A"], "")`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "get: http://localhost/health")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Split(profile.attributes["flags"], "|"))`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+				putProfileAttribute(t, td, 1, "test", []any{"C", "D"})
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Split(profile.attributes["flags"], "|")) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Split(profile.attributes["not_exist"], "|"))`,
+			want:      func(_ pprofile.Profiles) {},
+		},
+		{
+			statement: `set(profile.attributes["test"], Substring(profile.attributes["total.string"], 3, 3))`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "456")
+				putProfileAttribute(t, td, 1, "test", "678")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Substring(profile.attributes["total.string"], 3, 3)) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "456")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], Substring(profile.attributes["not_exist"], 3, 3))`,
+			want:      func(_ pprofile.Profiles) {},
+		},
+		{
+			statement: `set(profile.attributes["test"], ["A", "B", "C"]) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", []any{"A", "B", "C"})
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], ConvertCase(profile.original_payload_format, "lower")) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "operationa")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], ConvertCase(profile.original_payload_format, "upper")) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "OPERATIONA")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], ConvertCase(profile.original_payload_format, "snake")) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "operation_a")
+			},
+		},
+		{
+			statement: `set(profile.attributes["test"], ConvertCase(profile.original_payload_format, "camel")) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "OperationA")
+			},
+		},
+		{
+			statement: `merge_maps(profile.attributes, ParseJSON("{\"json_test\":\"pass\"}"), "insert") where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "json_test", "pass")
+			},
+		},
+		/*
+			{
+					statement: `limit(profile.attributes, 0, []) where profile.body == "operationA"`,
+					want: func(td pprofile.Profiles) {
+						td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+					},
+				},
+		*/
+		{
+			statement: `set(profile.attributes["test"], Log(1)) where profile.original_payload_format == "operationA"`,
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", float64(0.0))
+			},
+		},
+		{
+			statement: `replace_match(profile.original_payload_format, "*", "12345")`,
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(0).SetOriginalPayloadFormat("12345")
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(1).SetOriginalPayloadFormat("12345")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.statement, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_MixContext(t *testing.T) {
+	tests := []struct {
+		name              string
+		contextStatements []common.ContextStatements
+		want              func(td pprofile.Profiles)
+	}{
+		{
+			name: "set resource and then use",
+			contextStatements: []common.ContextStatements{
+				{
+					Context: "resource",
+					Statements: []string{
+						`set(attributes["test"], "pass")`,
+					},
+				},
+				{
+					Context: "profile",
+					Statements: []string{
+						`set(attributes["test"], "pass") where resource.attributes["test"] == "pass"`,
+					},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "set scope and then use",
+			contextStatements: []common.ContextStatements{
+				{
+					Context: "scope",
+					Statements: []string{
+						`set(attributes["test"], "pass")`,
+					},
+				},
+				{
+					Context: "profile",
+					Statements: []string{
+						`set(attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`,
+					},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "order matters",
+			contextStatements: []common.ContextStatements{
+				{
+					Context: "profile",
+					Statements: []string{
+						`set(attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`,
+					},
+				},
+				{
+					Context: "scope",
+					Statements: []string{
+						`set(attributes["test"], "pass")`,
+					},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "reuse context",
+			contextStatements: []common.ContextStatements{
+				{
+					Context: "scope",
+					Statements: []string{
+						`set(attributes["test"], "pass")`,
+					},
+				},
+				{
+					Context: "profile",
+					Statements: []string{
+						`set(attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`,
+					},
+				},
+				{
+					Context: "scope",
+					Statements: []string{
+						`set(attributes["test"], "fail")`,
+					},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "fail")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_InferredMixContext(t *testing.T) {
+	tests := []struct {
+		name              string
+		contextStatements []common.ContextStatements
+		want              func(td pprofile.Profiles)
+	}{
+		{
+			name: "set resource and then use",
+			contextStatements: []common.ContextStatements{
+				{
+					Statements: []string{`set(resource.attributes["test"], "pass")`},
+				},
+				{
+					Statements: []string{`set(profile.attributes["test"], "pass") where resource.attributes["test"] == "pass"`},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "set scope and then use",
+			contextStatements: []common.ContextStatements{
+				{
+					Statements: []string{`set(scope.attributes["test"], "pass")`},
+				},
+				{
+					Statements: []string{`set(profile.attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "order matters",
+			contextStatements: []common.ContextStatements{
+				{
+					Statements: []string{`set(profile.attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`},
+				},
+				{
+					Statements: []string{`set(scope.attributes["test"], "pass")`},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "reuse context",
+			contextStatements: []common.ContextStatements{
+				{
+					Statements: []string{`set(scope.attributes["test"], "pass")`},
+				},
+				{
+					Statements: []string{`set(profile.attributes["test"], "pass") where instrumentation_scope.attributes["test"] == "pass"`},
+				},
+				{
+					Statements: []string{`set(scope.attributes["test"], "fail")`},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "fail")
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_ErrorMode(t *testing.T) {
+	tests := []struct {
+		statement string
+		context   common.ContextID
+	}{
+		{
+			context: "resource",
+		},
+		{
+			context: "scope",
+		},
+		{
+			context: "profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.context), func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		errorMode     ottl.ErrorMode
+		statements    []common.ContextStatements
+		want          func(td pprofile.Profiles)
+		wantErrorWith string
+	}{
+		{
+			name:      "profile: statements group with error mode",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(profile.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(profile.attributes["test"], "pass") where profile.dropped_attributes_count == 1`}},
+			},
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name:      "profile: statements group error mode does not affect default",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(profile.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(profile.attributes["pass"], ParseJSON(true))`}},
+			},
+			wantErrorWith: "expected string but got bool",
+		},
+		{
+			name:      "resource: statements group with error mode",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["test"], "pass")`}},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name:      "resource: statements group error mode does not affect default",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(true))`}},
+			},
+			wantErrorWith: "expected string but got bool",
+		},
+		{
+			name:      "scope: statements group with error mode",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["test"], "pass")`}},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name:      "scope: statements group error mode does not affect default",
+			errorMode: ottl.PropagateError,
+			statements: []common.ContextStatements{
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(true))`}},
+			},
+			wantErrorWith: "expected string but got bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			if tt.wantErrorWith != "" {
+				if err == nil {
+					t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
+				}
+				assert.Contains(t, err.Error(), tt.wantErrorWith)
+				return
+			}
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_ProcessProfiles_CacheAccess(t *testing.T) {
+	tests := []struct {
+		name       string
+		statements []common.ContextStatements
+		want       func(td pprofile.Profiles)
+	}{
+		{
+			name: "resource:resource.cache",
+			statements: []common.ContextStatements{
+				{Statements: []string{
+					`set(resource.cache["test"], "pass")`,
+					`set(resource.attributes["test"], resource.cache["test"])`,
+				}},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "resource:cache",
+			statements: []common.ContextStatements{
+				{
+					Context: common.Resource,
+					Statements: []string{
+						`set(cache["test"], "pass")`,
+						`set(attributes["test"], cache["test"])`,
+					},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).Resource().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "scope:scope.cache",
+			statements: []common.ContextStatements{
+				{Statements: []string{
+					`set(scope.cache["test"], "pass")`,
+					`set(scope.attributes["test"], scope.cache["test"])`,
+				}},
+			},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "scope:cache",
+			statements: []common.ContextStatements{{
+				Context: common.Scope,
+				Statements: []string{
+					`set(cache["test"], "pass")`,
+					`set(attributes["test"], cache["test"])`,
+				},
+			}},
+			want: func(td pprofile.Profiles) {
+				td.ResourceProfiles().At(0).ScopeProfiles().At(0).Scope().Attributes().PutStr("test", "pass")
+			},
+		},
+		{
+			name: "profile:profile.cache",
+			statements: []common.ContextStatements{
+				{Statements: []string{
+					`set(profile.cache["test"], "pass")`,
+					`set(profile.attributes["test"], profile.cache["test"])`,
+				}},
+			},
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "profile:cache",
+			statements: []common.ContextStatements{{
+				Context: common.Profile,
+				Statements: []string{
+					`set(cache["test"], "pass")`,
+					`set(attributes["test"], cache["test"])`,
+				},
+			}},
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+		{
+			name: "cache isolation",
+			statements: []common.ContextStatements{
+				{
+					Statements: []string{`set(profile.cache["shared"], "fail")`},
+				},
+				{
+					Statements: []string{
+						`set(profile.cache["test"], "pass")`,
+						`set(profile.attributes["test"], profile.cache["test"])`,
+						`set(profile.attributes["test"], profile.cache["shared"])`,
+					},
+				},
+				{
+					Context: common.Profile,
+					Statements: []string{
+						`set(cache["test"], "pass")`,
+						`set(attributes["test"], cache["test"])`,
+						`set(attributes["test"], cache["shared"])`,
+						`set(attributes["test"], profile.cache["shared"])`,
+					},
+				},
+				{
+					Statements: []string{`set(profile.attributes["test"], "pass") where profile.cache["shared"] == "fail"`},
+				},
+			},
+			want: func(td pprofile.Profiles) {
+				putProfileAttribute(t, td, 0, "test", "pass")
+				putProfileAttribute(t, td, 1, "test", "pass")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := constructProfiles()
+			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			require.NoError(t, err)
+
+			_, err = processor.ProcessProfiles(context.Background(), td)
+			assert.NoError(t, err)
+
+			exTd := constructProfiles()
+			tt.want(exTd)
+
+			assert.Equal(t, exTd, td)
+		})
+	}
+}
+
+func Test_NewProcessor_ConditionsParse(t *testing.T) {
+	type testCase struct {
+		name          string
+		statements    []common.ContextStatements
+		wantErrorWith string
+	}
+
+	contextsTests := map[string][]testCase{"profile": nil, "resource": nil, "scope": nil}
+	for ctx := range contextsTests {
+		contextsTests[ctx] = []testCase{
+			{
+				name: "inferred: condition with context",
+				statements: []common.ContextStatements{
+					{
+						Statements: []string{fmt.Sprintf(`set(%s.cache["test"], "pass")`, ctx)},
+						Conditions: []string{fmt.Sprintf(`%s.cache["test"] == ""`, ctx)},
+					},
+				},
+			},
+			{
+				name: "inferred: condition without context",
+				statements: []common.ContextStatements{
+					{
+						Statements: []string{fmt.Sprintf(`set(%s.cache["test"], "pass")`, ctx)},
+						Conditions: []string{`cache["test"] == ""`},
+					},
+				},
+				wantErrorWith: `missing context name for path "cache[test]"`,
+			},
+			{
+				name: "context defined: condition without context",
+				statements: []common.ContextStatements{
+					{
+						Context:    common.ContextID(ctx),
+						Statements: []string{`set(cache["test"], "pass")`},
+						Conditions: []string{`cache["test"] == ""`},
+					},
+				},
+			},
+			{
+				name: "context defined: condition with context",
+				statements: []common.ContextStatements{
+					{
+						Context:    common.ContextID(ctx),
+						Statements: []string{`set(attributes["test"], "pass")`},
+						Conditions: []string{fmt.Sprintf(`%s.cache["test"] == ""`, ctx)},
+					},
+				},
+			},
+		}
+	}
+
+	for ctx, tests := range contextsTests {
+		t.Run(ctx, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+					if tt.wantErrorWith != "" {
+						if err == nil {
+							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
+						}
+						assert.Contains(t, err.Error(), tt.wantErrorWith)
+						return
+					}
+					require.NoError(t, err)
+				})
+			}
+		})
+	}
+}
+
+func constructProfiles() pprofile.Profiles {
+	return pprofiletest.Profiles{
+		ResourceProfiles: []pprofiletest.ResourceProfile{
+			{
+				Resource: pprofiletest.Resource{
+					Attributes: []pprofiletest.Attribute{{Key: "host.name", Value: "localhost"}},
+				},
+				ScopeProfiles: []pprofiletest.ScopeProfile{
+					{
+						SchemaURL: "test_schema_url",
+						Scope: pprofiletest.Scope{
+							Name: "scope",
+						},
+						Profile: []pprofiletest.Profile{
+							{
+								Attributes: []pprofiletest.Attribute{
+									{Key: "http.method", Value: "get"},
+									{Key: "http.path", Value: "/health"},
+									{Key: "http.url", Value: "http://localhost/health"},
+									{Key: "flags", Value: "A|B|C"},
+									{Key: "total.string", Value: "123456789"},
+								},
+								ProfileID:              profileID,
+								TimeNanos:              1111,
+								DurationNanos:          222,
+								DroppedAttributesCount: 1,
+								OriginalPayloadFormat:  "operationA",
+							},
+							{
+								Attributes: []pprofiletest.Attribute{
+									{Key: "http.method", Value: "get"},
+									{Key: "http.path", Value: "/health"},
+									{Key: "http.url", Value: "http://localhost/health"},
+									{Key: "flags", Value: "C|D"},
+									{Key: "total.string", Value: "345678"},
+								},
+								ProfileID:              profileID,
+								TimeNanos:              3333,
+								DurationNanos:          444,
+								DroppedAttributesCount: 1,
+								OriginalPayloadFormat:  "",
+							},
+						},
+					},
+				},
+			},
+		},
+	}.Transform()
+}
+
+func putProfileAttribute(t *testing.T, pp pprofile.Profiles, idx int, key string, value any) {
+	pv := pcommon.NewValueEmpty()
+	assert.NoError(t, pv.FromRaw(value))
+	profile := pp.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(idx)
+	assert.NoError(t, PutAttribute(profile.AttributeTable(), profile, key, pv))
+}
+
+func clearProfileAttributes(pp pprofile.Profiles, idx int) {
+	profile := pp.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(idx)
+	profile.AttributeIndices().FromRaw([]int32{})
+	//	profile.AttributeTable().RemoveIf(func(pprofile.Attribute) bool { return true })
+}
+
+// deleteProfileAttribute works as deleteKey() in func_delete_key.go.
+func deleteProfileAttribute(pp pprofile.Profiles, idx int, key string) {
+	profile := pp.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(idx)
+	indices := profile.AttributeIndices().AsRaw()
+	for i := range indices {
+		if profile.AttributeTable().At(int(indices[i])).Key() == key {
+			indices[i] = indices[len(indices)-1]
+			profile.AttributeIndices().FromRaw(indices[:len(indices)-1])
+			return
+		}
+	}
+}
+
+// deleteProfileAttribute works as deleteMatchingKeys() in func_delete_matching_keys.go.
+func deleteProfileAttributeSequential(pp pprofile.Profiles, idx int, key string) { //nolint:unparam
+	profile := pp.ResourceProfiles().At(0).ScopeProfiles().At(0).Profiles().At(idx)
+	indices := profile.AttributeIndices().AsRaw()
+	j := 0
+	for i := range indices {
+		if profile.AttributeTable().At(int(indices[i])).Key() == key {
+			continue
+		}
+		indices[j] = indices[i]
+		j++
+	}
+	if j == len(indices) {
+		// No matching keys found, nothing to do.
+		return
+	}
+	profile.AttributeIndices().FromRaw(indices[:j])
+}
+
+type attributable interface {
+	AttributeIndices() pcommon.Int32Slice
+}
+
+var errTooManyTableEntries = errors.New("too many entries in AttributeTable")
+
+// PutAttribute updates an AttributeTable and a record's AttributeIndices to
+// add a new attribute.
+// The record can be any struct that implements an `AttributeIndices` method.
+func PutAttribute(table pprofile.AttributeTableSlice, record attributable, key string, value pcommon.Value) error {
+	for i := range record.AttributeIndices().Len() {
+		idx := int(record.AttributeIndices().At(i))
+		if idx < 0 || idx >= table.Len() {
+			return fmt.Errorf("index value %d out of range in AttributeIndices[%d]", idx, i)
+		}
+		attr := table.At(idx)
+		if attr.Key() == key {
+			if attr.Value().Equal(value) {
+				// Attribute already exists, nothing to do.
+				return nil
+			}
+
+			// If the attribute table already contains the key/value pair, just update the index.
+			for j := range table.Len() {
+				a := table.At(j)
+				if a.Key() == key && a.Value().Equal(value) {
+					if j > math.MaxInt32 {
+						return errTooManyTableEntries
+					}
+					record.AttributeIndices().SetAt(i, int32(j))
+					return nil
+				}
+			}
+
+			if table.Len() >= math.MaxInt32 {
+				return errTooManyTableEntries
+			}
+
+			// Add the key/value pair as a new attribute to the table...
+			entry := table.AppendEmpty()
+			entry.SetKey(key)
+			value.CopyTo(entry.Value())
+
+			// ...and update the existing index.
+			record.AttributeIndices().SetAt(i, int32(table.Len()-1))
+			return nil
+		}
+	}
+
+	if record.AttributeIndices().Len() >= math.MaxInt32 {
+		return errors.New("too many entries in AttributeIndices")
+	}
+
+	for j := range table.Len() {
+		a := table.At(j)
+		if a.Key() == key && a.Value().Equal(value) {
+			if j > math.MaxInt32 {
+				return errTooManyTableEntries
+			}
+			// Add the index of the existing attribute to the indices.
+			record.AttributeIndices().Append(int32(j))
+			return nil
+		}
+	}
+
+	if table.Len() >= math.MaxInt32 {
+		return errTooManyTableEntries
+	}
+
+	// Add the key/value pair as a new attribute to the table...
+	entry := table.AppendEmpty()
+	entry.SetKey(key)
+	value.CopyTo(entry.Value())
+
+	// ...and add the new index to the indices.
+	record.AttributeIndices().Append(int32(table.Len() - 1))
+	return nil
+}

--- a/processor/transformprocessor/testdata/config.yaml
+++ b/processor/transformprocessor/testdata/config.yaml
@@ -23,6 +23,14 @@ transform:
     - context: resource
       statements:
         - set(attributes["name"], "bear")
+  profile_statements:
+    - context: profile
+      statements:
+        - set(original_payload_format, "bear") where attributes["http.path"] == "/animal"
+        - keep_keys(attributes, ["http.method", "http.path"])
+    - context: resource
+      statements:
+        - set(attributes["name"], "bear")
 
 transform/with_conditions:
   trace_statements:
@@ -43,6 +51,12 @@ transform/with_conditions:
         - attributes["http.path"] == "/animal"
       statements:
         - set(body, "bear")     
+  profile_statements:
+    - context: profile
+      conditions:
+        - attributes["http.path"] == "/animal"
+      statements:
+        - set(original_payload_format, "bear")
 
 transform/ignore_errors:
   error_mode: ignore
@@ -72,6 +86,13 @@ transform/bad_syntax_trace:
         - set(name, "bear" where attributes["http.path"] == "/animal"
         - keep_keys(attributes, ["http.method", "http.path"])
 
+transform/bad_syntax_profile:
+  log_statements:
+    - context: profile
+      statements:
+        - set(original_payload_format, "bear" where attributes["http.path"] == "/animal"
+        - keep_keys(attributes, ["http.method", "http.path"])
+
 transform/bad_syntax_multi_signal:
   trace_statements:
     - context: span
@@ -87,6 +108,11 @@ transform/bad_syntax_multi_signal:
     - context: log
       statements:
         - set(body, "bear" none["http.path"] == "/animal"
+        - keep_keys(attributes, ["http.method", "http.path"])
+  profile_statements:
+    - context: profile
+      statements:
+        - set(original_payload_format, "bear" none["http.path"] == "/animal"
         - keep_keys(attributes, ["http.method", "http.path"])
 
 transform/unknown_function_log:
@@ -108,6 +134,13 @@ transform/unknown_function_trace:
     - context: span
       statements:
         - set(name, "bear") where attributes["http.path"] == "/animal"
+        - not_a_function(attributes, ["http.method", "http.path"])
+
+transform/unknown_function_profile:
+  log_statements:
+    - context: profile
+      statements:
+        - set(original_payload_format, "bear") where attributes["http.path"] == "/animal"
         - not_a_function(attributes, ["http.method", "http.path"])
 
 transform/unknown_context:
@@ -132,6 +165,10 @@ transform/structured_configuration_with_path_context:
     - context: log
       statements:
         - set(log.body, "bear") where log.attributes["http.path"] == "/animal"
+  profile_statements:
+    - context: profile
+      statements:
+        - set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"
 
 transform/structured_configuration_with_inferred_context:
   trace_statements:
@@ -146,6 +183,10 @@ transform/structured_configuration_with_inferred_context:
     - statements:
       - set(log.body, "bear") where log.attributes["http.path"] == "/animal"
       - set(resource.attributes["name"], "bear")
+  profile_statements:
+    - statements:
+        - set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"
+        - set(resource.attributes["name"], "bear")
 
 transform/flat_configuration:
   trace_statements:
@@ -156,6 +197,9 @@ transform/flat_configuration:
     - set(resource.attributes["name"], "bear")
   log_statements:
     - set(log.body, "bear") where log.attributes["http.path"] == "/animal"
+    - set(resource.attributes["name"], "bear")
+  profile_statements:
+    - set(profile.original_payload_format, "bear") where profile.attributes["http.path"] == "/animal"
     - set(resource.attributes["name"], "bear")
 
 transform/mixed_configuration_styles:
@@ -190,6 +234,12 @@ transform/context_statements_error_mode:
     - statements:
         - set(resource.attributes["name"], "ignore")
   log_statements:
+    - error_mode: propagate
+      statements:
+        - set(resource.attributes["name"], "propagate")
+    - statements:
+        - set(resource.attributes["name"], "ignore")
+  profile_statements:
     - error_mode: propagate
       statements:
         - set(resource.attributes["name"], "propagate")


### PR DESCRIPTION
Initial PR for profiles support in the transform processor.

Fixes #39009 

## Review
The first commit "[processor/transform] Add support for profiles]" contains the actual changes to the transformprocessor.
The other commits contain the code changes from other PRs that haven't been merged yet but that are required or wanted. [Here is the list of PRs and issues](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39009#issuecomment-2835413049).
