### PR TITLE
[cmd/opampsupervisor] The previously unused server.endpoint option has been enabled. 

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -728,9 +728,12 @@ func (s *Supervisor) startOpAMPServer() error {
 	s.telemetrySettings.Logger.Debug("Starting OpAMP server...")
 
 	connected := &atomic.Bool{}
-
+	opampEndpoint, err := url.Parse(s.config.Server.Endpoint)
+	if err != nil {
+		return err
+	}
 	err = s.opampServer.Start(flattenedSettings{
-		endpoint: fmt.Sprintf("localhost:%d", s.opampServerPort),
+		endpoint: opampEndpoint.Host,
 		onConnecting: func(_ *http.Request) (bool, int) {
 			// Only allow one agent to be connected the this server at a time.
 			alreadyConnected := connected.Swap(true)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The server.endpoint was always provided but was not being used. Additionally, although it was specified together with the scheme, an error occurs in opampServer.Start if the scheme is included, so only the Hostname is used.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A
Fixes
N/A
<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A
<!--Describe the documentation added.-->
#### Documentation
N/A
<!--Please delete paragraphs that you did not use before submitting.-->
