### PR TITLE
[cmd/opampsupervisor] Only report applying if config is changed

### DIFF
--- a/.chloggen/fix_supervisor-dont-report-applying.yaml
+++ b/.chloggen/fix_supervisor-dont-report-applying.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "opampsupervisor"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Supervisor will no longer report a config status of "applying" if the config has not changed'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39500]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1690,7 +1690,9 @@ func (s *Supervisor) processRemoteConfigMessage(msg *protobufs.AgentRemoteConfig
 	if err != nil {
 		s.telemetrySettings.Logger.Error("Error composing merged config. Reporting failed remote config status.", zap.Error(err))
 		s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
-	} else {
+	}
+	if configChanged {
+		// only report applying if the config has changed and will run agent with new config
 		s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLYING, "")
 	}
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -827,7 +827,7 @@ service:
 
 		remoteConfigStatusUpdated := false
 		mc := &mockOpAMPClient{
-			setRemoteConfigStatusFunc: func(rcs *protobufs.RemoteConfigStatus) error {
+			setRemoteConfigStatusFunc: func(_ *protobufs.RemoteConfigStatus) error {
 				remoteConfigStatusUpdated = true
 				return nil
 			},
@@ -864,7 +864,7 @@ service:
 		})
 
 		// initially write & store config so that we have the same config when we send the remote config message
-		err := os.WriteFile(filepath.Join(configStorageDir, lastRecvRemoteConfigFile), []byte(testConfigMessage), 0644)
+		err := os.WriteFile(filepath.Join(configStorageDir, lastRecvRemoteConfigFile), []byte(testConfigMessage), 0o600)
 		require.NoError(t, err)
 
 		s.cfgState.Store(&configState{

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -783,6 +783,107 @@ service:
 		assert.Nil(t, s.cfgState.Load())
 		assert.True(t, remoteConfigStatusUpdated)
 	})
+	t.Run("RemoteConfig - Don't report status if config is not changed", func(t *testing.T) {
+		const testConfigMessage = `receivers:
+  debug:`
+
+		const expectedMergedConfig = `extensions:
+    health_check:
+        endpoint: localhost:8000
+    opamp:
+        capabilities:
+            reports_available_components: false
+        instance_uid: 018fee23-4a51-7303-a441-73faed7d9deb
+        ppid: 88888
+        ppid_poll_interval: 5s
+        server:
+            ws:
+                endpoint: ws://127.0.0.1:0/v1/opamp
+                tls:
+                    insecure: true
+receivers:
+    debug: null
+service:
+    extensions:
+        - health_check
+        - opamp
+    telemetry:
+        logs:
+            encoding: json
+        resource: null
+`
+
+		// the remote config message we will send that will get merged and compared with the initial config
+		remoteConfig := &protobufs.AgentRemoteConfig{
+			Config: &protobufs.AgentConfigMap{
+				ConfigMap: map[string]*protobufs.AgentConfigFile{
+					"": {
+						Body: []byte(testConfigMessage),
+					},
+				},
+			},
+			ConfigHash: []byte("hash"),
+		}
+
+		remoteConfigStatusUpdated := false
+		mc := &mockOpAMPClient{
+			setRemoteConfigStatusFunc: func(rcs *protobufs.RemoteConfigStatus) error {
+				remoteConfigStatusUpdated = true
+				return nil
+			},
+		}
+
+		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
+		configStorageDir := t.TempDir()
+		s := Supervisor{
+			telemetrySettings: newNopTelemetrySettings(),
+			pidProvider:       staticPIDProvider(88888),
+			config: config.Supervisor{
+				Storage: config.Storage{
+					Directory: configStorageDir,
+				},
+			},
+			hasNewConfig:                 make(chan struct{}, 1),
+			persistentState:              &persistentState{InstanceID: testUUID},
+			agentConfigOwnMetricsSection: &atomic.Value{},
+			effectiveConfig:              &atomic.Value{},
+			opampClient:                  mc,
+			agentDescription:             &atomic.Value{},
+			cfgState:                     &atomic.Value{},
+			agentHealthCheckEndpoint:     "localhost:8000",
+			customMessageToServer:        make(chan *protobufs.CustomMessage, 10),
+			doneChan:                     make(chan struct{}),
+		}
+
+		require.NoError(t, s.createTemplates())
+
+		// need to set the agent description as part of initialization
+		s.agentDescription.Store(&protobufs.AgentDescription{
+			IdentifyingAttributes:    []*protobufs.KeyValue{},
+			NonIdentifyingAttributes: []*protobufs.KeyValue{},
+		})
+
+		// initially write & store config so that we have the same config when we send the remote config message
+		err := os.WriteFile(filepath.Join(configStorageDir, lastRecvRemoteConfigFile), []byte(testConfigMessage), 0644)
+		require.NoError(t, err)
+
+		s.cfgState.Store(&configState{
+			mergedConfig:     expectedMergedConfig,
+			configMapIsEmpty: false,
+		})
+
+		s.onMessage(context.Background(), &types.MessageData{
+			RemoteConfig: remoteConfig,
+		})
+
+		// assert the remote config status callback was not called
+		assert.False(t, remoteConfigStatusUpdated)
+		// assert the config file and stored data are still the same
+		fileContent, err := os.ReadFile(filepath.Join(configStorageDir, lastRecvRemoteConfigFile))
+		require.NoError(t, err)
+		assert.Contains(t, string(fileContent), testConfigMessage)
+		assert.Equal(t, expectedMergedConfig, s.cfgState.Load().(*configState).mergedConfig)
+	})
 }
 
 func Test_handleAgentOpAMPMessage(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Right now, the Supervisor will always report to the OpAMP server an "Applying" status when it receives a remote config (assuming there's no issue building the merged config). This is a problem because if the new config is not different from the current config, the Supervisor never restarts the Collector with the new config and the status "Applied" is never reported to the server.

This change makes it so the Supervisor only reports the "Applying" status to the OpAMP server if the new config is different from the current and we intend to apply and restart the Collector.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
