### PR TITLE
[extension/redisstorageextension] fixed batch read from redis storage extension

### DIFF
--- a/extension/storage/redisstorageextension/extension_test.go
+++ b/extension/storage/redisstorageextension/extension_test.go
@@ -200,6 +200,12 @@ func TestRedisKey(t *testing.T) {
 			{Type: storage.Delete, Key: "key1"},
 		}
 
+		opsExpectedValues := [][]byte{
+			[]byte("val1"),
+			[]byte("val1"),
+			nil,
+		}
+
 		mock.ExpectSet(client.prefix+"key1", []byte("val1"), 0).SetVal("OK")
 		mock.ExpectGet(client.prefix + "key1").SetVal("val1")
 		mock.ExpectDel(client.prefix + "key1").SetVal(1)
@@ -207,6 +213,10 @@ func TestRedisKey(t *testing.T) {
 		err := client.Batch(ctx, ops...)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
+
+		for i, op := range ops {
+			require.Equal(t, opsExpectedValues[i], op.Value)
+		}
 	})
 
 	t.Run("single operations", func(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Pipeline batched operation in redis storage extension for the persistent exporter queue fixed.

Redis storage extension for the persistent storage is not working properly. 
The problem is that consumer batch operation which includes read (Redis GET) while read data from Redis doesn't return
them in calling code. 
This PR is to fix this problem. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
UT update to catch the issue.
Also problem is reproducible with enabling mentioned extension:
```
extensions:
  redis_storage:
  redis_storage/all_settings:
    endpoint: localhost:6379
    password: ""
    db: 0
    expiration: 5m
    prefix: test_

service:
  extensions: [redis_storage, redis_storage/all_settings]
  pipelines:
    traces:
      receivers: [oltp]
      exporters: [<any real extension>]
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
