### PR TITLE
[processor/transform] Create `Additional*Funcs` config properties to provide additional OTTL funcs programatically.

### DIFF
--- a/.chloggen/fcovalente-transform-processor-add-custom-func.yaml
+++ b/.chloggen/fcovalente-transform-processor-add-custom-func.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add properties AdditionalLogFuncs, AdditionalSpanFuncs and AdditionalMetricFuncs to the transform processor Config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39698]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -722,6 +722,11 @@ transform:
 
 The configuration can be used also with `delete_matching_keys()` to copy the attributes that do not match the regular expression.
 
+## Additional OTTL Functions
+The Config `AdditionalLogFuncs`, `AdditionalSpanFuncs` and `AdditionalMetricFuncs` properties can be set programatically by
+instantiating the transform processor. The provided OTTL functions would be accessible in the resulting processor. This properties
+cannot be set through a yaml configuration.
+
 ## Troubleshooting
 
 When using OTTL you can enable debug logging in the collector to print out useful information,

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -45,6 +45,8 @@ type Config struct {
 
 	FlattenData bool `mapstructure:"flatten_data"`
 	logger      *zap.Logger
+
+	AdditionalOTTLFunc []ottl.Factory[K]
 }
 
 // Unmarshal is used internally by mapstructure to parse the transformprocessor configuration (Config),

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
@@ -46,7 +47,7 @@ type Config struct {
 	FlattenData bool `mapstructure:"flatten_data"`
 	logger      *zap.Logger
 
-	AdditionalOTTLFunc []ottl.Factory[K]
+	AdditionalOTTLFunc []ottl.Factory[ottllog.TransformContext] `mapstructure:"-"`
 }
 
 // Unmarshal is used internally by mapstructure to parse the transformprocessor configuration (Config),
@@ -161,7 +162,7 @@ func (c *Config) Validate() error {
 	}
 
 	if len(c.LogStatements) > 0 {
-		pc, err := common.NewLogParserCollection(component.TelemetrySettings{Logger: zap.NewNop()}, common.WithLogParser(logs.LogFunctions()))
+		pc, err := common.NewLogParserCollection(component.TelemetrySettings{Logger: zap.NewNop()}, common.WithLogParser(logs.LogFunctions(c.AdditionalOTTLFunc)))
 		if err != nil {
 			return err
 		}

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -49,7 +49,7 @@ func createLogsProcessor(
 ) (processor.Logs, error) {
 	oCfg := cfg.(*Config)
 
-	proc, err := logs.NewProcessor(oCfg.LogStatements, oCfg.ErrorMode, oCfg.FlattenData, set.TelemetrySettings, oCfg.AdditionalOTTLFunc)
+	proc, err := logs.NewProcessor(oCfg.LogStatements, oCfg.ErrorMode, oCfg.FlattenData, set.TelemetrySettings, oCfg.AdditionalLogFuncs)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
 	}
@@ -70,7 +70,7 @@ func createTracesProcessor(
 ) (processor.Traces, error) {
 	oCfg := cfg.(*Config)
 
-	proc, err := traces.NewProcessor(oCfg.TraceStatements, oCfg.ErrorMode, set.TelemetrySettings)
+	proc, err := traces.NewProcessor(oCfg.TraceStatements, oCfg.ErrorMode, set.TelemetrySettings, oCfg.AdditionalSpanFuncs)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
 	}
@@ -92,7 +92,7 @@ func createMetricsProcessor(
 	oCfg := cfg.(*Config)
 	oCfg.logger = set.Logger
 
-	proc, err := metrics.NewProcessor(oCfg.MetricStatements, oCfg.ErrorMode, set.TelemetrySettings)
+	proc, err := metrics.NewProcessor(oCfg.MetricStatements, oCfg.ErrorMode, set.TelemetrySettings, oCfg.AdditionalMetricFuncs)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
 	}

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -49,7 +49,7 @@ func createLogsProcessor(
 ) (processor.Logs, error) {
 	oCfg := cfg.(*Config)
 
-	proc, err := logs.NewProcessor(oCfg.LogStatements, oCfg.ErrorMode, oCfg.FlattenData, set.TelemetrySettings)
+	proc, err := logs.NewProcessor(oCfg.LogStatements, oCfg.ErrorMode, oCfg.FlattenData, set.TelemetrySettings, oCfg.AdditionalOTTLFunc)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config for \"transform\" processor %w", err)
 	}

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -9,12 +9,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func LogFunctions(additionalLogFuncs []ottl.Factory) map[string]ottl.Factory[ottllog.TransformContext] {
+func LogFunctions(additionalLogFuncs []ottl.Factory[ottllog.TransformContext]) map[string]ottl.Factory[ottllog.TransformContext] {
 	// No logs-only functions yet.
 	logFunctions := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
 	for _, fn := range additionalLogFuncs {
-		logFn := fn[ottllog.TransformContext]
-		logFunctions[logFn.Name()] = logFn
+		logFunctions[fn.Name()] = fn
 	}
 	return logFunctions
 }

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -9,7 +9,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func LogFunctions() map[string]ottl.Factory[ottllog.TransformContext] {
+func LogFunctions(additionalLogFuncs []ottl.Factory) map[string]ottl.Factory[ottllog.TransformContext] {
 	// No logs-only functions yet.
-	return ottlfuncs.StandardFuncs[ottllog.TransformContext]()
+	logFunctions := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
+	for _, fn := range additionalLogFuncs {
+		logFn := fn[ottllog.TransformContext]
+		logFunctions[logFn.Name()] = logFn
+	}
+	return logFunctions
 }

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
 func Test_LogFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
-	actual := LogFunctions()
+	actual := LogFunctions([]ottl.Factory[ottllog.TransformContext]{})
 	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -31,7 +31,7 @@ func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
 }
 
 func createTestLogFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -24,15 +24,14 @@ func Test_LogFunctions(t *testing.T) {
 	}
 }
 
