### PR TITLE
Testing changes from collector-core#12825

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -207,6 +207,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.124.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver v0.124.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver v0.124.0
@@ -270,3 +271,5 @@ providers:
 # file before passing it to OCB, to ensure that local versions are used for all
 # Contrib modules.
 replaces:
+  - go.opentelemetry.io/collector/config/confighttp => github.com/cardinalhq/opentelemetry-collector/config/confighttp v0.0.0-20250411101659-db48f79d3530
+  - go.opentelemetry.io/collector/config/configcompression => github.com/cardinalhq/opentelemetry-collector/config/configcompression v0.0.0-20250411101659-db48f79d3530

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -125,3 +125,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
+
+replace go.opentelemetry.io/collector/config/confighttp => github.com/cardinalhq/opentelemetry-collector/config/confighttp v0.0.0-20250411101659-db48f79d3530
+
+replace go.opentelemetry.io/collector/config/configcompression => github.com/cardinalhq/opentelemetry-collector/config/configcompression v0.0.0-20250411101659-db48f79d3530

--- a/receiver/prometheusremotewritereceiver/go.sum
+++ b/receiver/prometheusremotewritereceiver/go.sum
@@ -73,6 +73,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cardinalhq/opentelemetry-collector/config/configcompression v0.0.0-20250411101659-db48f79d3530 h1:pavUdrm0qcw+T6Ahj37a2Em/5JkQdfzI9fb3Xdi1jR4=
+github.com/cardinalhq/opentelemetry-collector/config/configcompression v0.0.0-20250411101659-db48f79d3530/go.mod h1:QwbNpaOl6Me+wd0EdFuEJg0Cc+WR42HNjJtdq4TwE6w=
+github.com/cardinalhq/opentelemetry-collector/config/confighttp v0.0.0-20250411101659-db48f79d3530 h1:dg/d/Zt/YX27nTbzRYpPubXHN9ycytnhBOvoEBDZv4M=
+github.com/cardinalhq/opentelemetry-collector/config/confighttp v0.0.0-20250411101659-db48f79d3530/go.mod h1:BtYNadyllgk9yyDnsvGh5vMy8tO1h7Z73A0v9yUBmmY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -446,10 +450,6 @@ go.opentelemetry.io/collector/component/componenttest v0.124.0 h1:Wsc+DmDrWTFs/a
 go.opentelemetry.io/collector/component/componenttest v0.124.0/go.mod h1:NQ4ATOzMFc7QA06B993tq8o27DR0cu/JR/zK7slGJ3E=
 go.opentelemetry.io/collector/config/configauth v0.124.0 h1:Qcu800axWnpX0xRfW+9Jyos9+GTR6m7gTIF1udEihEo=
 go.opentelemetry.io/collector/config/configauth v0.124.0/go.mod h1:Hz5PQnTvNk2yFp50rzf85H3k0MkdwEBdYUxhpRZn75E=
-go.opentelemetry.io/collector/config/configcompression v1.30.0 h1:NKbywIEfL2PBiKnm9F2X2tbPNO0WzOQY08yWmndI3uM=
-go.opentelemetry.io/collector/config/configcompression v1.30.0/go.mod h1:QwbNpaOl6Me+wd0EdFuEJg0Cc+WR42HNjJtdq4TwE6w=
-go.opentelemetry.io/collector/config/confighttp v0.124.0 h1:W75DaPeLUuGbJtX3cTXOK0b53S5zrUsh6g5UfB6Wzsw=
-go.opentelemetry.io/collector/config/confighttp v0.124.0/go.mod h1:hiTu8HFgnzSitrogLz1urQn/+FzNzarqYk4BICy/ABs=
 go.opentelemetry.io/collector/config/configopaque v1.30.0 h1:vR2UxmzLwmkmQwyh16w8MyLODKdpNVKh0L3JFOZKzQ8=
 go.opentelemetry.io/collector/config/configopaque v1.30.0/go.mod h1:GYQiC8IejBcwE8z0O4DwbBR/Hf6U7d8DTf+cszyqwFs=
 go.opentelemetry.io/collector/config/configtls v1.30.0 h1:wLTRV5hn/FWKWNjZ/9/ckkeD2mqWzAtwzP1kQv1YZZE=


### PR DESCRIPTION
This PR's intention is only to test changes made by https://github.com/open-telemetry/opentelemetry-collector/pull/12825

I've added a test that only passes if I add the replace directives, which proves it works :)
Without them, the test fails with:
```
--- FAIL: TestSnappyCompression (0.01s)
    --- FAIL: TestSnappyCompression/request_0 (0.00s)
        /Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:477: 
            	Error Trace:	/Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:477
            	Error:      	Not equal: 
            	            	expected: 204
            	            	actual  : 400
            	Test:       	TestSnappyCompression/request_0
        /Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:478: snappy: corrupt input
            
    --- FAIL: TestSnappyCompression/request_1 (0.00s)
        /Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:477: 
            	Error Trace:	/Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:477
            	Error:      	Not equal: 
            	            	expected: 204
            	            	actual  : 400
            	Test:       	TestSnappyCompression/request_1
        /Users/arthursens/Documents/projetos/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/receiver_test.go:478: snappy: corrupt input
            
FAIL
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver	0.370s
```

I've also done some manual testing, by building the collector with the remotewrite receiver and also with the replace directives. The error I used to see in Prometheus before this change:
```
time=2025-04-15T21:25:13.165Z level=ERROR source=queue_manager.go:1670 msg="non-recoverable error" component=remote remote_name=2757a8 url=http://localhost:9091/api/v1/write failedSampleCount=563 failedHistogramCount=0 failedExemplarCount=0 err="server returned HTTP status 400 Bad Request: snappy: corrupt input\n"
```

Has been replaced with a new error 🥳 
```
time=2025-04-15T21:30:56.747Z level=ERROR source=queue_manager.go:1670 msg="non-recoverable error" component=remote remote_name=2757a8 url=http://localhost:9091/api/v1/write failedSampleCount=563 failedHistogramCount=0 failedExemplarCount=0 err="server returned HTTP status 400 Bad Request: unsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_cycles_automatic_gc_cycles_total\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_cycles_forced_gc_cycles_total\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_cycles_total_gc_cycles_total\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds_sum\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_duration_seconds_count\"\nunsupported metric type \"METRIC_TYPE_UNSPECIFIED\" for metric \"go_gc_gogc_percent\"\nunsupported metric type \"METRIC"
```

Things are still not 100% correct, but at least snappy decoding is not a problem anymore :)