### PR TITLE
[chore][pkg/ottl] Disallow setting empty profile IDs

### DIFF
--- a/pkg/ottl/contexts/internal/ctxprofile/profile.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile.go
@@ -6,6 +6,7 @@ package ctxprofile // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -333,8 +334,11 @@ func accessProfileID[K ProfileContext]() ottl.StandardGetSetter[K] {
 			return tCtx.GetProfile().ProfileID(), nil
 		},
 		Setter: func(_ context.Context, tCtx K, val any) error {
-			if i, ok := val.(pprofile.ProfileID); ok {
-				tCtx.GetProfile().SetProfileID(i)
+			if id, ok := val.(pprofile.ProfileID); ok {
+				if id.IsEmpty() {
+					return errors.New("profile ids must not be empty")
+				}
+				tCtx.GetProfile().SetProfileID(id)
 			}
 			return nil
 		},
@@ -352,6 +356,9 @@ func accessStringProfileID[K ProfileContext]() ottl.StandardGetSetter[K] {
 				id, err := ctxcommon.ParseProfileID(s)
 				if err != nil {
 					return err
+				}
+				if id.IsEmpty() {
+					return errors.New("profile ids must not be empty")
 				}
 				tCtx.GetProfile().SetProfileID(id)
 			}

--- a/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
+++ b/pkg/ottl/contexts/internal/ctxprofile/profile_test.go
@@ -4,6 +4,7 @@
 package ctxprofile // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxprofile"
 import (
 	"context"
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
@@ -105,8 +106,21 @@ func TestPathGetSetter(t *testing.T) {
 			val:  createProfileID(),
 		},
 		{
+			path:     "profile_id",
+			val:      pprofile.NewProfileIDEmpty(),
+			setFails: true,
+		},
+		{
 			path: "profile_id string",
 			val:  createProfileID().String(),
+		},
+		{
+			path: "profile_id string",
+			val: func() string {
+				id := pprofile.NewProfileIDEmpty()
+				return hex.EncodeToString(id[:])
+			}(),
+			setFails: true,
 		},
 		{
 			path: "attribute_indices",


### PR DESCRIPTION
#### Description
Disallow setting empty profile IDs via the OTTL accessor.

See discussion at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39587#discussion_r2060237611