### PR TITLE
[receiver/tcplog] remove `SplitFuncBuilder` from mapstructure

### DIFF
--- a/.chloggen/tcplog-remove-function-mapstructure.yaml
+++ b/.chloggen/tcplog-remove-function-mapstructure.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: tcplogreceiver 
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix collector panic while unmarshaling configuration in opamp supervisor
+note: Ignore SplitFuncBuilder field to prevent panic during config marshaling
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [39474]

--- a/.chloggen/tcplog-remove-function-mapstructure.yaml
+++ b/.chloggen/tcplog-remove-function-mapstructure.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tcplogreceiver 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix collector panic while unmarshaling configuration in opamp supervisor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/input/tcp/config.go
+++ b/pkg/stanza/operator/input/tcp/config.go
@@ -71,7 +71,7 @@ type BaseConfig struct {
 	Encoding         string                  `mapstructure:"encoding,omitempty"`
 	SplitConfig      split.Config            `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config             `mapstructure:",squash"`
-	SplitFuncBuilder SplitFuncBuilder
+	SplitFuncBuilder SplitFuncBuilder        `mapstructure:"-"`
 }
 
 type SplitFuncBuilder func(enc encoding.Encoding) (bufio.SplitFunc, error)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `SplitFuncBuilder` field is part of the collector's effective configuration, which it shouldn't be. We can't marshal/unmarshal functions. This PR removes it.
It also solves a collector panic reported by https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39474

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39474

<!--Please delete paragraphs that you did not use before submitting.-->
