### PR TITLE
Promote @braydonk to approver role

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/open-telemetry/teams/collector-contrib-triagers))
 
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
-- [Braydon Kains](https://github.com/braydonk), Google
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace
 - [Israel Blancas](https://github.com/iblancasa), Coralogix
 - [James Moessis](https://github.com/jamesmoessis), Atlassian
@@ -92,6 +91,7 @@ Emeritus Triagers:
 Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs/open-telemetry/teams/collector-contrib-approvers)):
 
 - [Arthur Silva Sens](https://github.com/ArthurSens), Grafana Labs
+- [Braydon Kains](https://github.com/braydonk), Google
 - [Christos Markou](https://github.com/ChrsMark), Elastic
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google (on leave)


### PR DESCRIPTION
@braydonk has been doing great work on this repo, especially on everything related to system/host metrics. The maintainers would like to propose @braydonk as an approver of the OpenTelemetry Collector Contrib.

PRs reviewed:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Abraydonk+ PRs authored:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Abraydonk+ Issues created:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+author%3Abraydonk+ Issues commented:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+commenter%3Abraydonk+ Commits:
https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?author=braydonk&since=2023-05-31&until=now
