### PR TITLE
[chore] fix otlp receiver configuration, disable http

### DIFF
--- a/cmd/telemetrygen/internal/e2etest/logs_test.go
+++ b/cmd/telemetrygen/internal/e2etest/logs_test.go
@@ -25,6 +25,7 @@ func TestGenerateLogs(t *testing.T) {
 	rCfg := f.CreateDefaultConfig()
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.(*otlpreceiver.Config).GRPC.NetAddr.Endpoint = endpoint
+	rCfg.(*otlpreceiver.Config).HTTP = nil
 	r, err := f.CreateLogs(context.Background(), receivertest.NewNopSettings(f.Type()), rCfg, sink)
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())

--- a/cmd/telemetrygen/internal/e2etest/metrics_test.go
+++ b/cmd/telemetrygen/internal/e2etest/metrics_test.go
@@ -25,6 +25,7 @@ func TestGenerateMetrics(t *testing.T) {
 	rCfg := f.CreateDefaultConfig()
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.(*otlpreceiver.Config).GRPC.NetAddr.Endpoint = endpoint
+	rCfg.(*otlpreceiver.Config).HTTP = nil
 	r, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), rCfg, sink)
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())

--- a/cmd/telemetrygen/internal/e2etest/traces_test.go
+++ b/cmd/telemetrygen/internal/e2etest/traces_test.go
@@ -25,6 +25,7 @@ func TestGenerateTraces(t *testing.T) {
 	rCfg := f.CreateDefaultConfig()
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	rCfg.(*otlpreceiver.Config).GRPC.NetAddr.Endpoint = endpoint
+	rCfg.(*otlpreceiver.Config).HTTP = nil
 	r, err := f.CreateTraces(context.Background(), receivertest.NewNopSettings(f.Type()), rCfg, sink)
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())


### PR DESCRIPTION
This fixes issues reported in tests about binding to port 4318.

It turns out we don't need to use that port at all.

This change disables trying to bind to port 4318.