### PR TITLE
support user defined CA path for service account using the `ca_file` configtls option

### DIFF
--- a/.chloggen/kubelet-client.yaml
+++ b/.chloggen/kubelet-client.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/kubeletstats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support user defined CA path for service account using the configtls option `ca_file`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39291]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -103,6 +103,27 @@ collector is running to be used as the endpoint. If the hostNetwork flag is
 set, and the collector is running in a pod, this hostname will resolve to the
 node's network namespace.
 
+#### Custom CA
+
+The service account client, by default, uses the CA certificate located at 
+`/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` to validate the kubelet certificate. 
+If the kubelet server uses a certificate issued by a different CA, 
+specify the custom CA certificate path using the `ca_file` option.
+
+##### AKS Custom CA example
+
+This use case applies to AKS cluster, where the kubelet certificate is issued by 
+`/etc/kubernetes/certs/kubeletserver.crt`
+
+```yaml
+receivers:
+  kubeletstats:
+    collection_interval: 20s
+    auth_type: "serviceAccount"
+    endpoint: "https://${env:K8S_NODE_NAME}:10250"
+    ca_file: "/etc/kubernetes/certs/kubeletserver.crt"
+```
+
 ### Read Only Endpoint Example
 
 The following config can be used to collect Kubelet metrics from read-only endpoint:


### PR DESCRIPTION
#### Description
This PR allows user to define a custom CA for service account . 
If ca_file is set, we load the user defined CA Path and skip the service account CA Path
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39291

<!--Describe what testing was performed and which tests were added.-->
Added an extra unit test and manually validated that it addressed the issue on [AKS](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39291) 


#### Documentation

Update the kubeletstats receiver README with info on when to use custom CA
