### PR TITLE
[chore][ping code owners] Attempt to match component and label identically when possible

### DIFF
--- a/.github/workflows/scripts/get-label-from-component.sh
+++ b/.github/workflows/scripts/get-label-from-component.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script is used to get the component label from a given COMPONENT.
+# The key here is to match a single component based on the input component,
+# and match it exactly.
+#
+
+set -euo pipefail
+
+get_label() {
+  MATCHING_LABELS=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
+
+  if [ -z "${MATCHING_LABELS}" ]; then
+    echo "Should never get here: No matching labels found for component: $COMPONENT"
+  fi
+
+  LABEL_NAME=""
+  for POTENTIAL_LABEL in ${MATCHING_LABELS}; do
+    if [ "$POTENTIAL_LABEL" = "$COMPONENT" ]; then
+      LABEL_NAME=$POTENTIAL_LABEL
+      break
+    fi
+  done
+
+  if [ -z "${LABEL_NAME}" ]; then
+    LABEL_NAME="${MATCHING_LABELS[0]}"
+  fi
+
+  echo $LABEL_NAME
+}
+
+if [[ -z "${COMPONENT:-}" ]]; then
+    echo "COMPONENT has not been set, please ensure it is set."
+    exit 1
+fi
+
+echo "$(get_label)"

--- a/.github/workflows/scripts/get-label-from-component.sh
+++ b/.github/workflows/scripts/get-label-from-component.sh
@@ -14,7 +14,8 @@ get_label() {
   MATCHING_LABELS=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt)
 
   if [ -z "${MATCHING_LABELS}" ]; then
-    echo "Should never get here: No matching labels found for component: $COMPONENT"
+    echo ""
+    return
   fi
 
   LABEL_NAME=""

--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -13,7 +13,7 @@ if [[ -z "${COMPONENT:-}" || -z "${ISSUE:-}" ]]; then
 fi
 
 CUR_DIRECTORY=$(dirname "$0")
-COMPONENT=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $1}' .github/component_labels.txt | head -n 1)
+COMPONENT=$(COMPONENT="${COMPONENT}" "${CUR_DIRECTORY}/get-label-from-component.sh" || true)
 # Some labels are unrelated to components. These labels do not have code owners,
 # e.g "os:windows", "priority:p1", and "chore"
 if [[ -z "${COMPONENT}" ]]; then

--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -33,7 +33,7 @@ if [[ -n "${TITLE_COMPONENT}" && ! ("${TITLE_COMPONENT}" =~ " ") ]]; then
   if [[ -n "${CODEOWNERS}" ]]; then
     PING_LINES+="- ${TITLE_COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
-    LABEL_NAME=$(awk -v path="${TITLE_COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt | head -n 1)
+    LABEL_NAME=$(COMPONENT="${TITLE_COMPONENT}" "${CUR_DIRECTORY}/get-label-from-component.sh" || true)
     if (( "${#LABEL_NAME}" <= 50 )); then
       LABELS+="${LABEL_NAME}"
     else
@@ -55,7 +55,8 @@ for COMPONENT in ${BODY_COMPONENTS}; do
 
     PING_LINES+="- ${COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${COMPONENT}"]=1
-    LABEL_NAME=$(awk -v path="${COMPONENT}" 'index($1, path) > 0 || index($2, path) > 0 {print $2}' .github/component_labels.txt | head -n 1)
+    LABEL_NAME=$(COMPONENT="${COMPONENT}" "${CUR_DIRECTORY}/get-label-from-component.sh" || true)
+
     if (( "${#LABEL_NAME}" > 50 )); then
       echo "'${LABEL_NAME}' exceeds GitHub's 50-character limit on labels, skipping adding a label"
       continue
@@ -68,6 +69,7 @@ for COMPONENT in ${BODY_COMPONENTS}; do
   fi
 done
 
+# TODO: This check isn't working, it always returns no related components
 if [[ -v PINGED_COMPONENTS[@] ]]; then
   echo "The issue was associated with components:" "${!PINGED_COMPONENTS[@]}"
 else

--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -34,6 +34,7 @@ if [[ -n "${TITLE_COMPONENT}" && ! ("${TITLE_COMPONENT}" =~ " ") ]]; then
     PING_LINES+="- ${TITLE_COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
     LABEL_NAME=$(COMPONENT="${TITLE_COMPONENT}" "${CUR_DIRECTORY}/get-label-from-component.sh" || true)
+
     if (( "${#LABEL_NAME}" <= 50 )); then
       LABELS+="${LABEL_NAME}"
     else


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The logic for pinging code owners where multiple labels matched a given component returned the first in alphabetical order. This worked generally as the first alphabetical response was the minimal matching value, as shown in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38844. However, this breaks on the kafka receiver labels. The component labels are sorted in alphabetical order by the full component name. This means `receiver/kafkametricsreceiver` is before `receiver/kafkareceiver` in the list. When the `receiver/kafka` component is referenced, the `receiver/kafkametrics` label is returned as it's the first matching label in alphabetical order.

This change is to try to match component and label identically. If there's no identical match, return the first label in alphabetical order.

Existing logic has been broken out into a separate script to avoid duplicating the logic.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Unexpected behavior was found in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39129.
`receiver/kafka` was the component, the label `receiver/kafkametrics` was added incorrectly, and the code owners were pinged for `receiver/kafka` correctly. When I removed the `receiver/kafkametrics` label and added `receiver/kafka`, the code owners were pinged for `receiver/kafkametrics` incorrectly.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
```
# Testing issue where bug was detected
$ .github/workflows/scripts/ping-codeowners-on-new-issue.sh 
No related components were given
Adding the following labels: receiver/kafka
Pinging code owners:
- receiver/kafka: @pavolloffay @MovieStoreGuy @axw

 See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself.
# Testing other components
$ export COMPONENT="os:windows"
$ .github/workflows/scripts/get-label-from-component.sh

$ export COMPONENT="receiver/hostmetrics"
$ .github/workflows/scripts/get-label-from-component.sh
receiver/hostmetrics
$ export COMPONENT="receiver/kafka"
$ .github/workflows/scripts/get-label-from-component.sh
receiver/kafka
$ export COMPONENT="receiver/kafkametrics"
$ .github/workflows/scripts/get-label-from-component.sh
receiver/kafkametrics
$ export COMPONENT="extension/encoding"
$ .github/workflows/scripts/get-label-from-component.sh
extension/encoding
$ export ISSUE=39129
$ COMPONENT="receiver/kafka"
$ .github/workflows/scripts/ping-codeowners-issues.sh 
Pinging code owners for receiver/kafka: @pavolloffay @MovieStoreGuy @axw. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself. For example, comment '/label priority:p2 -needs-triaged' to set the priority and remove the needs-triaged label.
$ COMPONENT="receiver/kafkametrics"
$ .github/workflows/scripts/ping-codeowners-issues.sh 
Pinging code owners for receiver/kafkametrics: @dmitryax. See [Adding Labels via Comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#adding-labels-via-comments) if you do not have permissions to add labels yourself. For example, comment '/label priority:p2 -needs-triaged' to set the priority and remove the needs-triaged label.
```