### PR TITLE
[receiver/azuremonitorreceiver] Renamed the `auth` field to `credentials`

### DIFF
--- a/.chloggen/azuremonitorreceiver_rename-auth-field.yaml
+++ b/.chloggen/azuremonitorreceiver_rename-auth-field.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'azuremonitorreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Renamed the `auth` field to `credentials` in the azuremonitorreceiver configuration."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39738]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -23,7 +23,7 @@ The following settings are required:
 
 The following settings are optional:
 
-- `auth` (default = service_principal): Specifies the used authentication method. Supported values are `service_principal`, `workload_identity`, `managed_identity`, `default_credentials`.
+- `credentials` (default = service_principal): Specifies the used authentication method. Supported values are `service_principal`, `workload_identity`, `managed_identity`, `default_credentials`.
 - `resource_groups` (default = none): Filter metrics for specific resource groups, not setting a value will scrape metrics for all resources in the subscription.
 - `services` (default = none): Filter metrics for specific services, not setting a value will scrape metrics for all services integrated with Azure Monitor.
 - `metrics` (default = none): Filter metrics by name and aggregations. Not setting a value will scrape all metrics and their aggregations.
@@ -122,7 +122,7 @@ Using [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/develope
 receivers:
   azuremonitor:
     subscription_ids: ["${subscription_id}"]
-    auth: "workload_identity"
+    credentials: "workload_identity"
     tenant_id: "${env:AZURE_TENANT_ID}"
     client_id: "${env:AZURE_CLIENT_ID}"
     federated_token_file: "${env:AZURE_FEDERATED_TOKEN_FILE}"
@@ -134,7 +134,7 @@ Using [Managed Identity](https://learn.microsoft.com/en-us/azure/developer/go/az
 receivers:
   azuremonitor:
     subscription_ids: ["${subscription_id}"]
-    auth: "managed_identity"
+    credentials: "managed_identity"
     client_id: "${env:AZURE_CLIENT_ID}"
 ```
 
@@ -144,7 +144,7 @@ Using [Environment Variables](https://learn.microsoft.com/en-us/azure/developer/
 receivers:
   azuremonitor:
     subscription_ids: ["${subscription_id}"]
-    auth: "default_credentials"
+    credentials: "default_credentials"
 ```
 
 Overriding dimensions for a particular metric:

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -242,7 +242,7 @@ type Config struct {
 	Cloud                             string                        `mapstructure:"cloud"`
 	SubscriptionIDs                   []string                      `mapstructure:"subscription_ids"`
 	DiscoverSubscriptions             bool                          `mapstructure:"discover_subscriptions"`
-	Authentication                    string                        `mapstructure:"auth"`
+	Credentials                       string                        `mapstructure:"credentials"`
 	TenantID                          string                        `mapstructure:"tenant_id"`
 	ClientID                          string                        `mapstructure:"client_id"`
 	ClientSecret                      string                        `mapstructure:"client_secret"`
@@ -272,7 +272,7 @@ func (c Config) Validate() (err error) {
 		err = multierr.Append(err, errMissingSubscriptionIDs)
 	}
 
-	switch c.Authentication {
+	switch c.Credentials {
 	case servicePrincipal:
 		if c.TenantID == "" {
 			err = multierr.Append(err, errMissingTenantID)
@@ -301,7 +301,7 @@ func (c Config) Validate() (err error) {
 	case managedIdentity:
 	case defaultCredentials:
 	default:
-		return fmt.Errorf("authentication %v is not supported. supported authentications include [%v,%v,%v,%v]", c.Authentication, servicePrincipal, workloadIdentity, managedIdentity, defaultCredentials)
+		return fmt.Errorf("credentials %v is not supported. supported authentications include [%v,%v,%v,%v]", c.Credentials, servicePrincipal, workloadIdentity, managedIdentity, defaultCredentials)
 	}
 
 	if c.Cloud != azureCloud && c.Cloud != azureGovernmentCloud && c.Cloud != azureChinaCloud {

--- a/receiver/azuremonitorreceiver/factory.go
+++ b/receiver/azuremonitorreceiver/factory.go
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 		MaximumNumberOfMetricsInACall:     20,
 		MaximumNumberOfRecordsPerResource: 10,
 		Services:                          monitorServices,
-		Authentication:                    servicePrincipal,
+		Credentials:                       servicePrincipal,
 		Cloud:                             defaultCloud,
 	}
 }

--- a/receiver/azuremonitorreceiver/factory_test.go
+++ b/receiver/azuremonitorreceiver/factory_test.go
@@ -45,7 +45,7 @@ func TestNewFactory(t *testing.T) {
 					CacheResourcesDefinitions:         24 * 60 * 60,
 					MaximumNumberOfMetricsInACall:     20,
 					MaximumNumberOfRecordsPerResource: 10,
-					Authentication:                    servicePrincipal,
+					Credentials:                       servicePrincipal,
 					Cloud:                             defaultCloud,
 				}
 

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -159,7 +159,7 @@ func (s *azureScraper) unloadSubscription(id string) {
 }
 
 func (s *azureScraper) loadCredentials() (err error) {
-	switch s.cfg.Authentication {
+	switch s.cfg.Credentials {
 	case defaultCredentials:
 		if s.cred, err = s.azDefaultCredentialsFunc(nil); err != nil {
 			return err
@@ -183,7 +183,7 @@ func (s *azureScraper) loadCredentials() (err error) {
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown authentication %v", s.cfg.Authentication)
+		return fmt.Errorf("unknown credentials %v", s.cfg.Credentials)
 	}
 	return nil
 }

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -112,7 +112,7 @@ func (s *azureBatchScraper) unloadSubscription(id string) {
 
 // TODO: duplicate
 func (s *azureBatchScraper) loadCredentials() (err error) {
-	switch s.cfg.Authentication {
+	switch s.cfg.Credentials {
 	case defaultCredentials:
 		if s.cred, err = s.azDefaultCredentialsFunc(nil); err != nil {
 			return err
@@ -136,7 +136,7 @@ func (s *azureBatchScraper) loadCredentials() (err error) {
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown authentication %v", s.cfg.Authentication)
+		return fmt.Errorf("unknown credentials %v", s.cfg.Credentials)
 	}
 	return nil
 }

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -90,7 +90,7 @@ func TestAzureScraperStart(t *testing.T) {
 			name: "service_principal",
 			testFunc: func(t *testing.T) {
 				cfg := createDefaultTestConfig()
-				cfg.Authentication = servicePrincipal
+				cfg.Credentials = servicePrincipal
 				s := &azureScraper{
 					cfg:                 cfg,
 					time:                timeMock,
@@ -109,7 +109,7 @@ func TestAzureScraperStart(t *testing.T) {
 			name: "workload_identity",
 			testFunc: func(t *testing.T) {
 				cfg := createDefaultTestConfig()
-				cfg.Authentication = workloadIdentity
+				cfg.Credentials = workloadIdentity
 				s := &azureScraper{
 					cfg:                 cfg,
 					time:                timeMock,
@@ -128,7 +128,7 @@ func TestAzureScraperStart(t *testing.T) {
 			name: "managed_identity",
 			testFunc: func(t *testing.T) {
 				cfg := createDefaultTestConfig()
-				cfg.Authentication = managedIdentity
+				cfg.Credentials = managedIdentity
 				s := &azureScraper{
 					cfg:                   cfg,
 					time:                  timeMock,
@@ -147,7 +147,7 @@ func TestAzureScraperStart(t *testing.T) {
 			name: "default_credentials",
 			testFunc: func(t *testing.T) {
 				cfg := createDefaultTestConfig()
-				cfg.Authentication = defaultCredentials
+				cfg.Credentials = defaultCredentials
 				s := &azureScraper{
 					cfg:                      cfg,
 					time:                     timeMock,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Doing this breaking change to prepare usage of azure auth extension and be able to set the auth config like it's usually done for the different authentication by extensions

```yaml
auth:
  authenticator: 'azureauth/prd'
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Unblocks #39658

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
