### PR TITLE
[chore][pkg/ottl] docs: fix `ottlprofile` minimum version note

### DIFF
--- a/pkg/ottl/contexts/ottlprofile/README.md
+++ b/pkg/ottl/contexts/ottlprofile/README.md
@@ -1,7 +1,7 @@
 # Profile Context
 
 > [!NOTE]
-> This documentation applies only to version `0.121.0` and later. Information on earlier versions is not available.
+> This documentation applies only to version `0.124.0` and later. Information on earlier versions is not available.
 
 The Profile Context is a Context implementation for [pdata Profiles](https://github.com/open-telemetry/opentelemetry-collector/tree/main/pdata/pprofile), the collector's internal representation for OTLP profile data.  This Context should be used when interacted with OTLP profiles.
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The initial OTTL support for profiles was released with version `v0.124.0`, not `v0.121.0`.
