### PR TITLE
[receiver/sqlqueryreceiver] Use one connection pool per receiver

### DIFF
--- a/.chloggen/39270-sqlquery-pool.yaml
+++ b/.chloggen/39270-sqlquery-pool.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: sqlqueryreceiver
+issues: [39270]
+change_logs: [user]
+
+note: respect `max_open_conn` configuration for multiple queries

--- a/receiver/sqlqueryreceiver/internal/database_sql.go
+++ b/receiver/sqlqueryreceiver/internal/database_sql.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver/internal"
+
+import (
+	"database/sql"
+	"sync"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery"
+)
+
+func NewPool(opener sqlquery.SQLOpenerFunc, driver string, dsn string, maxOpenConns int) interface {
+	DB() (*sql.DB, error)
+} {
+	return &sqlPool{
+		DriverName:     driver,
+		DataSourceName: dsn,
+		MaxOpenConns:   maxOpenConns,
+		Opener:         opener,
+	}
+}
+
+type sqlPool struct {
+	DriverName     string
+	DataSourceName string
+	MaxOpenConns   int
+	Opener         sqlquery.SQLOpenerFunc
+
+	mutex sync.Mutex
+	db    *sql.DB
+}
+
+// DB initializes and returns the [sql.DB] pool. It is safe to call concurrently.
+// Depending on the driver, this might also connect to the database backend.
+//
+// This method exists to satisfy [sqlquery.DbProviderFunc], but the way
+// [sqlquery.Scraper] closes [sql.DB] can interfere with other Scrapers.
+func (sp *sqlPool) DB() (*sql.DB, error) {
+	sp.mutex.Lock()
+	defer sp.mutex.Unlock()
+
+	if sp.db == nil {
+		db, err := sp.Opener(sp.DriverName, sp.DataSourceName)
+
+		if err == nil && db != nil {
+			db.SetMaxOpenConns(sp.MaxOpenConns)
+			sp.db = db
+		}
+
+		return sp.db, err
+	}
+
+	return sp.db, nil
+}

--- a/receiver/sqlqueryreceiver/receiver.go
+++ b/receiver/sqlqueryreceiver/receiver.go
@@ -5,7 +5,6 @@ package sqlqueryreceiver // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
@@ -15,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver/internal/metadata"
 )
 
@@ -39,29 +39,22 @@ func createMetricsReceiverFunc(sqlOpenerFunc sqlquery.SQLOpenerFunc, clientProvi
 	) (receiver.Metrics, error) {
 		sqlCfg := cfg.(*Config)
 		var opts []scraperhelper.ControllerOption
+		pool := internal.NewPool(sqlOpenerFunc, sqlCfg.Driver, sqlCfg.DataSource, sqlCfg.MaxOpenConn)
+
 		for i, query := range sqlCfg.Queries {
 			if len(query.Metrics) == 0 {
 				continue
 			}
 			id := component.MustNewIDWithName("sqlqueryreceiver", fmt.Sprintf("query-%d: %s", i, query.SQL))
-			dbProviderFunc := func() (*sql.DB, error) {
-				dbPool, err := sqlOpenerFunc(sqlCfg.Driver, sqlCfg.DataSource)
-				if err != nil {
-					return nil, err
-				}
 
-				if dbPool != nil {
-					dbPool.SetMaxOpenConns(sqlCfg.MaxOpenConn)
-				}
-				return dbPool, nil
-			}
 			scope := pcommon.NewInstrumentationScope()
 			scope.SetName(metadata.ScopeName)
-			mp := sqlquery.NewScraper(id, query, sqlCfg.ControllerConfig, settings.Logger, sqlCfg.Telemetry, dbProviderFunc, clientProviderFunc, scope)
+			mp := sqlquery.NewScraper(id, query, sqlCfg.ControllerConfig, settings.Logger, sqlCfg.Telemetry, pool.DB, clientProviderFunc, scope)
 
 			opt := scraperhelper.AddScraper(metadata.Type, mp)
 			opts = append(opts, opt)
 		}
+
 		return scraperhelper.NewMetricsController(
 			&sqlCfg.ControllerConfig,
 			settings,


### PR DESCRIPTION
#### Description
Rather than creating a separate `*sql.DB` provider function for each query, this creates one provider for the receiver and passes a method value to each query. The method uses a mutex to ensure exactly one `*sql.DB` is created when it is called concurrently.

The `max_open_conn` config is defined in `sqlqueryreceiver`, so I put the implementation in its `internal` package.

#### Link to tracking issue
Fixes #39270

#### Testing
Using the configuration and steps in #39270, I see only one connection to Postgres:

```console
$ psql -h localhost -U postgres -c 'SELECT pid, backend_type, datname, usename, query, state FROM pg_stat_activity'
┌─────┬──────────────────────────────┬──────────┬──────────┬────────────────────────────────────────────────────────────────────────────────┬────────┐
│ pid │         backend_type         │ datname  │ usename  │                                     query                                      │ state  │
├─────┼──────────────────────────────┼──────────┼──────────┼────────────────────────────────────────────────────────────────────────────────┼────────┤
│  68 │ client backend               │ postgres │ postgres │ SELECT 3 AS number                                                             │ idle   │
│  70 │ client backend               │ postgres │ postgres │ SELECT pid, backend_type, datname, usename, query, state FROM pg_stat_activity │ active │
│  65 │ autovacuum launcher          │ ␀        │ ␀        │                                                                                │ ␀      │
│  66 │ logical replication launcher │ ␀        │ postgres │                                                                                │ ␀      │
│  61 │ checkpointer                 │ ␀        │ ␀        │                                                                                │ ␀      │
│  62 │ background writer            │ ␀        │ ␀        │                                                                                │ ␀      │
│  64 │ walwriter                    │ ␀        │ ␀        │                                                                                │ ␀      │
└─────┴──────────────────────────────┴──────────┴──────────┴────────────────────────────────────────────────────────────────────────────────┴────────┘
(7 rows)
```
