### PR TITLE
Disable default search metrics

### DIFF
--- a/.chloggen/disable-default-search-metrics.yaml
+++ b/.chloggen/disable-default-search-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkenterprisereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "disabled default metrics to prevent unexpected Splunk enterprise behavior"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39068]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/disable-default-search-metrics.yaml
+++ b/.chloggen/disable-default-search-metrics.yaml
@@ -7,7 +7,7 @@ change_type: 'breaking'
 component: splunkenterprisereceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "disabled default metrics to prevent unexpected Splunk enterprise behavior"
+note: "disabled default metrics except for splunkHealth to ensure scrapes run on Splunk instance are opt-in"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [39068]

--- a/receiver/splunkenterprisereceiver/README.md
+++ b/receiver/splunkenterprisereceiver/README.md
@@ -20,7 +20,7 @@ jobs.
 
 ## Configuration
 
-By default the Splunk Enterprise receiver is not configured to gather any metrics (i.e. there are no metrics enabled by default).
+**By default the Splunk Enterprise receiver is not configured to gather any metrics other than `splunk.health`**
 
 The following settings are required, omitting them will either cause your receiver to fail to compile or result in 4/5xx return codes during scraping. 
 

--- a/receiver/splunkenterprisereceiver/README.md
+++ b/receiver/splunkenterprisereceiver/README.md
@@ -20,6 +20,8 @@ jobs.
 
 ## Configuration
 
+By default the Splunk Enterprise receiver is not configured to gather any metrics (i.e. there are no metrics enabled by default).
+
 The following settings are required, omitting them will either cause your receiver to fail to compile or result in 4/5xx return codes during scraping. 
 
 **NOTE:** These must be set for each Splunk instance type (indexer, search head, or cluster master) from which you wish to pull metrics. At present, only one of each type is accepted, per configured receiver instance. This means, for example, that if you have three different "indexer" type instances that you would like to pull metrics from you will need to configure three different `splunkenterprise` receivers for each indexer node you wish to monitor.

