### PR TITLE
[chore][Makefile] Add make target to build Supervisor container image with a Collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,10 @@ endif
 docker-otelcontribcol:
 	COMPONENT=otelcontribcol $(MAKE) docker-component
 
+.PHONY: docker-supervisor-otelcontribcol
+docker-supervisor-otelcontribcol: docker-otelcontribcol
+	COMPONENT=opampsupervisor $(MAKE) docker-component
+
 .PHONY: docker-telemetrygen
 docker-telemetrygen:
 	GOOS=linux GOARCH=$(GOARCH) $(MAKE) telemetrygen
@@ -433,6 +437,12 @@ telemetrygen:
 telemetrygenlite:
 	cd ./cmd/telemetrygen && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/telemetrygen_$(GOOS)_$(GOARCH)$(EXTENSION) \
 		-tags $(GO_BUILD_TAGS) -ldflags $(GO_BUILD_LDFLAGS) .
+
+# Build the Supervisor executable.
+.PHONY: opampsupervisor
+opampsupervisor:
+	cd ./cmd/opampsupervisor && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/opampsupervisor_$(GOOS)_$(GOARCH)$(EXTENSION) \
+		-tags $(GO_BUILD_TAGS) .
 
 MODULES="internal/buildscripts/modules"
 .PHONY: update-core-modules

--- a/cmd/opampsupervisor/Dockerfile
+++ b/cmd/opampsupervisor/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 COPY --from=prep --chmod=777 --chown=${USER_UID}:${USER_GID} /etc/otel/supervisor-data /etc/otel/supervisor-data
 COPY --chmod=755 opampsupervisor /
 COPY ./examples/supervisor_docker.yaml /etc/otel/supervisor.yaml
-COPY --from=col --chmod=755 /otelcol-contrib /otelcontribcol
+COPY --from=col --chmod=755 /otelcontribcol /otelcontribcol
 
 EXPOSE 4317 55680 55679
 ENTRYPOINT ["/opampsupervisor"]

--- a/cmd/opampsupervisor/Dockerfile
+++ b/cmd/opampsupervisor/Dockerfile
@@ -1,0 +1,21 @@
+FROM otelcontribcol AS col
+
+FROM alpine:latest@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS prep
+RUN apk --update add ca-certificates
+RUN mkdir -p /etc/otel/supervisor-data/
+
+FROM scratch
+
+ARG USER_UID=10001
+ARG USER_GID=10001
+USER ${USER_UID}:${USER_GID}
+
+COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=prep --chmod=777 --chown=${USER_UID}:${USER_GID} /etc/otel/supervisor-data /etc/otel/supervisor-data
+COPY --chmod=755 opampsupervisor /
+COPY ./examples/supervisor_docker.yaml /etc/otel/supervisor.yaml
+COPY --from=col --chmod=755 /otelcol-contrib /otelcontribcol
+
+EXPOSE 4317 55680 55679
+ENTRYPOINT ["/opampsupervisor"]
+CMD ["--config", "/etc/otel/supervisor.yaml"]

--- a/cmd/opampsupervisor/examples/supervisor_docker.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_docker.yaml
@@ -1,0 +1,22 @@
+server:
+  endpoint: wss://127.0.0.1:4320/v1/opamp
+  tls:
+    # Disable verification to test locally.
+    # Don't do this in production.
+    insecure_skip_verify: true
+    # For more TLS settings see config/configtls.ClientConfig
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+
+agent:
+  executable: /otelcontribcol
+
+storage:
+  directory: /etc/otel/supervisor-data/


### PR DESCRIPTION
#### Description

This PR adds a new Makefile target: `docker-supervisor-otelcontribcol`. This target builds an image of the Supervisor with the Contrib Collector included. The intention is to make it easier for anyone to test out Supervisor features and to be an example for those who want to build their own Supervisor+Collector images.  

#### Testing

Built and ran images locally.