### PR TITLE
Updated Apache Receiver compatibility

### DIFF
--- a/receiver/apachereceiver/README.md
+++ b/receiver/apachereceiver/README.md
@@ -16,7 +16,7 @@ This receiver fetches stats from a Apache Web Server instance using the `server-
 
 ## Prerequisites
 
-This receiver supports Apache Web Server version 2.4+
+This receiver supports Apache Web Server version 2.4.13+.
 
 ### mod_status module
 


### PR DESCRIPTION
Updated compatibility in Prereq section from 2.4+ to 2.4.13+ per this issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39758

