### PR TITLE
[chore]: fix testifylint rules (cmd,connector,testbed)

### DIFF
--- a/cmd/telemetrygen/pkg/logs/worker_test.go
+++ b/cmd/telemetrygen/pkg/logs/worker_test.go
@@ -177,7 +177,7 @@ func TestLogsWithOneTelemetryAttributes(t *testing.T) {
 
 		l.WalkAttributes(func(attr log.KeyValue) bool {
 			if attr.Key == telemetryAttrKeyOne {
-				assert.EqualValues(t, telemetryAttrValueOne, attr.Value.AsString())
+				assert.Equal(t, telemetryAttrValueOne, attr.Value.AsString())
 			}
 			return true
 		})

--- a/connector/signaltometricsconnector/factory_test.go
+++ b/connector/signaltometricsconnector/factory_test.go
@@ -24,7 +24,7 @@ func TestNewFactoryWithLogs(t *testing.T) {
 			name: "factory_type",
 			f: func(t *testing.T) {
 				factory := NewFactory()
-				require.EqualValues(t, metadata.Type, factory.Type())
+				require.Equal(t, metadata.Type, factory.Type())
 			},
 		},
 		{

--- a/testbed/testbed/data_providers_test.go
+++ b/testbed/testbed/data_providers_test.go
@@ -24,5 +24,5 @@ func TestGoldenDataProvider(t *testing.T) {
 		}
 		ms = append(ms, m)
 	}
-	require.Equal(t, len(dp.(*goldenDataProvider).metricsGenerated), len(ms))
+	require.Len(t, ms, len(dp.(*goldenDataProvider).metricsGenerated))
 }

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -72,7 +72,7 @@ type PerfTestValidator struct {
 }
 
 func (v *PerfTestValidator) Validate(tc *TestCase) {
-	if assert.EqualValues(tc.t,
+	if assert.Equal(tc.t,
 		int64(tc.LoadGenerator.DataItemsSent()),
 		int64(tc.MockBackend.DataItemsReceived()),
 		"Received and sent counters do not match.") {
@@ -130,7 +130,7 @@ func NewCorrectTestValidator(senderName string, receiverName string, provider Da
 }
 
 func (v *CorrectnessTestValidator) Validate(tc *TestCase) {
-	if assert.EqualValues(tc.t,
+	if assert.Equal(tc.t,
 		int64(tc.LoadGenerator.DataItemsSent())-int64(tc.LoadGenerator.PermanentErrors()),
 		int64(tc.MockBackend.DataItemsReceived()),
 		"Received and sent counters do not match.") {

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -316,7 +316,7 @@ func verifySingleSpan(
 			}
 		}
 	}
-	assert.EqualValues(t, 1, count, "must receive one span")
+	assert.Equal(t, 1, count, "must receive one span")
 }
 
 func TestTraceAttributesProcessor(t *testing.T) {
@@ -399,7 +399,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
 				require.Equal(t, 1, span.Attributes().Len())
 				attrVal, ok := span.Attributes().Get("new_attr")
 				assert.True(t, ok)
-				assert.EqualValues(t, "string value", attrVal.Str())
+				assert.Equal(t, "string value", attrVal.Str())
 			}
 
 			verifySingleSpan(t, tc, nodeToInclude, spanToInclude, verifySpan)
@@ -493,7 +493,7 @@ func TestTraceAttributesProcessorJaegerGRPC(t *testing.T) {
 		require.Equal(t, 1, span.Attributes().Len())
 		attrVal, ok := span.Attributes().Get("new_attr")
 		assert.True(t, ok)
-		assert.EqualValues(t, "string value", attrVal.Str())
+		assert.Equal(t, "string value", attrVal.Str())
 	}
 
 	verifySingleSpan(t, tc, nodeToInclude, spanToInclude, verifySpan)


### PR DESCRIPTION
#### Description

This fixes testifylint issues in cmd, connector and testbed folders discovered after golangci-lint@v2 upgrade