### PR TITLE
[receiver/webhookevent] Add new json splitter to webhookeventreceiver -- dead

### DIFF
--- a/.chloggen/webhook-json-splitter.yaml
+++ b/.chloggen/webhook-json-splitter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds configuration to split logs at JSON object boundaries.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39766]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -64,6 +64,21 @@ Three log records will be created from this example. The first two are JSON body
 
 This receiver does not attempt to marshal the body into a structured format as it is received so it cannot make a more intelligent determination about where the split records. 
 
+### Split logs at JSON boundary example
+
+If you don't have clear new-line splits between objects, the regex `}\s.{` will match the boundary between objects.
+`split_logs_at_json_boundary: true`
+
+```yaml
+{ "name": "francis", "city": "newyork", "multiple lines?": "you 
+know it!"}
+{ "name": "john", "city": "paris" }{ "name": "tim", "city": "london" }
+```
+
+This settings works when JSON objects have newlines in the middle of a string or multiple objects on a line.
+
+
+
 ### Configuration Example
 
 ```yaml

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	HealthPath                 string                   `mapstructure:"health_path"`                   // path for health check api. Default is /health_check
 	RequiredHeader             RequiredHeader           `mapstructure:"required_header"`               // optional setting to set a required header for all requests to have
 	SplitLogsAtNewLine         bool                     `mapstructure:"split_logs_at_newline"`         // optional setting to split logs into multiple log records
+	SplitLogsAtJSONBoundary    bool                     `mapstructure:"split_logs_at_json_boundary"`   // optional setting to split logs at JSON object boundaries
 	ConvertHeadersToAttributes bool                     `mapstructure:"convert_headers_to_attributes"` // optional to convert all headers to attributes
 	HeaderAttributeRegex       string                   `mapstructure:"header_attribute_regex"`        // optional to convert headers matching a regex to log attributes
 }
@@ -84,4 +85,8 @@ func (cfg *Config) Validate() error {
 	}
 
 	return errs
+}
+
+func (cfg *Config) ShouldSplitLogsAtJSONBoundary() bool {
+	return cfg.SplitLogsAtJSONBoundary
 }

--- a/receiver/webhookeventreceiver/factory.go
+++ b/receiver/webhookeventreceiver/factory.go
@@ -44,6 +44,7 @@ func createDefaultConfig() component.Config {
 		WriteTimeout:               defaultWriteTimeout,
 		ConvertHeadersToAttributes: false, // optional, off by default
 		SplitLogsAtNewLine:         false,
+		SplitLogsAtJSONBoundary:    false,
 	}
 }
 

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -5,6 +5,7 @@ package webhookeventreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"bufio"
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -25,21 +26,19 @@ func (er *eventReceiver) reqToLog(sc *bufio.Scanner,
 	headers http.Header,
 	query url.Values,
 ) (plog.Logs, int) {
-	if er.cfg.SplitLogsAtNewLine {
-		sc.Split(bufio.ScanLines)
-	} else {
-		// we simply dont split the data passed into scan (i.e. scan the whole thing)
-		// the downside to this approach is that only 1 log per request can be handled.
-		// NOTE: logs will contain these newline characters which could have formatting
-		// consequences downstream.
-		split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-			if !atEOF {
-				return 0, nil, nil
-			}
-			return 0, data, bufio.ErrFinalToken
+	fmt.Println("reqToLog")
+
+	// we simply dont split the data passed into scan (i.e. scan the whole thing)
+	// the downside to this approach is that only 1 log per request can be handled.
+	// NOTE: logs will contain these newline characters which could have formatting
+	// consequences downstream.
+	split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if !atEOF {
+			return 0, nil, nil
 		}
-		sc.Split(split)
+		return 0, data, bufio.ErrFinalToken
 	}
+	sc.Split(split)
 
 	log := plog.NewLogs()
 	resourceLog := log.ResourceLogs().AppendEmpty()
@@ -52,12 +51,20 @@ func (er *eventReceiver) reqToLog(sc *bufio.Scanner,
 	scopeLog.Scope().Attributes().PutStr("receiver", metadata.Type.String())
 
 	for sc.Scan() {
-		logRecord := scopeLog.LogRecords().AppendEmpty()
-		logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-		line := sc.Text()
-		logRecord.Body().SetStr(line)
-		if er.includeHeadersRegex != nil {
-			appendHeaders(headers, logRecord, er.includeHeadersRegex)
+		lines := []string{sc.Text()}
+		if er.cfg.SplitLogsAtNewLine {
+			lines = strings.Split(sc.Text(), "\n")
+		} else if er.cfg.ShouldSplitLogsAtJSONBoundary() {
+			lines = splitJSONObjects(sc.Text())
+		}
+
+		for _, line := range lines {
+			logRecord := scopeLog.LogRecords().AppendEmpty()
+			logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			logRecord.Body().SetStr(line)
+			if er.includeHeadersRegex != nil {
+				appendHeaders(headers, logRecord, er.includeHeadersRegex)
+			}
 		}
 	}
 
@@ -89,4 +96,29 @@ func appendHeaders(h http.Header, l plog.LogRecord, r *regexp.Regexp) {
 // prepend the header key with the "header." namespace
 func headerAttributeKey(header string) string {
 	return strings.Join([]string{headerNamespace, header}, ".")
+}
+
+func splitJSONObjects(data string) []string {
+	// Use regex to find boundaries between JSON objects
+	re := regexp.MustCompile(`}\s*{`)
+
+	// Find all matches
+	indices := re.FindAllStringIndex(data, -1)
+	if len(indices) == 0 {
+		return []string{data}
+	}
+
+	// Split the data at each boundary
+	var result []string
+	lastIdx := 0
+	for _, idx := range indices {
+		// Add the object up to the end of the closing brace
+		result = append(result, data[lastIdx:idx[0]+1])
+		// Start next object from the opening brace
+		lastIdx = idx[1] - 1
+	}
+	// Add the last object
+	result = append(result, data[lastIdx:])
+
+	return result
 }

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -305,6 +305,77 @@ func TestReqToLog(t *testing.T) {
 				require.Equal(t, 3, reqLen)
 			},
 		},
+		{
+			desc: "single multi-line JSON with JSON boundary splitting enabled",
+			sc: func() *bufio.Scanner {
+				reader := io.NopCloser(bytes.NewReader([]byte(`{
+				  "name": "francis",
+				  "address": {
+				    "city": "newyork",
+				    "zip": "10001",
+				    "country": "USA"
+				  },
+				  "tags": ["developer", "opentelemetry"]
+				}`)))
+				return bufio.NewScanner(reader)
+			}(),
+			config: &Config{
+				Path:                    defaultPath,
+				HealthPath:              defaultHealthPath,
+				ReadTimeout:             defaultReadTimeout,
+				WriteTimeout:            defaultWriteTimeout,
+				RequiredHeader:          RequiredHeader{Key: "X-Required-Header", Value: "password"},
+				HeaderAttributeRegex:    "",
+				SplitLogsAtNewLine:      false,
+				SplitLogsAtJSONBoundary: true,
+			},
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.Settings) {
+				// Should be a single log entry since it's one valid JSON object
+				require.Equal(t, 1, reqLen)
+
+				// Verify the log content
+				processLogRecords(reqLog, func(lr plog.LogRecord) {
+					bodyField := lr.Body()
+					body := bodyField.Str()
+					require.Contains(t, body, "francis")
+					require.Contains(t, body, "newyork")
+					require.Contains(t, body, "developer")
+				})
+			},
+		},
+		{
+			desc: "non-JSON data with JSON boundary splitting enabled",
+			sc: func() *bufio.Scanner {
+				reader := io.NopCloser(bytes.NewReader([]byte(`This is plain text
+				that spans multiple lines
+				and has no valid JSON structure.
+				It should be treated as a single log entry
+				despite having newlines and JSON boundary splitting enabled.`)))
+				return bufio.NewScanner(reader)
+			}(),
+			config: &Config{
+				Path:                    defaultPath,
+				HealthPath:              defaultHealthPath,
+				ReadTimeout:             defaultReadTimeout,
+				WriteTimeout:            defaultWriteTimeout,
+				RequiredHeader:          RequiredHeader{Key: "X-Required-Header", Value: "password"},
+				HeaderAttributeRegex:    "",
+				SplitLogsAtNewLine:      false,
+				SplitLogsAtJSONBoundary: true,
+			},
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.Settings) {
+				// Should be a single log entry since there are no JSON boundaries
+				require.Equal(t, 1, reqLen)
+
+				// Verify the log content
+				processLogRecords(reqLog, func(lr plog.LogRecord) {
+					bodyField := lr.Body()
+					body := bodyField.Str()
+					require.Contains(t, body, "plain text")
+					require.Contains(t, body, "splitting enabled")
+				})
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -253,6 +253,58 @@ func TestReqToLog(t *testing.T) {
 				})
 			},
 		},
+		{
+			desc: "multiple JSON objects in one scan due to missing newline split",
+			sc: func() *bufio.Scanner {
+				// Simulate input where two JSON objects are separated by a newline,
+				// but the scanner is not splitting at newlines.
+				reader := io.NopCloser(bytes.NewReader([]byte(`{ "name": "francis", "city": "newyork" }
+{ "name": "john", "city": "paris" }`)))
+				return bufio.NewScanner(reader)
+			}(),
+			config: &Config{
+				Path:                 defaultPath,
+				HealthPath:           defaultHealthPath,
+				ReadTimeout:          defaultReadTimeout,
+				WriteTimeout:         defaultWriteTimeout,
+				RequiredHeader:       RequiredHeader{Key: "X-Required-Header", Value: "password"},
+				HeaderAttributeRegex: "",
+				SplitLogsAtNewLine:   true,
+			},
+			tt: func(t *testing.T, _ plog.Logs, reqLen int, _ receiver.Settings) {
+				// If the bug is present, reqLen will be 1 (both objects in one log record).
+				// The correct behavior is reqLen == 2 (each object in its own log record).
+				require.Equal(t, 2, reqLen)
+			},
+		},
+		{
+			desc: "multiple JSON objects in split at JSON boundary",
+			sc: func() *bufio.Scanner {
+				// Simulate input where two JSON objects are separated by a newline,
+				// but the scanner is not splitting at newlines.
+				reader := io.NopCloser(bytes.NewReader([]byte(`{
+				  "name": "francis", 
+				  "city": "newyork" 
+				}
+                { "name": "john", "city": "paris" }{ "name": "tim", "city": "london" }`)))
+				return bufio.NewScanner(reader)
+			}(),
+			config: &Config{
+				Path:                    defaultPath,
+				HealthPath:              defaultHealthPath,
+				ReadTimeout:             defaultReadTimeout,
+				WriteTimeout:            defaultWriteTimeout,
+				RequiredHeader:          RequiredHeader{Key: "X-Required-Header", Value: "password"},
+				HeaderAttributeRegex:    "",
+				SplitLogsAtNewLine:      false,
+				SplitLogsAtJSONBoundary: true,
+			},
+			tt: func(t *testing.T, _ plog.Logs, reqLen int, _ receiver.Settings) {
+				// If the bug is present, reqLen will be 1 (both objects in one log record).
+				// The correct behavior is reqLen == 2 (each object in its own log record).
+				require.Equal(t, 3, reqLen)
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds the ability to split webhook body contents at JSON boundaries so you don't have to worry about newline characters.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39766

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a test case to show newline vs json handling. 
<!--Describe the documentation added.-->
#### Documentation

Readme was updated with an additional example. 
<!--Please delete paragraphs that you did not use before submitting.-->