-type TestLogFuncArguments[K any] struct {
-}
+type TestLogFuncArguments[K any] struct{}
 
 func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("TestLogFunc", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
 }
 
-func createTestLogFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(ctx context.Context, tCtx K) (any, error) {
+func createTestLogFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(_ context.Context, tCtx K) (any, error) {
 		return nil, nil
 	}, nil
 }
@@ -45,7 +44,7 @@ func Test_LogFunctions_AdditionalLogFuncs(t *testing.T) {
 	additionalLogFuncs := []ottl.Factory[ottllog.TransformContext]{testLogFuncFactory}
 	actual := LogFunctions(additionalLogFuncs)
 
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)
 	}

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -28,7 +28,7 @@ type TestLogFuncArguments[K any] struct {
 }
 
 func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("ExtractPatternsRubyRegex", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
+	return ottl.NewFactory("LogFunc", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
 }
 
 func createTestLogFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -33,7 +33,7 @@ func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
 
 func createTestLogFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
 	return func(ctx context.Context, tCtx K) (any, error) {
-		return "TestLogFuncResult", nil
+		return nil, nil
 	}, nil
 }
 

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -28,12 +28,12 @@ type TestLogFuncArguments[K any] struct {
 }
 
 func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("LogFunc", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
+	return ottl.NewFactory("TestLogFunc", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
 }
 
 func createTestLogFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
 	return func(ctx context.Context, tCtx K) (any, error) {
-		return nil, nil
+		return "TestLogFuncResult", nil
 	}, nil
 }
 

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -4,6 +4,7 @@
 package logs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,33 @@ func Test_LogFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
 	actual := LogFunctions([]ottl.Factory[ottllog.TransformContext]{})
 	require.Len(t, actual, len(expected))
