### PR TITLE
[chore] fix GH token permissions for release creation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -660,6 +660,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [lint, unittest, integration-tests]
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set Release Tag


### PR DESCRIPTION
This PR fixes an issue during the release process where the `publish-stable` pipeline job failed for the last 3 releases with an HTTP 403 ([0.123.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/14182150955/job/39731596593), [0.124.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/14457442306/job/40545089132), [0.124.1](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/14478035233/job/40609097804)).

It seems that the default `GITHUB_TOKEN` doesn't have enough permissions to create the release using the GH CLI.