### PR TITLE
Revert "[chore] do not fetch the whole repository when running CI"

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
+          fetch-depth: 0
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
           go-version: "1.23.8"

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
+          fetch-depth: 0
       - name: Get changed files
         id: changes
         run: |
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
+          fetch-depth: 0
       - name: Did windows files changed
         run: echo "changed=$(./.github/workflows/scripts/is_changed_file_windows.sh )" >> "$GITHUB_OUTPUT"
       - run: echo $(./.github/workflows/scripts/is_changed_file_windows.sh ${{ github.event.pull_request.base.sha }} ${{ github.sha }} )

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 1 }}
+          fetch-depth: 0
 
       - name: Get changes
         shell: bash


### PR DESCRIPTION
This appears to be causing CI failures. See comments on #38756