### PR TITLE
fix: set id when creating new consumer group handlers

### DIFF
--- a/.chloggen/set-id-when-creating-consumer-group-handlers.yaml
+++ b/.chloggen/set-id-when-creating-consumer-group-handlers.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: kafkareceiver
+issues: [39483]
+change_logs: [user]
+
+note: "`name` label will be correctly set in receiver metrics"

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -162,6 +162,7 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 		}
 	}
 	consumerGroup := &tracesConsumerGroupHandler{
+		id:                c.settings.ID,
 		logger:            c.settings.Logger,
 		encoding:          c.config.Traces.Encoding,
 		unmarshaler:       c.unmarshaler,
@@ -263,6 +264,7 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 		}
 	}
 	metricsConsumerGroup := &metricsConsumerGroupHandler{
+		id:                c.settings.ID,
 		logger:            c.settings.Logger,
 		encoding:          c.config.Metrics.Encoding,
 		unmarshaler:       c.unmarshaler,
@@ -364,6 +366,7 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 		}
 	}
 	logsConsumerGroup := &logsConsumerGroupHandler{
+		id:                c.settings.ID,
 		logger:            c.settings.Logger,
 		encoding:          c.config.Logs.Encoding,
 		unmarshaler:       c.unmarshaler,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Sets the ID correctly on the consumer group handlers so that the `name` label gets populated in created metrics.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39483