### PR TITLE
[chore][exporter/datadog] Appease nolintlint linter by moving the directive to end of lines

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -319,8 +319,7 @@ func (f *factory) createMetricsExporter(
 		// Start the hostmetadata pusher once.
 		// It sends the hostmetadata for the host where the collector is running.
 		if cfg.HostMetadata.Enabled {
-			//nolint:staticcheck
-			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource {
+			if cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource { //nolint:staticcheck
 				set.Logger.Warn("first_resource has no effect when serializer exporter is used for exporting metrics")
 			}
 			f.onceMetadata.Do(func() {

--- a/exporter/datadogexporter/hostmetadata.go
+++ b/exporter/datadogexporter/hostmetadata.go
@@ -11,12 +11,11 @@ import (
 // newMetadataConfigfromConfig creates a new metadata pusher config from the main
 func newMetadataConfigfromConfig(cfg *datadogconfig.Config) hostmetadata.PusherConfig {
 	return hostmetadata.PusherConfig{
-		ConfigHostname:  cfg.Hostname,
-		ConfigTags:      cfg.HostMetadata.Tags,
-		MetricsEndpoint: cfg.Metrics.Endpoint,
-		APIKey:          string(cfg.API.Key),
-		//nolint:staticcheck
-		UseResourceMetadata: cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource,
+		ConfigHostname:      cfg.Hostname,
+		ConfigTags:          cfg.HostMetadata.Tags,
+		MetricsEndpoint:     cfg.Metrics.Endpoint,
+		APIKey:              string(cfg.API.Key),
+		UseResourceMetadata: cfg.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource, //nolint:staticcheck
 		InsecureSkipVerify:  cfg.TLSSetting.InsecureSkipVerify,
 		ClientConfig:        cfg.ClientConfig,
 		RetrySettings:       cfg.BackOffConfig,


### PR DESCRIPTION
I believe this issue was introduced in the new golangci-lint version PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39062