### PR TITLE
[processor/datadogsemantics] Clean up datadogsemanticsprocessor traces code

### DIFF
--- a/processor/datadogsemanticsprocessor/processor.go
+++ b/processor/datadogsemanticsprocessor/processor.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"strings"
+
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/processor/datadogsemanticsprocessor/processor.go
+++ b/processor/datadogsemanticsprocessor/processor.go
@@ -9,9 +9,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"

--- a/processor/datadogsemanticsprocessor/processor.go
+++ b/processor/datadogsemanticsprocessor/processor.go
@@ -7,17 +7,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
-	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
-func insertAttrIfMissing(sattr pcommon.Map, key string, value any) (err error) {
-	if _, ok := sattr.Get(key); !ok {
+func (tp *tracesProcessor) insertAttrIfMissingOrShouldOverride(sattr pcommon.Map, key string, value any) (err error) {
+	if _, ok := sattr.Get(key); tp.overrideIncomingDatadogFields || !ok {
 		switch v := value.(type) {
 		case string:
 			sattr.PutStr(key, v)
@@ -37,74 +37,73 @@ func (tp *tracesProcessor) processTraces(ctx context.Context, td ptrace.Traces) 
 		otelres := rspan.Resource()
 		rattr := otelres.Attributes()
 		for j := 0; j < rspan.ScopeSpans().Len(); j++ {
+			if service := traceutil.GetOTelService(otelres, true); service != "" {
+				if err = tp.insertAttrIfMissingOrShouldOverride(rattr, "datadog.service", service); err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+			if serviceVersion, ok := otelres.Attributes().Get(semconv.AttributeServiceVersion); ok {
+				if err = tp.insertAttrIfMissingOrShouldOverride(rattr, "datadog.version", serviceVersion.AsString()); err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+			if env := traceutil.GetOTelEnv(otelres); env != "" {
+				if err = tp.insertAttrIfMissingOrShouldOverride(rattr, "datadog.env", env); err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+
+			if tp.overrideIncomingDatadogFields {
+				rattr.Remove("datadog.host.name")
+			}
+
+			if src, ok := tp.attrsTranslator.ResourceToSource(ctx, otelres, traceutil.SignalTypeSet, nil); ok && src.Kind == source.HostnameKind {
+				if err = tp.insertAttrIfMissingOrShouldOverride(rattr, "datadog.host.name", src.Identifier); err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+
 			libspans := rspan.ScopeSpans().At(j)
 			for k := 0; k < libspans.Spans().Len(); k++ {
 				otelspan := libspans.Spans().At(k)
 				sattr := otelspan.Attributes()
-				if tp.overrideIncomingDatadogFields {
-					sattr.RemoveIf(func(k string, _ pcommon.Value) bool {
-						return strings.HasPrefix(k, "datadog.")
-					})
-					if ddHostname, ok := rattr.Get("datadog.host.name"); ok && ddHostname.AsString() == "" {
-						rattr.Remove("datadog.host.name")
-					}
-				}
-				if err = insertAttrIfMissing(sattr, "datadog.service", traceutil.GetOTelService(otelres, true)); err != nil {
-					return ptrace.Traces{}, err
-				}
-				if err = insertAttrIfMissing(sattr, "datadog.name", traceutil.GetOTelOperationNameV2(otelspan)); err != nil {
-					return ptrace.Traces{}, err
-				}
-				if err = insertAttrIfMissing(sattr, "datadog.resource", traceutil.GetOTelResourceV2(otelspan, otelres)); err != nil {
-					return ptrace.Traces{}, err
-				}
-				if err = insertAttrIfMissing(sattr, "datadog.type", traceutil.GetOTelSpanType(otelspan, otelres)); err != nil {
-					return ptrace.Traces{}, err
-				}
-				if src, ok := tp.attrsTranslator.ResourceToSource(ctx, otelres, traceutil.SignalTypeSet, nil); ok && src.Kind == source.HostnameKind {
-					if err = insertAttrIfMissing(otelres.Attributes(), "datadog.host.name", src.Identifier); err != nil {
-						return ptrace.Traces{}, err
-					}
-				}
 
+				if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.name", traceutil.GetOTelOperationNameV2(otelspan)); err != nil {
+					return ptrace.Traces{}, err
+				}
+				if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.resource", traceutil.GetOTelResourceV2(otelspan, otelres)); err != nil {
+					return ptrace.Traces{}, err
+				}
+				if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.type", traceutil.GetOTelSpanType(otelspan, otelres)); err != nil {
+					return ptrace.Traces{}, err
+				}
 				spanKind := otelspan.Kind()
-				if err = insertAttrIfMissing(sattr, "datadog.span.kind", traceutil.OTelSpanKindName(spanKind)); err != nil {
+				if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.span.kind", traceutil.OTelSpanKindName(spanKind)); err != nil {
 					return ptrace.Traces{}, err
 				}
-				if env := traceutil.GetOTelEnv(otelres); env != "" {
-					if err = insertAttrIfMissing(sattr, "datadog.env", env); err != nil {
-						return ptrace.Traces{}, err
-					}
-				}
-				if serviceVersion, ok := otelres.Attributes().Get(semconv.AttributeServiceVersion); ok {
-					if err = insertAttrIfMissing(sattr, "datadog.version", serviceVersion.AsString()); err != nil {
-						return ptrace.Traces{}, err
-					}
-				}
-
 				metaMap := make(map[string]string)
 				code := traceutil.GetOTelStatusCode(otelspan)
 				if code != 0 {
-					if err = insertAttrIfMissing(sattr, "datadog.http_status_code", fmt.Sprintf("%d", code)); err != nil {
+					if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.http_status_code", fmt.Sprintf("%d", code)); err != nil {
 						return ptrace.Traces{}, err
 					}
 				}
 				ddError := int64(status2Error(otelspan.Status(), otelspan.Events(), metaMap))
-				if err = insertAttrIfMissing(sattr, "datadog.error", ddError); err != nil {
+				if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.error", ddError); err != nil {
 					return ptrace.Traces{}, err
 				}
 				if metaMap["error.msg"] != "" {
-					if err = insertAttrIfMissing(sattr, "datadog.error.msg", metaMap["error.msg"]); err != nil {
+					if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.error.msg", metaMap["error.msg"]); err != nil {
 						return ptrace.Traces{}, err
 					}
 				}
 				if metaMap["error.type"] != "" {
-					if err = insertAttrIfMissing(sattr, "datadog.error.type", metaMap["error.type"]); err != nil {
+					if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.error.type", metaMap["error.type"]); err != nil {
 						return ptrace.Traces{}, err
 					}
 				}
 				if metaMap["error.stack"] != "" {
-					if err = insertAttrIfMissing(sattr, "datadog.error.stack", metaMap["error.stack"]); err != nil {
+					if err = tp.insertAttrIfMissingOrShouldOverride(sattr, "datadog.error.stack", metaMap["error.stack"]); err != nil {
 						return ptrace.Traces{}, err
 					}
 				}

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -5,8 +5,9 @@ package datadogsemanticsprocessor
 
 import (
 	"context"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 	"github.com/stretchr/testify/assert"

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -5,6 +5,7 @@ package datadogsemanticsprocessor
 
 import (
 	"context"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
@@ -104,6 +105,12 @@ func TestNilBatch(t *testing.T) {
 	m.assertBatchesLen(1)
 }
 
+func assertKeyInAttributesMatchesValue(t *testing.T, attr pcommon.Map, key string, expected string) {
+	v, ok := attr.Get(key)
+	require.True(t, ok)
+	require.Equal(t, expected, v.AsString())
+}
+
 func TestBasicTranslation(t *testing.T) {
 	tests := []struct {
 		name                          string
@@ -143,35 +150,27 @@ func TestBasicTranslation(t *testing.T) {
 			},
 			fn: func(out *ptrace.Traces) {
 				rs := out.ResourceSpans().At(0)
-				res := rs.Resource()
-				span := rs.ScopeSpans().At(0).Spans().At(0)
-				ddservice, _ := span.Attributes().Get("datadog.service")
-				require.Equal(t, "test-service", ddservice.AsString())
-				ddname, _ := span.Attributes().Get("datadog.name")
-				require.Equal(t, "test-operation", ddname.AsString())
-				ddresource, _ := span.Attributes().Get("datadog.resource")
-				require.Equal(t, "test-resource", ddresource.AsString())
-				ddType, _ := span.Attributes().Get("datadog.type")
-				require.Equal(t, "web", ddType.AsString())
-				ddSpanKind, _ := span.Attributes().Get("datadog.span.kind")
-				require.Equal(t, "server", ddSpanKind.AsString())
-				env, _ := span.Attributes().Get("datadog.env")
-				require.Equal(t, "spanenv2", env.AsString())
-				version, _ := span.Attributes().Get("datadog.version")
-				require.Equal(t, "v2", version.AsString())
-				statusCode, _ := span.Attributes().Get("datadog.http_status_code")
-				require.Equal(t, "200", statusCode.AsString())
-				ddError, _ := span.Attributes().Get("datadog.error")
-				require.Equal(t, int64(0), ddError.Int())
-				_, ok := span.Attributes().Get("datadog.error.msg")
-				require.False(t, ok)
-				_, ok = span.Attributes().Get("datadog.error.type")
-				require.False(t, ok)
-				_, ok = span.Attributes().Get("datadog.error.stack")
-				require.False(t, ok)
+				rattr := rs.Resource().Attributes()
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.service", "test-service")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.env", "spanenv2")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.version", "v2")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.host.name", "test-host-name")
 
-				ddHost, _ := res.Attributes().Get("datadog.host.name")
-				require.Equal(t, "test-host-name", ddHost.AsString())
+				span := rs.ScopeSpans().At(0).Spans().At(0)
+				sattr := span.Attributes()
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.name", "test-operation")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.resource", "test-resource")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.type", "web")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.span.kind", "server")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.http_status_code", "200")
+				ddError, _ := sattr.Get("datadog.error")
+				require.Equal(t, int64(0), ddError.Int())
+				_, ok := sattr.Get("datadog.error.msg")
+				require.False(t, ok)
+				_, ok = sattr.Get("datadog.error.type")
+				require.False(t, ok)
+				_, ok = sattr.Get("datadog.error.stack")
+				require.False(t, ok)
 			},
 		},
 		{
@@ -186,7 +185,9 @@ func TestBasicTranslation(t *testing.T) {
 						"resource.name":               "test-resource",
 						"deployment.environment.name": "spanenv2",
 						"host.name":                   "overridden-host-name",
-						"datadog.host.name":           "",
+						"datadog.host.name":           "specified-host-name",
+						"datadog.version":             "specified-version",
+						"service.version":             "overridden-version",
 					},
 					Spans: []*testutil.OTLPSpan{
 						{
@@ -216,7 +217,6 @@ func TestBasicTranslation(t *testing.T) {
 								"datadog.host.name":             "specified-hostname",
 								"datadog.span.kind":             "specified-span-kind",
 								"datadog.env":                   "specified-env",
-								"datadog.version":               "specified-version",
 								"datadog.http_status_code":      "500",
 								"datadog.error":                 1,
 								"datadog.error.msg":             "specified-error-msg",
@@ -231,30 +231,24 @@ func TestBasicTranslation(t *testing.T) {
 			},
 			fn: func(out *ptrace.Traces) {
 				rs := out.ResourceSpans().At(0)
-				span := rs.ScopeSpans().At(0).Spans().At(0)
-				ddservice, _ := span.Attributes().Get("datadog.service")
-				require.Equal(t, "test-service", ddservice.AsString())
-				ddname, _ := span.Attributes().Get("datadog.name")
-				require.Equal(t, "test-operation", ddname.AsString())
-				ddresource, _ := span.Attributes().Get("datadog.resource")
-				require.Equal(t, "test-resource", ddresource.AsString())
-				ddType, _ := span.Attributes().Get("datadog.type")
-				require.Equal(t, "web", ddType.AsString())
-				env, _ := span.Attributes().Get("datadog.env")
-				require.Equal(t, "spanenv2", env.AsString())
-				statusCode, _ := span.Attributes().Get("datadog.http_status_code")
-				require.Equal(t, "200", statusCode.AsString())
-				ddError, _ := span.Attributes().Get("datadog.error")
-				require.Equal(t, int64(1), ddError.Int())
-				ddErrorMsg, _ := span.Attributes().Get("datadog.error.msg")
-				require.Equal(t, "overridden-msg", ddErrorMsg.AsString())
-				ddErrorType, _ := span.Attributes().Get("datadog.error.type")
-				require.Equal(t, "overridden-type", ddErrorType.AsString())
-				ddErrorStack, _ := span.Attributes().Get("datadog.error.stack")
-				require.Equal(t, "overridden-stack", ddErrorStack.AsString())
+				rattr := rs.Resource().Attributes()
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.service", "test-service")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.env", "spanenv2")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.version", "overridden-version")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.host.name", "overridden-host-name")
 
-				ddHost, _ := rs.Resource().Attributes().Get("datadog.host.name")
-				require.Equal(t, "overridden-host-name", ddHost.AsString())
+				span := rs.ScopeSpans().At(0).Spans().At(0)
+				sattr := span.Attributes()
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.name", "test-operation")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.resource", "test-resource")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.type", "web")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.span.kind", "server")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.http_status_code", "200")
+				ddError, _ := sattr.Get("datadog.error")
+				require.Equal(t, int64(1), ddError.Int())
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.msg", "overridden-msg")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.type", "overridden-type")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.stack", "overridden-stack")
 			},
 		},
 		{
@@ -265,6 +259,9 @@ func TestBasicTranslation(t *testing.T) {
 					LibName:    "libname",
 					LibVersion: "1.2",
 					Attributes: map[string]any{
+						"datadog.service":             "specified-service",
+						"datadog.env":                 "specified-env",
+						"datadog.version":             "specified-version",
 						"service.name":                "test-service",
 						"resource.name":               "test-resource",
 						"deployment.environment.name": "spanenv2",
@@ -292,13 +289,10 @@ func TestBasicTranslation(t *testing.T) {
 							ParentID:   [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
 							Kind:       ptrace.SpanKindServer,
 							Attributes: map[string]any{
-								"datadog.service":               "specified-service",
 								"datadog.resource":              "specified-resource",
 								"datadog.name":                  "specified-operation",
 								"datadog.type":                  "specified-type",
 								"datadog.span.kind":             "specified-span-kind",
-								"datadog.env":                   "specified-env",
-								"datadog.version":               "specified-version",
 								"datadog.http_status_code":      "500",
 								"datadog.error":                 1,
 								"datadog.error.msg":             "specified-error-msg",
@@ -313,30 +307,24 @@ func TestBasicTranslation(t *testing.T) {
 			},
 			fn: func(out *ptrace.Traces) {
 				rs := out.ResourceSpans().At(0)
-				span := rs.ScopeSpans().At(0).Spans().At(0)
-				ddservice, _ := span.Attributes().Get("datadog.service")
-				require.Equal(t, "specified-service", ddservice.AsString())
-				ddname, _ := span.Attributes().Get("datadog.name")
-				require.Equal(t, "specified-operation", ddname.AsString())
-				ddresource, _ := span.Attributes().Get("datadog.resource")
-				require.Equal(t, "specified-resource", ddresource.AsString())
-				ddType, _ := span.Attributes().Get("datadog.type")
-				require.Equal(t, "specified-type", ddType.AsString())
-				env, _ := span.Attributes().Get("datadog.env")
-				require.Equal(t, "specified-env", env.AsString())
-				statusCode, _ := span.Attributes().Get("datadog.http_status_code")
-				require.Equal(t, "500", statusCode.AsString())
-				ddError, _ := span.Attributes().Get("datadog.error")
-				require.Equal(t, int64(1), ddError.Int())
-				ddErrorMsg, _ := span.Attributes().Get("datadog.error.msg")
-				require.Equal(t, "specified-error-msg", ddErrorMsg.AsString())
-				ddErrorType, _ := span.Attributes().Get("datadog.error.type")
-				require.Equal(t, "specified-error-type", ddErrorType.AsString())
-				ddErrorStack, _ := span.Attributes().Get("datadog.error.stack")
-				require.Equal(t, "specified-error-stack", ddErrorStack.AsString())
+				rattr := rs.Resource().Attributes()
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.service", "specified-service")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.env", "specified-env")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.version", "specified-version")
+				assertKeyInAttributesMatchesValue(t, rattr, "datadog.host.name", "")
 
-				ddHost, _ := rs.Resource().Attributes().Get("datadog.host.name")
-				require.Empty(t, ddHost.AsString())
+				span := rs.ScopeSpans().At(0).Spans().At(0)
+				sattr := span.Attributes()
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.name", "specified-operation")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.resource", "specified-resource")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.type", "specified-type")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.span.kind", "specified-span-kind")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.http_status_code", "500")
+				ddError, _ := sattr.Get("datadog.error")
+				require.Equal(t, int64(1), ddError.Int())
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.msg", "specified-error-msg")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.type", "specified-error-type")
+				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.stack", "specified-error-stack")
 			},
 		},
 	}

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Clean up code for traces in datadogsemanticsprocessor.

Small functionality changes:
- If there are fields that start with `datadog.*` that aren't set by the processor, the "overrideIncomingDatadogFields" option would remove them in the previous version. This is no longer the case, they will get left alone.
- "datadog.[service|env|version]" are now written to resource attributes instead of span attributes. This write only happens once.
- Changed override logic for `datadog.host.name` to align with other fields. in the previous version, the value in `datadog.host.name` was respected even if "overrideIncomingDatadogFields" is set, which is different than all other `datadog.*` namespaced attributes. The rationale was that `datadog.host.name` is a canonical way to set host name outside of the processor, so it should work regardless of the override setting - however, it would be confusing for this one attribute to be different, and it's fair to assume users know what they're doing if they opt in to `overrideIncomingDatadogFields`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Changed unit tests and verified by running processor locally

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
