### PR TITLE
[pkg/stanza/operator/input/windows] [receiver/windowseventlogreceiver] add raw XML query support

### DIFF
--- a/.chloggen/eventlogreceiver-query.yaml
+++ b/.chloggen/eventlogreceiver-query.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: eventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add raw XML query filtering option
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38517]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/pkg/stanza/operator/input/windows/config_all.go
+++ b/pkg/stanza/operator/input/windows/config_all.go
@@ -37,6 +37,7 @@ type Config struct {
 	SuppressRenderingInfo bool          `mapstructure:"suppress_rendering_info,omitempty"`
 	ExcludeProviders      []string      `mapstructure:"exclude_providers,omitempty"`
 	Remote                RemoteConfig  `mapstructure:"remote,omitempty"`
+	Query                 *string       `mapstructure:"query,omitempty"`
 }
 
 // RemoteConfig is the configuration for a remote server.

--- a/pkg/stanza/operator/input/windows/config_windows.go
+++ b/pkg/stanza/operator/input/windows/config_windows.go
@@ -24,8 +24,12 @@ func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, erro
 		return nil, err
 	}
 
-	if c.Channel == "" {
-		return nil, errors.New("missing required `channel` field")
+	if c.Channel == "" && c.Query == nil {
+		return nil, errors.New("either `channel` or `query` must be set")
+	}
+
+	if c.Channel != "" && c.Query != nil {
+		return nil, errors.New("either `channel` or `query` must be set, but not both")
 	}
 
 	if c.MaxReads < 1 {
@@ -52,6 +56,7 @@ func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, erro
 		raw:              c.Raw,
 		excludeProviders: excludeProvidersSet(c.ExcludeProviders),
 		remote:           c.Remote,
+		query:            c.Query,
 	}
 	input.startRemoteSession = input.defaultStartRemoteSession
 

--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -35,6 +35,7 @@ Tails and parses logs from windows event log API using the [opentelemetry-log-co
 | `retry_on_failure.max_interval`     | `30 seconds` | Upper bound on retry backoff interval. Once this value is reached the delay between consecutive retries will remain constant at the specified value.                                                                                           |
 | `retry_on_failure.max_elapsed_time` | `5 minutes`  | Maximum amount of time (including retries) spent trying to send a logs batch to a downstream consumer. Once this value is reached, the data is discarded. Retrying never stops if set to `0`.                                                  |
 | `remote`                              | object       | Remote configuration for connecting to a remote machine to collect logs. Includes server (the address of the remote server), with username, password, and optional domain.                                                    |
+| `query`                             | none         | XML query used for filtering events. See [Query Schema](https://learn.microsoft.com/en-us/windows/win32/wes/queryschema-schema)                                                                                                                |
 
 ### Operators
 
@@ -110,4 +111,22 @@ receivers:
             username: "user"
             password: "password"
             domain:   "domain"
+```
+
+#### XML Queries
+
+You can use XML queries to filter events. The query is passed to the `query` field in the configuration. The provided query must be a valid XML string. See [XML Event Queries](https://learn.microsoft.com/en-us/previous-versions/aa385231(v=vs.85)#xml-event-queries)
+
+The following example only forwards logs from the `Application` from `foo` or `bar` providers.
+
+```yaml
+receivers:
+  windowseventlog/query:
+    query: |
+      <QueryList>
+        <Query Id="0">
+          <Select Path="Application">*[System[Provider[@Name='foo']]]</Select>
+          <Select Path="Application">*[System[Provider[@Name='bar']]]</Select>
+        </Query>
+      </QueryList>
 ```

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -396,6 +396,7 @@ func assertEventSourceInstallation(t *testing.T, src string) (uninstallEventSour
 	return
 }
 
+//nolint:unparam // expectedEventCount might be greater than one in the future
 func assertExpectedLogRecords(t *testing.T, sink *consumertest.LogsSink, expectedEventSrc string, expectedEventCount int) []plog.LogRecord {
 	var actualLogRecords []plog.LogRecord
 


### PR DESCRIPTION
Example usage 

```yaml
receivers:
  windowseventlog/query:
    raw: true
    query: |
      <QueryList>
        <Query Id="0">
          <Select Path="Application">*[System[Provider[@Name='foo']]]</Select>
          <Select Path="Application">*[System[Provider[@Name='bar']]]</Select>
        </Query>
      </QueryList>

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    logs/query:
      receivers: [windowseventlog/query]
      exporters: [debug]
```

I tested it using `eventcreate`:
```powershell
eventcreate /t ERROR /id 100 /l application /d "Create event in application log"  /so foo
```