### PR TITLE
[receiver/filelog] Fix bug where max_concurrent_files: 1 caused receiver to freeze

### DIFF
--- a/.chloggen/fileconsumer-infinite-loop-fix.yaml
+++ b/.chloggen/fileconsumer-infinite-loop-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix frozen receiver when max_concurrent_files is 1
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39598]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -175,12 +175,18 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 	if err != nil {
 		return nil, err
 	}
+
+	maxBatchFiles := c.MaxConcurrentFiles / 2
+	if maxBatchFiles == 0 {
+		maxBatchFiles = 1
+	}
+
 	return &Manager{
 		set:              set,
 		readerFactory:    readerFactory,
 		fileMatcher:      fileMatcher,
 		pollInterval:     c.PollInterval,
-		maxBatchFiles:    c.MaxConcurrentFiles / 2,
+		maxBatchFiles:    maxBatchFiles,
 		maxBatches:       c.MaxBatches,
 		telemetryBuilder: telemetryBuilder,
 		noTracking:       o.noTracking,

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -881,6 +881,26 @@ func TestFileBatching(t *testing.T) {
 	require.ElementsMatch(t, expectedTokens, actualTokens)
 }
 
+func TestMaxConcurrentFilesOne(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	temp1 := filetest.OpenTemp(t, tempDir)
+	_, err := temp1.WriteString("file 0: written before start\n")
+	require.NoError(t, err)
+
+	cfg := NewConfig().includeDir(tempDir)
+	cfg.StartAt = "beginning"
+	cfg.MaxConcurrentFiles = 1
+
+	sink := emittest.NewSink()
+	operator := testManagerWithSink(t, cfg, sink)
+	operator.persister = testutil.NewUnscopedMockPersister()
+	operator.poll(context.Background())
+	sink.ExpectTokens(t, []byte("file 0: written before start"))
+}
+
 func TestFileBatchingRespectsStartAtEnd(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Resolves #39598