### PR TITLE
implement max size feature on file storage extension

### DIFF
--- a/.chloggen/file-storage-max-size.yaml
+++ b/.chloggen/file-storage-max-size.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/filestorage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added ability for filestorage extension to limit maximum file size
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38620]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -4,7 +4,6 @@
 package filestorage
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,13 +20,13 @@ import (
 func TestClientOperations(t *testing.T) {
 	dbFile := filepath.Join(t.TempDir(), "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, client.Close(context.TODO()))
+		require.NoError(t, client.Close(t.Context()))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testKey := "testKey"
 	testValue := []byte("testValue")
 
@@ -59,13 +58,13 @@ func TestClientBatchOperations(t *testing.T) {
 	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, client.Close(context.TODO()))
+		require.NoError(t, client.Close(t.Context()))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	testSetEntries := []*storage.Operation{
 		storage.SetOperation("testKey1", []byte("testValue1")),
 		storage.SetOperation("testKey2", []byte("testValue2")),
@@ -142,7 +141,7 @@ func TestNewClientTransactionErrors(t *testing.T) {
 				return tx.DeleteBucket(defaultBucket)
 			},
 			validate: func(t *testing.T, c *fileStorageClient) {
-				value, err := c.Get(context.Background(), testKey)
+				value, err := c.Get(t.Context(), testKey)
 				require.Error(t, err)
 				require.Equal(t, "storage not initialized", err.Error())
 				require.Nil(t, value)
@@ -154,7 +153,7 @@ func TestNewClientTransactionErrors(t *testing.T) {
 				return tx.DeleteBucket(defaultBucket)
 			},
 			validate: func(t *testing.T, c *fileStorageClient) {
-				err := c.Set(context.Background(), testKey, testValue)
+				err := c.Set(t.Context(), testKey, testValue)
 				require.Error(t, err)
 				require.Equal(t, "storage not initialized", err.Error())
 			},
@@ -165,7 +164,7 @@ func TestNewClientTransactionErrors(t *testing.T) {
 				return tx.DeleteBucket(defaultBucket)
 			},
 			validate: func(t *testing.T, c *fileStorageClient) {
-				err := c.Delete(context.Background(), testKey)
+				err := c.Delete(t.Context(), testKey)
 				require.Error(t, err)
 				require.Equal(t, "storage not initialized", err.Error())
 			},
@@ -177,10 +176,10 @@ func TestNewClientTransactionErrors(t *testing.T) {
 			tempDir := t.TempDir()
 			dbFile := filepath.Join(tempDir, "my_db")
 
-			client, err := newClient(zap.NewNop(), dbFile, timeout, &CompactionConfig{}, false)
+			client, err := newClient(zap.NewNop(), dbFile, timeout, 0, &CompactionConfig{}, false)
 			require.NoError(t, err)
 			t.Cleanup(func() {
-				require.NoError(t, client.Close(context.TODO()))
+				require.NoError(t, client.Close(t.Context()))
 			})
 
 			// Create a problem
@@ -201,11 +200,78 @@ func TestNewClientErrorsOnInvalidBucket(t *testing.T) {
 	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.Error(t, err)
 	require.Nil(t, client)
 
 	defaultBucket = temp
+}
+
+func TestMaxSizeNotExceeded(t *testing.T) {
+	cases := []struct {
+		name     string
+		mutation func(t *testing.T, client *fileStorageClient, k string, v []byte) error
+	}{
+		{
+			name: "batch",
+			mutation: func(t *testing.T, client *fileStorageClient, k string, v []byte) error {
+				batchWrite := []*storage.Operation{
+					storage.SetOperation(k, v),
+				}
+				return client.Batch(t.Context(), batchWrite...)
+			},
+		},
+		{
+			name: "set",
+			mutation: func(t *testing.T, client *fileStorageClient, k string, v []byte) error {
+				return client.Set(t.Context(), k, v)
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			dbFile := filepath.Join(tempDir, "my_db")
+
+			maxSize := 1024 * 1024
+
+			logger, _ := zap.NewDevelopment()
+			client, err := newClient(logger, dbFile, time.Second, maxSize, &CompactionConfig{}, false)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, client.Close(t.Context()))
+			})
+
+			// 1. Add some entries to the database below the max size
+			for numEntries := range 400 {
+				err = testCase.mutation(t, client, fmt.Sprintf("foo-%d", numEntries), make([]byte, 1024))
+				require.NoError(t, err)
+			}
+
+			err = client.db.Sync()
+			require.NoError(t, err)
+
+			// 2. Ensure file size smaller than maximum
+			totalSize, _, err := client.getDbSize()
+			require.NoError(t, err)
+			require.LessOrEqual(t, totalSize, int64(maxSize))
+
+			// 3. Add an entry beyond the maximum, it should fail
+			err = testCase.mutation(t, client, "foo-excess", make([]byte, 1024000))
+			require.ErrorIs(t, err, storage.ErrStorageFull)
+
+			// 4. Ensure the database can sync, still works, and is below max size
+			err = client.db.Sync()
+			require.NoError(t, err)
+
+			err = testCase.mutation(t, client, "foo-excess", make([]byte, 1024))
+			require.NoError(t, err)
+
+			totalSize, _, err = client.getDbSize()
+			require.NoError(t, err)
+			require.LessOrEqual(t, totalSize, int64(maxSize))
+		})
+	}
 }
 
 func TestClientReboundCompaction(t *testing.T) {
@@ -251,7 +317,7 @@ func TestClientReboundCompaction(t *testing.T) {
 			checkInterval := time.Second
 
 			logger, _ := zap.NewDevelopment()
-			client, err := newClient(logger, dbFile, time.Second, &CompactionConfig{
+			client, err := newClient(logger, dbFile, time.Second, 0, &CompactionConfig{
 				OnRebound:                  true,
 				CheckInterval:              checkInterval,
 				ReboundNeededThresholdMiB:  testCase.reboundNeededThresholdMiB,
@@ -259,11 +325,11 @@ func TestClientReboundCompaction(t *testing.T) {
 			}, false)
 			require.NoError(t, err)
 			t.Cleanup(func() {
-				require.NoError(t, client.Close(context.TODO()))
+				require.NoError(t, client.Close(t.Context()))
 			})
 
 			// 1. Fill up the database
-			ctx := context.Background()
+			ctx := t.Context()
 
 			entrySize := int64(400_000)
 
@@ -293,7 +359,7 @@ func TestClientReboundCompaction(t *testing.T) {
 			)
 
 			// 2. Remove the large entries
-			for i := 0; i < int(numEntries); i++ {
+			for i := range int(numEntries) {
 				_, realSize, err := client.getDbSize()
 				require.NoError(t, err)
 				if realSize < testCase.drainStorageBelowMiB*oneMiB {
@@ -340,7 +406,7 @@ func TestClientConcurrentCompaction(t *testing.T) {
 
 	stepInterval := time.Millisecond * 5
 
-	client, err := newClient(logger, dbFile, time.Second, &CompactionConfig{
+	client, err := newClient(logger, dbFile, time.Second, 0, &CompactionConfig{
 		OnRebound:                  true,
 		CheckInterval:              stepInterval * 2,
 		ReboundNeededThresholdMiB:  1,
@@ -351,10 +417,10 @@ func TestClientConcurrentCompaction(t *testing.T) {
 	t.Cleanup(func() {
 		// At least one compaction should have happened
 		require.GreaterOrEqual(t, len(logObserver.FilterMessage("finished compaction").All()), 1)
-		require.NoError(t, client.Close(context.TODO()))
+		require.NoError(t, client.Close(t.Context()))
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Make sure the compaction conditions will be met by putting and deleting large chunk of data
 	batchWrite := []*storage.Operation{
@@ -392,7 +458,7 @@ func TestClientConcurrentCompaction(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		t.Run(fmt.Sprintf("client-operations-thread-%d", i), func(t *testing.T) {
 			t.Parallel()
 			clientOperationsThread(t, i)
@@ -404,17 +470,16 @@ func BenchmarkClientGet(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
 	testKey := "testKey"
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_, err = client.Get(ctx, testKey)
 		require.NoError(b, err)
 	}
@@ -424,21 +489,19 @@ func BenchmarkClientGet100(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
-
 	testEntries := make([]*storage.Operation, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		testEntries[i] = storage.GetOperation(fmt.Sprintf("testKey-%d", i))
 	}
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		require.NoError(b, client.Batch(ctx, testEntries...))
 	}
 }
@@ -447,18 +510,17 @@ func BenchmarkClientSet(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
 	testKey := "testKey"
 	testValue := []byte("testValue")
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		require.NoError(b, client.Set(ctx, testKey, testValue))
 	}
 }
@@ -467,20 +529,19 @@ func BenchmarkClientSet100(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
-	ctx := context.Background()
 
 	testEntries := make([]*storage.Operation, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		testEntries[i] = storage.SetOperation(fmt.Sprintf("testKey-%d", i), []byte("testValue"))
 	}
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		require.NoError(b, client.Batch(ctx, testEntries...))
 	}
 }
@@ -489,17 +550,15 @@ func BenchmarkClientDelete(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
-
-	ctx := context.Background()
 	testKey := "testKey"
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		require.NoError(b, client.Delete(ctx, testKey))
 	}
 }
@@ -515,28 +574,27 @@ func BenchmarkClientSetLargeDB(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
-
-	for n := 0; n < entryCount; n++ {
+	for n := range entryCount {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Set(ctx, testKey, entry))
 	}
 
-	for n := 0; n < entryCount; n++ {
+	for n := range entryCount {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Delete(ctx, testKey))
 	}
 
 	testKey = "testKey"
 	testValue := []byte("testValue")
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+
+	for b.Loop() {
 		require.NoError(b, client.Set(ctx, testKey, testValue))
 	}
 }
@@ -552,15 +610,14 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
-
-	for n := 0; n < entryCount; n++ {
+	for n := range entryCount {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Set(ctx, testKey, entry))
 	}
@@ -569,9 +626,9 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 	require.NoError(b, err)
 
 	var tempClient *fileStorageClient
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		tempClient, err = newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+
+	for b.Loop() {
+		tempClient, err = newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StopTimer()
 		err = tempClient.Close(ctx)
@@ -589,34 +646,31 @@ func BenchmarkClientCompactLargeDBFile(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
-
-	for n := 0; n < entryCount; n++ {
+	for n := range entryCount {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Set(ctx, testKey, entry))
 	}
 
 	// Leave one key in the db
-	for n := 0; n < entryCount-1; n++ {
+	for n := range entryCount - 1 {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Delete(ctx, testKey))
 	}
 
 	require.NoError(b, client.Close(ctx))
 
-	b.ResetTimer()
-	b.StopTimer()
-	for n := 0; n < b.N; n++ {
+	for n := 0; b.Loop(); n++ {
 		testDbFile := filepath.Join(tempDir, fmt.Sprintf("my_db%d", n))
 		err = os.Link(dbFile, testDbFile)
 		require.NoError(b, err)
-		client, err = newClient(zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
+		client, err = newClient(zap.NewNop(), testDbFile, time.Second, 0, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StartTimer()
 		require.NoError(b, client.Compact(tempDir, time.Second, 65536))
@@ -633,34 +687,31 @@ func BenchmarkClientCompactDb(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, 0, &CompactionConfig{}, false)
 	require.NoError(b, err)
+	ctx := b.Context()
 	b.Cleanup(func() {
-		require.NoError(b, client.Close(context.TODO()))
+		require.NoError(b, client.Close(ctx))
 	})
 
-	ctx := context.Background()
-
-	for n := 0; n < entryCount; n++ {
+	for n := range entryCount {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Set(ctx, testKey, entry))
 	}
 
 	// Leave half the keys in the DB
-	for n := 0; n < entryCount/2; n++ {
+	for n := range entryCount / 2 {
 		testKey = fmt.Sprintf("testKey-%d", n)
 		require.NoError(b, client.Delete(ctx, testKey))
 	}
 
 	require.NoError(b, client.Close(ctx))
 
-	b.ResetTimer()
-	b.StopTimer()
-	for n := 0; n < b.N; n++ {
+	for n := 0; b.Loop(); n++ {
 		testDbFile := filepath.Join(tempDir, fmt.Sprintf("my_db%d", n))
 		err = os.Link(dbFile, testDbFile)
 		require.NoError(b, err)
-		client, err = newClient(zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
+		client, err = newClient(zap.NewNop(), testDbFile, time.Second, 0, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StartTimer()
 		require.NoError(b, client.Compact(tempDir, time.Second, 65536))

--- a/extension/storage/filestorage/config.go
+++ b/extension/storage/filestorage/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -21,6 +22,7 @@ var (
 type Config struct {
 	Directory string        `mapstructure:"directory,omitempty"`
 	Timeout   time.Duration `mapstructure:"timeout,omitempty"`
+	MaxSize   uint          `mapstructure:"max_size,omitempty"`
 
 	Compaction *CompactionConfig `mapstructure:"compaction,omitempty"`
 
@@ -82,6 +84,11 @@ func (cfg *Config) Validate() error {
 		} else if !info.IsDir() {
 			return fmt.Errorf("%s is not a directory", dir)
 		}
+	}
+
+	if cfg.MaxSize > math.MaxInt {
+		// this is because bbolt stores maximum size as a signed int
+		return fmt.Errorf("max size cannot be greater than %d", math.MaxInt)
 	}
 
 	if cfg.Compaction.MaxTransactionSize < 0 {

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -4,7 +4,6 @@
 package filestorage
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,7 +24,7 @@ import (
 )
 
 func TestExtensionIntegrity(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	se := newTestExtension(t)
 
 	type mockComponent struct {
@@ -101,7 +100,7 @@ func TestExtensionIntegrity(t *testing.T) {
 }
 
 func TestClientHandlesSimpleCases(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	se := newTestExtension(t)
 
 	client, err := se.GetClient(
@@ -145,7 +144,7 @@ func TestClientHandlesSimpleCases(t *testing.T) {
 }
 
 func TestTwoClientsWithDifferentNames(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	se := newTestExtension(t)
 
 	client1, err := se.GetClient(
@@ -232,14 +231,14 @@ func TestComponentNameWithUnsafeCharacters(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	cfg.Directory = tempDir
 
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
 	require.True(t, ok)
 
 	client, err := se.GetClient(
-		context.Background(),
+		t.Context(),
 		component.KindReceiver,
 		newTestEntity("my/slashed/component*"),
 		"",
@@ -248,11 +247,11 @@ func TestComponentNameWithUnsafeCharacters(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	client.Close(context.Background())
+	client.Close(t.Context())
 }
 
 func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tempDir := t.TempDir()
 
@@ -260,7 +259,7 @@ func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	cfg.Directory = tempDir
 
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -286,7 +285,7 @@ func newTestExtension(t *testing.T) storage.Extension {
 	cfg := f.CreateDefaultConfig().(*Config)
 	cfg.Directory = t.TempDir()
 
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -300,7 +299,7 @@ func newTestEntity(name string) component.ID {
 }
 
 func TestCompaction(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tempDir := t.TempDir()
 
@@ -308,7 +307,7 @@ func TestCompaction(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	cfg.Directory = tempDir
 
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -390,7 +389,7 @@ func TestCompaction(t *testing.T) {
 // TestCompactionRemoveTemp validates if temporary db used for compaction is removed afterwards
 // test is performed for both: the same and different than storage directories
 func TestCompactionRemoveTemp(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tempDir := t.TempDir()
 
@@ -398,7 +397,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	cfg.Directory = tempDir
 
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -454,7 +453,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 }
 
 func TestCleanupOnStart(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tempDir := t.TempDir()
 	// simulate left temporary compaction file from killed process
@@ -466,7 +465,7 @@ func TestCleanupOnStart(t *testing.T) {
 	cfg.Directory = tempDir
 	cfg.Compaction.Directory = tempDir
 	cfg.Compaction.CleanupOnStart = true
-	extension, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), cfg)
+	extension, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -490,7 +489,7 @@ func TestCleanupOnStart(t *testing.T) {
 }
 
 func TestCompactionOnStart(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	f := NewFactory()
 
 	logCore, logObserver := observer.New(zap.DebugLevel)
@@ -506,7 +505,7 @@ func TestCompactionOnStart(t *testing.T) {
 	cfg.Directory = tempDir
 	cfg.Compaction.Directory = tempDir
 	cfg.Compaction.OnStart = true
-	extension, err := f.Create(context.Background(), set, cfg)
+	extension, err := f.Create(t.Context(), set, cfg)
 	require.NoError(t, err)
 
 	se, ok := extension.(storage.Extension)
@@ -523,7 +522,7 @@ func TestCompactionOnStart(t *testing.T) {
 	t.Cleanup(func() {
 		// At least one compaction should have happened on start
 		require.GreaterOrEqual(t, len(logObserver.FilterMessage("finished compaction").All()), 1)
-		require.NoError(t, client.Close(context.TODO()))
+		require.NoError(t, client.Close(t.Context()))
 	})
 }
 
@@ -604,7 +603,7 @@ func TestDirectoryCreation(t *testing.T) {
 			f := NewFactory()
 			config := tt.config(t, f)
 			if config != nil {
-				ext, err := f.Create(context.Background(), extensiontest.NewNopSettings(f.Type()), config)
+				ext, err := f.Create(t.Context(), extensiontest.NewNopSettings(f.Type()), config)
 				require.NoError(t, err)
 				require.NotNil(t, ext)
 				tt.validate(t, config)

--- a/extension/storage/filestorage/factory.go
+++ b/extension/storage/filestorage/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 			CleanupOnStart:             false,
 		},
 		Timeout:              time.Second,
+		MaxSize:              0,
 		FSync:                false,
 		CreateDirectory:      false,
 		DirectoryPermissions: "0750",

--- a/extension/storage/filestorage/factory_test.go
+++ b/extension/storage/filestorage/factory_test.go
@@ -4,7 +4,6 @@
 package filestorage
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,8 +49,9 @@ func TestFactory(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
 			e, err := f.Create(
-				context.Background(),
+				ctx,
 				extensiontest.NewNopSettings(f.Type()),
 				test.config,
 			)
@@ -64,7 +64,6 @@ func TestFactory(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, e)
-				ctx := context.Background()
 				require.NoError(t, e.Start(ctx, componenttest.NewNopHost()))
 				require.NoError(t, e.Shutdown(ctx))
 			}

--- a/extension/storage/filestorage/go.mod
+++ b/extension/storage/filestorage/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.10.0
-	go.etcd.io/bbolt v1.4.0
+	go.etcd.io/bbolt v1.4.0-beta.0.0.20250425174651-88d2b5469521
 	go.opentelemetry.io/collector/component v1.30.1-0.20250428165858-4ed72bda40bd
 	go.opentelemetry.io/collector/component/componenttest v0.124.1-0.20250428165858-4ed72bda40bd
 	go.opentelemetry.io/collector/confmap v1.30.1-0.20250428165858-4ed72bda40bd

--- a/extension/storage/filestorage/go.sum
+++ b/extension/storage/filestorage/go.sum
@@ -42,8 +42,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
-go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
+go.etcd.io/bbolt v1.4.0-beta.0.0.20250425174651-88d2b5469521 h1:4BCyA7tmUAQ17qFMF/rq5xHWsPUyrXJdxR2uC5An1Jg=
+go.etcd.io/bbolt v1.4.0-beta.0.0.20250425174651-88d2b5469521/go.mod h1:i2EVz4nGVysO259d6NYN8XoFvhjYFZKIsvMbHp4hRv8=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/collector/component v1.30.1-0.20250428165858-4ed72bda40bd h1:cwHlvKqw5PzO1lXR80g4xwKvLNPTvJ44jqb2vUncKQY=


### PR DESCRIPTION
#### Description
This change allows the file storage extension to be configured with a maximum limit. The DB file will not exceed this limit when written to. If a write would cause the file to grow beyond this size, a new standard error (see https://github.com/open-telemetry/opentelemetry-collector/pull/12925) will be returned.

#### Link to tracking issue
Fixes #38620 

#### Testing
Unit tests were added to test this functionality.
