### PR TITLE
[exporter/datadog] fix a race in serializer

### DIFF
--- a/.chloggen/dd-serializer-race.yaml
+++ b/.chloggen/dd-serializer-race.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix a race condition in metric serializer exporter where the exporter may not be fully initialized when it receives metrics"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dd-serializer-race.yaml
+++ b/.chloggen/dd-serializer-race.yaml
@@ -10,7 +10,7 @@ component: datadogexporter
 note: "Fix a race condition in metric serializer exporter where the exporter may not be fully initialized when it receives metrics"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [39669]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -89,8 +89,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83 h1:LHDAmZp5/MTWIpDgjTPmIHUYj+ra+5C9IfrquQwN5cY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -89,8 +89,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270 h1:FO9aGFH0ZwzY3PoB1p+VJeZaPr0wo14fGnft55hcazQ=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -89,7 +89,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.124.1

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -89,7 +89,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.124.1

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -106,8 +106,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83 h1:LHDAmZp5/MTWIpDgjTPmIHUYj+ra+5C9IfrquQwN5cY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -106,8 +106,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270 h1:FO9aGFH0ZwzY3PoB1p+VJeZaPr0wo14fGnft55hcazQ=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -106,8 +106,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83 h1:LHDAmZp5/MTWIpDgjTPmIHUYj+ra+5C9IfrquQwN5cY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250428143048-1cb2fe523d83/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -106,8 +106,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelin
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:yFHxOq8IHRSuKbuuK2bdYGk04qOjy0x2hHesfFGITU8=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:k7GCr0Szffsqy7N6HOlgblNaW9VI90W5M9f296QymHE=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:3/9TNc7tFAcjDd1uG2Xz0X26+IrSi5p6lcj7LKB6x2g=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270 h1:FO9aGFH0ZwzY3PoB1p+VJeZaPr0wo14fGnft55hcazQ=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5 h1:vOspxze7RLom9vQZKeSB/AUYyUfs1WdVUEcgvhT1iKY=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.67.0-devel.0.20250424210921-914083d478e5/go.mod h1:guAOIcP0lAmLvKKZ9nUfbC9nIqscU7MDqL1glUrlGEA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270 h1:d41LmXGWfmupPeuc/Cw6ob1quBX6Z/fJJ1C4sXo++oA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270/go.mod h1:vI9y4FJ/hgPjNo+YaWRYHlv/ynCeApTlb9moz8rcMzI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:bUL168dwbZGsq3Btj1zT66Hv8VrwNCI3lnJCDy5sSIA=

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -90,7 +90,6 @@ func TestNewExporter(t *testing.T) {
 }
 
 func TestNewExporter_Serializer(t *testing.T) {
-	t.Skip("Flaky, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39601")
 	server := testutil.DatadogServerMock()
 	defer server.Close()
 


### PR DESCRIPTION
#### Description
Fix a race condition in metric serializer exporter where the exporter may not be fully initialized when it receives metrics

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39601

#### Testing
ran the test 100 times with no failures
```
go test -run TestNewExporter_Serializer -count 100 -timeout 1h
...
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter	513.392s
```