+	for k := range actual {
+		assert.Contains(t, expected, k)
+	}
+}
+
+type TestLogFuncArguments[K any] struct {
+}
+
+func NewTestLogFuncFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("ExtractPatternsRubyRegex", &TestLogFuncArguments[K]{}, createTestLogFunc[K])
+}
+
+func createTestLogFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		return nil, nil
+	}, nil
+}
+
+func Test_LogFunctions_AdditionalLogFuncs(t *testing.T) {
+	testLogFuncFactory := NewTestLogFuncFactory[ottllog.TransformContext]()
+	expected := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
+	expected[testLogFuncFactory.Name()] = testLogFuncFactory
+
+	additionalLogFuncs := []ottl.Factory[ottllog.TransformContext]{testLogFuncFactory}
+	actual := LogFunctions(additionalLogFuncs)
+
+	require.Equal(t, len(expected), len(actual))
 	for k := range actual {
 		assert.Contains(t, expected, k)
 	}

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -22,8 +23,8 @@ type Processor struct {
 	flatMode bool
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, flatMode bool, settings component.TelemetrySettings) (*Processor, error) {
-	pc, err := common.NewLogParserCollection(settings, common.WithLogParser(LogFunctions()), common.WithLogErrorMode(errorMode))
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, flatMode bool, settings component.TelemetrySettings, additionalLogFuncs []ottl.Factory[ottllog.TransformContext]) (*Processor, error) {
+	pc, err := common.NewLogParserCollection(settings, common.WithLogParser(LogFunctions(additionalLogFuncs)), common.WithLogErrorMode(errorMode))
 	if err != nil {
 		return nil, err
 	}

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -1302,7 +1302,7 @@ func Test_NewProcessor_AdditionalLogFuncs(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestLogFunc())`},
 				},
 			},
-			wantErrorWith:      fmt.Sprintf(`undefined function "TestLogFunc"`),
+			wantErrorWith:      `undefined function "TestLogFunc"`,
 			additionalLogFuncs: EmptyAdditionalLogFuncs,
 		},
 	}

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -57,7 +58,7 @@ func Test_ProcessLogs_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -98,7 +99,7 @@ func Test_ProcessLogs_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -139,7 +140,7 @@ func Test_ProcessLogs_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -180,7 +181,7 @@ func Test_ProcessLogs_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -434,7 +435,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "log", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "log", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -688,7 +689,7 @@ func Test_ProcessLogs_InferredLogContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -805,7 +806,7 @@ func Test_ProcessLogs_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -895,7 +896,7 @@ func Test_ProcessLogs_InferredMixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -928,7 +929,7 @@ func Test_ProcessLogs_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -1010,7 +1011,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.statements, tt.errorMode, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 			_, err = processor.ProcessLogs(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1137,7 +1138,7 @@ func Test_ProcessLogs_CacheAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -1257,7 +1258,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings())
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -1190,7 +1190,7 @@ func Test_ProcessLogs_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -1206,10 +1206,9 @@ func Test_ProcessLogs_InferredContextFromConditions(t *testing.T) {
 
 func Test_NewProcessor_ConditionsParse(t *testing.T) {
 	type testCase struct {
-		name               string
-		statements         []common.ContextStatements
-		wantErrorWith      string
-		additionalLogFuncs []ottl.Factory[ottllog.TransformContext]
+		name          string
+		statements    []common.ContextStatements
+		wantErrorWith string
 	}
 
 	contextsTests := map[string][]testCase{"log": nil}
@@ -1261,7 +1260,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), tt.additionalLogFuncs)
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -29,6 +29,8 @@ var (
 
 	traceID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	spanID  = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+
+	EmptyAdditionalLogFuncs = []ottl.Factory[ottllog.TransformContext]{}
 )
 
 func Test_ProcessLogs_ResourceContext(t *testing.T) {
@@ -58,7 +60,7 @@ func Test_ProcessLogs_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -99,7 +101,7 @@ func Test_ProcessLogs_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -140,7 +142,7 @@ func Test_ProcessLogs_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -181,7 +183,7 @@ func Test_ProcessLogs_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -435,7 +437,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "log", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "log", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -689,7 +691,7 @@ func Test_ProcessLogs_InferredLogContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -806,7 +808,7 @@ func Test_ProcessLogs_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -896,7 +898,7 @@ func Test_ProcessLogs_InferredMixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -929,7 +931,7 @@ func Test_ProcessLogs_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -1011,7 +1013,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor(tt.statements, tt.errorMode, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 			_, err = processor.ProcessLogs(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1138,7 +1140,7 @@ func Test_ProcessLogs_CacheAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), EmptyAdditionalLogFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessLogs(context.Background(), td)
@@ -1204,12 +1206,13 @@ func Test_ProcessLogs_InferredContextFromConditions(t *testing.T) {
 
 func Test_NewProcessor_ConditionsParse(t *testing.T) {
 	type testCase struct {
-		name          string
-		statements    []common.ContextStatements
-		wantErrorWith string
+		name               string
+		statements         []common.ContextStatements
+		wantErrorWith      string
+		additionalLogFuncs []ottl.Factory[ottllog.TransformContext]
 	}
 
-	contextsTests := map[string][]testCase{"log": nil, "resource": nil, "scope": nil}
+	contextsTests := map[string][]testCase{"log": nil}
 	for ctx := range contextsTests {
 		contextsTests[ctx] = []testCase{
 			{
@@ -1258,7 +1261,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottllog.TransformContext]{})
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), tt.additionalLogFuncs)
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
@@ -1269,6 +1272,53 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 					require.NoError(t, err)
 				})
 			}
+		})
+	}
+}
+
+func Test_NewProcessor_AdditionalLogFuncs(t *testing.T) {
+	type testCase struct {
+		name               string
+		statements         []common.ContextStatements
+		wantErrorWith      string
+		additionalLogFuncs []ottl.Factory[ottllog.TransformContext]
+	}
+
+	tests := []testCase{
+		{
+			name: "additional log funcs : statement with added log func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("log"),
+					Statements: []string{`set(cache["attr"], TestLogFunc())`},
+				},
+			},
+			additionalLogFuncs: []ottl.Factory[ottllog.TransformContext]{NewTestLogFuncFactory[ottllog.TransformContext]()},
+		},
+		{
+			name: "additional log funcs : statement with missing log func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("log"),
+					Statements: []string{`set(cache["attr"], TestLogFunc())`},
+				},
+			},
+			wantErrorWith:      fmt.Sprintf(`undefined function "TestLogFunc"`),
+			additionalLogFuncs: EmptyAdditionalLogFuncs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewProcessor(tt.statements, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), tt.additionalLogFuncs)
+			if tt.wantErrorWith != "" {
+				if err == nil {
+					t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
+				}
+				assert.Contains(t, err.Error(), tt.wantErrorWith)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -34,7 +34,7 @@ func DataPointFunctions() map[string]ottl.Factory[ottldatapoint.TransformContext
 	return functions
 }
 
-func MetricFunctions() map[string]ottl.Factory[ottlmetric.TransformContext] {
+func MetricFunctions(additionalMetricFuncs []ottl.Factory[ottlmetric.TransformContext]) map[string]ottl.Factory[ottlmetric.TransformContext] {
 	functions := ottlfuncs.StandardFuncs[ottlmetric.TransformContext]()
 
 	metricFunctions := ottl.CreateFactoryMap(
@@ -51,6 +51,10 @@ func MetricFunctions() map[string]ottl.Factory[ottlmetric.TransformContext] {
 
 	for k, v := range metricFunctions {
 		functions[k] = v
+	}
+
+	for _, fn := range additionalMetricFuncs {
+		functions[fn.Name()] = fn
 	}
 
 	return functions

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
@@ -60,7 +61,7 @@ func Test_MetricFunctions(t *testing.T) {
 	expected["scale_metric"] = newScaleMetricFactory()
 	expected["convert_exponential_histogram_to_histogram"] = newconvertExponentialHistToExplicitHistFactory()
 
-	actual := MetricFunctions()
+	actual := MetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{})
 	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -76,7 +76,7 @@ func NewTestMetricFuncFactory[K any]() ottl.Factory[K] {
 }
 
 func createTestMetricFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -73,7 +73,7 @@ type TestMetricFuncArguments[K any] struct {
 }
 
 func NewTestMetricFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("ExtractPatternsRubyRegex", &TestMetricFuncArguments[K]{}, createTestMetricFunc[K])
+	return ottl.NewFactory("MetricFunc", &TestMetricFuncArguments[K]{}, createTestMetricFunc[K])
 }
 
 func createTestMetricFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -73,7 +73,7 @@ type TestMetricFuncArguments[K any] struct {
 }
 
 func NewTestMetricFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("MetricFunc", &TestMetricFuncArguments[K]{}, createTestMetricFunc[K])
+	return ottl.NewFactory("TestMetricFunc", &TestMetricFuncArguments[K]{}, createTestMetricFunc[K])
 }
 
 func createTestMetricFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -69,15 +69,14 @@ func Test_MetricFunctions(t *testing.T) {
 	}
 }
 
-type TestMetricFuncArguments[K any] struct {
-}
+type TestMetricFuncArguments[K any] struct{}
 
 func NewTestMetricFuncFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("TestMetricFunc", &TestMetricFuncArguments[K]{}, createTestMetricFunc[K])
 }
 
-func createTestMetricFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(ctx context.Context, tCtx K) (any, error) {
+func createTestMetricFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(_ context.Context, tCtx K) (any, error) {
 		return nil, nil
 	}, nil
 }
@@ -99,7 +98,7 @@ func Test_MetricFunctions_AdditionalMetricFuncs(t *testing.T) {
 	additionalMetricFuncs := []ottl.Factory[ottlmetric.TransformContext]{testMetricFuncFactory}
 	actual := MetricFunctions(additionalMetricFuncs)
 
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)
 	}

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -20,8 +21,8 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings) (*Processor, error) {
-	pc, err := common.NewMetricParserCollection(settings, common.WithMetricParser(MetricFunctions()), common.WithDataPointParser(DataPointFunctions()), common.WithMetricErrorMode(errorMode))
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, additionalMetricFuncs []ottl.Factory[ottlmetric.TransformContext]) (*Processor, error) {
+	pc, err := common.NewMetricParserCollection(settings, common.WithMetricParser(MetricFunctions(additionalMetricFuncs)), common.WithDataPointParser(DataPointFunctions()), common.WithMetricErrorMode(errorMode))
 	if err != nil {
 		return nil, err
 	}

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -25,6 +25,8 @@ var (
 	StartTimestamp = pcommon.NewTimestampFromTime(StartTime)
 	TestTime       = time.Date(2021, 3, 12, 21, 27, 13, 322, time.UTC)
 	TestTimeStamp  = pcommon.NewTimestampFromTime(StartTime)
+
+	EmptyAdditionalMetricFuncs = []ottl.Factory[ottlmetric.TransformContext]{}
 )
 
 func Test_ProcessMetrics_ResourceContext(t *testing.T) {
@@ -54,7 +56,7 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -95,7 +97,7 @@ func Test_ProcessMetrics_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -136,7 +138,7 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -177,7 +179,7 @@ func Test_ProcessMetrics_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -352,7 +354,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -532,7 +534,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 			}
 
 			td := constructMetrics()
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -975,7 +977,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1423,7 +1425,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				contextStatements = append(contextStatements, common.ContextStatements{Context: "", Statements: []string{statement}})
 			}
 
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1561,7 +1563,7 @@ func Test_ProcessMetrics_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1601,7 +1603,7 @@ func Test_ProcessMetrics_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1704,7 +1706,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 			_, err = processor.ProcessMetrics(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1924,7 +1926,7 @@ func Test_ProcessMetrics_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1994,7 +1996,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
@@ -2005,6 +2007,53 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 					require.NoError(t, err)
 				})
 			}
+		})
+	}
+}
+
+func Test_NewProcessor_AdditionalMetricFuncs(t *testing.T) {
+	type testCase struct {
+		name                  string
+		statements            []common.ContextStatements
+		wantErrorWith         string
+		additionalMetricFuncs []ottl.Factory[ottlmetric.TransformContext]
+	}
+
+	tests := []testCase{
+		{
+			name: "additional metric funcs : statement with added metric func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("metric"),
+					Statements: []string{`set(cache["attr"], TestMetricFunc())`},
+				},
+			},
+			additionalMetricFuncs: []ottl.Factory[ottlmetric.TransformContext]{NewTestMetricFuncFactory[ottlmetric.TransformContext]()},
+		},
+		{
+			name: "additional metric funcs : statement with missing metric func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("metric"),
+					Statements: []string{`set(cache["attr"], TestMetricFunc())`},
+				},
+			},
+			wantErrorWith:         fmt.Sprintf(`undefined function "TestMetricFunc"`),
+			additionalMetricFuncs: EmptyAdditionalMetricFuncs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), tt.additionalMetricFuncs)
+			if tt.wantErrorWith != "" {
+				if err == nil {
+					t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
+				}
+				assert.Contains(t, err.Error(), tt.wantErrorWith)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -2038,7 +2038,7 @@ func Test_NewProcessor_AdditionalMetricFuncs(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestMetricFunc())`},
 				},
 			},
