### PR TITLE
[chore] Add constanca-m to codeowners of translator azurelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,7 +166,7 @@ pkg/stanza/                                                      @open-telemetry
 pkg/stanza/fileconsumer/                                         @open-telemetry/collector-contrib-approvers @djaglowski @andrzej-stencel
 pkg/status/                                                      @open-telemetry/collector-contrib-approvers @mwear
 pkg/translator/azure/                                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
-pkg/translator/azurelogs/                                        @open-telemetry/collector-contrib-approvers @atoulme @cparkins @MikeGoldsmith
+pkg/translator/azurelogs/                                        @open-telemetry/collector-contrib-approvers @atoulme @cparkins @MikeGoldsmith @constanca-m
 pkg/translator/faro/                                             @open-telemetry/collector-contrib-approvers @mar4uk @rlankfo
 pkg/translator/jaeger/                                           @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                             @open-telemetry/collector-contrib-approvers @gouthamve @mar4uk

--- a/pkg/translator/azurelogs/metadata.yaml
+++ b/pkg/translator/azurelogs/metadata.yaml
@@ -1,4 +1,4 @@
 status:
   class: "pkg"
   codeowners:
-    active: [atoulme, cparkins, MikeGoldsmith]
+    active: [atoulme, cparkins, MikeGoldsmith, constanca-m]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PRs adds myself (@constanca-m) to the codeowners of the component.

Work done:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39176
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39200

Work in progress:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39340

Work planned:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39186

The company I work at (Elastic) is relying on this component in one of our products, so I plan to keep contributing to it. I hope that this change will:
- Help and improve maintenance
- Prevent breaking changes without warning
- Help collaboration between codeowners from different companies.