### PR TITLE
[chore][extension/dbstorage] wait 10s before starting the extension

### DIFF
--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	ctypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
@@ -48,6 +49,10 @@ func TestExtensionIntegrityWithPostgres(t *testing.T) {
 		}
 	})
 	require.NoError(t, err)
+
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37079
+	// DB instantiation fails if we instantly try to connect to it, wait for 10s before starting the extension
+	time.Sleep(10 * time.Second)
 
 	testExtensionIntegrity(t, se)
 }


### PR DESCRIPTION
DB instantiation fails if we instantly try to connect to it. Wait for 10s before starting the extension as it most likely fails because it's not in a "healthy state" yet.

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37079