### PR TITLE
[receiver/k8seventsreceiver] add extraction rules for labels and annotations

### DIFF
--- a/.chloggen/k8s-events-receiver-extraction-rules.yaml
+++ b/.chloggen/k8s-events-receiver-extraction-rules.yaml
@@ -1,21 +1,21 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: sqlserverreceiver
+component: k8seventsreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "`host.name`, `sqlserver.computer.name`, and `sqlserver.instance.name` are now resource attributes instead of log attributes. We used to report `computer_name` and `instance_name` in the log attributes for top query collection and they are now deprecated. Now we report the three resources attributes in both top query collection and sample query collection."
+note: Add labels and annotations extraction from event
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [39555]
+issues: [39495]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: This change is only relevant for logs.
+subtext:
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
@@ -24,4 +24,4 @@ subtext: This change is only relevant for logs.
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user]
+change_logs: ["user"]

--- a/receiver/k8seventsreceiver/README.md
+++ b/receiver/k8seventsreceiver/README.md
@@ -81,6 +81,26 @@ data:
 EOF
 ```
 
+## Extracting attributes from event labels and annotations
+
+The k8seventsreceiver can also set resource attributes from k8s labels and annotations of event.
+This config represents a list of annotations/labels that are extracted from event and added to log.
+Each item is specified as a config of an optional tag_name (representing the tag name to tag the spans with),
+key (representing the key used to extract value) or key_regex (representing the key regex used to extract the value).
+
+A few examples to use this config are as follows:
+
+```yaml
+extract:
+  annotations: # same can be applied for labels
+    - tag_name: a1 # extracts value of annotation from event with key `annotation-one` and inserts it as a tag with key `a1`
+      key: annotation-one
+    - tag_name: k8s.event.annotations.$1 # extracts value of annotation from event with key matching the regex
+      key_regex: topology.kubernetes.io/(.*)
+  labels:
+    - key: label1 # extracts value of label from event with key `label1` and inserts it as a tag with key `k8s.event.labels.label1`
+```
+
 ### Service Account
 
 Create a service account that the collector should use.

--- a/receiver/k8seventsreceiver/config.go
+++ b/receiver/k8seventsreceiver/config.go
@@ -4,6 +4,9 @@
 package k8seventsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver"
 
 import (
+	"fmt"
+	"regexp"
+
 	k8s "k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -16,12 +19,33 @@ type Config struct {
 	// List of ‘namespaces’ to collect events from.
 	Namespaces []string `mapstructure:"namespaces"`
 
+	// Extract section allows specifying extraction rules to extract
+	// data from k8s event specs
+	Extract ExtractConfig `mapstructure:"extract"`
+
 	// For mocking
 	makeClient func(apiConf k8sconfig.APIConfig) (k8s.Interface, error)
 }
 
 func (cfg *Config) Validate() error {
-	return cfg.APIConfig.Validate()
+	if err := cfg.APIConfig.Validate(); err != nil {
+		return err
+	}
+
+	for _, f := range append(cfg.Extract.Labels, cfg.Extract.Annotations...) {
+		if f.Key != "" && f.KeyRegex != "" {
+			return fmt.Errorf("Out of Key or KeyRegex only one option is expected to be configured at a time, currently Key:%s and KeyRegex:%s", f.Key, f.KeyRegex)
+		}
+
+		if f.KeyRegex != "" {
+			_, err := regexp.Compile("^(?:" + f.KeyRegex + ")$")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (cfg *Config) getK8sClient() (k8s.Interface, error) {
@@ -29,4 +53,53 @@ func (cfg *Config) getK8sClient() (k8s.Interface, error) {
 		cfg.makeClient = k8sconfig.MakeClient
 	}
 	return cfg.makeClient(cfg.APIConfig)
+}
+
+// ExtractConfig section allows specifying extraction rules to extract
+// data from k8s event specs.
+type ExtractConfig struct {
+	// Annotations allows extracting data from event annotations and record it
+	// as resource attributes.
+	// It is a list of FieldExtractConfig type. See FieldExtractConfig
+	// documentation for more details.
+	Annotations []FieldExtractConfig `mapstructure:"annotations"`
+
+	// Labels allows extracting data from event labels and record it
+	// as resource attributes.
+	// It is a list of FieldExtractConfig type. See FieldExtractConfig
+	// documentation for more details.
+	Labels []FieldExtractConfig `mapstructure:"labels"`
+}
+
+// FieldExtractConfig allows specifying an extraction rule to extract a resource attribute from event
+// annotations (or labels).
+type FieldExtractConfig struct {
+	// TagName represents the name of the resource attribute that will be added to logs, metrics or spans.
+	// When not specified, a default tag name will be used of the format:
+	//   - k8s.event.annotations.<annotation key>
+	//   - k8s.event.labels.<label key>
+	// For example, if tag_name is not specified and the key is git_sha,
+	// then the attribute name will be `k8s.event.annotations.git_sha`.
+	// When key_regex is present, tag_name supports back reference to both named capturing and positioned capturing.
+	// For example, if your event spec contains the following labels,
+	//
+	// app.kubernetes.io/component: mysql
+	// app.kubernetes.io/version: 5.7.21
+	//
+	// and you'd like to add tags for all labels with prefix app.kubernetes.io/ and also trim the prefix,
+	// then you can specify the following extraction rules:
+	//
+	// extract:
+	//   labels:
+	//     - tag_name: $$1
+	//       key_regex: kubernetes.io/(.*)
+	//
+	// this will add the `component` and `version` tags to the spans or metrics.
+	TagName string `mapstructure:"tag_name"`
+
+	// Key represents the annotation (or label) name. This must exactly match an annotation (or label) name.
+	Key string `mapstructure:"key"`
+	// KeyRegex is a regular expression used to extract a Key that matches the regex.
+	// Out of Key or KeyRegex, only one option is expected to be configured at a time.
+	KeyRegex string `mapstructure:"key_regex"`
 }

--- a/receiver/k8seventsreceiver/config_test.go
+++ b/receiver/k8seventsreceiver/config_test.go
@@ -39,6 +39,16 @@ func TestLoadConfig(t *testing.T) {
 				APIConfig: k8sconfig.APIConfig{
 					AuthType: k8sconfig.AuthTypeServiceAccount,
 				},
+				Extract: ExtractConfig{
+					Annotations: []FieldExtractConfig{
+						{TagName: "a1", Key: "annotation-one"},
+						{TagName: "a2", KeyRegex: "annotation-two"},
+					},
+					Labels: []FieldExtractConfig{
+						{TagName: "l1", Key: "label1"},
+						{TagName: "l2", KeyRegex: "label2"},
+					},
+				},
 			},
 		},
 	}

--- a/receiver/k8seventsreceiver/factory.go
+++ b/receiver/k8seventsreceiver/factory.go
@@ -40,3 +40,14 @@ func createLogsReceiver(
 
 	return newReceiver(params, rCfg, consumer)
 }
+
+func createReceiverOpts(cfg component.Config) []option {
+	oCfg := cfg.(*Config)
+	var opts []option
+
+	// extraction rules
+	opts = append(opts, withExtractLabels(oCfg.Extract.Labels...))
+	opts = append(opts, withExtractAnnotations(oCfg.Extract.Annotations...))
+
+	return opts
+}

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.124.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.30.1-0.20250422165940-c47951a8bf71
+	go.opentelemetry.io/collector/component/componentstatus v0.124.0
 	go.opentelemetry.io/collector/component/componenttest v0.124.1-0.20250422165940-c47951a8bf71
 	go.opentelemetry.io/collector/confmap v1.30.1-0.20250422165940-c47951a8bf71
 	go.opentelemetry.io/collector/confmap/xconfmap v0.124.1-0.20250422165940-c47951a8bf71

--- a/receiver/k8seventsreceiver/go.sum
+++ b/receiver/k8seventsreceiver/go.sum
@@ -258,6 +258,8 @@ go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJyS
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/collector/component v1.30.1-0.20250422165940-c47951a8bf71 h1:jH2xa8nCHwxHr++P3USryb+6tggSYdPI5BlJL0eYlCc=
 go.opentelemetry.io/collector/component v1.30.1-0.20250422165940-c47951a8bf71/go.mod h1:EJEiaSRAqhhqNmwpf4b0/ArvUV8lsXtzt15jTgXenE0=
+go.opentelemetry.io/collector/component/componentstatus v0.124.0 h1:0WHaANNktxLIk+lN+CtgPBESI1MJBrfVW/LvNCbnMQ4=
+go.opentelemetry.io/collector/component/componentstatus v0.124.0/go.mod h1:a/wa8nxJGWOGuLwCN8gHCzFHCaUVZ+VyUYuKz9Yaq38=
 go.opentelemetry.io/collector/component/componenttest v0.124.1-0.20250422165940-c47951a8bf71 h1:0H+pHKPj/f914StJb3u0yNYhuTzbW0yHtoz7UWK2tys=
 go.opentelemetry.io/collector/component/componenttest v0.124.1-0.20250422165940-c47951a8bf71/go.mod h1:UJMX3BNqdKiuLFDxfEYSspyzAcA5m8LBwXbZ7Oluqto=
 go.opentelemetry.io/collector/confmap v1.30.1-0.20250422165940-c47951a8bf71 h1:PO2WQQhKK3gQJ74o92ImcSJJsCq+lYvQb6qKu3iNdcc=

--- a/receiver/k8seventsreceiver/internal/kube/kube.go
+++ b/receiver/k8seventsreceiver/internal/kube/kube.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/kube"
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ExtractionRules is used to specify the information that needs to be extracted
+// from event and added to the spans as tags.
+type ExtractionRules struct {
+	Annotations []FieldExtractionRule
+	Labels      []FieldExtractionRule
+}
+
+// FieldExtractionRule is used to specify which fields to extract from event fields
+// and inject into spans as attributes.
+type FieldExtractionRule struct {
+	// Name is used to as the Span tag name.
+	Name string
+	// Key is used to lookup k8s event fields.
+	Key string
+	// KeyRegex is a regular expression(full length match) used to extract a Key that matches the regex.
+	KeyRegex             *regexp.Regexp
+	HasKeyRegexReference bool
+	// Regex is a regular expression used to extract a sub-part of a field value.
+	// Full value is extracted when no regexp is provided.
+	Regex *regexp.Regexp
+}
+
+func (r *FieldExtractionRule) ExtractTagsFromMetadata(metadata map[string]string, formatter string) map[string]string {
+	tags := make(map[string]string)
+	if r.KeyRegex != nil {
+		for k, v := range metadata {
+			if r.KeyRegex.MatchString(k) && v != "" {
+				var name string
+				if r.HasKeyRegexReference {
+					var result []byte
+					name = string(r.KeyRegex.ExpandString(result, r.Name, k, r.KeyRegex.FindStringSubmatchIndex(k)))
+				} else {
+					name = fmt.Sprintf(formatter, k)
+				}
+				tags[name] = v
+			}
+		}
+	} else if v, ok := metadata[r.Key]; ok {
+		tags[r.Name] = r.extractField(v)
+	}
+	return tags
+}
+
+func (r *FieldExtractionRule) extractField(v string) string {
+	// Check if a subset of the field should be extracted with a regular expression
+	// instead of the whole field.
+	if r.Regex == nil {
+		return v
+	}
+
+	matches := r.Regex.FindStringSubmatch(v)
+	if len(matches) == 2 {
+		return matches[1]
+	}
+	return ""
+}

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/kube"
 )
 
 func TestK8sEventToLogData(t *testing.T) {
@@ -49,6 +51,68 @@ func TestK8sEventToLogDataWithApiAndResourceVersion(t *testing.T) {
 	attr, ok = attrs.Get("k8s.object.resource_version")
 	assert.True(t, ok)
 	assert.Equal(t, "7387066320", attr.AsString())
+}
+
+func TestK8sEventToLogDataWithExtractionRules(t *testing.T) {
+	k8sEvent := getEvent()
+	k8sEvent.Labels["testlabel"] = "test-key-label"
+	k8sEvent.Labels["app.kubernetes.io/by-key"] = "test-key-label"
+	k8sEvent.Labels["app.kubernetes.io/by-regex"] = "test-regex-label"
+	k8sEvent.Annotations["topology.kubernetes.io/by-key"] = "test-key-annotation"
+	k8sEvent.Annotations["topology.kubernetes.io/by-regex"] = "test-regex-annotation"
+
+	labelsRules, err := ExtractFieldRules("labels",
+		FieldExtractConfig{
+			Key: "testlabel",
+		},
+		FieldExtractConfig{
+			TagName: "k8s.event.labels.label_by_key",
+			Key:     "app.kubernetes.io/by-key",
+		},
+		FieldExtractConfig{
+			TagName:  "k8s.event.labels.$1",
+			KeyRegex: "app.kubernetes.io/(.*)",
+		})
+	assert.NoError(t, err)
+
+	annotationsRules, err := ExtractFieldRules("annotations", FieldExtractConfig{
+		TagName: "k8s.event.annotations.annotation_by_key",
+		Key:     "topology.kubernetes.io/by-key",
+	}, FieldExtractConfig{
+		TagName:  "k8s.event.annotations.$1",
+		KeyRegex: "topology.kubernetes.io/(.*)",
+	})
+	assert.NoError(t, err)
+
+	ld := k8sEventToLogData(zap.NewNop(), k8sEvent, &kube.ExtractionRules{
+		Labels:      labelsRules,
+		Annotations: annotationsRules,
+	})
+	assert.NoError(t, err)
+
+	rl := ld.ResourceLogs().At(0)
+	lr := rl.ScopeLogs().At(0)
+	attrs := lr.LogRecords().At(0).Attributes()
+
+	attr, ok := attrs.Get("k8s.event.labels.testlabel")
+	assert.True(t, ok)
+	assert.Equal(t, "test-key-label", attr.AsString())
+
+	attr, ok = attrs.Get("k8s.event.labels.label_by_key")
+	assert.True(t, ok)
+	assert.Equal(t, "test-key-label", attr.AsString())
+
+	attr, ok = attrs.Get("k8s.event.labels.by-regex")
+	assert.True(t, ok)
+	assert.Equal(t, "test-regex-label", attr.AsString())
+
+	attr, ok = attrs.Get("k8s.event.annotations.annotation_by_key")
+	assert.True(t, ok)
+	assert.Equal(t, "test-key-annotation", attr.AsString())
+
+	attr, ok = attrs.Get("k8s.event.annotations.by-regex")
+	assert.True(t, ok)
+	assert.Equal(t, "test-regex-annotation", attr.AsString())
 }
 
 func TestUnknownSeverity(t *testing.T) {

--- a/receiver/k8seventsreceiver/options.go
+++ b/receiver/k8seventsreceiver/options.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8seventsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver"
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/kube"
+)
+
+// option represents a configuration option that can be passes.
+// to the k8s-tagger
+type option func(*k8seventsReceiver) error
+
+// withExtractLabels allows specifying options to control extraction of event labels.
+func withExtractLabels(labels ...FieldExtractConfig) option {
+	return func(p *k8seventsReceiver) error {
+		labels, err := ExtractFieldRules("labels", labels...)
+		if err != nil {
+			return err
+		}
+		p.rules.Labels = labels
+		return nil
+	}
+}
+
+// withExtractAnnotations allows specifying options to control extraction of event annotations tags.
+func withExtractAnnotations(annotations ...FieldExtractConfig) option {
+	return func(p *k8seventsReceiver) error {
+		annotations, err := ExtractFieldRules("annotations", annotations...)
+		if err != nil {
+			return err
+		}
+		p.rules.Annotations = annotations
+		return nil
+	}
+}
+
+func ExtractFieldRules(fieldType string, fields ...FieldExtractConfig) ([]kube.FieldExtractionRule, error) {
+	var rules []kube.FieldExtractionRule
+	for _, a := range fields {
+		name := a.TagName
+
+		if name == "" && a.Key != "" {
+			// name for KeyRegex case is set at extraction time/runtime, skipped here
+			name = fmt.Sprintf("k8s.event.%v.%v", fieldType, a.Key)
+		}
+
+		var keyRegex *regexp.Regexp
+		var hasKeyRegexReference bool
+		if a.KeyRegex != "" {
+			var err error
+			keyRegex, err = regexp.Compile("^(?:" + a.KeyRegex + ")$")
+			if err != nil {
+				return rules, err
+			}
+
+			if keyRegex.NumSubexp() > 0 {
+				hasKeyRegexReference = true
+			}
+		}
+
+		rules = append(rules, kube.FieldExtractionRule{
+			Name: name, Key: a.Key, KeyRegex: keyRegex, HasKeyRegexReference: hasKeyRegexReference,
+		})
+	}
+	return rules, nil
+}

--- a/receiver/k8seventsreceiver/options_test.go
+++ b/receiver/k8seventsreceiver/options_test.go
@@ -1,0 +1,334 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8seventsreceiver
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver/internal/kube"
+)
+
+func TestWithExtractAnnotations(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []FieldExtractConfig
+		want      []kube.FieldExtractionRule
+		wantError string
+	}{
+		{
+			"empty",
+			[]FieldExtractConfig{},
+			nil,
+			"",
+		},
+		{
+			"basic",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-node",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-event-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+		{
+			"basic-node-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &k8seventsReceiver{}
+			opt := withExtractAnnotations(tt.args...)
+			err := opt(p)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, p.rules.Annotations)
+			}
+		})
+	}
+}
+
+func TestWithExtractLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []FieldExtractConfig
+		want      []kube.FieldExtractionRule
+		wantError string
+	}{
+		{
+			"empty",
+			[]FieldExtractConfig{},
+			nil,
+			"",
+		},
+		{
+			"basic",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-node",
+			[]FieldExtractConfig{
+				{
+					TagName: "tag1",
+					Key:     "key1",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name: "tag1",
+					Key:  "key1",
+				},
+			},
+			"",
+		},
+		{
+			"basic-event-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+		{
+			"basic-node-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("^(?:key*)$"),
+				},
+			},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &k8seventsReceiver{}
+			opt := withExtractLabels(tt.args...)
+			err := opt(p)
+			if tt.wantError != "" {
+				require.EqualError(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, p.rules.Labels)
+			}
+		})
+	}
+}
+
+func Test_extractFieldRules(t *testing.T) {
+	type args struct {
+		fieldType string
+		fields    []FieldExtractConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []kube.FieldExtractionRule
+		wantErr bool
+	}{
+		{
+			name: "default",
+			args: args{"labels", []FieldExtractConfig{
+				{
+					Key: "key",
+				},
+			}},
+			want: []kube.FieldExtractionRule{
+				{
+					Name: "k8s.event.labels.key",
+					Key:  "key",
+				},
+			},
+		},
+		{
+			name: "basic",
+			args: args{"field", []FieldExtractConfig{
+				{
+					TagName: "name",
+					Key:     "key",
+				},
+			}},
+			want: []kube.FieldExtractionRule{
+				{
+					Name: "name",
+					Key:  "key",
+				},
+			},
+		},
+		{
+			name: "keyregex-capture-group",
+			args: args{"labels", []FieldExtractConfig{
+				{
+					TagName:  "$0-$1-$2",
+					KeyRegex: "(key)(.*)",
+				},
+			}},
+			want: []kube.FieldExtractionRule{
+				{
+					Name:                 "$0-$1-$2",
+					KeyRegex:             regexp.MustCompile("^(?:(key)(.*))$"),
+					HasKeyRegexReference: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractFieldRules(tt.args.fieldType, tt.args.fields...)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/receiver/k8seventsreceiver/testdata/config.yaml
+++ b/receiver/k8seventsreceiver/testdata/config.yaml
@@ -1,3 +1,14 @@
 k8s_events:
 k8s_events/all_settings:
-  namespaces: [ default, my_namespace ]
+  namespaces: [default, my_namespace]
+  extract:
+    annotations:
+      - tag_name: a1 # extracts value of annotation with key `annotation-one` and inserts it as a tag with key `a1`
+        key: annotation-one
+      - tag_name: a2 # extracts value of annotation with key `annotation-two` with regexp and inserts it as a tag with key `a2`
+        key_regex: annotation-two
+    labels:
+      - tag_name: l1 # extracts value of label with key `label1` and inserts it as a tag with key `l1`
+        key: label1
+      - tag_name: l2 # extracts value of label with key `label2` with regexp and inserts it as a tag with key `l2`
+        key_regex: label2


### PR DESCRIPTION
Inspired by k8sattributesprocessor introduce the similar configuration syntax to support labels and annotations extraction from event

#### Testing

- [x] Unit tests for configuration, event processing and rules
- [x] Manual docker image testing on kind cluster 

#### Documentation

- Updated k8seventsreceiver README with configuration examples
