### PR TITLE
[processor/resourcedetection] Use cluster version for EKS identifier

### DIFF
--- a/.chloggen/ResourceDetectionEKS.yaml
+++ b/.chloggen/ResourceDetectionEKS.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: change the EKS cluster identifier and check the cluster version instead of the existence of aws-auth configmap
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39479]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -40,7 +40,6 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
-	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
 )
 
@@ -164,6 +163,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.32.3 // indirect
+	k8s.io/apimachinery v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect


### PR DESCRIPTION
#### Description
`-eks-` substring exists on all eks releases from what we have seen and I also verified by checking the repo https://github.com/aws/eks-distro/tree/main
This PR changes the EKS logic to check the cluster version and check if it contains the substring `_eks_` to flag the cluster as EKS.
Unit tests are updated and code cleaned up.

#### Link to tracking issue
Fixes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39479

#### Testing
Unit test
```
2025-04-18T15:44:02.285Z	info	internal/resourcedetection.go:188	detected resource information	{"resource": {"cloud.account.id":"906383545488","cloud.availability_zone":"us-west-2a","cloud.platform":"aws_eks","cloud.provider":"aws","cloud.region":"us-west-2","host.id":"i-091f2d176accf9126","host.image.id":"ami-05dbe843e7dc0237c","host.name":"ip-192-168-103-137.us-west-2.compute.internal","host.type":"c6a.large","k8s.cluster.name":"OTL-UI-Cluster","os.type":"linux"}}
```

