### PR TITLE
[chore] [pkg/stanza] make it possible to tell emitters apart in logs

### DIFF
--- a/pkg/stanza/operator/helper/emitter.go
+++ b/pkg/stanza/operator/helper/emitter.go
@@ -70,7 +70,7 @@ func (o flushIntervalOption) apply(e *BatchingLogEmitter) {
 
 // NewBatchingLogEmitter creates a new receiver output
 func NewBatchingLogEmitter(set component.TelemetrySettings, consumerFunc func(context.Context, []*entry.Entry), opts ...EmitterOption) *BatchingLogEmitter {
-	op, _ := NewOutputConfig("log_emitter", "log_emitter").Build(set)
+	op, _ := NewOutputConfig("batching_log_emitter", "batching_log_emitter").Build(set)
 	e := &BatchingLogEmitter{
 		OutputOperator: op,
 		maxBatchSize:   defaultMaxBatchSize,
@@ -205,7 +205,7 @@ type SynchronousLogEmitter struct {
 }
 
 func NewSynchronousLogEmitter(set component.TelemetrySettings, consumerFunc func(context.Context, []*entry.Entry)) *SynchronousLogEmitter {
-	op, _ := NewOutputConfig("log_emitter", "log_emitter").Build(set)
+	op, _ := NewOutputConfig("synchronous_log_emitter", "synchronous_log_emitter").Build(set)
 	return &SynchronousLogEmitter{
 		OutputOperator: op,
 		consumerFunc:   consumerFunc,


### PR DESCRIPTION
#### Description

After introducing the feature gate `stanza.synchronousLogEmitter` it is not possible to tell which log emitter (SynchronousLogEmitter or BatchingLogEmitter) is being used just by looking at debug logs.

This is what the operator logs look like when built on current `main` (https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/a372d054d5984a68caf1392e7f952395e69adf3c). Note the part `"operator_id": "log_emitter", "operator_type": "log_emitter"`:

```console
$ otelcol-contrib-0.124.1-linux_amd64 --config config.yaml
2025-04-25T10:04:40.110+0200    info    service@v0.124.1-0.20250422165940-c47951a8bf71/service.go:199   Setting up own telemetry...
...
2025-04-25T10:04:40.112+0200    info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs"}
2025-04-25T10:04:40.112+0200    debug   pipeline/directed.go:59 Starting operator       {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "log_emitter", "operator_type": "log_emitter"}
2025-04-25T10:04:40.112+0200    debug   pipeline/directed.go:63 Started operator        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "log_emitter", "operator_type": "log_emitter"}
```

I'm fixing this in this pull request by naming the two log emitter outputs differently.

Here's what the logs look like after the change - note the part `"operator_id": "batching_log_emitter", "operator_type": "batching_log_emitter"`:

```console
$ /bin/otelcontribcol_linux_amd64 --config config.yaml
2025-04-25T10:02:10.563+0200    info    service@v0.124.1-0.20250422165940-c47951a8bf71/service.go:199   Setting up own telemetry...
...
2025-04-25T10:02:10.566+0200    info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs"}
2025-04-25T10:02:10.566+0200    debug   pipeline/directed.go:59 Starting operator       {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "batching_log_emitter", "operator_type": "batching_log_emitter"}
2025-04-25T10:02:10.566+0200    debug   pipeline/directed.go:63 Started operator        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "batching_log_emitter", "operator_type": "batching_log_emitter"}
```

And with feature gate switched on - note the part `"operator_id": "synchronous_log_emitter", "operator_type": "synchronous_log_emitter"`:

```console
$ bin/otelcontribcol_linux_amd64 --config config.yaml --feature-gates=stanza.synchronousLogEmitter 
2025-04-25T10:02:16.529+0200    info    service@v0.124.1-0.20250422165940-c47951a8bf71/service.go:199   Setting up own telemetry...
...
2025-04-25T10:02:16.532+0200    info    adapter/receiver.go:41  Starting stanza receiver        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs"}
2025-04-25T10:02:16.532+0200    debug   pipeline/directed.go:59 Starting operator       {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "synchronous_log_emitter", "operator_type": "synchronous_log_emitter"}
2025-04-25T10:02:16.532+0200    debug   pipeline/directed.go:63 Started operator        {"otelcol.component.id": "filelog", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "synchronous_log_emitter", "operator_type": "synchronous_log_emitter"}
```