### PR TITLE
[pkg/stanza] fileconsumer should close file if it is renamed

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -180,6 +180,19 @@ func (r *Reader) readHeader(ctx context.Context) (doneReadingFile bool) {
 }
 
 func (r *Reader) readContents(ctx context.Context) {
+	defer func() {
+		// If we've read to the end, close the file
+		if r.file != nil {
+			if info, err := r.file.Stat(); err == nil {
+				currentPath := r.file.Name()
+				if r.Offset >= info.Size() && currentPath != r.fileName {
+					// Close if we've read everything OR if the file has been renamed
+					r.close()
+				}
+			}
+		}
+	}()
+
 	var buf []byte
 	if r.TokenLenState.MinimumLength <= r.initialBufferSize {
 		bufPtr := r.getBufPtrFromPool()


### PR DESCRIPTION
#### Description

We noticed currently it hold the file descriptor open waiting for new content even if the file was rotated/renamed by something like logrotated. Ideally it should free up the file descriptor and space of renamed file if EOF is reached.

#### Testing

This test suite verifies two key behaviours:
### EOF Closing Test:
1. Creates a file with content
2. Reads the file to EOF
3. Verifies the file is closed by attempting to rename it
4. If the file descriptor is still open, the rename operation would fail

### Rename Closing Test:
1. Creates a file and writes initial content
2. Reads the initial content
3. Renames the file while the reader is active
4. Writes more content to both the renamed file and a new file with the original name
5. Verifies that both files can be read correctly
6. Implicitly verifies that file descriptors are properly managed during rotation
