### PR TITLE
[exporter/azureblob] Fix Azure Blob Storage name to avoid breaking file extension

### DIFF
--- a/.chloggen/fix_azure_blob_name.yaml
+++ b/.chloggen/fix_azure_blob_name.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: 'bug_fix'
+change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: azureblobexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix Azure Blob Storage name to avoid breaking file extension"
+note: "Add SerialNumBeforeExtension option to BlobNameFormat in Azure Blob exporter as an option to avoid breaking file extension"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [39593]

--- a/.chloggen/fix_azure_blob_name.yaml
+++ b/.chloggen/fix_azure_blob_name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureblobexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix Azure Blob Storage name to avoid breaking file extension"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39593]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/azureblobexporter/README.md
+++ b/exporter/azureblobexporter/README.md
@@ -36,6 +36,7 @@ The following settings can be optionally configured and have default values:
   - logs_format (default `2006/01/02/logs_15_04_05.json`): blob name format.
   - traces_format (default `2006/01/02/traces_15_04_05.json`): blob name format.
   - serial_num_range (default `10000`): a range of random number to be appended after blob_name. e.g. `blob_name_{serial_num}`.
+  - serial_num_before_extension (default `false`): places the serial number before the file extension if there is one. e.g `blob_name{serial_num}.json` instead of `blob_name_{serial_num}.json`
 - format (default `json`): `json` or `proto`. which present otel json or otel protobuf format, the file extension will be `json` or `pb`.
 - encodings (default using encoding specified in `format`, which is `json`): if specified, uses the encoding extension to encode telemetry data. Overrides format.
   - logs (default `nil`): encoding component id.

--- a/exporter/azureblobexporter/README.md
+++ b/exporter/azureblobexporter/README.md
@@ -36,7 +36,7 @@ The following settings can be optionally configured and have default values:
   - logs_format (default `2006/01/02/logs_15_04_05.json`): blob name format.
   - traces_format (default `2006/01/02/traces_15_04_05.json`): blob name format.
   - serial_num_range (default `10000`): a range of random number to be appended after blob_name. e.g. `blob_name_{serial_num}`.
-  - serial_num_before_extension (default `false`): places the serial number before the file extension if there is one. e.g `blob_name{serial_num}.json` instead of `blob_name_{serial_num}.json`
+  - serial_num_before_extension (default `false`): places the serial number before the file extension if there is one. e.g `blob_name_{serial_num}.json` instead of `blob_name.json_{serial_num}`
 - format (default `json`): `json` or `proto`. which present otel json or otel protobuf format, the file extension will be `json` or `pb`.
 - encodings (default using encoding specified in `format`, which is `json`): if specified, uses the encoding extension to encode telemetry data. Overrides format.
   - logs (default `nil`): encoding component id.

--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -27,12 +27,12 @@ type (
 )
 
 type BlobNameFormat struct {
-	MetricsFormat  string            `mapstructure:"metrics_format"`
-	LogsFormat     string            `mapstructure:"logs_format"`
-	TracesFormat   string            `mapstructure:"traces_format"`
-	SerialNumRange int64             `mapstructure:"serial_num_range"`
-	SerialNumBeforeExtension bool    `mapstructure:"serial_num_before_extension"`
-	Params         map[string]string `mapstructure:"params"`
+	MetricsFormat            string            `mapstructure:"metrics_format"`
+	LogsFormat               string            `mapstructure:"logs_format"`
+	TracesFormat             string            `mapstructure:"traces_format"`
+	SerialNumRange           int64             `mapstructure:"serial_num_range"`
+	SerialNumBeforeExtension bool              `mapstructure:"serial_num_before_extension"`
+	Params                   map[string]string `mapstructure:"params"`
 }
 
 type AppendBlob struct {

--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -31,6 +31,7 @@ type BlobNameFormat struct {
 	LogsFormat     string            `mapstructure:"logs_format"`
 	TracesFormat   string            `mapstructure:"traces_format"`
 	SerialNumRange int64             `mapstructure:"serial_num_range"`
+	SerialNumBeforeExtension bool    `mapstructure:"serial_num_before_extension"`
 	Params         map[string]string `mapstructure:"params"`
 }
 

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -164,11 +164,17 @@ func (e *azureBlobExporter) generateBlobName(signal pipeline.Signal) (string, er
 	default:
 		return "", fmt.Errorf("unsupported signal type: %v", signal)
 	}
-	// Append a random number and do so before the file extension if there is one
-	ext := filepath.Ext(format)
-	formatWithoutExt := strings.TrimSuffix(format, ext)
-	randInt := randomInRange(0, int(e.config.BlobNameFormat.SerialNumRange))
-	blobName := fmt.Sprintf("%s_%d%s", now.Format(formatWithoutExt), randInt, ext)
+	var blobName string
+	if e.config.BlobNameFormat.SerialNumBeforeExtension {
+		// Append a random number and do so before the file extension if there is one
+		ext := filepath.Ext(format)
+		formatWithoutExt := strings.TrimSuffix(format, ext)
+		randInt := randomInRange(0, int(e.config.BlobNameFormat.SerialNumRange))
+		blobName = fmt.Sprintf("%s_%d%s", now.Format(formatWithoutExt), randInt, ext)
+	} else {
+		// Appends the random number after any potential file extension to minimize performance impact when high throughput
+		blobName = fmt.Sprintf("%s_%d", now.Format(format), randomInRange(0, int(e.config.BlobNameFormat.SerialNumRange)))
+	}
 	return blobName, nil
 }
 
