### PR TITLE
[chore][Makefile] Make docker-component work on linux/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,8 @@ run:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
-	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
-	cp ./bin/$(COMPONENT)_linux_amd64 ./cmd/$(COMPONENT)/$(COMPONENT)
+	GOOS=linux GOARCH=$(GOARCH) $(MAKE) $(COMPONENT)
+	cp ./bin/$(COMPONENT)_linux_$(GOARCH) ./cmd/$(COMPONENT)/$(COMPONENT)
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 


### PR DESCRIPTION
#### Description

This PR improves the `docker-component` make target so that it can build the component's binary according to the `GOARCH` environment variable. 

Effectively this makes it easier for anyone on non-amd64 systems to build container images locally for testing or any other reason.

#### Testing

Used this myself since a while.

