### PR TITLE
[chore] OTEL-2552 Part 2.0 Datadog Extension - internal/payload

### DIFF
--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/datad
 go 1.23.0
 
 require (
+	github.com/DataDog/datadog-agent/pkg/serializer v0.64.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.124.1
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.30.1-0.20250422165940-c47951a8bf71

--- a/extension/datadogextension/go.sum
+++ b/extension/datadogextension/go.sum
@@ -1,5 +1,7 @@
 github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel h1:ReGJuAAOw+/AcuNtNeD7dyk//FKjNCmtaq6tkLRNhe8=
 github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel/go.mod h1:b5ikXuJHhxN0I0mReyhe/10Lq/ZtkKTaAG6L0GuEY8s=
+github.com/DataDog/datadog-agent/pkg/serializer v0.64.3 h1:KefKTYDsajtyx+/oK+HR4FaXi1wZqkavTH9ub3szS2Q=
+github.com/DataDog/datadog-agent/pkg/serializer v0.64.3/go.mod h1:/ZG8je7Ua39dQPNkziIEtWTB/Nknpwwzm8lJBX/ynNw=
 github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.64.3 h1:YHTifHfjkN+s4tLRLu+tkm+zSe1e5WA7AZIvp4Rljts=
 github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.64.3/go.mod h1:nucHXjvT1az8xBedqPRQox07woPX6KUzZLkAjKYvXwI=
 github.com/DataDog/datadog-agent/pkg/util/log v0.64.3 h1:JpT79bpG8nKNWSPsTWLxAZ2I8an7Dav3ArfH1p2yi+Q=

--- a/extension/datadogextension/internal/payload/moduleinfojson.go
+++ b/extension/datadogextension/internal/payload/moduleinfojson.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payload // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+
+import (
+	"encoding/json"
+)
+
+// ModuleInfoJSON holds data on all modules in the collector
+// It is built to make checking module info quicker when building active/configured components list
+// (don't need to iterate through a whole list of modules, just do key/value pair in map)
+type ModuleInfoJSON struct {
+	components map[string]CollectorModule
+}
+
+func NewModuleInfoJSON() *ModuleInfoJSON {
+	return &ModuleInfoJSON{
+		components: make(map[string]CollectorModule),
+	}
+}
+
+func (m *ModuleInfoJSON) getKey(typeStr, kindStr string) string {
+	return typeStr + ":" + kindStr
+}
+
+func (m *ModuleInfoJSON) AddComponent(comp CollectorModule) {
+	key := m.getKey(comp.Type, comp.Kind)
+	m.components[key] = comp
+	// We don't ever expect two go modules to have the same type and kind
+	// as collector would not be able to distinguish between them for configuration
+	// and service/pipeline purposes.
+}
+
+func (m *ModuleInfoJSON) GetComponent(typeStr, kindStr string) (CollectorModule, bool) {
+	key := m.getKey(typeStr, kindStr)
+	comp, ok := m.components[key]
+	return comp, ok
+}
+
+func (m *ModuleInfoJSON) AddComponents(components []CollectorModule) {
+	for _, comp := range components {
+		m.AddComponent(comp)
+	}
+}
+
+func (m *ModuleInfoJSON) MarshalJSON() ([]byte, error) {
+	alias := struct {
+		Components []CollectorModule `json:"full_components"`
+	}{
+		Components: make([]CollectorModule, 0, len(m.components)),
+	}
+	for _, comp := range m.components {
+		alias.Components = append(alias.Components, comp)
+	}
+	return json.Marshal(alias)
+}
+
+func (m *ModuleInfoJSON) GetFullComponentsList() []CollectorModule {
+	fullComponents := make([]CollectorModule, 0, len(m.components))
+	for _, comp := range m.components {
+		fullComponents = append(fullComponents, comp)
+	}
+	return fullComponents
+}

--- a/extension/datadogextension/internal/payload/moduleinfojson_test.go
+++ b/extension/datadogextension/internal/payload/moduleinfojson_test.go
@@ -1,0 +1,151 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payload // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewModuleInfoJSON(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	assert.NotNil(t, modInfo)
+	assert.NotNil(t, modInfo.components)
+	assert.Empty(t, modInfo.components)
+}
+
+func TestAddComponent(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	comp := CollectorModule{
+		Type:       "receiver",
+		Kind:       "otlp",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	modInfo.AddComponent(comp)
+	assert.Len(t, modInfo.components, 1)
+	key := modInfo.getKey(comp.Type, comp.Kind)
+	assert.Equal(t, comp, modInfo.components[key])
+}
+
+func TestGetComponent(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	comp := CollectorModule{
+		Type:       "receiver",
+		Kind:       "otlp",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	modInfo.AddComponent(comp)
+	retrievedComp, ok := modInfo.GetComponent("receiver", "otlp")
+	assert.True(t, ok)
+	assert.Equal(t, comp, retrievedComp)
+
+	_, ok = modInfo.GetComponent("processor", "batch")
+	assert.False(t, ok)
+}
+
+func TestModuleInfoJSON_MarshalJSON(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	comp1 := CollectorModule{
+		Type:       "receiver",
+		Kind:       "otlp",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	comp2 := CollectorModule{
+		Type:       "processor",
+		Kind:       "batch",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/batchprocessor",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	modInfo.AddComponent(comp1)
+	modInfo.AddComponent(comp2)
+
+	jsonData, err := json.Marshal(modInfo)
+	assert.NoError(t, err)
+
+	var actualJSON map[string]any
+	err = json.Unmarshal(jsonData, &actualJSON)
+	assert.NoError(t, err)
+
+	expectedJSON := `{
+			"full_components": [
+					{
+							"type": "receiver",
+							"kind": "otlp",
+							"gomod": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+							"version": "v0.30.0",
+							"configured": true
+					},
+					{
+							"type": "processor",
+							"kind": "batch",
+							"gomod": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/batchprocessor",
+							"version": "v0.30.0",
+							"configured": true
+					}
+			]
+	}`
+	var expectedJSONMap map[string]any
+	err = json.Unmarshal([]byte(expectedJSON), &expectedJSONMap)
+	assert.NoError(t, err)
+
+	assert.ElementsMatch(t, expectedJSONMap["full_components"], actualJSON["full_components"])
+}
+
+func TestAddComponents(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	comp1 := CollectorModule{
+		Type:       "receiver",
+		Kind:       "otlp",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	comp2 := CollectorModule{
+		Type:       "processor",
+		Kind:       "batch",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/batchprocessor",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	modInfo.AddComponents([]CollectorModule{comp1, comp2})
+
+	assert.Len(t, modInfo.components, 2)
+	key1 := modInfo.getKey(comp1.Type, comp1.Kind)
+	key2 := modInfo.getKey(comp2.Type, comp2.Kind)
+	assert.Equal(t, comp1, modInfo.components[key1])
+	assert.Equal(t, comp2, modInfo.components[key2])
+}
+
+func TestGetFullComponentsList(t *testing.T) {
+	modInfo := NewModuleInfoJSON()
+	comp1 := CollectorModule{
+		Type:       "receiver",
+		Kind:       "otlp",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpreceiver",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	comp2 := CollectorModule{
+		Type:       "processor",
+		Kind:       "batch",
+		Gomod:      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/batchprocessor",
+		Version:    "v0.30.0",
+		Configured: true,
+	}
+	modInfo.AddComponents([]CollectorModule{comp1, comp2})
+
+	fullComponentsList := modInfo.GetFullComponentsList()
+	assert.Len(t, fullComponentsList, 2)
+	assert.Contains(t, fullComponentsList, comp1)
+	assert.Contains(t, fullComponentsList, comp2)
+}

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -3,3 +3,101 @@
 
 // package payload will define the metadata payload schemas to be forwarded to Datadog backend
 package payload // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+)
+
+const (
+	payloadSplitErr = "could not split otel collector payload any more, payload is too big for intake"
+)
+
+// CustomBuildInfo is a struct that duplicates the fields of component.BuildInfo with custom JSON tags
+type CustomBuildInfo struct {
+	Command     string `json:"command"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+type OtelCollector struct {
+	HostKey           string             `json:"host_key"`
+	Hostname          string             `json:"hostname"`
+	HostnameSource    string             `json:"hostname_source"`
+	CollectorID       string             `json:"collector_id"`
+	CollectorVersion  string             `json:"collector_version"`
+	ConfigSite        string             `json:"config_site"`
+	APIKeyUUID        string             `json:"api_key_uuid"`
+	FullComponents    []CollectorModule  `json:"full_components"`
+	ActiveComponents  []ServiceComponent `json:"active_components"`
+	BuildInfo         CustomBuildInfo    `json:"build_info"`
+	FullConfiguration string             `json:"full_configuration"` // JSON passed as string
+	HealthStatus      string             `json:"health_status"`      // JSON passed as string
+}
+
+type CollectorModule struct {
+	Type       string `json:"type"`
+	Kind       string `json:"kind"`
+	Gomod      string `json:"gomod"`
+	Version    string `json:"version"`
+	Configured bool   `json:"configured"`
+}
+
+type ServiceComponent struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Kind            string `json:"kind"`
+	Pipeline        string `json:"pipeline"`
+	Gomod           string `json:"gomod"`
+	Version         string `json:"version"`
+	ComponentStatus string `json:"component_status"`
+}
+
+// Explicitly implement JSONMarshaler interface from datadog-agent
+var (
+	_ marshaler.JSONMarshaler = (*OtelCollectorPayload)(nil)
+)
+
+type OtelCollectorPayload struct {
+	Hostname  string        `json:"hostname"`
+	Timestamp int64         `json:"timestamp"`
+	Metadata  OtelCollector `json:"otel_collector"`
+	UUID      string        `json:"uuid"`
+}
+
+// MarshalJSON serializes a OtelCollectorPayload to JSON
+func (p *OtelCollectorPayload) MarshalJSON() ([]byte, error) {
+	type collectorPayloadAlias OtelCollectorPayload
+	return json.Marshal((*collectorPayloadAlias)(p))
+}
+
+// SplitPayload implements marshaler.AbstractMarshaler#SplitPayload.
+func (p *OtelCollectorPayload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
+	return nil, errors.New(payloadSplitErr)
+}
+
+// PrepareOtelCollectorPayload takes metadata from various config values and prepares an OtelCollector payload
+func PrepareOtelCollectorPayload(
+	hostname,
+	hostnameSource,
+	extensionUUID,
+	version,
+	site,
+	fullConfig string,
+	buildInfo CustomBuildInfo,
+) OtelCollector {
+	return OtelCollector{
+		HostKey:           "",
+		Hostname:          hostname,
+		HostnameSource:    hostnameSource,
+		CollectorID:       hostname + "-" + extensionUUID,
+		CollectorVersion:  version,
+		ConfigSite:        site,
+		APIKeyUUID:        "",
+		BuildInfo:         buildInfo,
+		FullConfiguration: fullConfig,
+	}
+}

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package payload // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPayloadInterface(t *testing.T) {
+	payload := &OtelCollectorPayload{}
+	_, err := payload.SplitPayload(1)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, payloadSplitErr)
+}
+
+func TestPrepareOtelCollectorPayload(t *testing.T) {
+	hostname := "test-hostname"
+	hostnameSource := "config"
+	extensionUUID := "test-uuid"
+	version := "1.0.0"
+	site := "datadoghq.com"
+	fullConfig := "{\"service\":{\"pipelines\":{\"traces\":{\"receivers\":[\"otlp\"],\"exporters\":[\"debug\"]}}}}"
+	buildInfo := CustomBuildInfo{
+		Command: "otelcol",
+		Version: "1.0.0",
+	}
+
+	expectedPayload := OtelCollector{
+		HostKey:           "",
+		Hostname:          hostname,
+		HostnameSource:    hostnameSource,
+		CollectorID:       hostname + "-" + extensionUUID,
+		CollectorVersion:  version,
+		ConfigSite:        site,
+		APIKeyUUID:        "",
+		BuildInfo:         buildInfo,
+		FullConfiguration: fullConfig,
+	}
+
+	actualPayload := PrepareOtelCollectorPayload(hostname, hostnameSource, extensionUUID, version, site, fullConfig, buildInfo)
+
+	assert.Equal(t, expectedPayload, actualPayload)
+}
+
+func TestOtelCollectorPayload_MarshalJSON(t *testing.T) {
+	oc := &OtelCollectorPayload{
+		Hostname:  "test_host",
+		Timestamp: time.Now().UnixNano(),
+		UUID:      "test-uuid",
+		Metadata: OtelCollector{
+			FullComponents: []CollectorModule{
+				{
+					Type:       "test_type",
+					Kind:       "test_kind",
+					Gomod:      "test_gomod",
+					Version:    "test_version",
+					Configured: true,
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(oc)
+	require.NoError(t, err)
+
+	var unmarshaled OtelCollectorPayload
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	require.NoError(t, err)
+	assert.Equal(t, oc.Hostname, unmarshaled.Hostname)
+	assert.Equal(t, oc.UUID, unmarshaled.UUID)
+	assert.Equal(t, oc.Metadata.FullComponents, unmarshaled.Metadata.FullComponents)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
adds internal/payload package for Datadog Extension to define otel_collector payload structure for infrastructure backend and helper methods
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

<!--Describe what testing was performed and which tests were added.-->
#### Testing
unit tests for new methods

<!--Describe the documentation added.-->
#### Documentation
not planning to add user-facing documentation for individual submodules; chloggen will be added README.md will be updated accordingly for main extension once that PR is proposed
<!--Please delete paragraphs that you did not use before submitting.-->
