### PR TITLE
[chore]: fix staticcheck rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ formatters:
   exclusions:
     paths:
       - third_party
-      - cmd/otelcontribcol
-      - cmd/oteltestbedcol
 
   settings:
     gci:
@@ -64,8 +62,6 @@ linters:
     # from this option's value (see exclude-dirs-use-default).
     paths:
       - third_party
-      - cmd/otelcontribcol
-      - cmd/oteltestbedcol
 
     presets:
       - comments
@@ -212,20 +208,9 @@ linters:
     staticcheck:
       checks:
         - all
-        - -QF1001 # FIXME
-        - -QF1002 # FIXME
-        - -QF1003 # FIXME
-        - -QF1006 # FIXME
-        - -QF1007 # FIXME
-        - -QF1008 # FIXME
-        - -QF1011 # FIXME
-        - -QF1012 # FIXME
-        - -ST1003 # FIXME
-        - -ST1005 # FIXME
-        - -ST1011 # FIXME
-        - -ST1016 # FIXME
-        - -ST1019 # FIXME
-        - -ST1023 # FIXME
+        - -ST1003 # FIXME: Poorly chosen identifier
+        - -ST1005 # FIXME: Incorrectly formatted error string
+        - -ST1011 # FIXME: Poorly chosen name for variable of type time.Duration
 
     testifylint:
       disable:

--- a/extension/cgroupruntimeextension/integration_test.go
+++ b/extension/cgroupruntimeextension/integration_test.go
@@ -252,15 +252,14 @@ func testServerECSMetadata(t *testing.T, containerCPU, taskCPU int) *httptest.Se
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
+		_, err := fmt.Fprintf(w, `{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)
 		assert.NoError(t, err)
 	})
 	mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf(
+		_, err := fmt.Fprintf(w,
 			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
 			containerCPU,
-			taskCPU,
-		)))
+			taskCPU)
 		assert.NoError(t, err)
 	})
 

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2metadata.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2metadata.go
@@ -71,10 +71,10 @@ func (emd *ec2Metadata) refresh(ctx context.Context) {
 		return
 	}
 
-	emd.instanceID = resp.InstanceIdentityDocument.InstanceID
-	emd.instanceType = resp.InstanceIdentityDocument.InstanceType
-	emd.region = resp.InstanceIdentityDocument.Region
-	emd.instanceIP = resp.InstanceIdentityDocument.PrivateIP
+	emd.instanceID = resp.InstanceID
+	emd.instanceType = resp.InstanceType
+	emd.region = resp.Region
+	emd.instanceIP = resp.PrivateIP
 
 	// notify ec2tags and ebsvolume that the instance id is ready
 	if emd.instanceID != "" {


### PR DESCRIPTION
#### Description

Enable all rules from staticcheck from golangci-lint@v2

NB: cmd/otelcontribcol and cmd/oteltestbedcol don't need to be excluded as they don't contain any golang file.