### PR TITLE
[chore][exporter/datadog] fix integration test

### DIFF
--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -457,7 +457,6 @@ func sendTracesComputeTopLevelBySpanKind(t *testing.T, endpoint string) {
 }
 
 func TestIntegrationLogs(t *testing.T) {
-	t.Skip("skipping test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39064")
 	// 1. Set up mock Datadog server
 	// See also https://github.com/DataDog/datadog-agent/blob/49c16e0d4deab396626238fa1d572b684475a53f/cmd/trace-agent/test/backend.go
 	seriesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.MetricV2Endpoint, ReqChan: make(chan []byte)}

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -97,7 +98,9 @@ func testIntegration(t *testing.T) {
 	server := testutil.DatadogServerMock(apmstatsRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
-	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	promPort := strconv.Itoa(commonTestutil.GetAvailablePort(t))
+	t.Setenv("PROM_SERVER_PORT", promPort)
+	t.Setenv("PROM_SERVER", fmt.Sprintf("localhost:%s", promPort))
 	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
@@ -292,7 +295,9 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	server := testutil.DatadogServerMock(apmstatsRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
-	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	promPort := strconv.Itoa(commonTestutil.GetAvailablePort(t))
+	t.Setenv("PROM_SERVER_PORT", promPort)
+	t.Setenv("PROM_SERVER", fmt.Sprintf("localhost:%s", promPort))
 	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
@@ -476,9 +481,10 @@ func TestIntegrationLogs(t *testing.T) {
 		}
 	})
 	defer server.Close()
-	thing := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("SERVER_URL", server.URL)
-	t.Setenv("PROM_SERVER", thing)
+	promPort := strconv.Itoa(commonTestutil.GetAvailablePort(t))
+	t.Setenv("PROM_SERVER_PORT", promPort)
+	t.Setenv("PROM_SERVER", fmt.Sprintf("localhost:%s", promPort))
 	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)

--- a/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
@@ -32,8 +32,16 @@ exporters:
 service:
   telemetry:
     metrics:
-      level: basic
-      address: ${env:PROM_SERVER}
+      level: "basic"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: ${env:PROM_SERVER_PORT}
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   pipelines:
     traces:
       receivers: [otlp]

--- a/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
@@ -36,8 +36,16 @@ exporters:
 service:
   telemetry:
     metrics:
-      level: basic
-      address: ${env:PROM_SERVER}
+      level: "basic"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: ${env:PROM_SERVER_PORT}
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   pipelines:
     logs:
       receivers: [otlp]

--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -8,7 +8,9 @@ package integrationtest // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -65,7 +67,9 @@ func testIntegrationInternalMetrics(t *testing.T, expectedMetrics map[string]str
 	server := testutil.DatadogServerMock(seriesRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
-	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	promPort := strconv.Itoa(commonTestutil.GetAvailablePort(t))
+	t.Setenv("PROM_SERVER_PORT", promPort)
+	t.Setenv("PROM_SERVER", fmt.Sprintf("localhost:%s", promPort))
 	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)


### PR DESCRIPTION
#### Description
https://github.com/open-telemetry/opentelemetry-collector/pull/12756 deprecates telemetry::metrics::address so need to adopt the new configs in test yamls.

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39064
