### PR TITLE
receiver/kafkareceiver: fix hyphenated text encodings

### DIFF
--- a/.chloggen/kafkareceiver-textencoding.yaml
+++ b/.chloggen/kafkareceiver-textencoding.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix support for built-in text encodings with hyphens in the encoding name
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39793]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/encoding_test.go
+++ b/receiver/kafkareceiver/encoding_test.go
@@ -131,6 +131,19 @@ func TestNewLogsUnmarshaler(t *testing.T) {
 				assert.NoError(t, plogtest.CompareLogs(logs, actual, plogtest.IgnoreObservedTimestamp()))
 			},
 		},
+		{
+			encoding: "text_utf-16", // hyphen in the name
+			input: func() []byte {
+				out, _ := unicode.UTF16(
+					unicode.LittleEndian,
+					unicode.IgnoreBOM,
+				).NewEncoder().Bytes([]byte("hello world"))
+				return out
+			}(),
+			check: func(t *testing.T, actual plog.Logs) {
+				assert.NoError(t, plogtest.CompareLogs(logs, actual, plogtest.IgnoreObservedTimestamp()))
+			},
+		},
 	} {
 		t.Run(tc.encoding, func(t *testing.T) {
 			u := mustNewLogsUnmarshaler(t, tc.encoding, componenttest.NewNopHost())


### PR DESCRIPTION
#### Description

Fix support for text encodings with hyphens in their names.

If the encoding name has a hyphen then it is an invalid extension ID, but we should not return an error due to this if it's a built-in encoding.

#### Link to tracking issue

Fixes #39793

#### Testing

Added a new unit test covering hyphenated text encoding names (fails without the associated fix).

#### Documentation

N/A