-			wantErrorWith:         fmt.Sprintf(`undefined function "TestMetricFunc"`),
+			wantErrorWith:         `undefined function "TestMetricFunc"`,
 			additionalMetricFuncs: EmptyAdditionalMetricFuncs,
 		},
 	}

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -53,7 +54,7 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -94,7 +95,7 @@ func Test_ProcessMetrics_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -135,7 +136,7 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -176,7 +177,7 @@ func Test_ProcessMetrics_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -351,7 +352,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -531,7 +532,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 			}
 
 			td := constructMetrics()
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -974,7 +975,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1422,7 +1423,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				contextStatements = append(contextStatements, common.ContextStatements{Context: "", Statements: []string{statement}})
 			}
 
-			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1560,7 +1561,7 @@ func Test_ProcessMetrics_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1600,7 +1601,7 @@ func Test_ProcessMetrics_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1703,7 +1704,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 			_, err = processor.ProcessMetrics(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1923,7 +1924,7 @@ func Test_ProcessMetrics_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)
@@ -1993,7 +1994,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlmetric.TransformContext]{})
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -1869,7 +1869,7 @@ func Test_ProcessMetrics_CacheAccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
-			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalMetricFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(context.Background(), td)

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -10,11 +10,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func SpanFunctions() map[string]ottl.Factory[ottlspan.TransformContext] {
+func SpanFunctions(additionalSpanFuncs []ottl.Factory[ottlspan.TransformContext]) map[string]ottl.Factory[ottlspan.TransformContext] {
 	// No trace-only functions yet.
 	m := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
 	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
 	m[isRootSpanFactory.Name()] = isRootSpanFactory
+
+	for _, fn := range additionalSpanFuncs {
+		m[fn.Name()] = fn
+	}
+
 	return m
 }
 

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -34,7 +34,7 @@ func NewTestSpanFuncFactory[K any]() ottl.Factory[K] {
 }
 
 func createTestSpanFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -4,6 +4,7 @@
 package traces
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,36 @@ func Test_SpanFunctions(t *testing.T) {
 	expected[isRootSpanFactory.Name()] = isRootSpanFactory
 	actual := SpanFunctions([]ottl.Factory[ottlspan.TransformContext]{})
 	require.Len(t, actual, len(expected))
+	for k := range actual {
+		assert.Contains(t, expected, k)
+	}
+}
+
+type TestSpanFuncArguments[K any] struct {
+}
+
+func NewTestSpanFuncFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("ExtractPatternsRubyRegex", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
+}
+
+func createTestSpanFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		return nil, nil
+	}, nil
+}
+
+func Test_SpanFunctions_AdditionalSpanFuncs(t *testing.T) {
+	testSpanFuncFactory := NewTestSpanFuncFactory[ottlspan.TransformContext]()
+
+	expected := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
+	expected[testSpanFuncFactory.Name()] = testSpanFuncFactory
+	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
+	expected[isRootSpanFactory.Name()] = isRootSpanFactory
+
+	additionalSpanFuncs := []ottl.Factory[ottlspan.TransformContext]{testSpanFuncFactory}
+	actual := SpanFunctions(additionalSpanFuncs)
+
+	require.Equal(t, len(expected), len(actual))
 	for k := range actual {
 		assert.Contains(t, expected, k)
 	}

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -27,15 +27,14 @@ func Test_SpanFunctions(t *testing.T) {
 	}
 }
 
