### PR TITLE
[receiver/k8sobjectsreceiver] Refactor Validate to only validate static config 

### DIFF
--- a/.chloggen/k8sobjectsrecevier_validate_refactor.yaml
+++ b/.chloggen/k8sobjectsrecevier_validate_refactor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sobjectsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Refactor Validate() to only validate static config without external calls to Kubernetes API server as discussed in [38851](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38851#discussion_r2046811250).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38803]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/k8sobjectsrecevier_validate_refactor.yaml
+++ b/.chloggen/k8sobjectsrecevier_validate_refactor.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: k8sobjectsreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Refactor Validate() to only validate static config without external calls to Kubernetes API server as discussed in [38851](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38851#discussion_r2046811250).
+note: Check for K8s API objects existence on receiver startup and not during config validation.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [38803]

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -2,7 +2,7 @@
 # the value `-o pipefail` (or `set -o pipefail`) is added to each shell command that make runs
 # otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause
 # test to pass in CI when they should not.
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 .SHELLFLAGS = -o pipefail -c
 
 # SRC_ROOT is the top of the source tree.

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -2,7 +2,7 @@
 # the value `-o pipefail` (or `set -o pipefail`) is added to each shell command that make runs
 # otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause
 # test to pass in CI when they should not.
-SHELL = /usr/bin/env bash
+SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
 # SRC_ROOT is the top of the source tree.

--- a/receiver/k8sobjectsreceiver/config.go
+++ b/receiver/k8sobjectsreceiver/config.go
@@ -58,28 +58,7 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	validObjects, err := c.getValidObjects()
-	if err != nil {
-		return err
-	}
 	for _, object := range c.Objects {
-		gvrs, ok := validObjects[object.Name]
-		if !ok {
-			availableResource := make([]string, len(validObjects))
-			for k := range validObjects {
-				availableResource = append(availableResource, k)
-			}
-			return fmt.Errorf("resource %v not found. Valid resources are: %v", object.Name, availableResource)
-		}
-
-		gvr := gvrs[0]
-		for i := range gvrs {
-			if gvrs[i].Group == object.Group {
-				gvr = gvrs[i]
-				break
-			}
-		}
-
 		if object.Mode == "" {
 			object.Mode = defaultMode
 		} else if _, ok := modeMap[object.Mode]; !ok {
@@ -93,8 +72,6 @@ func (c *Config) Validate() error {
 		if object.Mode == PullMode && len(object.ExcludeWatchType) != 0 {
 			return errors.New("the Exclude config can only be used with watch mode")
 		}
-
-		object.gvr = gvr
 	}
 	return nil
 }

--- a/receiver/k8sobjectsreceiver/config_test.go
+++ b/receiver/k8sobjectsreceiver/config_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiWatch "k8s.io/apimachinery/pkg/watch"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -23,9 +22,8 @@ func TestLoadConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		id          component.ID
-		expected    *Config
-		expectedErr string
+		id       component.ID
+		expected *Config
 	}{
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
@@ -40,12 +38,6 @@ func TestLoadConfig(t *testing.T) {
 						Interval:      time.Hour,
 						FieldSelector: "status.phase=Running",
 						LabelSelector: "environment in (production),tier in (frontend)",
-						exclude:       make(map[apiWatch.EventType]bool),
-						gvr: &schema.GroupVersionResource{
-							Group:    "",
-							Version:  "v1",
-							Resource: "pods",
-						},
 					},
 					{
 						Name:       "events",
@@ -54,14 +46,6 @@ func TestLoadConfig(t *testing.T) {
 						Group:      "events.k8s.io",
 						ExcludeWatchType: []apiWatch.EventType{
 							apiWatch.Deleted,
-						},
-						exclude: map[apiWatch.EventType]bool{
-							apiWatch.Deleted: true,
-						},
-						gvr: &schema.GroupVersionResource{
-							Group:    "events.k8s.io",
-							Version:  "v1",
-							Resource: "events",
 						},
 					},
 				},
@@ -79,23 +63,11 @@ func TestLoadConfig(t *testing.T) {
 						Mode:            PullMode,
 						ResourceVersion: "1",
 						Interval:        time.Hour,
-						exclude:         make(map[apiWatch.EventType]bool),
-						gvr: &schema.GroupVersionResource{
-							Group:    "",
-							Version:  "v1",
-							Resource: "pods",
-						},
 					},
 					{
 						Name:     "events",
 						Mode:     PullMode,
 						Interval: time.Hour,
-						exclude:  make(map[apiWatch.EventType]bool),
-						gvr: &schema.GroupVersionResource{
-							Group:    "events.k8s.io",
-							Version:  "v1",
-							Resource: "events",
-						},
 					},
 				},
 			},
@@ -113,12 +85,6 @@ func TestLoadConfig(t *testing.T) {
 						Namespaces:      []string{"default"},
 						Group:           "events.k8s.io",
 						ResourceVersion: "",
-						exclude:         make(map[apiWatch.EventType]bool),
-						gvr: &schema.GroupVersionResource{
-							Group:    "events.k8s.io",
-							Version:  "v1",
-							Resource: "events",
-						},
 					},
 					{
 						Name:            "events",
@@ -126,23 +92,9 @@ func TestLoadConfig(t *testing.T) {
 						Namespaces:      []string{"default"},
 						Group:           "events.k8s.io",
 						ResourceVersion: "2",
-						exclude:         make(map[apiWatch.EventType]bool),
-						gvr: &schema.GroupVersionResource{
-							Group:    "events.k8s.io",
-							Version:  "v1",
-							Resource: "events",
-						},
 					},
 				},
 			},
