### PR TITLE
[chore] Skip flaky tests on Datadog exporter

### DIFF
--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -558,6 +558,7 @@ func sendLogs(t *testing.T, numLogs int, endpoint string) {
 }
 
 func TestIntegrationHostMetrics_WithRemapping_LegacyMetricClient(t *testing.T) {
+	t.Skip("Flaky, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39585")
 	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
 	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), false))
 	require.NoError(t, featuregate.GlobalRegistry().Set("exporter.datadogexporter.metricexportserializerclient", false))

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -90,6 +90,7 @@ func TestNewExporter(t *testing.T) {
 }
 
 func TestNewExporter_Serializer(t *testing.T) {
+	t.Skip("Flaky, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39601")
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Skips flaky tests so that they don't cause issues to others while we investigate why they are flaky.

Relates to #39601 and #39585