### PR TITLE
[chore][k8sattributesprocessor] Start informers in the provider function

### DIFF
--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -102,7 +102,17 @@ type Client interface {
 }
 
 // ClientProvider defines a func type that returns a new Client.
-type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, ExtractionRules, Filters, []Association, Excludes, APIClientsetProvider, InformersFactoryList, bool, time.Duration) (Client, error)
+type ClientProvider func(
+	component.TelemetrySettings,
+	k8sconfig.APIConfig,
+	ExtractionRules,
+	Filters,
+	[]Association,
+	Excludes,
+	APIClientsetProvider,
+	InformersFactoryList,
+	bool, time.Duration,
+) (Client, error)
 
 // APIClientsetProvider defines a func type that initializes and return a new kubernetes
 // Clientset object.

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -267,7 +267,17 @@ func TestNewProcessor(t *testing.T) {
 }
 
 func TestProcessorBadClientProvider(t *testing.T) {
-	clientProvider := func(_ component.TelemetrySettings, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _ time.Duration) (kube.Client, error) {
+	clientProvider := func(
+		_ component.TelemetrySettings,
+		_ k8sconfig.APIConfig,
+		_ kube.ExtractionRules,
+		_ kube.Filters,
+		_ []kube.Association,
+		_ kube.Excludes,
+		_ kube.APIClientsetProvider,
+		_ kube.InformersFactoryList,
+		_ bool, _ time.Duration,
+	) (kube.Client, error) {
 		return nil, errors.New("bad client error")
 	}
 


### PR DESCRIPTION
#### Description

We'd like instances of the k8sattributes processor to share local K8s resource caches (represented by the `informer` concept from client-go). See #36234 for the justification and a broad overview. This change is the first in a series of refactors necessary to make this possible.

In order to share informers, the processor cannot be responsible for starting them. This PR moves that logic to informer provider functions. Informers are still stopped by closing a channel provided at construction.

The processor also makes no assumptions about whether the informers will keep running after `Stop` is called. As a result, it needs to explicitly track its own event handler registration, and unregister in an orderly matter when stopping.

See #36604 for all the refactoring changes put together. I've split this PR out to make review easier.

#### Link to tracking issue
Part of #36234
Split out from #36604

#### Testing

Modified existing tests.
