### PR TITLE
[chore] fix golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ formatters:
   enable:
     - gci
     - gofumpt
-    - goimports
 
   exclusions:
     paths:
@@ -16,12 +15,6 @@ formatters:
         - standard
         - default
         - prefix(github.com/open-telemetry/opentelemetry-collector-contrib)
-
-    goimports:
-      # put imports beginning with prefix after 3rd-party packages;
-      # it's a comma-separated list of prefixes
-      local-prefixes:
-        - github.com/open-telemetry/opentelemetry-collector-contrib
 
 issues:
   # Maximum issues count per one linter.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,8 @@ linters:
         - G115
         - G402
         - G404
+        - G104
+        - G302
 
     govet:
       # TODO: Enable this and fix the alignment issues.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,8 +63,8 @@ linters:
     presets:
       - comments
       - common-false-positives
-      - std-error-handling
       - legacy
+      - std-error-handling
 
     # Excluding configuration per-path, per-linter, per-text and per-source
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,7 +63,6 @@ linters:
     presets:
       - comments
       - common-false-positives
-      - legacy
       - std-error-handling
 
     # Excluding configuration per-path, per-linter, per-text and per-source
@@ -121,15 +120,6 @@ linters:
         - fieldalignment
 
       enable-all: true
-
-      # settings per analyzer
-      settings:
-        printf: # analyzer name, run `go tool vet help` to see all analyzers
-          funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Infof
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Warnf
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Errorf
-            - (github.com/golangci/golangci-lint/v2/pkg/logutils.Log).Fatalf
 
     misspell:
       ignore-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,7 @@ linters:
       - comments
       - common-false-positives
       - std-error-handling
+      - legacy
 
     # Excluding configuration per-path, per-linter, per-text and per-source
     rules:
@@ -113,8 +114,6 @@ linters:
         - G115
         - G402
         - G404
-        - G104
-        - G302
 
     govet:
       # TODO: Enable this and fix the alignment issues.

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -211,7 +211,7 @@ fmt: $(GOFUMPT) $(GOIMPORTS)
 
 .PHONY: lint
 lint: $(LINT) checklicense misspell
-	$(LINT) run --path-prefix $(shell basename "$(CURDIR)")
+	$(LINT) run
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK)

--- a/extension/storage/storagetest/doc.go
+++ b/extension/storage/storagetest/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package stanzareceiver implements a receiver that can be used by the
+// Package storagetest implements a receiver that can be used by the
 // OpenTelemetry collector to receive logs using the stanza log agent
 package storagetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"


### PR DESCRIPTION
#### Description

- gci and goimports are working on the same scope; only one is enough.
- removes settings that are just a copy-paste of golangci-lint configuration, but they are not applicable to this project.
- `--path-prefix` is useless with v2 because golangci-lint uses the location of the configuration file, by default, to create output paths. (Currently, the locations are wrong.)
