### PR TITLE
[extension/opamp] Load TLS config only for wss and https endpoints

### DIFF
--- a/.chloggen/opampextension-conditional-tls.yaml
+++ b/.chloggen/opampextension-conditional-tls.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skips loading TLS config for insecure endpoints
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39515]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -4,7 +4,10 @@
 package opampextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension"
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -143,7 +146,21 @@ func (s OpAMPServer) GetHeaders() map[string]configopaque.String {
 	return map[string]configopaque.String{}
 }
 
-func (s OpAMPServer) GetTLSSetting() configtls.ClientConfig {
+// GetTLSConfig returns a TLS config if the endpoint is secure (wss or https)
+func (s OpAMPServer) GetTLSConfig(ctx context.Context) (*tls.Config, error) {
+	parsedURL, err := url.Parse(s.GetEndpoint())
+	if err != nil {
+		return nil, fmt.Errorf("parse server endpoint: %w", err)
+	}
+
+	if parsedURL.Scheme != "wss" && parsedURL.Scheme != "https" {
+		return nil, nil
+	}
+
+	return s.getTLSSetting().LoadTLSConfig(ctx)
+}
+
+func (s OpAMPServer) getTLSSetting() configtls.ClientConfig {
 	if s.WS != nil {
 		return s.WS.TLSSetting
 	} else if s.HTTP != nil {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -110,7 +110,7 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 		header.Set(k, string(v))
 	}
 
-	tls, err := o.cfg.Server.GetTLSSetting().LoadTLSConfig(ctx)
+	tls, err := o.cfg.Server.GetTLSConfig(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Loads TLS config for the OpAMP Extension's OpAMP agent only if the `server::ws::endpoint`/`server::http::endpoint` config is set to a URL with scheme `wss`/`https`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39515

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added unit tests
- Tested manually with the steps described in **Steps to Reproduce** in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39515

<!--Please delete paragraphs that you did not use before submitting.-->
