### PR TITLE
[receiver/googlecloudpubsub] add deprecation for build-in encoders

### DIFF
--- a/.chloggen/googlecloudpubsubreceiver-deprecate-buildin.yaml
+++ b/.chloggen/googlecloudpubsubreceiver-deprecate-buildin.yaml
@@ -1,0 +1,13 @@
+change_type: deprecation
+
+component: googlecloudpubsubreceiver
+
+note: Add deprecation warning for the build-in encoders
+
+issues: [39371]
+
+subtext: |
+  The build-in encoders `cloud_logging` and `raw_text` both have encoding extension alternatives and will be removed
+  in version v0.132.0 of the collector.
+
+change_logs: [user]

--- a/receiver/googlecloudpubsubreceiver/README.md
+++ b/receiver/googlecloudpubsubreceiver/README.md
@@ -74,11 +74,12 @@ Extensions. The non OTLP build in encodings will be deprecated as soon as extens
 | raw_text          | Wrap in an OTLP log message                    |
 
 With `cloud_logging`, the receiver can be used to bring Cloud Logging messages into an OpenTelemetry pipeline. You'll
-first need to [set up a logging sink][sink-docs] with a Pub/Sub topic as its destination. Note that the `cloud_logging`
-integration is considered **alpha** as the semantic convention on some of the conversion are not stabilized yet.
+first need to [set up a logging sink][sink-docs] with a Pub/Sub topic as its destination. The build-in encoding is
+**deprecated** and will be removed in v0.132.0: Use the `googlecloudlogentry` encoding extension instead.
 
 With `raw_text`, the receiver can be used for ingesting arbitrary text message on a Pubsub subscription, wrapping them
-in OTLP Log messages.
+in OTLP Log messages.  The build-in encoding is **deprecated** and will be removed in v0.132.0: Use the `text` encoding
+extension instead.
 
 When no encoding is specified, the receiver will try to discover the type of the data by looking at the `ce-type` and
 `content-type` attributes of the message. These message attributes are set by the `googlepubsubexporter`.

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -181,8 +181,10 @@ func (receiver *pubsubReceiver) setMarshallerFromEncodingID(encodingID buildInEn
 		case otlpProtoLog:
 			receiver.logsUnmarshaler = &plog.ProtoUnmarshaler{}
 		case rawTextLog:
+			receiver.settings.Logger.Warn("build-in raw_text encoding is deprecated and will be removed in v0.132.0, use the text encoding extension instead")
 			receiver.logsUnmarshaler = unmarshalLogStrings{}
 		case cloudLogging:
+			receiver.settings.Logger.Warn("build-in cloud_logging encoding is deprecated and will be removed in v0.132.0, use the googlecloudlogentry encoding extension instead")
 			receiver.logsUnmarshaler = unmarshalCloudLoggingLogEntry{}
 		default:
 			return fmt.Errorf("cannot start receiver: build in encoding %s is not supported for logs", receiver.config.Encoding)


### PR DESCRIPTION
#### Description
Add deprecation warning for the build-in encoders. The build-in encoders `cloud_logging` and `raw_text` both have encoding extension alternatives and will be removed in version v0.132.0 of the collector

#### Link to tracking issue
Fixes #39371

#### Testing
Started the collector with the encoders selected and see the warning

#### Documentation
Added deprecation to the README
