### PR TITLE
[chore][pkg/ottl] Add test case demonstrating insertion of missing elements

### DIFF
--- a/pkg/ottl/ottlfuncs/func_insert_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_insert_xml_test.go
@@ -107,6 +107,13 @@ func Test_InsertXML(t *testing.T) {
 			want:      `<a>foo</a>`,
 			expectErr: `InsertXML XPath selected non-element: "foo"`,
 		},
+		{
+			name:     "insert missing elements",
+			document: `<a><b>has b</b></a><a></a><a><b>also has b</b></a>`,
+			xPath:    "//a[not(b)]", // elements of a which do not have a b
+			subdoc:   `<b></b>`,
+			want:     `<a><b>has b</b></a><a><b></b></a><a><b>also has b</b></a>`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This just adds a test cases which demonstrates insertion of a missing element.

This stems from a windows event log manipulation question, where some `Data` nodes contain text content and others do not. 

```xml
<EventData>
    <Data Name='NonEmptyValue'>I have data</Data>
    <Data Name='EmptyValue'></Data>
</EventData>
```

In order to prepare this for `ParseSimplifiedXML`, users may wish to execute `ConvertAttributesToElementsXML`, giving

```xml
<EventData>
    <Data>
        I have data
        <Name>NonEmptyValue</Name>
    </Data>
    <Data>
        <Name>EmptyValue</Name>
    </Data>
</EventData>
```

and then `ConvertTextToElementsXML` which would produce 

```xml
<EventData>
    <Data>
        <Name>NonEmptyValue</Name>
        <value>I have data</value>
    </Data>
    <Data>
        <Name>EmptyValue</Name>
    </Data>
</EventData>
```

At this point, if using `ParseSimplifiedXML`, the data elements would produce different structures.

In order to remedy this, the user should insert an empty `value` element as appropriate using `set(body, InsertXML(body, "//Data[not(value)]", "<value></value>"))`, which will yield a normalized structure:

```xml
<EventData>
    <Data>
        <Name>NonEmptyValue</Name>
        <value>I have data</value>
    </Data>
    <Data>
        <Name>EmptyValue</Name>
        <value></value>
    </Data>
</EventData>
```