### PR TITLE
[cmd/opampsupervisor] Fix OpAMP Supervisor macOS example config

### DIFF
--- a/.chloggen/opampsupervisor-macos-example.yaml
+++ b/.chloggen/opampsupervisor-macos-example.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixes OpAMP Supervisor macOS example config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39492]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/examples/supervisor_darwin.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_darwin.yaml
@@ -1,11 +1,10 @@
 server:
-  endpoint: ws://127.0.0.1:4320/v1/opamp
+  endpoint: wss://127.0.0.1:4320/v1/opamp
   tls:
     # Disable verification to test locally.
     # Don't do this in production.
     insecure_skip_verify: true
     # For more TLS settings see config/configtls.ClientConfig
-    insecure: true
 
 capabilities:
   reports_effective_config: true
@@ -21,20 +20,3 @@ agent:
 
 storage:
   directory: .
-
-telemetry:
-  traces:
-    processors:
-      - simple:
-          exporter:
-            otlp:
-              protocol: http/protobuf
-              endpoint: http://localhost:4318
-  logs:
-    level: debug
-    processors:
-      - simple:
-          exporter:
-            otlp:
-              protocol: http/protobuf
-              endpoint: http://localhost:4318


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes the macOS [example config](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/ec1e5061f599d47ec17c5e4783f60e9ea3a0d1e2/cmd/opampsupervisor/examples/supervisor_darwin.yaml) and makes it consistent with the Linux and Windows configs, so that the Supervisor can successfully connect to the [go-opamp server](https://github.com/open-telemetry/opamp-go/tree/d646431dacb432f56a84111bf94c9741692f53c0/internal/examples/server).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39492

<!--Describe what testing was performed and which tests were added.-->
#### Testing

1. In [open-telemetry/opamp-go](https://github.com/open-telemetry/opamp-go):

```
cd internal/examples/server
go run .
```

2. In [open-telemetry/opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib):

```
make otelcontribcol
cd cmd/opampsupervisor
go run . --config examples/supervisor_darwin.yaml
```

<!--Please delete paragraphs that you did not use before submitting.-->