-		},
-		{
-			id:          component.NewIDWithName(metadata.Type, "invalid_mode"),
-			expectedErr: "invalid mode: invalid_mode",
-		},
-		{
-			id:          component.NewIDWithName(metadata.Type, "exclude_deleted_with_pull"),
-			expectedErr: "the Exclude config can only be used with watch mode",
 		},
 	}
 
@@ -158,75 +110,76 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(cfg))
 
-			err = cfg.Validate()
-			if tt.expectedErr != "" {
-				assert.EqualError(t, err, tt.expectedErr)
-				return
-			}
-
-			// Initialize exclude maps and GVR after validation
-			for i, obj := range cfg.Objects {
-				obj.exclude = make(map[apiWatch.EventType]bool)
-				for _, item := range obj.ExcludeWatchType {
-					obj.exclude[item] = true
-				}
-
-				// Set GVR based on object name and group
-				obj.gvr = &schema.GroupVersionResource{
-					Group:    obj.Group,
-					Version:  "v1",
-					Resource: obj.Name,
-				}
-				if tt.expected != nil && i < len(tt.expected.Objects) {
-					obj.gvr = tt.expected.Objects[i].gvr
-				}
-			}
-
-			assert.NoError(t, err)
 			assert.Equal(t, tt.expected.AuthType, cfg.AuthType)
 			assert.Equal(t, tt.expected.Objects, cfg.Objects)
 		})
 	}
 }
 
