### PR TITLE
[receiver/googlecloudpubsub] add ignore_encoding_error configuration

### DIFF
--- a/.chloggen/pubsub-ignore-encoding-error.yaml
+++ b/.chloggen/pubsub-ignore-encoding-error.yaml
@@ -1,0 +1,16 @@
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudpubsubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `ignore_encoding_error` configuration to ignore decoding failures from the configured encoder
+
+issues: [38164]
+
+subtext: |
+  Introduce a setting to ignore errors when the configured encoder. It's advised to set this to `true` when using 
+  a custom encoder, and use `receiver.googlecloudpubsub.encoding_error` metric to monitor the number of errors. 
+  Ignoring the error will cause the receiver to drop the message.
+
+change_logs: [user]

--- a/.chloggen/pubsub-ignore-encoding-error.yaml
+++ b/.chloggen/pubsub-ignore-encoding-error.yaml
@@ -1,4 +1,4 @@
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: googlecloudpubsubreceiver
@@ -10,7 +10,7 @@ issues: [38164]
 
 subtext: |
   Introduce a setting to ignore errors when the configured encoder. It's advised to set this to `true` when using 
-  a custom encoder, and use `receiver.googlecloudpubsub.encoding_error` metric to monitor the number of errors. 
+  a custom encoder, and use the new `receiver.googlecloudpubsub.encoding_error` metric to monitor the number of errors. 
   Ignoring the error will cause the receiver to drop the message.
 
 change_logs: [user]

--- a/receiver/googlecloudpubsubreceiver/README.md
+++ b/receiver/googlecloudpubsubreceiver/README.md
@@ -30,6 +30,9 @@ The following configuration options are supported:
   or switching between [global and regional service endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints).
 * `insecure` (Optional): allows performing “insecure” SSL connections and transfers, useful when connecting to a local
    emulator instance. Only has effect if Endpoint is not ""
