### PR TITLE
[stanza] Remove unnecessary slice allocation to track errors (even nil)

### DIFF
--- a/.chloggen/stanza-error.yaml
+++ b/.chloggen/stanza-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unnecessary slice allocation to track errors (even nil)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39367]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint.go
+++ b/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.uber.org/multierr"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -32,19 +33,19 @@ func SaveKey(ctx context.Context, persister operator.Persister, rmds []*reader.M
 		return fmt.Errorf("encode num files: %w", err)
 	}
 
-	var errs []error
+	var errs error
 	// Encode each known file
 	for _, rmd := range rmds {
 		if err := enc.Encode(rmd); err != nil {
-			errs = append(errs, fmt.Errorf("encode metadata: %w", err))
+			errs = multierr.Append(errs, fmt.Errorf("encode metadata: %w", err))
 		}
 	}
 	ops = append(ops, storage.SetOperation(key, buf.Bytes()))
 	if err := persister.Batch(ctx, ops...); err != nil {
-		errs = append(errs, fmt.Errorf("persist known files: %w", err))
+		errs = multierr.Append(errs, fmt.Errorf("persist known files: %w", err))
 	}
 
-	return errors.Join(errs...)
+	return errs
 }
 
 // Load loads the most recent set of files to the database
@@ -71,7 +72,7 @@ func LoadKey(ctx context.Context, persister operator.Persister, key string) ([]*
 	}
 
 	// Decode each of the known files
-	var errs []error
+	var errs error
 	rmds := make([]*reader.Metadata, 0, knownFileCount)
 	for i := 0; i < knownFileCount; i++ {
 		rmd := new(reader.Metadata)
@@ -92,7 +93,7 @@ func LoadKey(ctx context.Context, persister operator.Persister, key string) ([]*
 				}
 				delete(rmd.FileAttributes, "HeaderAttributes")
 			default:
-				errs = append(errs, errors.New("migrate header attributes: unexpected format"))
+				errs = multierr.Append(errs, errors.New("migrate header attributes: unexpected format"))
 			}
 		}
 
@@ -100,5 +101,5 @@ func LoadKey(ctx context.Context, persister operator.Persister, key string) ([]*
 		rmds = append(rmds, rmd)
 	}
 
-	return rmds, errors.Join(errs...)
+	return rmds, errs
 }

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -4,12 +4,12 @@
 package finder // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher/internal/finder"
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"slices"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"go.uber.org/multierr"
 )
 
 func Validate(globs []string) error {
@@ -30,7 +30,7 @@ func FindFiles(includes []string, excludes []string) ([]string, error) {
 	for _, include := range includes {
 		matches, err := doublestar.FilepathGlob(include, doublestar.WithFilesOnly(), doublestar.WithFailOnIOErrors())
 		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("find files with '%s' pattern: %w", include, err))
+			errs = multierr.Append(errs, fmt.Errorf("find files with '%s' pattern: %w", include, err))
 			// the same pattern could cause an IO error due to one file or directory,
 			// but also could still find files without `doublestar.WithFailOnIOErrors()`.
 			matches, _ = doublestar.FilepathGlob(include, doublestar.WithFilesOnly())

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/expr-lang/expr/vm"
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -78,11 +79,11 @@ func (t *TransformerOperator) CanProcess() bool {
 }
 
 func (t *TransformerOperator) ProcessBatchWith(ctx context.Context, entries []*entry.Entry, process ProcessFunction) error {
-	var errs []error
+	var errs error
 	for i := range entries {
-		errs = append(errs, process(ctx, entries[i]))
+		errs = multierr.Append(errs, process(ctx, entries[i]))
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 // ProcessWith will process an entry with a transform function.

--- a/pkg/stanza/operator/input/windows/publishercache.go
+++ b/pkg/stanza/operator/input/windows/publishercache.go
@@ -6,7 +6,7 @@
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (
-	"errors"
+	"go.uber.org/multierr"
 )
 
 type publisherCache struct {
@@ -43,9 +43,7 @@ func (c *publisherCache) evictAll() error {
 	var errs error
 	for _, publisher := range c.cache {
 		if publisher.Valid() {
-			if err := publisher.Close(); err != nil {
-				errs = errors.Join(errs, err)
-			}
+			errs = multierr.Append(errs, publisher.Close())
 		}
 	}
 

--- a/pkg/stanza/operator/output/file/output.go
+++ b/pkg/stanza/operator/output/file/output.go
@@ -6,11 +6,11 @@ package file // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"sync"
 	"text/template"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -54,11 +54,11 @@ func (o *Output) Stop() error {
 }
 
 func (o *Output) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	var errs []error
+	var errs error
 	for i := range entries {
-		errs = append(errs, o.Process(ctx, entries[i]))
+		errs = multierr.Append(errs, o.Process(ctx, entries[i]))
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 // Process will write an entry to the output file.

--- a/pkg/stanza/operator/output/stdout/output.go
+++ b/pkg/stanza/operator/output/stdout/output.go
@@ -6,9 +6,9 @@ package stdout // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"sync"
 
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -23,11 +23,11 @@ type Output struct {
 }
 
 func (o *Output) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	var errs []error
+	var errs error
 	for i := range entries {
-		errs = append(errs, o.Process(ctx, entries[i]))
+		errs = multierr.Append(errs, o.Process(ctx, entries[i]))
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 // Process will log entries received.

--- a/pkg/stanza/operator/transformer/router/transformer.go
+++ b/pkg/stanza/operator/transformer/router/transformer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/expr-lang/expr/vm"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -36,11 +37,11 @@ func (t *Transformer) CanProcess() bool {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	var errs []error
+	var errs error
 	for i := range entries {
-		errs = append(errs, t.Process(ctx, entries[i]))
+		errs = multierr.Append(errs, t.Process(ctx, entries[i]))
 	}
-	return errors.Join(errs...)
+	return errs
 }
 
 // Process will route incoming entries based on matching expressions

--- a/pkg/stanza/testutil/mocks.go
+++ b/pkg/stanza/testutil/mocks.go
@@ -5,11 +5,11 @@ package testutil // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	context "context"
-	goerrors "errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -85,11 +85,11 @@ func (f *FakeOutput) Stop() error { return nil }
 func (f *FakeOutput) Type() string { return "fake_output" }
 
 func (f *FakeOutput) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	var errs []error
+	var errs error
 	for i := range entries {
-		errs = append(errs, f.Process(ctx, entries[i]))
+		errs = multierr.Append(errs, f.Process(ctx, entries[i]))
 	}
-	return goerrors.Join(errs...)
+	return errs
 }
 
 // Process will place all incoming entries on the Received channel of a fake output


### PR DESCRIPTION
The most inefficient usages are in ProcessBatch and ProcessBatchWith, where we allocate a slice of errors even if return value is nil.

Changed all usages to make sure we don't repeat that mistake and establish a healthier pattern.