### PR TITLE
Support unnamed groups in carbon receiver regex parser

### DIFF
--- a/.chloggen/carbon-unnamed-regex-groups.yaml
+++ b/.chloggen/carbon-unnamed-regex-groups.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: carbonexporter
+component: carbonreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support unnamed groups in carbon receiver regex parser

--- a/.chloggen/carbon-unnamed-regex-groups.yaml
+++ b/.chloggen/carbon-unnamed-regex-groups.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: carbonexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support unnamed groups in carbon receiver regex parser
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39137]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/carbonreceiver/config_test.go
+++ b/receiver/carbonreceiver/config_test.go
@@ -69,6 +69,12 @@ func TestLoadConfig(t *testing.T) {
 								MetricType: "cumulative",
 							},
 							{
+								Regexp: `(optional_prefix\.)?(?P<key_just>test)\.(?P<key_match>.*)`,
+							},
+							{
+								Regexp: `(experiment(?P<key_experiment>[0-9]+)\.)?(?P<key_just>test)\.(?P<key_match>.*)`,
+							},
+							{
 								Regexp: `(?P<key_just>test)\.(?P<key_match>.*)`,
 							},
 						},

--- a/receiver/carbonreceiver/protocol/regex_parser.go
+++ b/receiver/carbonreceiver/protocol/regex_parser.go
@@ -168,10 +168,19 @@ func (rpp *regexPathParser) ParsePath(path string, parsedPath *ParsedPath) error
 			attributes := pcommon.NewMap()
 
 			for i := 1; i < len(ms); i++ {
-				if strings.HasPrefix(nms[i], metricNameCapturePrefix) {
-					metricNameLookup[nms[i]] = ms[i]
+				groupName, groupValue := nms[i], ms[i]
+				if groupName == "" {
+					// Skip unnamed groups.
+					continue
+				}
+				if groupValue == "" {
+					// Skip unmatched groups.
+					continue
+				}
+				if strings.HasPrefix(groupName, metricNameCapturePrefix) {
+					metricNameLookup[groupName] = groupValue
 				} else {
-					attributes.PutStr(nms[i][len(keyCapturePrefix):], ms[i])
+					attributes.PutStr(groupName[len(keyCapturePrefix):], groupValue)
 				}
 			}
 

--- a/receiver/carbonreceiver/protocol/regex_parser_test.go
+++ b/receiver/carbonreceiver/protocol/regex_parser_test.go
@@ -179,7 +179,6 @@ func Test_regexParser_parsePath(t *testing.T) {
 func Test_regexParser_parsePath_simple_unnamed_group(t *testing.T) {
 	config := RegexParserConfig{
 		Rules: []*RegexRule{
-
 			{
 				Regexp:     `(prefix\.)?(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.cpu\.seconds`,
 				NamePrefix: "cpu_seconds",
@@ -249,7 +248,6 @@ func Test_regexParser_parsePath_simple_unnamed_group(t *testing.T) {
 func Test_regexParser_parsePath_key_inside_unnamed_group(t *testing.T) {
 	config := RegexParserConfig{
 		Rules: []*RegexRule{
-
 			{
 				Regexp:     `(job=(?P<key_job>[^.]+).)?(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.cpu\.seconds`,
 				NamePrefix: "cpu_seconds",

--- a/receiver/carbonreceiver/protocol/regex_parser_test.go
+++ b/receiver/carbonreceiver/protocol/regex_parser_test.go
@@ -176,6 +176,150 @@ func Test_regexParser_parsePath(t *testing.T) {
 	}
 }
 
+func Test_regexParser_parsePath_simple_unnamed_group(t *testing.T) {
+	config := RegexParserConfig{
+		Rules: []*RegexRule{
+
+			{
+				Regexp:     `(prefix\.)?(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.cpu\.seconds`,
+				NamePrefix: "cpu_seconds",
+			},
+		},
+	}
+
+	require.NoError(t, compileRegexRules(config.Rules))
+	rp := &regexPathParser{
+		rules: config.Rules,
+	}
+
+	tests := []struct {
+		name           string
+		path           string
+		wantName       string
+		wantAttributes pcommon.Map
+		wantMetricType TargetMetricType
+		wantErr        bool
+	}{
+		{
+			name:           "no_rule_match",
+			path:           "service_name.host01.rpc.duration.seconds",
+			wantName:       "service_name.host01.rpc.duration.seconds",
+			wantAttributes: pcommon.NewMap(),
+		},
+		{
+			name:     "match_no_prefix",
+			path:     "service_name.host00.cpu.seconds",
+			wantName: "cpu_seconds",
+			wantAttributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("svc", "service_name")
+				m.PutStr("host", "host00")
+				return m
+			}(),
+		},
+		{
+			name:     "match_optional_prefix",
+			path:     "prefix.service_name.host00.cpu.seconds",
+			wantName: "cpu_seconds",
+			wantAttributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("svc", "service_name")
+				m.PutStr("host", "host00")
+				return m
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsedPath{}
+			err := rp.ParsePath(tt.path, &got)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.wantName, got.MetricName)
+			assert.Equal(t, tt.wantAttributes, got.Attributes)
+			assert.Equal(t, tt.wantMetricType, got.MetricType)
+		})
+	}
+}
+
+func Test_regexParser_parsePath_key_inside_unnamed_group(t *testing.T) {
+	config := RegexParserConfig{
+		Rules: []*RegexRule{
+
+			{
+				Regexp:     `(job=(?P<key_job>[^.]+).)?(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.cpu\.seconds`,
+				NamePrefix: "cpu_seconds",
+				MetricType: string(GaugeMetricType),
+			},
+		},
+	}
+
+	require.NoError(t, compileRegexRules(config.Rules))
+	rp := &regexPathParser{
+		rules: config.Rules,
+	}
+
+	tests := []struct {
+		name           string
+		path           string
+		wantName       string
+		wantAttributes pcommon.Map
+		wantMetricType TargetMetricType
+		wantErr        bool
+	}{
+		{
+			name:           "no_rule_match",
+			path:           "service_name.host01.rpc.duration.seconds",
+			wantName:       "service_name.host01.rpc.duration.seconds",
+			wantAttributes: pcommon.NewMap(),
+		},
+		{
+			name:     "match_missing_optional_key",
+			path:     "service_name.host00.cpu.seconds",
+			wantName: "cpu_seconds",
+			wantAttributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("svc", "service_name")
+				m.PutStr("host", "host00")
+				return m
+			}(),
+			wantMetricType: GaugeMetricType,
+		},
+		{
+			name:     "match_present_optional_key",
+			path:     "job=71972c09-de94-4a4e-a8a7-ad3de050a141.service_name.host00.cpu.seconds",
+			wantName: "cpu_seconds",
+			wantAttributes: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("job", "71972c09-de94-4a4e-a8a7-ad3de050a141")
+				m.PutStr("svc", "service_name")
+				m.PutStr("host", "host00")
+				return m
+			}(),
+			wantMetricType: GaugeMetricType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsedPath{}
+			err := rp.ParsePath(tt.path, &got)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.Equal(t, tt.wantName, got.MetricName)
+			assert.Equal(t, tt.wantAttributes, got.Attributes)
+			assert.Equal(t, tt.wantMetricType, got.MetricType)
+		})
+	}
+}
+
 var res struct {
 	name       string
 	attributes pcommon.Map

--- a/receiver/carbonreceiver/testdata/config.yaml
+++ b/receiver/carbonreceiver/testdata/config.yaml
@@ -48,7 +48,11 @@ carbon/regex:
           # type is used to select the metric type to be set, the default is
           # "gauge", the other alternative is "cumulative".
           type: cumulative
-        # The second rule for this "regex" parser.
+        # The second rule matches metric with or without a prefix.
+        - regexp: "(optional_prefix\\.)?(?P<key_just>test)\\.(?P<key_match>.*)"
+        # The third rule parses an optional dimension with key "experiment".
+        - regexp: "(experiment(?P<key_experiment>[0-9]+)\\.)?(?P<key_just>test)\\.(?P<key_match>.*)"
+        # The forth rule for this "regex" parser.
         - regexp: "(?P<key_just>test)\\.(?P<key_match>.*)"
       # Name separator is used when concatenating named regular expression
       # captures prefixed with "name_"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adding a feature - support for unnamed groups in carbon receiver regex parser. This makes it possible to parse a wider range of metrics, e.g. optional metric prefix or optional metric tags. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a test for a rule with an optional prefix: `"(prefix\.)?..."`

Added a test for a rule with an optional metric label: `"(job=(?P<key_job>[^.]+)\.)?..."`

<!--Describe the documentation added.-->
#### Documentation

Added an example with an optional prefix and an optional metric label
