### PR TITLE
[receiver/fluentforward] move struct to internal, do not expose in API

### DIFF
--- a/.chloggen/move_ack_to_internal.yaml
+++ b/.chloggen/move_ack_to_internal.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fluentforwardreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport AckResponse
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39831]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/fluentforwardreceiver/internal/ack.go
+++ b/receiver/fluentforwardreceiver/internal/ack.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package fluentforwardreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver/internal"
 
 import "github.com/tinylib/msgp/msgp"
 

--- a/receiver/fluentforwardreceiver/internal/ack_test.go
+++ b/receiver/fluentforwardreceiver/internal/ack_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package fluentforwardreceiver
+package internal
 
 import (
 	"bytes"

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tinylib/msgp/msgp"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver/internal/metadata"
 )
 
@@ -125,7 +126,7 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 		// messages -- this is the only thing that sends data back to the
 		// client.
 		if event.Chunk() != "" {
-			err := msgp.Encode(conn, AckResponse{Ack: event.Chunk()})
+			err := msgp.Encode(conn, internal.AckResponse{Ack: event.Chunk()})
 			if err != nil {
 				return fmt.Errorf("failed to acknowledge chunk %s: %w", event.Chunk(), err)
 			}


### PR DESCRIPTION
This struct is internal to the receiver and not exposed as part of Config.