--- a/receiver/splunkenterprisereceiver/documentation.md
+++ b/receiver/splunkenterprisereceiver/documentation.md
@@ -12,6 +12,16 @@ metrics:
     enabled: false
 ```
 
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
 ### splunk.aggregation.queue.ratio
 
 Gauge tracking the average indexer aggregation queue ration (%). *Note:** Search is best run against a Cluster Manager.
@@ -40,254 +50,6 @@ Gauge tracking the number of buckets and their searchable status. *Note:** Searc
 | ---- | ----------- | ------ |
 | splunk.host | The name of the splunk host | Any Str |
 | splunk.indexer.searchable | The searchability status reported for a specific object | Any Str |
-
-### splunk.indexer.avg.rate
-
-Gauge tracking the average rate of indexed data. **Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KBy | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.indexer.cpu.time
-
-Gauge tracking the number of indexing process cpu seconds per instance
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {s} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.indexer.queue.ratio
-
-Gauge tracking the average indexer index queue ration (%). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {%} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.indexer.raw.write.time
-
-Gauge tracking the number of raw write seconds per instance
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {s} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.indexes.avg.size
-
-Gauge tracking the indexes and their average size (gb). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| Gb | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.indexes.avg.usage
-
-Gauge tracking the indexes and their average usage (%). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {%} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.indexes.bucket.count
-
-Gauge tracking the indexes and their bucket counts. *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {count} | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.indexes.median.data.age
-
-Gauge tracking the indexes and their median data age (days). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {days} | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.indexes.size
-
-Gauge tracking the indexes and their total size (gb). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| Gb | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.io.avg.iops
-
-Gauge tracking the average IOPs used per instance
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {iops} | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.license.index.usage
-
-Gauge tracking the indexed license usage per index
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.parse.queue.ratio
-
-Gauge tracking the average indexer parser queue ration (%). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {%} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.pipeline.set.count
-
-Gauge tracking the number of pipeline sets per indexer. **Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KBy | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.scheduler.avg.execution.latency
-
-Gauge tracking the average execution latency of scheduled searches
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ms} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.scheduler.avg.run.time
-
-Gauge tracking the average runtime of scheduled searches
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ms} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.scheduler.completion.ratio
-
-Gauge tracking the ratio of completed to skipped scheduled searches
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {%} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-### splunk.typing.queue.ratio
-
-Gauge tracking the average indexer typing queue ration (%). *Note:** Search is best run against a Cluster Manager.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {%} | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.host | The name of the splunk host | Any Str |
-
-## Optional Metrics
-
-The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
-
-```yaml
-metrics:
-  <metric_name>:
-    enabled: true
-```
 
 ### splunk.data.indexes.extended.bucket.count
 
@@ -405,6 +167,62 @@ The status ('red', 'yellow', or 'green') of the Splunk server. Health of 'red' p
 | splunk.feature | The Feature name from the Splunk Health Introspection Endpoint | Any Str |
 | splunk.feature.health | The Health (in color form) of a Splunk Feature from the Splunk Health Introspection Endpoint | Any Str |
 
+### splunk.indexer.avg.rate
+
+Gauge tracking the average rate of indexed data. **Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| KBy | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.indexer.cpu.time
+
+Gauge tracking the number of indexing process cpu seconds per instance
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {s} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.indexer.queue.ratio
+
+Gauge tracking the average indexer index queue ration (%). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {%} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.indexer.raw.write.time
+
+Gauge tracking the number of raw write seconds per instance
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {s} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
 ### splunk.indexer.throughput
 
 Gauge tracking average bytes per second throughput of indexer. *Note:** Must be pointed at specific indexer `endpoint` and gathers metrics from only that indexer.
@@ -418,6 +236,90 @@ Gauge tracking average bytes per second throughput of indexer. *Note:** Must be 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | splunk.indexer.status | The status message reported for a specific object | Any Str |
+
+### splunk.indexes.avg.size
+
+Gauge tracking the indexes and their average size (gb). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| Gb | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.indexes.avg.usage
+
+Gauge tracking the indexes and their average usage (%). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {%} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.indexes.bucket.count
+
+Gauge tracking the indexes and their bucket counts. *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {count} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.indexes.median.data.age
+
+Gauge tracking the indexes and their median data age (days). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {days} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.indexes.size
+
+Gauge tracking the indexes and their total size (gb). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| Gb | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.io.avg.iops
+
+Gauge tracking the average IOPs used per instance
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {iops} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
 
 ### splunk.kvstore.backup.status
 
@@ -462,6 +364,90 @@ This is the overall status of the kvstore for the given deployment.
 | splunk.kvstore.storage.engine | The backend storage used by the KV store | Any Str |
 | splunk.kvstore.external | Value denoting if the KV store is using an external service | Any Str |
 | splunk.kvstore.status.value | The string value of the status returned when reporting on KV store using the introspection endpoint | Any Str |
+
+### splunk.license.index.usage
+
+Gauge tracking the indexed license usage per index
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| By | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.index.name | The name of the index reporting a specific KPI | Any Str |
+
+### splunk.parse.queue.ratio
+
+Gauge tracking the average indexer parser queue ration (%). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {%} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.pipeline.set.count
+
+Gauge tracking the number of pipeline sets per indexer. **Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| KBy | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.scheduler.avg.execution.latency
+
+Gauge tracking the average execution latency of scheduled searches
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {ms} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.scheduler.avg.run.time
+
+Gauge tracking the average runtime of scheduled searches
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {ms} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.scheduler.completion.ratio
+
+Gauge tracking the ratio of completed to skipped scheduled searches
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {%} | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
 
 ### splunk.server.introspection.queues.current
 
@@ -597,6 +583,20 @@ Gauge tracking number of scheduled search artifacts currently on disk. Note:* Mu
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {search_artifacts} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.host | The name of the splunk host | Any Str |
+
+### splunk.typing.queue.ratio
+
+Gauge tracking the average indexer typing queue ration (%). *Note:** Search is best run against a Cluster Manager.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {%} | Gauge | Double |
 
 #### Attributes
 

--- a/receiver/splunkenterprisereceiver/documentation.md
+++ b/receiver/splunkenterprisereceiver/documentation.md
@@ -12,6 +12,21 @@ metrics:
     enabled: false
 ```
 
+### splunk.health
+
+The status ('red', 'yellow', or 'green') of the Splunk server. Health of 'red' produces a 0 while all other colors produce a 1.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {status} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| splunk.feature | The Feature name from the Splunk Health Introspection Endpoint | Any Str |
+| splunk.feature.health | The Health (in color form) of a Splunk Feature from the Splunk Health Introspection Endpoint | Any Str |
+
 ## Optional Metrics
 
 The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
@@ -151,21 +166,6 @@ Size in bytes on disk of this index *Note:** Must be pointed at specific indexer
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | splunk.index.name | The name of the index reporting a specific KPI | Any Str |
-
-### splunk.health
-
-The status ('red', 'yellow', or 'green') of the Splunk server. Health of 'red' produces a 0 while all other colors produce a 1.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {status} | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| splunk.feature | The Feature name from the Splunk Health Introspection Endpoint | Any Str |
-| splunk.feature.health | The Health (in color form) of a Splunk Feature from the Splunk Health Introspection Endpoint | Any Str |
 
 ### splunk.indexer.avg.rate
 

