### PR TITLE
Duplicated atributes extracting from k8s

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -125,9 +125,6 @@ processors:
         - k8s.cronjob.name
         - k8s.statefulset.name
         - k8s.statefulset.uid
-        - container.image.name
-        - container.image.tag
-        - container.id
         - k8s.container.name
         - container.image.name
         - container.image.tag


### PR DESCRIPTION
Atributtes duplicated line 128-130 with 132-134
        - container.image.name
        - container.image.tag
        - container.id

#### Description
Some attributes are duplicated in the sample configuration of collector in the datadog  exporter

