### PR TITLE
[chore] Remove log about otlp_json being experimental

### DIFF
--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -88,9 +88,6 @@ func (f *pulsarExporterFactory) createTracesExporter(
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultTracesTopic
 	}
-	if oCfg.Encoding == "otlp_json" {
-		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
-	}
 	exp, err := newTracesExporter(oCfg, set, f.tracesMarshalers)
 	if err != nil {
 		return nil, err
@@ -119,9 +116,6 @@ func (f *pulsarExporterFactory) createMetricsExporter(
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultMetricsTopic
 	}
-	if oCfg.Encoding == "otlp_json" {
-		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
-	}
 	exp, err := newMetricsExporter(oCfg, set, f.metricsMarshalers)
 	if err != nil {
 		return nil, err
@@ -149,9 +143,6 @@ func (f *pulsarExporterFactory) createLogsExporter(
 	oCfg := *(cfg.(*Config))
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultLogsTopic
-	}
-	if oCfg.Encoding == "otlp_json" {
-		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
 	exp, err := newLogsExporter(oCfg, set, f.logsMarshalers)
 	if err != nil {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Remove logging that states otlp_json is experimental. OTLP/JSON has been stable for over 2 years: https://github.com/open-telemetry/opentelemetry-specification/pull/2930
cf. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39222
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
N/A
<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A
<!--Describe the documentation added.-->
#### Documentation
N/A
<!--Please delete paragraphs that you did not use before submitting.-->