-type TestSpanFuncArguments[K any] struct {
-}
+type TestSpanFuncArguments[K any] struct{}
 
 func NewTestSpanFuncFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("TestSpanFunc", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
 }
 
-func createTestSpanFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(ctx context.Context, tCtx K) (any, error) {
+func createTestSpanFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(_ context.Context, tCtx K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
@@ -18,7 +19,7 @@ func Test_SpanFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
 	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
 	expected[isRootSpanFactory.Name()] = isRootSpanFactory
-	actual := SpanFunctions()
+	actual := SpanFunctions([]ottl.Factory[ottlspan.TransformContext]{})
 	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -51,7 +51,7 @@ func Test_SpanFunctions_AdditionalSpanFuncs(t *testing.T) {
 	additionalSpanFuncs := []ottl.Factory[ottlspan.TransformContext]{testSpanFuncFactory}
 	actual := SpanFunctions(additionalSpanFuncs)
 
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for k := range actual {
 		assert.Contains(t, expected, k)
 	}

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -31,7 +31,7 @@ type TestSpanFuncArguments[K any] struct {
 }
 
 func NewTestSpanFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("ExtractPatternsRubyRegex", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
+	return ottl.NewFactory("SpanFunc", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
 }
 
 func createTestSpanFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -31,7 +31,7 @@ type TestSpanFuncArguments[K any] struct {
 }
 
 func NewTestSpanFuncFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("SpanFunc", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
+	return ottl.NewFactory("TestSpanFunc", &TestSpanFuncArguments[K]{}, createTestSpanFunc[K])
 }
 
 func createTestSpanFunc[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -20,8 +21,8 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings) (*Processor, error) {
-	pc, err := common.NewTraceParserCollection(settings, common.WithSpanParser(SpanFunctions()), common.WithSpanEventParser(SpanEventFunctions()), common.WithTraceErrorMode(errorMode))
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, additionalSpanFuncs []ottl.Factory[ottlspan.TransformContext]) (*Processor, error) {
+	pc, err := common.NewTraceParserCollection(settings, common.WithSpanParser(SpanFunctions(additionalSpanFuncs)), common.WithSpanEventParser(SpanEventFunctions()), common.WithTraceErrorMode(errorMode))
 	if err != nil {
 		return nil, err
 	}

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -1425,7 +1425,7 @@ func Test_NewProcessor_AdditionalSpanFuncs(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestSpanFunc())`},
 				},
 			},
-			wantErrorWith:       fmt.Sprintf(`undefined function "TestSpanFunc"`),
+			wantErrorWith:       `undefined function "TestSpanFunc"`,
 			additionalSpanFuncs: EmptyAdditionalSpanFuncs,
 		},
 	}

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
@@ -58,7 +59,7 @@ func Test_ProcessTraces_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -99,7 +100,7 @@ func Test_ProcessTraces_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -140,7 +141,7 @@ func Test_ProcessTraces_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -181,7 +182,7 @@ func Test_ProcessTraces_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -481,7 +482,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -781,7 +782,7 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -811,7 +812,7 @@ func Test_ProcessTraces_SpanEventContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "spanevent", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "spanevent", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -841,7 +842,7 @@ func Test_ProcessTraces_InferredSpanEventContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -958,7 +959,7 @@ func Test_ProcessTraces_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -994,7 +995,7 @@ func Test_ProcessTraces_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -1096,7 +1097,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 			_, err = processor.ProcessTraces(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1310,7 +1311,7 @@ func Test_ProcessTraces_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -1380,7 +1381,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings())
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
@@ -1431,7 +1432,7 @@ func BenchmarkTwoSpans(b *testing.B) {
 
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(b, err)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
@@ -1473,7 +1474,7 @@ func BenchmarkHundredSpans(b *testing.B) {
 	}
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings())
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
 			assert.NoError(b, err)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -30,6 +30,8 @@ var (
 	traceID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	spanID  = [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 	spanID2 = [8]byte{8, 7, 6, 5, 4, 3, 2, 1}
+
+	EmptyAdditionalSpanFuncs = []ottl.Factory[ottlspan.TransformContext]{}
 )
 
 func Test_ProcessTraces_ResourceContext(t *testing.T) {
@@ -59,7 +61,7 @@ func Test_ProcessTraces_ResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -100,7 +102,7 @@ func Test_ProcessTraces_InferredResourceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -141,7 +143,7 @@ func Test_ProcessTraces_ScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -182,7 +184,7 @@ func Test_ProcessTraces_InferredScopeContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -482,7 +484,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -782,7 +784,7 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -812,7 +814,7 @@ func Test_ProcessTraces_SpanEventContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "spanevent", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "spanevent", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -842,7 +844,7 @@ func Test_ProcessTraces_InferredSpanEventContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -959,7 +961,7 @@ func Test_ProcessTraces_MixContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -995,7 +997,7 @@ func Test_ProcessTraces_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -1097,7 +1099,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 			_, err = processor.ProcessTraces(context.Background(), td)
 			if tt.wantErrorWith != "" {
@@ -1311,7 +1313,7 @@ func Test_ProcessTraces_InferredContextFromConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(t, err)
 
 			_, err = processor.ProcessTraces(context.Background(), td)
@@ -1381,7 +1383,7 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 		t.Run(ctx, func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+					_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 					if tt.wantErrorWith != "" {
 						if err == nil {
 							t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
@@ -1432,7 +1434,7 @@ func BenchmarkTwoSpans(b *testing.B) {
 
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(b, err)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
@@ -1474,7 +1476,7 @@ func BenchmarkHundredSpans(b *testing.B) {
 	}
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), []ottl.Factory[ottlspan.TransformContext]{})
+			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), EmptyAdditionalSpanFuncs)
 			assert.NoError(b, err)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
@@ -1482,6 +1484,53 @@ func BenchmarkHundredSpans(b *testing.B) {
 				_, err = processor.ProcessTraces(context.Background(), td)
 				assert.NoError(b, err)
 			}
+		})
+	}
+}
+
+func Test_NewProcessor_AdditionalSpanFuncs(t *testing.T) {
+	type testCase struct {
+		name                string
+		statements          []common.ContextStatements
+		wantErrorWith       string
+		additionalSpanFuncs []ottl.Factory[ottlspan.TransformContext]
+	}
+
+	tests := []testCase{
+		{
+			name: "additional span funcs : statement with added span func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("span"),
+					Statements: []string{`set(cache["attr"], TestSpanFunc())`},
+				},
+			},
+			additionalSpanFuncs: []ottl.Factory[ottlspan.TransformContext]{NewTestSpanFuncFactory[ottlspan.TransformContext]()},
+		},
+		{
+			name: "additional span funcs : statement with missing span func",
+			statements: []common.ContextStatements{
+				{
+					Context:    common.ContextID("span"),
+					Statements: []string{`set(cache["attr"], TestSpanFunc())`},
+				},
+			},
+			wantErrorWith:       fmt.Sprintf(`undefined function "TestSpanFunc"`),
+			additionalSpanFuncs: EmptyAdditionalSpanFuncs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewProcessor(tt.statements, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), tt.additionalSpanFuncs)
+			if tt.wantErrorWith != "" {
+				if err == nil {
+					t.Errorf("expected error containing '%s', got: <nil>", tt.wantErrorWith)
+				}
+				assert.Contains(t, err.Error(), tt.wantErrorWith)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
#### Description
Add properties `AdditionalLogFuncs`, `AdditionalSpanFuncs` and `AdditionalMetricFuncs` to the `transform` processor [Config](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/transformprocessor/config.go#L34-L48) . This will enable users to programatically add custom OTTL functions for logs, metrics or traces to the resulting processor.

Some details about the solution :

- This Config properties can only be set programatically.
- This Config properties can not be set through a config file.
- This enables users of the `transform` processor to customize their OTTL functions as needed.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39698

**Note : There is a similar followup proposed update for the `processor/filter`.**

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added unit tests for the modified methods and functions.

<!--Describe the documentation added.-->
#### Documentation
- Added `Additional OTTL Functions` section to README.

<!--Please delete paragraphs that you did not use before submitting.-->