-func TestValidateResourceConflict(t *testing.T) {
-	rCfg := createDefaultConfig().(*Config)
-
-	// Test default mode is set when not specified
-	rCfg.Objects = []*K8sObjectsConfig{
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		desc        string
+		cfg         *Config
+		expectedErr string
+	}{
 		{
-			Name: "pods",
+			desc: "invalid mode",
+			cfg: &Config{
+				Objects: []*K8sObjectsConfig{
+					{
+						Name: "pods",
+						Mode: "invalid_mode",
+					},
+				},
+			},
+			expectedErr: "invalid mode: invalid_mode",
 		},
-	}
-
-	err := rCfg.Validate()
-	require.NoError(t, err)
-	assert.Equal(t, defaultMode, rCfg.Objects[0].Mode)
-	assert.Equal(t, defaultPullInterval, rCfg.Objects[0].Interval)
-
-	// Test pull mode with no interval gets default interval
-	rCfg.Objects = []*K8sObjectsConfig{
 		{
-			Name: "pods",
-			Mode: PullMode,
+			desc: "exclude watch type with pull mode",
+			cfg: &Config{
+				Objects: []*K8sObjectsConfig{
+					{
+						Name: "pods",
+						Mode: PullMode,
+						ExcludeWatchType: []apiWatch.EventType{
+							apiWatch.Deleted,
+						},
+					},
+				},
+			},
+			expectedErr: "the Exclude config can only be used with watch mode",
 		},
-	}
-
-	err = rCfg.Validate()
-	require.NoError(t, err)
-	assert.Equal(t, defaultPullInterval, rCfg.Objects[0].Interval)
-
-	// Test exclude watch type with pull mode returns error
-	rCfg.Objects = []*K8sObjectsConfig{
 		{
-			Name: "pods",
-			Mode: PullMode,
-			ExcludeWatchType: []apiWatch.EventType{
-				apiWatch.Deleted,
+			desc: "default mode is set",
+			cfg: &Config{
+				Objects: []*K8sObjectsConfig{
+					{
+						Name: "pods",
+					},
+				},
+			},
+		},
+		{
+			desc: "default interval for pull mode",
+			cfg: &Config{
+				Objects: []*K8sObjectsConfig{
+					{
+						Name: "pods",
+						Mode: PullMode,
+					},
+				},
 			},
 		},
 	}
 
-	err = rCfg.Validate()
-	assert.EqualError(t, err, "the Exclude config can only be used with watch mode")
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -12,7 +12,6 @@ require (
 	go.opentelemetry.io/collector/component v1.30.0
 	go.opentelemetry.io/collector/component/componenttest v0.124.0
 	go.opentelemetry.io/collector/confmap v1.30.0
-	go.opentelemetry.io/collector/confmap/xconfmap v0.124.0
 	go.opentelemetry.io/collector/consumer v1.30.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.124.0
 	go.opentelemetry.io/collector/pdata v1.30.0

--- a/receiver/k8sobjectsreceiver/receiver_test.go
+++ b/receiver/k8sobjectsreceiver/receiver_test.go
@@ -21,8 +21,11 @@ import (
 func TestNewReceiver(t *testing.T) {
 	t.Parallel()
 
+	mockClient := newMockDynamicClient()
 	rCfg := createDefaultConfig().(*Config)
-	rCfg.makeDynamicClient = newMockDynamicClient().getMockDynamicClient
+	rCfg.makeDynamicClient = mockClient.getMockDynamicClient
+	rCfg.makeDiscoveryClient = getMockDiscoveryClient
+
 	r, err := newReceiver(
 		receivertest.NewNopSettings(metadata.Type),
 		rCfg,

--- a/receiver/k8sobjectsreceiver/testdata/config.yaml
+++ b/receiver/k8sobjectsreceiver/testdata/config.yaml
@@ -2,6 +2,7 @@ k8sobjects:
   objects:
     - name: pods
       mode: pull
+      interval: 1h
       label_selector: environment in (production),tier in (frontend)
       field_selector: status.phase=Running
     - name: events
@@ -13,9 +14,11 @@ k8sobjects/pull_with_resource:
   objects:
     - name: pods
       mode: pull
+      interval: 1h
       resource_version: "1"
     - name: events
       mode: pull
+      interval: 1h
 k8sobjects/watch_with_resource:
   objects:
     - name: events

--- a/receiver/k8sobjectsreceiver/testdata/config.yaml
+++ b/receiver/k8sobjectsreceiver/testdata/config.yaml
@@ -36,3 +36,7 @@ k8sobjects/exclude_deleted_with_pull:
     - name: events
       mode: pull
       exclude_watch_type: [DELETED]
+k8sobjects/invalid_mode:
+  objects:
+    - name: pods
+      mode: invalid_mode


### PR DESCRIPTION
#### Description

Refactor Validate() to only validate static config without external calls to Kubernetes API server as discussed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38851#discussion_r2046811250

Once this is merged, the PR linked above should introduce `error_mode` implemented in `start` too.

#### Link to tracking issue
It is related to the issue and follow-up PR mentioned above, but it doesn't fix the issue.

#### Testing

I've refactored the tests in config_test.go, so we are not testing object discovery and added new tests for additional failure modes.
I've build a dev images, and validated that functionality is the same as before the refactor.

#### Documentation

This is a "breaking change" in a sense we are changing what we are validating in Validate. The new validation logic will not fail when objects are missing. The receiver will fail the same way in this case, but in `start`.