### PR TITLE
[receiver/datadog] Address semconv noncompliance

### DIFF
--- a/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
+++ b/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Address semantic conventions noncompliance and add support for http/db
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36924]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Bump semantic conventions to v1.27.0
+  Add support for http and db attributes
+  Use datadog's base service as service.name
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
+++ b/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
@@ -16,7 +16,7 @@ issues: [36924]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  * Bump semantic conventions to v1.27.0
+  * Bump semantic conventions to v1.30.0
   * Add support for http and db attributes
   * Use datadog's base service as service.name when available
   * Set `server.address` on client/producer/consumer spans

--- a/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
+++ b/.chloggen/datadog_receiver_address_semconv_noncompliance.yaml
@@ -16,9 +16,11 @@ issues: [36924]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Bump semantic conventions to v1.27.0
-  Add support for http and db attributes
-  Use datadog's base service as service.name
+  * Bump semantic conventions to v1.27.0
+  * Add support for http and db attributes
+  * Use datadog's base service as service.name when available
+  * Set `server.address` on client/producer/consumer spans
+  * Properly name postgresql/redis/servlet/spring spans
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
 
 func strPtr(s string) *string       { return &s }
@@ -401,13 +401,13 @@ func TestTranslateSeriesV2(t *testing.T) {
 				requireMetricAndDataPointCounts(t, result, 1, 0)
 
 				require.Equal(t, 1, result.ResourceMetrics().Len())
-				v, exists := result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeHostName)
+				v, exists := result.ResourceMetrics().At(0).Resource().Attributes().Get(string(semconv.HostNameKey))
 				require.True(t, exists)
 				require.Equal(t, "Host1", v.AsString())
-				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeDeploymentEnvironmentName)
+				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(string(semconv.DeploymentEnvironmentNameKey))
 				require.True(t, exists)
 				require.Equal(t, "tag1", v.AsString())
-				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeServiceVersion)
+				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(string(semconv.ServiceVersionKey))
 				require.True(t, exists)
 				require.Equal(t, "tag2", v.AsString())
 

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func strPtr(s string) *string       { return &s }
@@ -400,13 +401,13 @@ func TestTranslateSeriesV2(t *testing.T) {
 				requireMetricAndDataPointCounts(t, result, 1, 0)
 
 				require.Equal(t, 1, result.ResourceMetrics().Len())
-				v, exists := result.ResourceMetrics().At(0).Resource().Attributes().Get("host.name")
+				v, exists := result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeHostName)
 				require.True(t, exists)
 				require.Equal(t, "Host1", v.AsString())
-				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get("deployment.environment")
+				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeDeploymentEnvironmentName)
 				require.True(t, exists)
 				require.Equal(t, "tag1", v.AsString())
