### PR TITLE
[exporter/datadog] Enable instrumentation_scope_metadata_as_tags by d…

### DIFF
--- a/.chloggen/ibraheem_enable_instrumentation_scope_metadata_as_tags_by_default_in_datadogexporter.yaml
+++ b/.chloggen/ibraheem_enable_instrumentation_scope_metadata_as_tags_by_default_in_datadogexporter.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable instrumentation_scope_metadata_as_tags by default in datadogexporter. Scope attributes are now added as tags to metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39767]

--- a/.chloggen/ibraheem_enable_instrumentation_scope_metadata_as_tags_by_default_in_datadogexporter.yaml
+++ b/.chloggen/ibraheem_enable_instrumentation_scope_metadata_as_tags_by_default_in_datadogexporter.yaml
@@ -11,3 +11,7 @@ note: Enable instrumentation_scope_metadata_as_tags by default in datadogexporte
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [39767]
+
+subtext: |
+  If you have too many unique values for instrumentation scope attributes, this may cause cardinality issues.
+  If this is a concern, you can disable this by setting `datadog.metrics.instrumentation_scope_metadata_as_tags` to `false`.

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -332,7 +332,7 @@ func CreateDefaultConfig() component.Config {
 			DeltaTTL: 3600,
 			ExporterConfig: MetricsExporterConfig{
 				ResourceAttributesAsTags:           false,
-				InstrumentationScopeMetadataAsTags: false,
+				InstrumentationScopeMetadataAsTags: true,
 			},
 			HistConfig: HistogramConfig{
 				Mode:             "distributions",

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -118,6 +118,9 @@ func TestValidate(t *testing.T) {
 			cfg: &Config{
 				API: APIConfig{Key: "aaaaaaa"},
 				Metrics: MetricsConfig{
+					ExporterConfig: MetricsExporterConfig{
+						InstrumentationScopeMetadataAsTags: true,
+					},
 					HistConfig: HistogramConfig{
 						Mode:             HistogramModeNoBuckets,
 						SendAggregations: false,
@@ -419,6 +422,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 		},
 
 		Metrics: MetricsConfig{
+			ExporterConfig: MetricsExporterConfig{
+				InstrumentationScopeMetadataAsTags: true,
+			},
 			TCPAddrConfig: confignet.TCPAddrConfig{
 				Endpoint: "https://api.datadoghq.com",
 			},
@@ -492,6 +498,9 @@ func TestLoadConfig(t *testing.T) {
 				},
 
 				Metrics: MetricsConfig{
+					ExporterConfig: MetricsExporterConfig{
+						InstrumentationScopeMetadataAsTags: true,
+					},
 					TCPAddrConfig: confignet.TCPAddrConfig{
 						Endpoint: "https://api.datadoghq.com",
 					},
@@ -551,6 +560,9 @@ func TestLoadConfig(t *testing.T) {
 					FailOnInvalidKey: true,
 				},
 				Metrics: MetricsConfig{
+					ExporterConfig: MetricsExporterConfig{
+						InstrumentationScopeMetadataAsTags: true,
+					},
 					TCPAddrConfig: confignet.TCPAddrConfig{
 						Endpoint: "https://api.datadoghq.eu",
 					},
@@ -615,6 +627,9 @@ func TestLoadConfig(t *testing.T) {
 					FailOnInvalidKey: false,
 				},
 				Metrics: MetricsConfig{
+					ExporterConfig: MetricsExporterConfig{
+						InstrumentationScopeMetadataAsTags: true,
+					},
 					TCPAddrConfig: confignet.TCPAddrConfig{
 						Endpoint: "https://api.datadoghq.test",
 					},
@@ -675,6 +690,9 @@ func TestLoadConfig(t *testing.T) {
 				},
 
 				Metrics: MetricsConfig{
+					ExporterConfig: MetricsExporterConfig{
+						InstrumentationScopeMetadataAsTags: true,
+					},
 					TCPAddrConfig: confignet.TCPAddrConfig{
 						Endpoint: "https://api.datadoghq.com",
 					},


### PR DESCRIPTION
…efault

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The config for serializerexporter that is imported by datadog-agent will use instrumentation scope attributes to populate tags in the Datadog backend in exported signals. No functionality changes in this PR - it will have an effect once this config is imported in datadog-agent (no changelog needed)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Ran collector locally with no value specified for instrumentation_scope_metadata_as_tags, sent metrics with scope attributes; validated that scope attributes are used. Ran with instrumentation_scope_metadata_as_tags specified as false, validated that scope attributes are not used

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
