### PR TITLE
[receiver/windowsservice] Added receiver scrape wireframe

### DIFF
--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -3,3 +3,39 @@
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver/internal/metadata"
+)
+
+type windowsServiceScraper struct {
+	scm      serviceManager
+	settings receiver.Settings
+	conf     *Config
+	mb       *metadata.MetricsBuilder
+}
+
+func newWindowsServiceScraper(settings receiver.Settings, cfg *Config) windowsServiceScraper {
+	return windowsServiceScraper{
+		settings: settings,
+		mb:       metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),
+	}
+}
+
+func (ws *windowsServiceScraper) start(ctx context.Context, _ component.Host) (err error) {
+	return nil
+}
+
+func (ws *windowsServiceScraper) shutdown(ctx context.Context) (err error) {
+	return nil
+}
+
+func (ws *windowsServiceScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
+	return ws.mb.Emit(), nil
+}

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -3,3 +3,43 @@
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import (
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+/*
+* Functions and structs which are used to interact with the Windows service api.
+*
+* Primary functions are connecting to the Service Control Manager (SCM) to gather service information on scrape.
+*
+* Docs may be found at https://learn.microsoft.com/en-us/windows/win32/services/services
+* and "https://learn.microsoft.com/en-us/windows/win32/api/winsvc/"
+**/
+
+// service manager "client"
+type serviceManager struct {
+	handle windows.Handle // handle to SCM database
+}
+
+// get SCM database handle
+func scmConnect() (*serviceManager, error) {
+	var h windows.Handle
+	return &serviceManager{
+		h,
+	}, nil
+}
+
+func (sm *serviceManager) disconnect() error {
+	return nil
+}
+
+func (sm *serviceManager) listServices() ([]string, error) {
+	var s []string
+	return s, nil
+}
+
+func (sm *serviceManager) openService() (*mgr.Service, error) {
+	return nil, nil
+}

--- a/receiver/windowsservicereceiver/winservice.go
+++ b/receiver/windowsservicereceiver/winservice.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import "golang.org/x/sys/windows/svc/mgr"
+
+/**
+* Windows Service representation and associated functions. These handle
+* interacting with the SCM and martialing service information returned by the
+* windows api calls.
+**/
+
+// receiver representation of a service
+type winService struct {
+	service       *mgr.Service
+	serviceStatus uint32
+	startType     uint32
+}
+
+func getService(mgr *serviceManager, sname string) (*winService, error) {
+	return &winService{}, nil
+}
+
+func (w *winService) getStatus() error {
+	return nil
+}
+
+func (w *winService) getConfig() error {
+	return nil
+}

--- a/receiver/windowsservicereceiver/winservice_test.go
+++ b/receiver/windowsservicereceiver/winservice_test.go
@@ -1,0 +1,5 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"


### PR DESCRIPTION
#### Description
This PR adds the outline for the scraping functionality to the Windows Service receiver. This outlines the intended structure including how the receiver will access the win32 api and serialize the results. The actual implementation details will be submitted in a separate PR once the approach and framework is agreed upon.

The primary motivation for breaking the PRs up like this is to prevent scope creep and keep code light and easy to review.

#### Link to tracking issue
Fixes [38619](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38619)

#### Testing
No testing required at this point.

#### Documentation
README.md included as well as scratch notes on the components.