### PR TITLE
[testbed][benchmarks] Fix filelog checkpoint test

### DIFF
--- a/.chloggen/fix-testbed-tests.yaml
+++ b/.chloggen/fix-testbed-tests.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: testbed
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Specify `storage` parameter for filelog receiver in benchmarks 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix-testbed-tests.yaml
+++ b/.chloggen/fix-testbed-tests.yaml
@@ -10,7 +10,7 @@ component: testbed
 note: Specify `storage` parameter for filelog receiver in benchmarks 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [39217]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -58,8 +58,10 @@ func TestLog10kDPS(t *testing.T) {
 			},
 		},
 		{
-			name:     "filelog checkpoints",
-			sender:   datasenders.NewFileLogWriter(t),
+			name: "filelog checkpoints",
+			sender: datasenders.NewFileLogWriter(t).WithStorage(`
+    storage: file_storage
+`),
 			receiver: testbed.NewOTLPDataReceiver(testutil.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,


### PR DESCRIPTION
We need to specify the storage extension for `filelog` receiver in the benchmarks for `filelog checkpoints` test. Currently, the `storage` parameter is not specified, and the test behaves as if no storage extension is being used.