### PR TITLE
[opampsupervisor] Allow the agents to start be started without receiving a remote config

### DIFF
--- a/.chloggen/supervisor-start-only-local-config.yaml
+++ b/.chloggen/supervisor-start-only-local-config.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for the opampsupervisor to be able to start with only local config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38794]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
-	koanfmaps "github.com/knadh/koanf/maps"
+	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
@@ -1796,10 +1796,10 @@ func (s *Supervisor) getTracer() trace.Tracer {
 // extension lists by concatenating the two.
 // Will be resolved by https://github.com/open-telemetry/opentelemetry-collector/issues/8754
 func configMergeFunc(src, dest map[string]any) error {
-	srcExtensions := koanfmaps.Search(src, []string{"service", "extensions"})
-	destExtensions := koanfmaps.Search(dest, []string{"service", "extensions"})
+	srcExtensions := maps.Search(src, []string{"service", "extensions"})
+	destExtensions := maps.Search(dest, []string{"service", "extensions"})
 
-	koanfmaps.Merge(src, dest)
+	maps.Merge(src, dest)
 
 	if destExt, ok := destExtensions.([]any); ok {
 		if srcExt, ok := srcExtensions.([]any); ok {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1194,7 +1194,6 @@ func (s *Supervisor) setupOwnTelemetry(_ context.Context, settings *protobufs.Co
 func (s *Supervisor) composeMergedConfig(config *protobufs.AgentRemoteConfig) (configChanged bool, err error) {
 	k := koanf.New("::")
 
-	configMapExists := config.GetConfig().GetConfigMap() != nil
 	configMapIsEmpty := len(config.GetConfig().GetConfigMap()) == 0
 
 	if !configMapIsEmpty {
@@ -1275,7 +1274,7 @@ func (s *Supervisor) composeMergedConfig(config *protobufs.AgentRemoteConfig) (c
 
 	newConfigState := &configState{
 		mergedConfig:     string(newMergedConfigBytes),
-		configMapIsEmpty: configMapExists && configMapIsEmpty,
+		configMapIsEmpty: configMapIsEmpty && config != nil,
 	}
 
 	configChanged = false

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1191,13 +1191,13 @@ func (s *Supervisor) setupOwnTelemetry(_ context.Context, settings *protobufs.Co
 // 1) the remote config from OpAMP Server
 // 2) the own metrics config section
 // 3) the local override config that is hard-coded in the Supervisor.
-func (s *Supervisor) composeMergedConfig(config *protobufs.AgentRemoteConfig) (configChanged bool, err error) {
+func (s *Supervisor) composeMergedConfig(incomingConfig *protobufs.AgentRemoteConfig) (configChanged bool, err error) {
 	k := koanf.New("::")
 
-	configMapIsEmpty := len(config.GetConfig().GetConfigMap()) == 0
+	hasIncomingConfigMap := len(incomingConfig.GetConfig().GetConfigMap()) != 0
 
-	if !configMapIsEmpty {
-		c := config.GetConfig()
+	if hasIncomingConfigMap {
+		c := incomingConfig.GetConfig()
 
 		// Sort to make sure the order of merging is stable.
 		var names []string
@@ -1274,7 +1274,7 @@ func (s *Supervisor) composeMergedConfig(config *protobufs.AgentRemoteConfig) (c
 
 	newConfigState := &configState{
 		mergedConfig:     string(newMergedConfigBytes),
-		configMapIsEmpty: configMapIsEmpty && config != nil,
+		configMapIsEmpty: (incomingConfig != nil && !hasIncomingConfigMap),
 	}
 
 	configChanged = false

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1804,7 +1805,7 @@ func configMergeFunc(src, dest map[string]any) error {
 	if destExt, ok := destExtensions.([]any); ok {
 		if srcExt, ok := srcExtensions.([]any); ok {
 			if service, ok := dest["service"].(map[string]any); ok {
-				allExt := append(destExt, srcExt...)
+				allExt := slices.Concat(destExt, srcExt)
 				// This is a small hack to ensure that the order is consitent and
 				// follows this simple rule: extensions from [src], then from [dest],
 				// in the order that they appear.

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1678,10 +1678,6 @@ func (s *Supervisor) onMessage(ctx context.Context, msg *types.MessageData) {
 
 // processRemoteConfigMessage processes an AgentRemoteConfig message, returning true if the agent config has changed.
 func (s *Supervisor) processRemoteConfigMessage(msg *protobufs.AgentRemoteConfig) bool {
-	if msg == nil {
-		return false
-	}
-
 	if err := s.saveLastReceivedConfig(msg); err != nil {
 		s.telemetrySettings.Logger.Error("Could not save last received remote config", zap.Error(err))
 	}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1678,6 +1678,10 @@ func (s *Supervisor) onMessage(ctx context.Context, msg *types.MessageData) {
 
 // processRemoteConfigMessage processes an AgentRemoteConfig message, returning true if the agent config has changed.
 func (s *Supervisor) processRemoteConfigMessage(msg *protobufs.AgentRemoteConfig) bool {
+	if msg == nil {
+		return false
+	}
+
 	if err := s.saveLastReceivedConfig(msg); err != nil {
 		s.telemetrySettings.Logger.Error("Could not save last received remote config", zap.Error(err))
 	}

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -4,7 +4,6 @@
 package supervisor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -19,6 +18,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/knadh/koanf/v2"
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -172,34 +174,6 @@ func Test_NewSupervisorFailedStorageCreation(t *testing.T) {
 }
 
 func Test_composeEffectiveConfig(t *testing.T) {
-	acceptsRemoteConfig := true
-	s := Supervisor{
-		telemetrySettings:            newNopTelemetrySettings(),
-		persistentState:              &persistentState{},
-		config:                       config.Supervisor{Capabilities: config.Capabilities{AcceptsRemoteConfig: acceptsRemoteConfig}, Agent: config.Agent{ConfigFiles: []string{"testdata/local_config1.yaml", "testdata/local_config2.yaml"}}},
-		pidProvider:                  staticPIDProvider(1234),
-		hasNewConfig:                 make(chan struct{}, 1),
-		agentConfigOwnMetricsSection: &atomic.Value{},
-		cfgState:                     &atomic.Value{},
-		agentHealthCheckEndpoint:     "localhost:8000",
-	}
-
-	agentDesc := &atomic.Value{}
-	agentDesc.Store(&protobufs.AgentDescription{
-		IdentifyingAttributes: []*protobufs.KeyValue{
-			{
-				Key: "service.name",
-				Value: &protobufs.AnyValue{
-					Value: &protobufs.AnyValue_StringValue{
-						StringValue: "otelcol",
-					},
-				},
-			},
-		},
-	})
-
-	s.agentDescription = agentDesc
-
 	fileLogConfig := `
 receivers:
   filelog:
@@ -216,26 +190,120 @@ service:
       receivers: [filelog]
       exporters: [file]`
 
-	require.NoError(t, s.createTemplates())
-	require.NoError(t, s.loadAndWriteInitialMergedConfig())
+	// load expected effective config bytes once
+	effectiveConfig, err := os.ReadFile("../testdata/collector/effective_config.yaml")
+	require.NoError(t, err)
 
-	configChanged, err := s.composeMergedConfig(&protobufs.AgentRemoteConfig{
-		Config: &protobufs.AgentConfigMap{
-			ConfigMap: map[string]*protobufs.AgentConfigFile{
-				"": {
-					Body: []byte(fileLogConfig),
+	mergedEffectiveConfig, err := os.ReadFile("./testdata/merged_effective_config.yaml")
+	require.NoError(t, err)
+
+	mergedLocalConfig, err := os.ReadFile("./testdata/merged_local_config.yaml")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                string
+		configFiles         []string
+		acceptsRemoteConfig bool
+		remoteConfig        *protobufs.AgentRemoteConfig
+		wantErr             bool
+		wantChanged         bool
+		wantConfig          []byte
+	}{
+		{
+			name:                "can accept remote config, receives one",
+			configFiles:         []string{"testdata/local_config1.yaml", "testdata/local_config2.yaml"},
+			acceptsRemoteConfig: true,
+			remoteConfig: &protobufs.AgentRemoteConfig{
+				Config: &protobufs.AgentConfigMap{
+					ConfigMap: map[string]*protobufs.AgentConfigFile{
+						"": {Body: []byte(fileLogConfig)},
+					},
 				},
 			},
+			wantErr:     false,
+			wantChanged: true,
+			wantConfig:  effectiveConfig,
 		},
-	})
-	require.NoError(t, err)
+		{
+			name:                "can accept remote config, receives none",
+			configFiles:         []string{"testdata/local_config1.yaml", "testdata/local_config2.yaml"},
+			acceptsRemoteConfig: true,
+			remoteConfig:        nil,
+			wantErr:             false,
+			wantChanged:         true,
+			wantConfig:          mergedLocalConfig,
+		},
+		{
+			name:                "cannot accept remote config, receives one",
+			configFiles:         []string{"../testdata/collector/effective_config_without_extensions.yaml"},
+			acceptsRemoteConfig: false,
+			remoteConfig: &protobufs.AgentRemoteConfig{
+				Config: &protobufs.AgentConfigMap{
+					ConfigMap: map[string]*protobufs.AgentConfigFile{
+						"": {Body: []byte(fileLogConfig)},
+					},
+				},
+			},
+			wantErr:     false,
+			wantChanged: true,
+			wantConfig:  effectiveConfig,
+		},
+		{
+			name:                "cannot accept remote config, receives none",
+			configFiles:         []string{"../testdata/collector/effective_config_without_extensions.yaml"},
+			acceptsRemoteConfig: false,
+			remoteConfig:        nil,
+			wantErr:             false,
+			wantChanged:         false,
+			wantConfig:          mergedEffectiveConfig,
+		},
+	}
 
-	expectedConfig, err := os.ReadFile("../testdata/collector/effective_config.yaml")
-	require.NoError(t, err)
-	expectedConfig = bytes.ReplaceAll(expectedConfig, []byte("\r\n"), []byte("\n"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Supervisor{
+				telemetrySettings:            newNopTelemetrySettings(),
+				persistentState:              &persistentState{},
+				config:                       config.Supervisor{Capabilities: config.Capabilities{AcceptsRemoteConfig: tt.acceptsRemoteConfig}, Agent: config.Agent{ConfigFiles: tt.configFiles}},
+				pidProvider:                  staticPIDProvider(1234),
+				hasNewConfig:                 make(chan struct{}, 1),
+				agentConfigOwnMetricsSection: &atomic.Value{},
+				cfgState:                     &atomic.Value{},
+				agentHealthCheckEndpoint:     "localhost:8000",
+			}
+			agentDesc := &atomic.Value{}
+			agentDesc.Store(&protobufs.AgentDescription{
+				IdentifyingAttributes: []*protobufs.KeyValue{
+					{
+						Key: "service.name",
+						Value: &protobufs.AnyValue{
+							Value: &protobufs.AnyValue_StringValue{StringValue: "otelcol"},
+						},
+					},
+				},
+			})
+			s.agentDescription = agentDesc
 
-	require.True(t, configChanged)
-	require.Equal(t, string(expectedConfig), s.cfgState.Load().(*configState).mergedConfig)
+			require.NoError(t, s.createTemplates())
+			require.NoError(t, s.loadAndWriteInitialMergedConfig())
+
+			changed, err := s.composeMergedConfig(tt.remoteConfig)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantChanged, changed)
+			got := s.cfgState.Load().(*configState).mergedConfig
+
+			k := koanf.New("::")
+			k.Load(rawbytes.Provider(tt.wantConfig), yaml.Parser(), koanf.WithMergeFunc(configMergeFunc))
+			gotParsed, err := k.Marshal(yaml.Parser())
+
+			require.NoError(t, err)
+			require.Equal(t, string(gotParsed), got)
+		})
+	}
 }
 
 func Test_onMessage(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -297,7 +297,9 @@ service:
 			got := s.cfgState.Load().(*configState).mergedConfig
 
 			k := koanf.New("::")
-			k.Load(rawbytes.Provider(tt.wantConfig), yaml.Parser(), koanf.WithMergeFunc(configMergeFunc))
+			err = k.Load(rawbytes.Provider(tt.wantConfig), yaml.Parser(), koanf.WithMergeFunc(configMergeFunc))
+			require.NoError(t, err)
+
 			gotParsed, err := k.Marshal(yaml.Parser())
 
 			require.NoError(t, err)

--- a/cmd/opampsupervisor/supervisor/testdata/merged_effective_config.yaml
+++ b/cmd/opampsupervisor/supervisor/testdata/merged_effective_config.yaml
@@ -1,0 +1,51 @@
+exporters:
+  file:
+    path: /test/logs/output.log
+  file/2:
+    path: ./foo
+  nop:
+extensions:
+  health_check:
+    endpoint: localhost:8000
+  opamp:
+    capabilities:
+      reports_available_components: false
+    instance_uid: 00000000-0000-0000-0000-000000000000
+    ppid: 1234
+    ppid_poll_interval: 5s
+    server:
+      ws:
+        endpoint: ws://127.0.0.1:0/v1/opamp
+        tls:
+          insecure: true
+receivers:
+  filelog:
+    include:
+      - /test/logs/input.log
+    start_at: beginning
+  journald:
+    directory: /run/log/journal
+    priority: info
+    units:
+      - ssh
+  nop:
+service:
+  extensions:
+    - health_check
+    - opamp
+  pipelines:
+    traces:
+      exporters:
+        - nop
+      receivers:
+        - nop
+    logs:
+      exporters:
+        - file
+      receivers:
+        - filelog
+  telemetry:
+    logs:
+      encoding: json
+    resource:
+      service.name: otelcol

--- a/cmd/opampsupervisor/supervisor/testdata/merged_local_config.yaml
+++ b/cmd/opampsupervisor/supervisor/testdata/merged_local_config.yaml
@@ -1,0 +1,40 @@
+exporters:
+  file/2:
+    path: ./foo
+  nop:
+extensions:
+  health_check:
+    endpoint: localhost:8000
+  opamp:
+    capabilities:
+      reports_available_components: false
+    instance_uid: 00000000-0000-0000-0000-000000000000
+    ppid: 1234
+    ppid_poll_interval: 5s
+    server:
+      ws:
+        endpoint: ws://127.0.0.1:0/v1/opamp
+        tls:
+          insecure: true
+receivers:
+  journald:
+    directory: /run/log/journal
+    priority: info
+    units:
+      - ssh
+  nop:
+service:
+  extensions:
+    - health_check
+    - opamp
+  pipelines:
+    traces:
+      exporters:
+        - nop
+      receivers:
+        - nop
+  telemetry:
+    logs:
+      encoding: json
+    resource:
+      service.name: otelcol

--- a/cmd/opampsupervisor/testdata/collector/effective_config_without_extensions.yaml
+++ b/cmd/opampsupervisor/testdata/collector/effective_config_without_extensions.yaml
@@ -1,0 +1,41 @@
+exporters:
+    file:
+        path: /test/logs/output.log
+    file/2:
+        path: ./foo
+extensions:
+    health_check:
+        endpoint: localhost:8000
+    opamp:
+        capabilities:
+            reports_available_components: false
+        instance_uid: 00000000-0000-0000-0000-000000000000
+        ppid: 1234
+        ppid_poll_interval: 5s
+        server:
+            ws:
+                endpoint: ws://127.0.0.1:0/v1/opamp
+                tls:
+                    insecure: true
+receivers:
+    filelog:
+        include:
+            - /test/logs/input.log
+        start_at: beginning
+    journald:
+        directory: /run/log/journal
+        priority: info
+        units:
+            - ssh
+service:
+    pipelines:
+        logs:
+            exporters:
+                - file
+            receivers:
+                - filelog
+    telemetry:
+        logs:
+            encoding: json
+        resource:
+            service.name: otelcol

--- a/cmd/opampsupervisor/testdata/collector/nop_config.yaml
+++ b/cmd/opampsupervisor/testdata/collector/nop_config.yaml
@@ -1,0 +1,11 @@
+receivers:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters: [nop]

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
@@ -17,3 +17,7 @@ storage:
 agent:
   executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
   health_check_port: {{ .healthcheck_port }}
+  {{- if .local_config }}
+  config_files:
+    - {{ .local_config }}
+  {{- end }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR allows the Supervisor to start agents without having received a remote configuration from the backend, which is a totally valid scenario after the addition of the local configuration feature (see #38671). 

This is achieved by setting `configMapIsEmpty` within `Supervisor.composeMergedConfig` only IF the remote config msg given to it is not `nil`. It is necessary because this method is not only called when handling remote config msgs (which guarantees they are not nil), but also when setting up "own telemetry" and processing agent identification. In these two places it is given `Supervisor.remoteConfig` -- potentially `nil` if no remote config has been received or the server has no `OffersRemoteConfig` capability.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38794. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Added unit tests covering more cases of the `Supervisor.composeMergedConfig` method and changed the test itself to use table tests.
- Added an e2e test covering the case where a Supervisor starts without last received config, with nop backend, and (valid) local configuration.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
