### PR TITLE
[chore]: remove testifylint from internal/tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,14 +215,6 @@ golint:
 gogovulncheck:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="govulncheck"
 
-.PHONY: gotestifylint
-gotestifylint:
-	$(MAKE) $(FOR_GROUP_TARGET) TARGET="testifylint"
-
-.PHONY: gotestifylint-fix
-gotestifylint-fix:
-	$(MAKE) $(FOR_GROUP_TARGET) TARGET="testifylint-fix"
-
 .PHONY: goporto
 goporto: $(PORTO)
 	$(PORTO) -w --include-internal --skip-dirs "^cmd$$" ./

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -73,11 +73,9 @@ GOFUMPT             := $(TOOLS_BIN_DIR)/gofumpt
 GOVULNCHECK         := $(TOOLS_BIN_DIR)/govulncheck
 GCI                 := $(TOOLS_BIN_DIR)/gci
 GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
-TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 CHECKAPI            := $(TOOLS_BIN_DIR)/checkapi
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run,encoded-compare
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
@@ -238,15 +236,6 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 .PHONY: moddownload
 moddownload:
 	$(GOCMD) mod download
-
-.PHONY: testifylint
-testifylint: $(TESTIFYLINT)
-	@echo "running $(TESTIFYLINT)"
-	$(TESTIFYLINT) $(TESTIFYLINT_OPT) ./...
-
-.PHONY: testifylint-fix
-testifylint-fix:
-	@$(MAKE) testifylint TESTIFYLINT_OPT="${TESTIFYLINT_OPT} --fix"
 
 .PHONY: gci
 gci: $(TOOLS_BIN_DIR)/gci

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
 go 1.23.0
 
 require (
-	github.com/Antonboom/testifylint v1.6.0
 	github.com/Khan/genqlient v0.8.0
 	github.com/client9/misspell v0.3.4
 	github.com/daixiang0/gci v0.13.6
@@ -35,6 +34,7 @@ require (
 	github.com/Abirdcfly/dupword v0.1.3 // indirect
 	github.com/Antonboom/errname v1.1.0 // indirect
 	github.com/Antonboom/nilnil v1.1.0 // indirect
+	github.com/Antonboom/testifylint v1.6.0 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Crocmagnon/fatcontext v0.7.1 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,7 +11,6 @@ package tools // import "github.com/open-telemetry/opentelemetry-collector-contr
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 
 import (
-	_ "github.com/Antonboom/testifylint"
 	_ "github.com/Khan/genqlient"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/daixiang0/gci"


### PR DESCRIPTION
#### Description

golangci-lint is now able to apply suggested fixes from testifylint with `golangci-lint --fix` .
This PR removes the direct dependency to testifylint and the associated makefiles.