@@ -209,7 +215,6 @@ func (e *azureBlobExporter) ConsumeTraces(ctx context.Context, td ptrace.Traces)
 func (e *azureBlobExporter) consumeData(ctx context.Context, data []byte, signal pipeline.Signal) error {
 	// Generate a unique blob name
 	blobName, err := e.generateBlobName(signal)
-	fmt.Println("BLOB NAME: ", blobName, " config name", e.config.BlobNameFormat.MetricsFormat)
 	if err != nil {
 		return fmt.Errorf("failed to generate blobname: %w", err)
 	}

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -149,6 +149,36 @@ func TestGenerateBlobName(t *testing.T) {
 
 	ae := newAzureBlobExporter(c, zaptest.NewLogger(t), pipeline.SignalMetrics)
 
+	now := time.Now()
+	metricsBlobName, err := ae.generateBlobName(pipeline.SignalMetrics)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(metricsBlobName, now.Format(c.BlobNameFormat.MetricsFormat)))
+
+	logsBlobName, err := ae.generateBlobName(pipeline.SignalLogs)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(logsBlobName, now.Format(c.BlobNameFormat.LogsFormat)))
+
+	tracesBlobName, err := ae.generateBlobName(pipeline.SignalTraces)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(tracesBlobName, now.Format(c.BlobNameFormat.TracesFormat)))
+}
+
+func TestGenerateBlobNameSerialNumBefore(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{
+		BlobNameFormat: &BlobNameFormat{
+			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
+			LogsFormat:     "2006/01/02/logs_15_04_05.json",
+			TracesFormat:   "2006/01/02/traces_15_04_05",  // no extension
+			SerialNumRange: 10000,
+			SerialNumBeforeExtension: true,
+			Params:         map[string]string{},
+		},
+	}
+
+	ae := newAzureBlobExporter(c, zaptest.NewLogger(t), pipeline.SignalMetrics)
+
 	assertFormat := func(blobName string, format string) {
 		ext := filepath.Ext(format)
 		formatWithoutExt := strings.TrimSuffix(format, ext)

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -149,18 +149,25 @@ func TestGenerateBlobName(t *testing.T) {
 
 	ae := newAzureBlobExporter(c, zaptest.NewLogger(t), pipeline.SignalMetrics)
 
+	assertFormat := func(blobName string, format string) {
+		ext := filepath.Ext(format)
+		formatWithoutExt := strings.TrimSuffix(format, ext)
+		assert.True(t, strings.HasPrefix(blobName, formatWithoutExt))
+		assert.True(t, strings.HasSuffix(blobName, ext))
+	}
+
 	now := time.Now()
 	metricsBlobName, err := ae.generateBlobName(pipeline.SignalMetrics)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(metricsBlobName, now.Format(c.BlobNameFormat.MetricsFormat)))
+	assertFormat(metricsBlobName, now.Format(c.BlobNameFormat.MetricsFormat))
 
 	logsBlobName, err := ae.generateBlobName(pipeline.SignalLogs)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(logsBlobName, now.Format(c.BlobNameFormat.LogsFormat)))
+	assertFormat(logsBlobName, now.Format(c.BlobNameFormat.LogsFormat))
 
 	tracesBlobName, err := ae.generateBlobName(pipeline.SignalTraces)
 	assert.NoError(t, err)
-	assert.True(t, strings.HasPrefix(tracesBlobName, now.Format(c.BlobNameFormat.TracesFormat)))
+	assertFormat(tracesBlobName, now.Format(c.BlobNameFormat.TracesFormat))
 }
 
 func getMockAzBlobClient() *mockAzBlobClient {

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -168,12 +168,12 @@ func TestGenerateBlobNameSerialNumBefore(t *testing.T) {
 
 	c := &Config{
 		BlobNameFormat: &BlobNameFormat{
-			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
-			LogsFormat:     "2006/01/02/logs_15_04_05.json",
-			TracesFormat:   "2006/01/02/traces_15_04_05",  // no extension
-			SerialNumRange: 10000,
+			MetricsFormat:            "2006/01/02/metrics_15_04_05.json",
+			LogsFormat:               "2006/01/02/logs_15_04_05.json",
+			TracesFormat:             "2006/01/02/traces_15_04_05", // no extension
+			SerialNumRange:           10000,
 			SerialNumBeforeExtension: true,
-			Params:         map[string]string{},
+			Params:                   map[string]string{},
 		},
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add Fix Azure Blob Storage name to avoid breaking file extension. Previously the final blob names looked like the following:
```
2025/04/24/traces_00_59_20.json_6651
```
^(this is the actual result I took from one of the raw logs generated from running the unit test)

Now they properly append the random number before the file extension:
```
2025/04/24/traces_00_59_49_4913.json
```

EDIT: This logic has now been made configurable instead of the default.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39593

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a new test `TestGenerateBlobNameSerialNumBefore`

<!--Describe the documentation added.-->
#### Documentation
Updated the `README.md` with the new config option

<!--Please delete paragraphs that you did not use before submitting.-->