+* `ignore_encoding_error` (Optional): Ignore errors when the configured encoder fails to decoding a PubSub messages.
+  It's advised to set this to `true` when using a custom encoder, and use `receiver.googlecloudpubsub.encoding_error`
+  metric to monitor the number of errors. Ignoring the error will cause the receiver to drop the message.
 
 ```yaml
 receivers:

--- a/receiver/googlecloudpubsubreceiver/config.go
+++ b/receiver/googlecloudpubsubreceiver/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// Lock down the compression of the payload, leave empty for attribute based detection
 	Compression string `mapstructure:"compression"`
 
+	// Ignore errors when the configured encoder fails to decoding a PubSub messages
+	IgnoreEncodingError bool `mapstructure:"ignore_encoding_error"`
+
 	// The client id that will be used by Pubsub to make load balancing decisions
 	ClientID string `mapstructure:"client_id"`
 }

--- a/receiver/googlecloudpubsubreceiver/documentation.md
+++ b/receiver/googlecloudpubsubreceiver/documentation.md
@@ -6,6 +6,18 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol_receiver.googlecloudpubsub.encoding_error
+
+Number of times a message couldn't be decoded by the configured encoder
+
+The receiver reads messages from Google Cloud Pub/Sub and tries to decode the message using the configured
+encoder. Each time a message fails to decoded the counter is increased. 
+
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Sum | Int | true |
+
 ### otelcol_receiver.googlecloudpubsub.stream_restarts
 
 Number of times the stream (re)starts due to a Pub/Sub servers connection close

--- a/receiver/googlecloudpubsubreceiver/internal/metadata/generated_telemetry.go
+++ b/receiver/googlecloudpubsubreceiver/internal/metadata/generated_telemetry.go
@@ -26,6 +26,7 @@ type TelemetryBuilder struct {
 	meter                                   metric.Meter
 	mu                                      sync.Mutex
 	registrations                           []metric.Registration
+	ReceiverGooglecloudpubsubEncodingError  metric.Int64Counter
 	ReceiverGooglecloudpubsubStreamRestarts metric.Int64Counter
 }
 
@@ -58,6 +59,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
+	builder.ReceiverGooglecloudpubsubEncodingError, err = builder.meter.Int64Counter(
+		"otelcol_receiver.googlecloudpubsub.encoding_error",
+		metric.WithDescription("Number of times a message couldn't be decoded by the configured encoder"),
+		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
 	builder.ReceiverGooglecloudpubsubStreamRestarts, err = builder.meter.Int64Counter(
 		"otelcol_receiver.googlecloudpubsub.stream_restarts",
 		metric.WithDescription("Number of times the stream (re)starts due to a Pub/Sub servers connection close"),

--- a/receiver/googlecloudpubsubreceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/receiver/googlecloudpubsubreceiver/internal/metadatatest/generated_telemetrytest.go
@@ -21,6 +21,22 @@ func NewSettings(tt *componenttest.Telemetry) receiver.Settings {
 	return set
 }
 
+func AssertEqualReceiverGooglecloudpubsubEncodingError(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_receiver.googlecloudpubsub.encoding_error",
+		Description: "Number of times a message couldn't be decoded by the configured encoder",
+		Unit:        "1",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_receiver.googlecloudpubsub.encoding_error")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualReceiverGooglecloudpubsubStreamRestarts(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_receiver.googlecloudpubsub.stream_restarts",

--- a/receiver/googlecloudpubsubreceiver/internal/metadatatest/generated_telemetrytest_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/metadatatest/generated_telemetrytest_test.go
@@ -20,7 +20,11 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.ReceiverGooglecloudpubsubEncodingError.Add(context.Background(), 1)
 	tb.ReceiverGooglecloudpubsubStreamRestarts.Add(context.Background(), 1)
+	AssertEqualReceiverGooglecloudpubsubEncodingError(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualReceiverGooglecloudpubsubStreamRestarts(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())

--- a/receiver/googlecloudpubsubreceiver/metadata.yaml
+++ b/receiver/googlecloudpubsubreceiver/metadata.yaml
@@ -21,6 +21,16 @@ telemetry:
         The receiver uses the Google Cloud Pub/Sub StreamingPull API and keeps a open connection. The Pub/Sub servers
         recurrently close the connection after a time period to avoid a long-running sticky connection. This metric
         counts the number of the resets that occurred during the lifetime of the container.
+    receiver.googlecloudpubsub.encoding_error:
+      enabled: true
+      description: Number of times a message couldn't be decoded by the configured encoder
+      unit: "1"
+      sum:
+        value_type: int
+        monotonic: true
+      extended_documentation: |
+        The receiver reads messages from Google Cloud Pub/Sub and tries to decode the message using the configured
+        encoder. Each time a message fails to decoded the counter is increased. 
 
 tests:
   config:

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver/internal"
@@ -279,10 +281,14 @@ func (receiver *pubsubReceiver) handleTrace(ctx context.Context, payload []byte,
 		return err
 	}
 	otlpData, err := receiver.tracesUnmarshaler.UnmarshalTraces(payload)
-	count := otlpData.SpanCount()
 	if err != nil {
+		receiver.increaseEncodingErrorMetric(ctx, "traces")
+		if receiver.config.IgnoreEncodingError {
+			return nil
+		}
 		return err
 	}
+	count := otlpData.SpanCount()
 	ctx = receiver.obsrecv.StartTracesOp(ctx)
 	err = receiver.tracesConsumer.ConsumeTraces(ctx, otlpData)
 	receiver.obsrecv.EndTracesOp(ctx, reportFormatProtobuf, count, err)
@@ -295,10 +301,14 @@ func (receiver *pubsubReceiver) handleMetric(ctx context.Context, payload []byte
 		return err
 	}
 	otlpData, err := receiver.metricsUnmarshaler.UnmarshalMetrics(payload)
-	count := otlpData.MetricCount()
 	if err != nil {
+		receiver.increaseEncodingErrorMetric(ctx, "metrics")
+		if receiver.config.IgnoreEncodingError {
+			return nil
+		}
 		return err
 	}
+	count := otlpData.MetricCount()
 	ctx = receiver.obsrecv.StartMetricsOp(ctx)
 	err = receiver.metricsConsumer.ConsumeMetrics(ctx, otlpData)
 	receiver.obsrecv.EndMetricsOp(ctx, reportFormatProtobuf, count, err)
@@ -311,14 +321,27 @@ func (receiver *pubsubReceiver) handleLog(ctx context.Context, payload []byte, c
 		return err
 	}
 	otlpData, err := receiver.logsUnmarshaler.UnmarshalLogs(payload)
-	count := otlpData.LogRecordCount()
 	if err != nil {
+		receiver.increaseEncodingErrorMetric(ctx, "logs")
+		if receiver.config.IgnoreEncodingError {
+			return nil
+		}
 		return err
 	}
+	count := otlpData.LogRecordCount()
 	ctx = receiver.obsrecv.StartLogsOp(ctx)
 	err = receiver.logsConsumer.ConsumeLogs(ctx, otlpData)
 	receiver.obsrecv.EndLogsOp(ctx, reportFormatProtobuf, count, err)
 	return nil
+}
+
+func (receiver *pubsubReceiver) increaseEncodingErrorMetric(ctx context.Context, signal string) {
+	receiver.telemetryBuilder.ReceiverGooglecloudpubsubEncodingError.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("otelcol.component.kind", "receiver"),
+			attribute.String("otelcol.component.id", receiver.settings.ID.String()),
+			attribute.String("otelcol.signal", signal),
+		))
 }
 
 func (receiver *pubsubReceiver) detectEncoding(attributes map[string]string) (otlpEncoding buildInEncoding, otlpCompression buildInCompression) {


### PR DESCRIPTION
#### Description
Introduce a setting to ignore errors when the configured encoder. It's advised to set this to `true` when using 
a custom encoder, and use `receiver.googlecloudpubsub.encoding_error` metric to monitor the number of errors. 
Ignoring the error will cause the receiver to drop the message.

#### Link to tracking issue
#38164

#### Testing
Tested with a custom encoder and introducing bogus message to the topic.

#### Documentation
Added the configuration setting to the README