### PR TITLE
[receiver/awsxray] update to aws-sdk-go-v2

### DIFF
--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xr
 go 1.23.0
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30
 	github.com/aws/aws-sdk-go-v2/service/xray v1.31.4
@@ -16,6 +15,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.55.7 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.14 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect

--- a/internal/aws/xray/telemetry/recorder_test.go
+++ b/internal/aws/xray/telemetry/recorder_test.go
@@ -9,20 +9,29 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/request"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRecordConnectionError(t *testing.T) {
-	type testParameters struct {
+	tests := []struct {
+		name  string
 		input error
 		want  func() types.TelemetryRecord
-	}
-	testCases := []testParameters{
+	}{
 		{
-			input: awserr.NewRequestFailure(nil, http.StatusInternalServerError, ""),
+			name: "5xx error",
+			input: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{
+						Response: &http.Response{
+							StatusCode: http.StatusInternalServerError,
+						},
+					},
+				},
+			},
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
 				record.BackendConnectionErrors.HTTPCode5XXCount = aws.Int32(1)
@@ -30,7 +39,16 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
-			input: awserr.NewRequestFailure(nil, http.StatusBadRequest, ""),
+			name: "4xx error",
+			input: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{
+						Response: &http.Response{
+							StatusCode: http.StatusBadRequest,
+						},
+					},
+				},
+			},
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
 				record.BackendConnectionErrors.HTTPCode4XXCount = aws.Int32(1)
@@ -38,7 +56,16 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
-			input: awserr.NewRequestFailure(nil, http.StatusFound, ""),
+			name: "Other error (302)",
+			input: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{
+						Response: &http.Response{
+							StatusCode: http.StatusFound,
+						},
+					},
+				},
+			},
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
 				record.BackendConnectionErrors.OtherCount = aws.Int32(1)
@@ -46,7 +73,8 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
-			input: awserr.New(request.ErrCodeResponseTimeout, "", nil),
+			name:  "response timeout",
+			input: &awshttp.ResponseTimeoutError{},
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
 				record.BackendConnectionErrors.TimeoutCount = aws.Int32(1)
@@ -54,7 +82,8 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
-			input: awserr.New(request.ErrCodeRequestError, "", nil),
+			name:  "request error",
+			input: &smithyhttp.RequestSendError{},
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
 				record.BackendConnectionErrors.UnknownHostCount = aws.Int32(1)
@@ -62,14 +91,7 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
-			input: awserr.New(request.ErrCodeSerialization, "", nil),
-			want: func() types.TelemetryRecord {
-				record := NewRecord()
-				record.BackendConnectionErrors.OtherCount = aws.Int32(1)
-				return record
-			},
-		},
-		{
+			name:  "other error (test)",
 			input: errors.New("test"),
 			want: func() types.TelemetryRecord {
 				record := NewRecord()
@@ -78,14 +100,18 @@ func TestRecordConnectionError(t *testing.T) {
 			},
 		},
 		{
+			name:  "no error",
 			input: nil,
 			want:  NewRecord,
 		},
 	}
+
 	recorder := NewRecorder()
-	for _, testCase := range testCases {
-		recorder.RecordConnectionError(testCase.input)
-		snapshot := recorder.Rotate()
-		assert.Equal(t, testCase.want().BackendConnectionErrors, snapshot.BackendConnectionErrors)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder.RecordConnectionError(test.input)
+			snapshot := recorder.Rotate()
+			assert.Equal(t, test.want().BackendConnectionErrors, snapshot.BackendConnectionErrors)
+		})
 	}
 }

--- a/internal/aws/xray/tracesegment_test.go
+++ b/internal/aws/xray/tracesegment_test.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxra
 go 1.23.0
 
 require (
-	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/service/xray v1.31.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -34,7 +34,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
+	github.com/aws/aws-sdk-go v1.55.7 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.29.14 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect

--- a/receiver/awsxrayreceiver/internal/translator/aws_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/aws_test.go
@@ -6,7 +6,7 @@ package translator
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/otel/semconv/v1.18.0"

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -6,7 +6,7 @@ package translator
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
aws-sdk-go is being [deprecated on July 31, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/). This PR updates `receiver/awsxray` and finishes updating `internal/aws/xray` to aws-sdk-go-v2.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37732 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I converted the existing unit tests to aws-sdk-go-v2 as well, keeping the original intent of the tests.