-				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get("service.version")
+				v, exists = result.ResourceMetrics().At(0).Resource().Attributes().Get(semconv.AttributeServiceVersion)
 				require.True(t, exists)
 				require.Equal(t, "tag2", v.AsString())
 

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -63,6 +63,12 @@ var datadogKnownResourceAttributes = map[string]string{
 	"http.url":                     string(semconv.URLFullKey),
 	"http.useragent":               string(semconv.UserAgentOriginalKey),
 
+	// DB
+	"db.type":      semconv.AttributeDBSystem,
+	"db.operation": semconv.AttributeDBOperationName,
+	"db.instance":  semconv.AttributeDBCollectionName,
+	"db.pool.name": semconv.AttributeDBClientConnectionPoolName,
+
 	// Other
 	"process_id":       string(semconv.ProcessPIDKey),
 	"error.stacktrace": string(semconv.ExceptionStacktraceKey),

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -50,6 +50,19 @@ var datadogKnownResourceAttributes = map[string]string{
 	"kube_namespace":      string(semconv.K8SNamespaceNameKey),
 	"pod_name":            string(semconv.K8SPodNameKey),
 
+	// HTTP
+	"http.client_ip":               string(semconv.ClientAddressKey),
+	"http.response.content_length": string(semconv.HTTPResponseBodySizeKey),
+	"http.status_code":             string(semconv.HTTPResponseStatusCodeKey),
+	"http.request.content_length":  string(semconv.HTTPRequestBodySizeKey),
+	"http.referer":                 "http.request.header.referer",
+	"http.method":                  string(semconv.HTTPRequestMethodKey),
+	"http.route":                   string(semconv.HTTPRouteKey),
+	"http.version":                 string(semconv.NetworkProtocolVersionKey),
+	"http.server_name":             string(semconv.ServerAddressKey),
+	"http.url":                     string(semconv.URLFullKey),
+	"http.useragent":               string(semconv.UserAgentOriginalKey),
+
 	// Other
 	"process_id":       string(semconv.ProcessPIDKey),
 	"error.stacktrace": string(semconv.ExceptionStacktraceKey),
@@ -79,6 +92,15 @@ func translateDatadogTagToKeyValuePair(tag string) (key string, value string) {
 func translateDatadogKeyToOTel(k string) string {
 	if otelKey, ok := datadogKnownResourceAttributes[strings.ToLower(k)]; ok {
 		return otelKey
+	}
+
+	// HTTP dynamic attributes
+	if strings.HasPrefix(k, "http.response.headers.") { // type: string[]
+		header := strings.TrimPrefix(k, "http.response.headers.")
+		return "http.response.header." + header
+	} else if strings.HasPrefix(k, "http.request.headers.") { // type: string[]
+		header := strings.TrimPrefix(k, "http.request.headers.")
+		return "http.request.header." + header
 	}
 	return k
 }
@@ -136,7 +158,7 @@ func tagsToAttributes(tags []string, host string, stringPool *StringPool) attrib
 	for _, tag := range tags {
 		key, val = translateDatadogTagToKeyValuePair(tag)
 		if attr, ok := datadogKnownResourceAttributes[key]; ok {
-			val = stringPool.Intern(val)                               // No need to intern the key if we already have it
+			val = stringPool.Intern(val)                       // No need to intern the key if we already have it
 			if attr == string(semconv.ContainerImageTagsKey) { // type: string[]
 				attrs.resource.PutEmptySlice(attr).AppendEmpty().SetStr(val)
 			} else {
@@ -145,7 +167,12 @@ func tagsToAttributes(tags []string, host string, stringPool *StringPool) attrib
 		} else {
 			key = stringPool.Intern(translateDatadogKeyToOTel(key))
 			val = stringPool.Intern(val)
-			attrs.dp.PutStr(key, val)
+			if strings.HasPrefix(key, "http.request.header.") || strings.HasPrefix(key, "http.response.header.") {
+				// type string[]
+				attrs.resource.PutEmptySlice(key).AppendEmpty().SetStr(val)
+			} else {
+				attrs.dp.PutStr(key, val)
+			}
 		}
 	}
 

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -64,10 +64,10 @@ var datadogKnownResourceAttributes = map[string]string{
 	"http.useragent":               string(semconv.UserAgentOriginalKey),
 
 	// DB
-	"db.type":      semconv.AttributeDBSystem,
-	"db.operation": semconv.AttributeDBOperationName,
-	"db.instance":  semconv.AttributeDBCollectionName,
-	"db.pool.name": semconv.AttributeDBClientConnectionPoolName,
+	"db.type":      string(semconv.DBSystemKey),
+	"db.operation": string(semconv.DBOperationNameKey),
+	"db.instance":  string(semconv.DBCollectionNameKey),
+	"db.pool.name": string(semconv.DBClientConnectionPoolNameKey),
 
 	// Other
 	"process_id":       string(semconv.ProcessPIDKey),

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
 
 // See:
@@ -64,7 +64,7 @@ var datadogKnownResourceAttributes = map[string]string{
 	"http.useragent":               string(semconv.UserAgentOriginalKey),
 
 	// DB
-	"db.type":      string(semconv.DBSystemKey),
+	"db.type":      string(semconv.DBSystemNameKey),
 	"db.operation": string(semconv.DBOperationNameKey),
 	"db.instance":  string(semconv.DBCollectionNameKey),
 	"db.pool.name": string(semconv.DBClientConnectionPoolNameKey),

--- a/receiver/datadogreceiver/internal/translator/tags_test.go
+++ b/receiver/datadogreceiver/internal/translator/tags_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 )
 
 func TestGetMetricAttributes(t *testing.T) {
@@ -33,7 +33,7 @@ func TestGetMetricAttributes(t *testing.T) {
 			tags: []string{},
 			host: "host",
 			expectedResourceAttrs: newMapFromKV(t, map[string]any{
-				semconv.AttributeHostName: "host",
+				string(semconv.HostNameKey): "host",
 			}),
 			expectedScopeAttrs: pcommon.NewMap(),
 			expectedDpAttrs:    pcommon.NewMap(),
@@ -43,10 +43,10 @@ func TestGetMetricAttributes(t *testing.T) {
 			tags: []string{"env:prod", "service:my-service", "version:1.0"},
 			host: "host",
 			expectedResourceAttrs: newMapFromKV(t, map[string]any{
-				semconv.AttributeHostName:                  "host",
-				semconv.AttributeDeploymentEnvironmentName: "prod",
-				semconv.AttributeServiceName:               "my-service",
-				semconv.AttributeServiceVersion:            "1.0",
+				string(semconv.HostNameKey):                  "host",
+				string(semconv.DeploymentEnvironmentNameKey): "prod",
+				string(semconv.ServiceNameKey):               "my-service",
+				string(semconv.ServiceVersionKey):            "1.0",
 			}),
 			expectedScopeAttrs: pcommon.NewMap(),
 			expectedDpAttrs:    pcommon.NewMap(),
@@ -56,8 +56,8 @@ func TestGetMetricAttributes(t *testing.T) {
 			tags: []string{"env:prod", "foo"},
 			host: "host",
 			expectedResourceAttrs: newMapFromKV(t, map[string]any{
-				semconv.AttributeHostName:                  "host",
-				semconv.AttributeDeploymentEnvironmentName: "prod",
+				string(semconv.HostNameKey):                  "host",
+				string(semconv.DeploymentEnvironmentNameKey): "prod",
 			}),
 			expectedScopeAttrs: pcommon.NewMap(),
 			expectedDpAttrs: newMapFromKV(t, map[string]any{
@@ -164,7 +164,7 @@ func TestImageTags(t *testing.T) {
 	pool := newStringPool()
 
 	attrs := tagsToAttributes(tags, host, pool)
-	imageTags, _ := attrs.resource.Get(semconv.AttributeContainerImageTags)
+	imageTags, _ := attrs.resource.Get(string(semconv.ContainerImageTagsKey))
 	assert.Equal(t, expected, imageTags.AsString())
 }
 

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -152,14 +152,14 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 	}
 	sharedAttributes := pcommon.NewMap()
 	for k, v := range map[string]string{
-		string(semconv.ContainerIDKey):           payload.ContainerID,
-		string(semconv.TelemetrySDKLanguageKey):  payload.LanguageName,
-		string(semconv.ProcessRuntimeVersionKey): payload.LanguageVersion,
+		string(semconv.ContainerIDKey):               payload.ContainerID,
+		string(semconv.TelemetrySDKLanguageKey):      payload.LanguageName,
+		string(semconv.ProcessRuntimeVersionKey):     payload.LanguageVersion,
 		string(semconv.DeploymentEnvironmentNameKey): payload.Env,
-		string(semconv.HostNameKey):              payload.Hostname,
-		string(semconv.ServiceVersionKey):        payload.AppVersion,
-		string(semconv.TelemetrySDKNameKey):      "Datadog",
-		string(semconv.TelemetrySDKVersionKey):   payload.TracerVersion,
+		string(semconv.HostNameKey):                  payload.Hostname,
+		string(semconv.ServiceVersionKey):            payload.AppVersion,
+		string(semconv.TelemetrySDKNameKey):          "Datadog",
+		string(semconv.TelemetrySDKVersionKey):       payload.TracerVersion,
 	} {
 		if v != "" {
 			sharedAttributes.PutStr(k, v)

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -93,6 +93,8 @@ func traceID64to128(span *pb.Span, traceIDCache *simplelru.LRU[uint64, pcommon.T
 func getSpanName(span *pb.Span) string {
 	if span.Name == "servlet.request" || span.Name == "spring.handler" {
 		return span.Resource
+	} else if span.Name == "postgresql.query" {
+		return span.Resource
 	}
 	return span.Name
 }

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -54,6 +54,7 @@ var spanProcessor = map[string]func(*pb.Span, *ptrace.Span) error{
 
 	// Database
 	"postgresql.query": processDBSpan,
+	"redis.query":      processDBSpan,
 }
 
 func upsertHeadersAttributes(req *http.Request, attrs pcommon.Map) {

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -98,7 +98,7 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 		string(semconv.ContainerIDKey):           payload.ContainerID,
 		string(semconv.TelemetrySDKLanguageKey):  payload.LanguageName,
 		string(semconv.ProcessRuntimeVersionKey): payload.LanguageVersion,
-		string(semconv.DeploymentEnvironmentKey): payload.Env,
+		string(semconv.DeploymentEnvironmentNameKey): payload.Env,
 		string(semconv.HostNameKey):              payload.Hostname,
 		string(semconv.ServiceVersionKey):        payload.AppVersion,
 		string(semconv.TelemetrySDKNameKey):      "Datadog",

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -136,6 +136,11 @@ func ToTraces(logger *zap.Logger, payload *pb.TracerPayload, req *http.Request, 
 
 	for _, trace := range traces {
 		for _, span := range trace {
+			// Restore base service name as the service name.
+			// Without this, internal spans such as postgresql queries have a service.name set to postgresql
+			if val, ok := span.Meta["_dd.base_service"]; ok {
+				span.Service = val
+			}
 			slice, exist := groupByService[span.Service]
 			if !exist {
 				slice = ptrace.NewSpanSlice()

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -343,7 +343,6 @@ func TestToTracesServiceName(t *testing.T) {
 						assert.Equal(t, tt.expectedSpanName, span.Name())
 					}
 				}
-
 			}
 		})
 	}
@@ -474,10 +473,11 @@ func TestProcessSpanByName(t *testing.T) {
 		},
 	}
 
+	//nolint:govet
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			span := ptrace.NewSpan()
-			_ = processSpanByName(&tt.span, &span)
+			processSpanByName(&tt.span, &span)
 			assert.Equal(t, tt.expectedSpanName, span.Name())
 		})
 	}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -435,6 +435,16 @@ func TestProcessSpanByName(t *testing.T) {
 			},
 		},
 		{
+			"db-redis",
+			"redis",
+			pb.Span{
+				Name: "redis.query",
+				Meta: map[string]string{
+					"db.type": "redis",
+				},
+			},
+		},
+		{
 			"internal-spring-handler",
 			"ShippingController.shipOrder",
 			pb.Span{

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	vmsgp "github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/otel/semconv/v1.16.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -11,15 +11,14 @@ import (
 	"strconv"
 	"testing"
 
-	"go.opentelemetry.io/collector/pdata/ptrace"
-
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vmsgp "github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -555,7 +555,7 @@ func TestToTracesServerAddress(t *testing.T) {
 				Header: http.Header{},
 			}
 
-			traces := ToTraces(payload, req)
+			traces, _ := ToTraces(zap.NewNop(), payload, req, nil)
 			for _, rs := range traces.ResourceSpans().All() {
 				for _, ss := range rs.ScopeSpans().All() {
 					for _, span := range ss.Spans().All() {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
**Note: this PR addresses several things, happy to split it in multiple PRs if it helps.** 

In #36924, a number of noncompliances were identified. This PR addresses most of them:
> Misalignments applying to all span types
> 
> * A resource attribute deployment.resource.name should be defined instead of the span attribute deployment.environment: Str(production)
> * A resource attribute process.pid should be defined instead of the attribute process.id

Addressed by bumping semconv to latest in the collector (1.30.0)

> Misalignments applying to HTTP server span
> 
> * Adopt new OTel Semantic Conventions http.request.method and http.response.status_code instead of http.method and http.status_code
> * The span name should be ${http.request.method} ${http.route}, the attribute dd.span.Resource is right for this span type
>     * OTTL transformation to fix the pb: set (name, attributes["dd.span.Resource"]) where name == "servlet.request"

Added in 89e2bffbdf887a1d979e6e89773817a71c31456b

> Misalignment applying to internal Spring Framework spans(span name spring.handler)
> 
> Span should be kind = SpanKind.SPAN_KIND_INTERNAL
> * OTTL transformation to fix the pb: set (kind, SPAN_KIND_INTERNAL) where kind == SPAN_KIND_SERVER and name == "spring.handler"
> * Span name should be the Java method nam hat is carried over by the dd.span.Resource attribute
>     * OTTL transformation to fix the pb: `set (name, attributes["dd.span.Resource"]) where name

I didn't add the span kind transformation for now as it seemed too involved for the receiver, happy to get feedback on that. Rest in 89e2bffbdf887a1d979e6e89773817a71c31456b

> Misalignments applying to Database client spans
> 
> * The resource attribute service.name should be set to the value of the span attribute _dd.base_service

Done in d067d37c186430cf4ba8b035f3a98e9cb4c2035b. This might be a big change though.

> * Rename the following span attributes
>     * db.type -> db.system
>     * db.operation -> db.operation.name
>     * db.instance -> db.name
> * The span name should be set to ${db.operation.name} ${}

Done in f78caac4f2aa32c5c96ed6d8fcbc1cf7d4166e11

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
#36924 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests were updated.

<!--Please delete paragraphs that you did not use before submitting.-->
