### PR TITLE
[chore] Add tests for scrapers using Windows perfcounters

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
@@ -12,9 +12,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/scraper/scrapertest"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/perfcounters"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata"
 )
 
 func TestStopSamplingWithoutStart(t *testing.T) {
@@ -119,4 +123,30 @@ func Benchmark_SampleLoad(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		s.sampleLoad()
 	}
+}
+
+func TestLoadScrapeWithRealData(t *testing.T) {
+	config := Config{
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	scraper := newLoadScraper(context.Background(), scrapertest.NewNopSettings(metadata.Type), &config)
+
+	err := scraper.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err, "Failed to start the load scraper")
+	defer func() {
+		assert.NoError(t, scraper.shutdown(context.Background()), "Failed to shutdown the load scraper")
+	}()
+
+	metrics, err := scraper.scrape(context.Background())
+	require.NoError(t, err, "Failed to scrape metrics")
+	require.NotNil(t, metrics, "Metrics cannot be nil")
+
+	// Expected metric names for load scraper
+	expectedMetrics := map[string]bool{
+		"system.cpu.load_average.1m":  false,
+		"system.cpu.load_average.5m":  false,
+		"system.cpu.load_average.15m": false,
+	}
+
+	internal.AssertExpectedMetrics(t, expectedMetrics, metrics)
 }

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -74,3 +74,53 @@ func AssertSameTimeStampForMetrics(t *testing.T, metrics pmetric.MetricSlice, st
 		}
 	}
 }
+
+// AssertExpectedMetrics checks that metrics contains expected metrics and no other metrics.
+// It also checks that each expected metric has at least one data point.
+func AssertExpectedMetrics(t *testing.T, expectedMetrics map[string]bool, actualMetrics pmetric.Metrics) {
+	unexpectedMetrics := map[string]bool{}
+
+	metricsCount := 0
+	totalDataPointCount := 0
+
+	metricsSlice := actualMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
+	for i := 0; i < metricsSlice.Len(); i++ {
+		metricsCount++
+		metricsSlice.At(i)
+		metric := metricsSlice.At(i)
+		switch metric.Type() {
+		case pmetric.MetricTypeSum:
+			totalDataPointCount += metric.Sum().DataPoints().Len()
+		case pmetric.MetricTypeGauge:
+			totalDataPointCount += metric.Gauge().DataPoints().Len()
+		case pmetric.MetricTypeHistogram:
+			totalDataPointCount += metric.Histogram().DataPoints().Len()
+		case pmetric.MetricTypeExponentialHistogram:
+			totalDataPointCount += metric.ExponentialHistogram().DataPoints().Len()
+		case pmetric.MetricTypeSummary:
+			totalDataPointCount += metric.Summary().DataPoints().Len()
+		default:
+			assert.Fail(t, "Unexpected metric type")
+		}
+
+		metricName := metric.Name()
+		if _, ok := expectedMetrics[metricName]; ok {
+			expectedMetrics[metricName] = true
+		} else {
+			unexpectedMetrics[metricName] = true
+		}
+	}
+
+	// Check that we have some metrics and data points
+	assert.Positive(t, metricsCount, "No metrics were collected")
+	assert.Positive(t, totalDataPointCount, "No data points were collected")
+
+	// Check that each expected metric has at least one data point
+	for metricName, hasDataPoints := range expectedMetrics {
+		assert.True(t, hasDataPoints, "Metric %s has no data points", metricName)
+	}
+	// Check that no unexpected metrics were collected
+	for metricName := range unexpectedMetrics {
+		assert.Fail(t, "Unexpected metric was collected", metricName)
+	}
+}


### PR DESCRIPTION
Adding tests collecting the actual Windows performance counters for scrapers using `internal/perfcounters`. The intent of these tests is to facilitate the migration from the vendored code of `internal/perfcounters` to the existing implementation in `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters`, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38858#issuecomment-2748552995 for details.