### PR TITLE
exporter/kafkaexporter: fix topic & message key

### DIFF
--- a/.chloggen/kafkaexporter-fixes.yaml
+++ b/.chloggen/kafkaexporter-fixes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix the default topic configuration, and default message partitioning
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39810, 39816]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -157,7 +157,7 @@ func (e *kafkaTracesMessager) marshalData(td ptrace.Traces) ([]marshaler.Message
 }
 
 func (e *kafkaTracesMessager) getTopic(ctx context.Context, td ptrace.Traces) string {
-	return getTopic(ctx, &e.config, td.ResourceSpans())
+	return getTopic(ctx, &e.config, e.config.Traces.Topic, td.ResourceSpans())
 }
 
 func (e *kafkaTracesMessager) partitionData(td ptrace.Traces) iter.Seq2[[]byte, ptrace.Traces] {
@@ -202,7 +202,7 @@ func (e *kafkaLogsMessager) marshalData(ld plog.Logs) ([]marshaler.Message, erro
 }
 
 func (e *kafkaLogsMessager) getTopic(ctx context.Context, ld plog.Logs) string {
-	return getTopic(ctx, &e.config, ld.ResourceLogs())
+	return getTopic(ctx, &e.config, e.config.Logs.Topic, ld.ResourceLogs())
 }
 
 func (e *kafkaLogsMessager) partitionData(ld plog.Logs) iter.Seq2[[]byte, plog.Logs] {
@@ -245,7 +245,7 @@ func (e *kafkaMetricsMessager) marshalData(md pmetric.Metrics) ([]marshaler.Mess
 }
 
 func (e *kafkaMetricsMessager) getTopic(ctx context.Context, md pmetric.Metrics) string {
-	return getTopic(ctx, &e.config, md.ResourceMetrics())
+	return getTopic(ctx, &e.config, e.config.Metrics.Topic, md.ResourceMetrics())
 }
 
 func (e *kafkaMetricsMessager) partitionData(md pmetric.Metrics) iter.Seq2[[]byte, pmetric.Metrics] {
@@ -274,7 +274,12 @@ type resource interface {
 	Resource() pcommon.Resource
 }
 
-func getTopic[T resource](ctx context.Context, cfg *Config, resources resourceSlice[T]) string {
+func getTopic[T resource](
+	ctx context.Context,
+	cfg *Config,
+	defaultTopic string,
+	resources resourceSlice[T],
+) string {
 	if cfg.TopicFromAttribute != "" {
 		for i := 0; i < resources.Len(); i++ {
 			rv, ok := resources.At(i).Resource().Attributes().Get(cfg.TopicFromAttribute)
@@ -287,17 +292,22 @@ func getTopic[T resource](ctx context.Context, cfg *Config, resources resourceSl
 	if ok {
 		return contextTopic
 	}
-	return cfg.Topic
+	return defaultTopic
 }
 
 func makeSaramaMessages(messages []marshaler.Message, topic string) []*sarama.ProducerMessage {
 	saramaMessages := make([]*sarama.ProducerMessage, len(messages))
 	for i, message := range messages {
-		saramaMessages[i] = &sarama.ProducerMessage{
+		msg := &sarama.ProducerMessage{
 			Topic: topic,
-			Key:   sarama.ByteEncoder(message.Key),
-			Value: sarama.ByteEncoder(message.Value),
 		}
+		if message.Key != nil {
+			msg.Key = sarama.ByteEncoder(message.Key)
+		}
+		if message.Value != nil {
+			msg.Value = sarama.ByteEncoder(message.Value)
+		}
+		saramaMessages[i] = msg
 	}
 	return saramaMessages
 }


### PR DESCRIPTION
#### Description

Use the correct config source for the default topic name, and don't set an empty message key if there's no partitioning.

#### Link to tracking issue

Fixes #39810
Fixes #39816

#### Testing

- Verified default configuration works
- Added unit tests that confirm message key is no longer set by default

I started adding a functional test using the kafkatest package, but kfake doesn't seem to like the Sarama client very much; I was unable to get that to work without hacking kfake.

#### Documentation

None