### PR TITLE
[exporter/awsxrayexporter] update to aws-sdk-go-v2

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -6,9 +6,10 @@ package awsxrayexporter // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"context"
 	"errors"
+	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/xray"
+	"github.com/aws/aws-sdk-go-v2/service/xray"
+	"github.com/aws/smithy-go"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
@@ -28,31 +29,23 @@ const (
 
 // newTracesExporter creates an exporter.Traces that converts to an X-Ray PutTraceSegments
 // request and then posts the request to the configured region's X-Ray endpoint.
-func newTracesExporter(
-	cfg *Config,
-	set exporter.Settings,
-	cn awsutil.ConnAttr,
-	registry telemetry.Registry,
-) (exporter.Traces, error) {
+func newTracesExporter(ctx context.Context, cfg *Config, set exporter.Settings, registry telemetry.Registry) (exporter.Traces, error) {
 	typeLog := zap.String("type", set.ID.Type().String())
 	nameLog := zap.String("name", set.ID.String())
 	logger := set.Logger
-	awsConfig, session, err := awsutil.GetAWSConfigSession(logger, cn, &cfg.AWSSessionSettings)
+	awsConfig, err := awsutil.GetAWSConfig(logger, &cfg.AWSSessionSettings)
 	if err != nil {
 		return nil, err
 	}
-	xrayClient := awsxray.NewXRayClient(logger, awsConfig, set.BuildInfo, session)
+	xrayClient := awsxray.NewXRayClient(logger, awsConfig, set.BuildInfo)
 	sender := telemetry.NewNopSender()
 	if cfg.TelemetryConfig.Enabled {
-		opts := telemetry.ToOptions(cfg.TelemetryConfig, session, &cfg.AWSSessionSettings)
+		opts := telemetry.ToOptions(ctx, cfg.TelemetryConfig, awsConfig, &cfg.AWSSessionSettings)
 		opts = append(opts, telemetry.WithLogger(set.Logger))
 		sender = registry.Register(set.ID, cfg.TelemetryConfig, xrayClient, opts...)
 	}
-	return exporterhelper.NewTraces(
-		context.TODO(),
-		set,
-		cfg,
-		func(_ context.Context, td ptrace.Traces) error {
+	return exporterhelper.NewTraces(context.Background(), set, cfg,
+		func(ctx context.Context, td ptrace.Traces) error {
 			var err error
 			logger.Debug("TracesExporter", typeLog, nameLog, zap.Int("#spans", td.SpanCount()))
 
@@ -65,9 +58,9 @@ func newTracesExporter(
 				} else {
 					nextOffset = offset + maxSegmentsPerPut
 				}
-				input := xray.PutTraceSegmentsInput{TraceSegmentDocuments: documents[offset:nextOffset]}
-				logger.Debug("request: " + input.String())
-				output, localErr := xrayClient.PutTraceSegments(&input)
+				input := &xray.PutTraceSegmentsInput{TraceSegmentDocuments: documents[offset:nextOffset]}
+				logger.Debug("request: " + fmt.Sprintf("%+v", input))
+				output, localErr := xrayClient.PutTraceSegments(ctx, input)
 				if localErr != nil {
 					logger.Debug("response error", zap.Error(localErr))
 					err = wrapErrorIfBadRequest(localErr) // record error
@@ -76,7 +69,7 @@ func newTracesExporter(
 					sender.RecordSegmentsSent(len(input.TraceSegmentDocuments))
 				}
 				if output != nil {
-					logger.Debug("response: " + output.String())
+					logger.Debug("response: " + fmt.Sprintf("%+v", output))
 				}
 				if err != nil {
 					break
@@ -85,7 +78,7 @@ func newTracesExporter(
 			return err
 		},
 		exporterhelper.WithStart(func(context.Context, component.Host) error {
-			sender.Start()
+			sender.Start(ctx)
 			return nil
 		}),
 		exporterhelper.WithShutdown(func(context.Context) error {
@@ -96,8 +89,8 @@ func newTracesExporter(
 	)
 }
 
-func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace.Traces) []*string {
-	documents := make([]*string, 0, td.SpanCount())
+func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace.Traces) []string {
+	documents := make([]string, 0, td.SpanCount())
 
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		rspans := td.ResourceSpans().At(i)
@@ -117,9 +110,7 @@ func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace
 					continue
 				}
 
-				for l := range documentsForSpan {
-					documents = append(documents, &documentsForSpan[l])
-				}
+				documents = append(documents, documentsForSpan...)
 			}
 		}
 	}
@@ -127,9 +118,10 @@ func extractResourceSpans(config component.Config, logger *zap.Logger, td ptrace
 }
 
 func wrapErrorIfBadRequest(err error) error {
-	var rfErr awserr.RequestFailure
-	if errors.As(err, &rfErr) && rfErr.StatusCode() < 500 {
+	var ae smithy.APIError
+	if errors.As(err, &ae) && ae.ErrorFault() == smithy.FaultClient {
 		return consumererror.NewPermanent(err)
 	}
+
 	return err
 }

--- a/exporter/awsxrayexporter/factory.go
+++ b/exporter/awsxrayexporter/factory.go
@@ -36,11 +36,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createTracesExporter(
-	_ context.Context,
-	params exporter.Settings,
-	cfg component.Config,
-) (exporter.Traces, error) {
+func createTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	eCfg := cfg.(*Config)
-	return newTracesExporter(eCfg, params, &awsutil.Conn{}, telemetry.GlobalRegistry())
+	return newTracesExporter(ctx, eCfg, params, telemetry.GlobalRegistry())
 }

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -3,7 +3,9 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxra
 go 1.23.0
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2/service/xray v1.31.2
+	github.com/aws/smithy-go v1.22.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.125.0
@@ -23,7 +25,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
+	github.com/aws/aws-sdk-go v1.55.7 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.14 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
@@ -35,7 +37,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/exporter/awsxrayexporter/go.sum
+++ b/exporter/awsxrayexporter/go.sum
@@ -24,8 +24,10 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
-github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
-github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2 h1:D+a2uduTeauyvCfeo4Ecb1OIYGKLLi3BwdGiZjEGgwc=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2/go.mod h1:SCgjo2KNA41rc34+CZmwj4DmuTwy3pBBy3+n35rDink=
+github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
+github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -6,7 +6,7 @@ package translator
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"

--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"

--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	awsP "github.com/aws/aws-sdk-go/aws"
+	awsP "github.com/aws/aws-sdk-go-v2/aws"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -4,6 +4,10 @@ go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30
+	github.com/aws/aws-sdk-go-v2/service/xray v1.31.2
+	github.com/aws/smithy-go v1.22.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.125.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.31.0
@@ -12,10 +16,8 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.14 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
@@ -24,7 +26,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -33,7 +34,6 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.31.0 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.125.0 // indirect

--- a/internal/aws/xray/go.sum
+++ b/internal/aws/xray/go.sum
@@ -24,6 +24,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2 h1:D+a2uduTeauyvCfeo4Ecb1OIYGKLLi3BwdGiZjEGgwc=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2/go.mod h1:SCgjo2KNA41rc34+CZmwj4DmuTwy3pBBy3+n35rDink=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/aws/xray/telemetry/nop_sender.go
+++ b/internal/aws/xray/telemetry/nop_sender.go
@@ -3,7 +3,11 @@
 
 package telemetry // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/telemetry"
 
-import "github.com/aws/aws-sdk-go/service/xray"
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/xray/types"
+)
 
 // NewNopSender returns a Sender that drops all data.
 func NewNopSender() Sender {
@@ -14,15 +18,15 @@ var nopSenderInstance Sender = &nopSender{}
 
 type nopSender struct{}
 
-func (n nopSender) Rotate() *xray.TelemetryRecord {
-	return nil
+func (n nopSender) Rotate() types.TelemetryRecord {
+	return types.TelemetryRecord{}
 }
 
 func (n nopSender) HasRecording() bool {
 	return false
 }
 
-func (n nopSender) Start() {
+func (n nopSender) Start(_ context.Context) {
 }
 
 func (n nopSender) Stop() {

--- a/internal/aws/xray/telemetry/nop_sender_test.go
+++ b/internal/aws/xray/telemetry/nop_sender_test.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,14 +14,14 @@ func TestNopRecorder(t *testing.T) {
 	assert.Same(t, nopSenderInstance, NewNopSender())
 	recorder := NewNopSender()
 	assert.NotPanics(t, func() {
-		recorder.Start()
+		recorder.Start(context.Background())
 		recorder.RecordConnectionError(nil)
 		recorder.RecordSegmentsSent(1)
 		recorder.RecordSegmentsSpillover(1)
 		recorder.RecordSegmentsRejected(1)
 		recorder.RecordSegmentsReceived(1)
 		assert.False(t, recorder.HasRecording())
-		assert.Nil(t, recorder.Rotate())
+		assert.Zero(t, recorder.Rotate())
 		recorder.Stop()
 	})
 }

--- a/internal/aws/xray/telemetry/recorder_test.go
+++ b/internal/aws/xray/telemetry/recorder_test.go
@@ -8,72 +8,72 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRecordConnectionError(t *testing.T) {
 	type testParameters struct {
 		input error
-		want  func() *xray.TelemetryRecord
+		want  func() types.TelemetryRecord
 	}
 	testCases := []testParameters{
 		{
 			input: awserr.NewRequestFailure(nil, http.StatusInternalServerError, ""),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.HTTPCode5XXCount = aws.Int64(1)
+				record.BackendConnectionErrors.HTTPCode5XXCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: awserr.NewRequestFailure(nil, http.StatusBadRequest, ""),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.HTTPCode4XXCount = aws.Int64(1)
+				record.BackendConnectionErrors.HTTPCode4XXCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: awserr.NewRequestFailure(nil, http.StatusFound, ""),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.OtherCount = aws.Int64(1)
+				record.BackendConnectionErrors.OtherCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: awserr.New(request.ErrCodeResponseTimeout, "", nil),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.TimeoutCount = aws.Int64(1)
+				record.BackendConnectionErrors.TimeoutCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: awserr.New(request.ErrCodeRequestError, "", nil),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.UnknownHostCount = aws.Int64(1)
+				record.BackendConnectionErrors.UnknownHostCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: awserr.New(request.ErrCodeSerialization, "", nil),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.OtherCount = aws.Int64(1)
+				record.BackendConnectionErrors.OtherCount = aws.Int32(1)
 				return record
 			},
 		},
 		{
 			input: errors.New("test"),
-			want: func() *xray.TelemetryRecord {
+			want: func() types.TelemetryRecord {
 				record := NewRecord()
-				record.BackendConnectionErrors.OtherCount = aws.Int64(1)
+				record.BackendConnectionErrors.OtherCount = aws.Int32(1)
 				return record
 			},
 		},

--- a/internal/aws/xray/telemetry/registry_test.go
+++ b/internal/aws/xray/telemetry/registry_test.go
@@ -21,7 +21,7 @@ func TestRegistry(t *testing.T) {
 			IncludeMetadata: false,
 			Contributors:    []component.ID{contribID},
 		},
-		&mockClient{},
+		&mockXRayClient{},
 	)
 	withSameID := r.Register(
 		newID,
@@ -29,7 +29,7 @@ func TestRegistry(t *testing.T) {
 			IncludeMetadata: true,
 			Contributors:    []component.ID{notCreatedID},
 		},
-		&mockClient{},
+		&mockXRayClient{},
 		WithResourceARN("arn"),
 	)
 	// still the same recorder

--- a/internal/aws/xray/telemetry/telemetrytest/sender_sink.go
+++ b/internal/aws/xray/telemetry/telemetrytest/sender_sink.go
@@ -4,6 +4,7 @@
 package telemetrytest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/telemetry/telemetrytest"
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/telemetry"
@@ -27,7 +28,7 @@ type SenderSink struct {
 	StopCount  *atomic.Int64
 }
 
-func (s SenderSink) Start() {
+func (s SenderSink) Start(_ context.Context) {
 	s.StartCount.Add(1)
 }
 

--- a/internal/aws/xray/telemetry/telemetrytest/sender_sink_test.go
+++ b/internal/aws/xray/telemetry/telemetrytest/sender_sink_test.go
@@ -4,6 +4,7 @@
 package telemetrytest
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func TestSink(t *testing.T) {
 	sink := NewSenderSink()
-	sink.Start()
+	sink.Start(context.Background())
 	sink.Stop()
 	assert.EqualValues(t, 1, sink.StartCount.Load())
 	assert.EqualValues(t, 1, sink.StopCount.Load())

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go-v2/service/xray v1.31.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy v0.125.0

--- a/receiver/awsxrayreceiver/go.sum
+++ b/receiver/awsxrayreceiver/go.sum
@@ -24,6 +24,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0c
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2 h1:D+a2uduTeauyvCfeo4Ecb1OIYGKLLi3BwdGiZjEGgwc=
+github.com/aws/aws-sdk-go-v2/service/xray v1.31.2/go.mod h1:SCgjo2KNA41rc34+CZmwj4DmuTwy3pBBy3+n35rDink=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -65,7 +65,7 @@ func TestTranslation(t *testing.T) {
 		expectedUnmarshallFailure bool
 		samplePath                string
 		expectedResourceAttrs     func(seg *awsxray.Segment) map[string]any
-		expectedRecord            xray.TelemetryRecord
+		expectedRecord            types.TelemetryRecord
 		propsPerSpan              func(t *testing.T, testCase string, seg *awsxray.Segment) []perSpanProperties
 		verification              func(testCase string,
 			actualSeg *awsxray.Segment,
@@ -88,9 +88,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeContainerID:          *seg.AWS.EKS.ContainerID,
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := defaultServerSpanAttrs(seg)
@@ -132,9 +132,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeTelemetrySDKLanguage: "java",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(18),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(18),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(t *testing.T, testCase string, seg *awsxray.Segment) []perSpanProperties {
 				rootSpanAttrs := pcommon.NewMap()
@@ -538,9 +538,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := defaultServerSpanAttrs(seg)
@@ -592,9 +592,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeTelemetrySDKLanguage:  "Go",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := defaultServerSpanAttrs(seg)
@@ -634,9 +634,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				res := perSpanProperties{
@@ -672,9 +672,9 @@ func TestTranslation(t *testing.T) {
 			expectedResourceAttrs: func(*awsxray.Segment) map[string]any {
 				return nil
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(18),
-				SegmentsRejectedCount: aws.Int64(18),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(18),
+				SegmentsRejectedCount: aws.Int32(18),
 			},
 			propsPerSpan: func(*testing.T, string, *awsxray.Segment) []perSpanProperties {
 				return nil
@@ -697,9 +697,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := pcommon.NewMap()
@@ -746,9 +746,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := pcommon.NewMap()
@@ -796,9 +796,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := pcommon.NewMap()
@@ -843,9 +843,9 @@ func TestTranslation(t *testing.T) {
 			expectedResourceAttrs: func(*awsxray.Segment) map[string]any {
 				return nil
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(1),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(1),
 			},
 			propsPerSpan: func(*testing.T, string, *awsxray.Segment) []perSpanProperties {
 				return nil
@@ -868,9 +868,9 @@ func TestTranslation(t *testing.T) {
 					conventions.AttributeCloudProvider: "unknown",
 				}
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(_ *testing.T, _ string, seg *awsxray.Segment) []perSpanProperties {
 				attrs := pcommon.NewMap()
@@ -912,9 +912,9 @@ func TestTranslation(t *testing.T) {
 			expectedResourceAttrs: func(*awsxray.Segment) map[string]any {
 				return nil
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(0),
-				SegmentsRejectedCount: aws.Int64(0),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(0),
+				SegmentsRejectedCount: aws.Int32(0),
 			},
 			propsPerSpan: func(*testing.T, string, *awsxray.Segment) []perSpanProperties {
 				return nil
@@ -937,9 +937,9 @@ func TestTranslation(t *testing.T) {
 			expectedResourceAttrs: func(*awsxray.Segment) map[string]any {
 				return nil
 			},
-			expectedRecord: xray.TelemetryRecord{
-				SegmentsReceivedCount: aws.Int64(1),
-				SegmentsRejectedCount: aws.Int64(1),
+			expectedRecord: types.TelemetryRecord{
+				SegmentsReceivedCount: aws.Int32(1),
+				SegmentsRejectedCount: aws.Int32(1),
 			},
 			propsPerSpan: func(*testing.T, string, *awsxray.Segment) []perSpanProperties {
 				return nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
aws-sdk-go is being [deprecated on July 31, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/). This PR updates `exporter/awsxrayexporter` and associated dependencies in `internal/aws/xray` to aws-sdk-go-v2.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37726 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I converted the existing unit tests to aws-sdk-go-v2 as well, keeping the original intent of the tests.