### PR TITLE
[extension/oidcauthextension] oidc ignore client/audience support

### DIFF
--- a/.chloggen/oidc-ignore-audience.yaml
+++ b/.chloggen/oidc-ignore-audience.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oidcauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ignore_audience config option for ignoring oidc audience
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36568]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: go-oidc SkipClientIDCheck is set based on config ignore_audience
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -14,8 +14,12 @@ type Config struct {
 
 	// Audience of the token, used during the verification.
 	// For example: "https://accounts.google.com" or "https://login.salesforce.com".
-	// Required.
+	// Required unless IgnoreAudience is true.
 	Audience string `mapstructure:"audience"`
+
+	// When true, this skips validating the audience field.
+	// Optional.
+	IgnoreAudience bool `mapstructure:"ignore_audience"`
 
 	// The local path for the issuer CA's TLS server cert.
 	// Optional.
@@ -31,7 +35,7 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-	if c.Audience == "" {
+	if c.Audience == "" && !c.IgnoreAudience {
 		return errNoAudienceProvided
 	}
 	if c.IssuerURL == "" {

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -68,7 +68,8 @@ func (e *oidcExtension) Start(ctx context.Context, _ component.Host) error {
 		return fmt.Errorf("failed to get configuration from the auth server: %w", err)
 	}
 	e.verifier = e.provider.Verifier(&oidc.Config{
-		ClientID: e.cfg.Audience,
+		ClientID:          e.cfg.Audience,
+		SkipClientIDCheck: e.cfg.IgnoreAudience,
 	})
 	return nil
 }

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -79,6 +79,76 @@ func TestOIDCAuthenticationSucceeded(t *testing.T) {
 	// TODO(jpkroehling): assert that the authentication routine set the subject/membership to the resource
 }
 
+func TestOIDCAuthenticationSucceededIgnoreAudienceMismatch(t *testing.T) {
+	// prepare
+	oidcServer, err := newOIDCServer()
+	require.NoError(t, err)
+	oidcServer.Start()
+	defer oidcServer.Close()
+
+	config := &Config{
+		IssuerURL:      oidcServer.URL,
+		Audience:       "unit-test",
+		IgnoreAudience: true,
+	}
+	p := newTestExtension(t, config)
+
+	err = p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]any{
+		"iss": oidcServer.URL,
+		"aud": "not-unit-test",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+	token, err := oidcServer.token(payload)
+	require.NoError(t, err)
+
+	srvAuth, ok := p.(extensionauth.Server)
+	require.True(t, ok)
+
+	// test
+	ctx, err := srvAuth.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+
+	// verify
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+}
+
+func TestOIDCAuthenticationFailAudienceMismatch(t *testing.T) {
+	// prepare
+	oidcServer, err := newOIDCServer()
+	require.NoError(t, err)
+	oidcServer.Start()
+	defer oidcServer.Close()
+
+	config := &Config{
+		IssuerURL: oidcServer.URL,
+		Audience:  "unit-test",
+	}
+	p := newTestExtension(t, config)
+
+	err = p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]any{
+		"iss": oidcServer.URL,
+		"aud": "not-unit-test",
+		"exp": time.Now().Add(time.Minute).Unix(),
+	})
+	token, err := oidcServer.token(payload)
+	require.NoError(t, err)
+
+	srvAuth, ok := p.(extensionauth.Server)
+	require.True(t, ok)
+
+	// test
+	_, err = srvAuth.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+
+	// verify
+	assert.Error(t, err)
+}
+
 func TestOIDCProviderForConfigWithTLS(t *testing.T) {
 	// prepare the CA cert for the TLS handler
 	cert := x509.Certificate{
@@ -439,6 +509,20 @@ func TestMissingClient(t *testing.T) {
 
 	// verify
 	assert.Equal(t, errNoAudienceProvided, err)
+}
+
+func TestIgnoreMissingClient(t *testing.T) {
+	// prepare
+	config := &Config{
+		IssuerURL:      "http://example.com/",
+		IgnoreAudience: true,
+	}
+
+	// test
+	err := config.Validate()
+
+	// verify
+	assert.NoError(t, err)
 }
 
 func TestMissingIssuerURL(t *testing.T) {


### PR DESCRIPTION
A second attempt after my neglect of this old [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36569).
I do apologize for the inconvenience.
Finally got the CLA figured out! Made a draft PR first this time to check.

Adds support for ignoring the audience/clientid in OIDC.
go-oidc has a [config option](https://github.com/coreos/go-oidc/blob/v3/oidc/verify.go#L94) for this, and the PR lets the collector use it.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36568

I built a custom collector, and tested with a couple of aws cognito app id / client ids and JWTs from them with and without the option enabled. Also added a unit test.