--- a/receiver/splunkenterprisereceiver/generated_package_test.go
+++ b/receiver/splunkenterprisereceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package splunkenterprisereceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/splunkenterprisereceiver/generated_package_test.go
+++ b/receiver/splunkenterprisereceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package splunkenterprisereceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/splunkenterprisereceiver/internal/metadata/generated_config.go
+++ b/receiver/splunkenterprisereceiver/internal/metadata/generated_config.go
@@ -100,7 +100,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		SplunkHealth: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		SplunkIndexerAvgRate: MetricConfig{
 			Enabled: false,

--- a/receiver/splunkenterprisereceiver/internal/metadata/generated_config.go
+++ b/receiver/splunkenterprisereceiver/internal/metadata/generated_config.go
@@ -73,10 +73,10 @@ type MetricsConfig struct {
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		SplunkAggregationQueueRatio: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkBucketsSearchableStatus: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkDataIndexesExtendedBucketCount: MetricConfig{
 			Enabled: false,
@@ -103,37 +103,37 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		SplunkIndexerAvgRate: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexerCPUTime: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexerQueueRatio: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexerRawWriteTime: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexerThroughput: MetricConfig{
 			Enabled: false,
 		},
 		SplunkIndexesAvgSize: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexesAvgUsage: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexesBucketCount: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexesMedianDataAge: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIndexesSize: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkIoAvgIops: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkKvstoreBackupStatus: MetricConfig{
 			Enabled: false,
@@ -145,22 +145,22 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		SplunkLicenseIndexUsage: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkParseQueueRatio: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkPipelineSetCount: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkSchedulerAvgExecutionLatency: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkSchedulerAvgRunTime: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkSchedulerCompletionRatio: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		SplunkServerIntrospectionQueuesCurrent: MetricConfig{
 			Enabled: false,
@@ -193,7 +193,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		SplunkTypingQueueRatio: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 	}
 }

--- a/receiver/splunkenterprisereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/splunkenterprisereceiver/internal/metadata/generated_metrics_test.go
@@ -59,11 +59,9 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkAggregationQueueRatioDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkBucketsSearchableStatusDataPoint(ts, 1, "splunk.host-val", "splunk.indexer.searchable-val")
 
@@ -91,46 +89,36 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordSplunkHealthDataPoint(ts, 1, "splunk.feature-val", "splunk.feature.health-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexerAvgRateDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexerCPUTimeDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexerQueueRatioDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexerRawWriteTimeDataPoint(ts, 1, "splunk.host-val")
 
 			allMetricsCount++
 			mb.RecordSplunkIndexerThroughputDataPoint(ts, 1, "splunk.indexer.status-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexesAvgSizeDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexesAvgUsageDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexesBucketCountDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexesMedianDataAgeDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIndexesSizeDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkIoAvgIopsDataPoint(ts, 1, "splunk.host-val")
 
@@ -143,27 +131,21 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordSplunkKvstoreStatusDataPoint(ts, 1, "splunk.kvstore.storage.engine-val", "splunk.kvstore.external-val", "splunk.kvstore.status.value-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkLicenseIndexUsageDataPoint(ts, 1, "splunk.index.name-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkParseQueueRatioDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkPipelineSetCountDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkSchedulerAvgExecutionLatencyDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkSchedulerAvgRunTimeDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkSchedulerCompletionRatioDataPoint(ts, 1, "splunk.host-val")
 
@@ -197,7 +179,6 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordSplunkServerSearchartifactsScheduledDataPoint(ts, 1, "splunk.host-val")
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkTypingQueueRatioDataPoint(ts, 1, "splunk.host-val")
 

--- a/receiver/splunkenterprisereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/splunkenterprisereceiver/internal/metadata/generated_metrics_test.go
@@ -86,6 +86,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordSplunkDataIndexesExtendedTotalSizeDataPoint(ts, 1, "splunk.index.name-val")
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSplunkHealthDataPoint(ts, 1, "splunk.feature-val", "splunk.feature.health-val")
 

--- a/receiver/splunkenterprisereceiver/metadata.yaml
+++ b/receiver/splunkenterprisereceiver/metadata.yaml
@@ -48,139 +48,138 @@ attributes:
 
 metrics:
   splunk.license.index.usage:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexed license usage per index
     unit: By
     gauge:
       value_type: int 
     attributes: [splunk.index.name]
   splunk.scheduler.avg.execution.latency:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average execution latency of scheduled searches
     unit: '{ms}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.scheduler.completion.ratio:
-    enabled: true
+    enabled: false
     description: Gauge tracking the ratio of completed to skipped scheduled searches
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.indexer.avg.rate:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average rate of indexed data. **Note:** Search is best run against a Cluster Manager.
     unit: KBy
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.pipeline.set.count:
-    enabled: true
+    enabled: false
     description: Gauge tracking the number of pipeline sets per indexer. **Note:** Search is best run against a Cluster Manager.
     unit: KBy
     gauge:
       value_type: int 
     attributes: [splunk.host]
   splunk.parse.queue.ratio:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average indexer parser queue ration (%). *Note:** Search is best run against a Cluster Manager.
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.aggregation.queue.ratio:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average indexer aggregation queue ration (%). *Note:** Search is best run against a Cluster Manager.
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.host]  
   splunk.typing.queue.ratio:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average indexer typing queue ration (%). *Note:** Search is best run against a Cluster Manager.
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.host]  
   splunk.indexer.queue.ratio:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average indexer index queue ration (%). *Note:** Search is best run against a Cluster Manager.
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.scheduler.avg.run.time:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average runtime of scheduled searches
     unit: '{ms}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.indexer.raw.write.time:
-    enabled: true
+    enabled: false
     description: Gauge tracking the number of raw write seconds per instance
     unit: '{s}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.indexer.cpu.time:
-    enabled: true
+    enabled: false
     description: Gauge tracking the number of indexing process cpu seconds per instance
     unit: '{s}'
     gauge:
       value_type: double 
     attributes: [splunk.host]
   splunk.io.avg.iops:
-    enabled: true
+    enabled: false
     description: Gauge tracking the average IOPs used per instance
     unit: '{iops}'
     gauge:
       value_type: int 
     attributes: [splunk.host]
   splunk.buckets.searchable.status:
-    enabled: true
+    enabled: false
     description: Gauge tracking the number of buckets and their searchable status. *Note:** Search is best run against a Cluster Manager.
     unit: '{count}'
     gauge:
       value_type: int 
     attributes: [splunk.host, splunk.indexer.searchable]
   splunk.indexes.bucket.count:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexes and their bucket counts. *Note:** Search is best run against a Cluster Manager.
     unit: '{count}'
     gauge:
       value_type: int 
     attributes: [splunk.index.name]
   splunk.indexes.size:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexes and their total size (gb). *Note:** Search is best run against a Cluster Manager.
     unit: Gb
     gauge:
       value_type: double 
     attributes: [splunk.index.name]
   splunk.indexes.avg.size:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexes and their average size (gb). *Note:** Search is best run against a Cluster Manager.
     unit: Gb
     gauge:
       value_type: double 
     attributes: [splunk.index.name]
   splunk.indexes.avg.usage:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexes and their average usage (%). *Note:** Search is best run against a Cluster Manager.
     unit: '{%}'
     gauge:
       value_type: double 
     attributes: [splunk.index.name]
   splunk.indexes.median.data.age:
-    enabled: true
+    enabled: false
     description: Gauge tracking the indexes and their median data age (days). *Note:** Search is best run against a Cluster Manager.
     unit: '{days}'
     gauge:
       value_type: int 
     attributes: [splunk.index.name]
-    
   # 'services/server/introspection/indexer'
   splunk.indexer.throughput:
     enabled: false

--- a/receiver/splunkenterprisereceiver/metadata.yaml
+++ b/receiver/splunkenterprisereceiver/metadata.yaml
@@ -352,7 +352,7 @@ metrics:
     attributes: [splunk.host]
   #`services/server/health/splunkd/details`
   splunk.health:
-    enabled: false
+    enabled: true
     description: The status ('red', 'yellow', or 'green') of the Splunk server. Health of 'red' produces a 0 while all other colors produce a 1.
     unit: "{status}"
     gauge:

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -1630,6 +1630,18 @@ func (s *splunkScraper) scrapeKVStoreStatus(ctx context.Context, now pcommon.Tim
 
 // Scrape dispatch artifacts
 func (s *splunkScraper) scrapeSearchArtifacts(ctx context.Context, now pcommon.Timestamp, errs chan error) {
+	// if NONE of the metrics set in this scrape are set we return early
+	if !(s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsAdhoc.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsScheduled.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsCompleted.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsIncomplete.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsInvalid.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsSavedsearches.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsJobCacheSize.Enabled ||
+		s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsJobCacheCount.Enabled) {
+		return
+	}
+
 	if !s.splunkClient.isConfigured(typeSh) {
 		return
 	}


### PR DESCRIPTION
#### Description
Removing default metrics (i.e. setting all metrics to `enabled: false`). This is primarily to prevent unwanted ad-hoc searches from running on Splunk Enterprise deployments which could have unforeseen side effects.

#### Documentation
The `README.md` was updated to reflect these changes.
