### PR TITLE
[exporter/datadog] deprecate first_resource

### DIFF
--- a/.chloggen/ddog-deprecate-cfg.yaml
+++ b/.chloggen/ddog-deprecate-cfg.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate config `host_metadata::first_resource`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Opt in to https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/ instead. Its behavior is more predictable and provides more flexibility."
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/ddog-deprecate-cfg.yaml
+++ b/.chloggen/ddog-deprecate-cfg.yaml
@@ -10,7 +10,7 @@ component: datadogexporter
 note: "Deprecate config `host_metadata::first_resource`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [39069]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -134,6 +134,7 @@ const (
 	// hostname-like attributes, it will fallback to 'config_or_system' behavior (see below).
 	//
 	// Do not use this hostname source if receiving data from multiple hosts.
+	//nolint:deprecated
 	HostnameSourceFirstResource HostnameSource = datadogconfig.HostnameSourceFirstResource
 
 	// Deprecated: [v0.110.0] Use `datadogconfig.HostnameSource` instead.

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -134,8 +134,7 @@ const (
 	// hostname-like attributes, it will fallback to 'config_or_system' behavior (see below).
 	//
 	// Do not use this hostname source if receiving data from multiple hosts.
-	//nolint:deprecated
-	HostnameSourceFirstResource HostnameSource = datadogconfig.HostnameSourceFirstResource
+	HostnameSourceFirstResource HostnameSource = datadogconfig.HostnameSourceFirstResource //nolint:staticcheck
 
 	// Deprecated: [v0.110.0] Use `datadogconfig.HostnameSource` instead.
 	// HostnameSourceConfigOrSystem picks the host metadata hostname from the 'hostname' setting,

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -319,6 +319,9 @@ func (f *factory) createMetricsExporter(
 		// Start the hostmetadata pusher once.
 		// It sends the hostmetadata for the host where the collector is running.
 		if cfg.HostMetadata.Enabled {
+			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource {
+				set.Logger.Warn("first_resource has no effect when serializer exporter is used for exporting metrics")
+			}
 			f.onceMetadata.Do(func() {
 				attrs := pcommon.NewMap()
 				go hostmetadata.RunPusher(ctx, set, pcfg, hostProvider, attrs, metadataReporter)

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -319,8 +319,7 @@ func (f *factory) createMetricsExporter(
 		// Start the hostmetadata pusher once.
 		// It sends the hostmetadata for the host where the collector is running.
 		if cfg.HostMetadata.Enabled {
-			//nolint:deprecated
-			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource {
+			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource { //nolint:staticcheck
 				set.Logger.Warn("first_resource has no effect when serializer exporter is used for exporting metrics")
 			}
 			f.onceMetadata.Do(func() {

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -319,6 +319,7 @@ func (f *factory) createMetricsExporter(
 		// Start the hostmetadata pusher once.
 		// It sends the hostmetadata for the host where the collector is running.
 		if cfg.HostMetadata.Enabled {
+			//nolint:deprecated
 			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource {
 				set.Logger.Warn("first_resource has no effect when serializer exporter is used for exporting metrics")
 			}

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -63,7 +63,6 @@ func TestNewExporter(t *testing.T) {
 		HostMetadata: HostMetadataConfig{
 			Enabled:        true,
 			ReporterPeriod: 30 * time.Minute,
-			HostnameSource: HostnameSourceFirstResource,
 		},
 	}
 	cfg.HostMetadata.SetSourceTimeout(50 * time.Millisecond)
@@ -86,7 +85,7 @@ func TestNewExporter(t *testing.T) {
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
 	recvMetadata := <-server.MetadataChan
-	assert.Equal(t, "custom-hostname", recvMetadata.InternalHostname)
+	assert.NotEmpty(t, recvMetadata.InternalHostname)
 }
 
 func TestNewExporter_Serializer(t *testing.T) {
@@ -115,7 +114,6 @@ func TestNewExporter_Serializer(t *testing.T) {
 		HostMetadata: HostMetadataConfig{
 			Enabled:        true,
 			ReporterPeriod: 30 * time.Minute,
-			HostnameSource: HostnameSourceFirstResource,
 		},
 	}
 	cfg.HostMetadata.SetSourceTimeout(50 * time.Millisecond)
@@ -501,7 +499,6 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 }
 
 func TestNewExporter_Zorkian(t *testing.T) {
-	t.Skip("skipping test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39064")
 	if isMetricExportV2Enabled() {
 		require.NoError(t, enableZorkianMetricExport())
 		defer require.NoError(t, enableNativeMetricExport())
@@ -529,7 +526,6 @@ func TestNewExporter_Zorkian(t *testing.T) {
 		HostMetadata: HostMetadataConfig{
 			Enabled:        true,
 			ReporterPeriod: 30 * time.Minute,
-			HostnameSource: HostnameSourceFirstResource,
 		},
 	}
 	params := exportertest.NewNopSettings(metadata.Type)
@@ -550,7 +546,7 @@ func TestNewExporter_Zorkian(t *testing.T) {
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
 	recvMetadata := <-server.MetadataChan
-	assert.Equal(t, "custom-hostname", recvMetadata.InternalHostname)
+	assert.NotEmpty(t, recvMetadata.InternalHostname)
 }
 
 func Test_metricsExporter_PushMetricsData_Zorkian(t *testing.T) {

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -274,6 +274,10 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 	}
 	c.warnings = append(c.warnings, renamingWarnings...)
 
+	if c.HostMetadata.HostnameSource == HostnameSourceFirstResource {
+		c.warnings = append(c.warnings, errors.New("first_resource is deprecated, opt in to https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/ instead"))
+	}
+
 	c.API.Key = configopaque.String(strings.TrimSpace(string(c.API.Key)))
 
 	// If an endpoint is not explicitly set, override it based on the site.

--- a/pkg/datadog/config/config_warnings_test.go
+++ b/pkg/datadog/config/config_warnings_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -166,4 +167,17 @@ func TestPeerTags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeprecateHostnameSourceFirstResource(t *testing.T) {
+	cfg := CreateDefaultConfig().(*Config)
+	cfgMap := confmap.NewFromStringMap(map[string]any{
+		"host_metadata": map[string]any{
+			"hostname_source": "first_resource",
+		},
+	})
+	err := cfgMap.Unmarshal(cfg)
+	require.NoError(t, err)
+	assert.Len(t, cfg.warnings, 1)
+	assert.ErrorContains(t, cfg.warnings[0], "first_resource is deprecated, opt in to https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/ instead")
 }

--- a/pkg/datadog/config/host.go
+++ b/pkg/datadog/config/host.go
@@ -13,6 +13,8 @@ import (
 type HostnameSource string
 
 const (
+	// Deprecated: [v0.124.0] opt in to https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/ instead
+	//
 	// HostnameSourceFirstResource picks the host metadata hostname from the resource
 	// attributes on the first OTLP payload that gets to the exporter. If it is lacking any
 	// hostname-like attributes, it will fallback to 'config_or_system' behavior (see below).


### PR DESCRIPTION
#### Description
Deprecate config `host_metadata::first_resource`. https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/  provides a better alternative.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39064

