### PR TITLE
[receiver_creator] Fix kafkametrics receiver instantiation

### DIFF
--- a/.chloggen/receiver_creator-fix-kafkametrics-instantiation.yaml
+++ b/.chloggen/receiver_creator-fix-kafkametrics-instantiation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver_creator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix kafkametrics receiver instantiation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -158,11 +158,8 @@ func mergeTemplatedAndDiscoveredConfigs(factory rcvr.Factory, templated, discove
 			endpointConfigKey: targetEndpoint,
 		})
 		if err := endpointConfig.Unmarshal(factory.CreateDefaultConfig()); err != nil {
-			// rather than attach to error content that can change over time,
-			// confirm the error only arises w/ ErrorUnused mapstructure setting ("invalid keys")
-			if err = endpointConfig.Unmarshal(factory.CreateDefaultConfig(), confmap.WithIgnoreUnused()); err == nil {
-				delete(discovered, endpointConfigKey)
-			}
+			// we assume that the error is due to unused keys in the config, so we need to remove endpoint key
+			delete(discovered, endpointConfigKey)
 		}
 	}
 	discoveredConfig := confmap.NewFromStringMap(discovered)


### PR DESCRIPTION
#### Description
Fix dynamic start of kafka metrics receiver

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39313. The issue is caused by adding the custom unmarshaler to the kafka metrics receiver, specifically [this line](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38634/files#diff-ac118f5e10dc8be3556f9c7b192ca2a98161c1289a5a0bc9ddaa812e397acfaaR65). The extra `Unmashall` call seems to be redundant. However, it's an establish practice in other receivers. So I don't want to change that yet. The change in `receiver_creator` also resolves the problem and doesn't have any side effects.

#### Testing
Follow reproducing steps from the issue