### PR TITLE
paths-labeller: support CODEOWNERS adhoc

### DIFF
--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -1,0 +1,3 @@
+---
+- 'Team:Fleet':
+    - 'exporter/elasticsearchexporter'

--- a/.github/paths-labeller.yml
+++ b/.github/paths-labeller.yml
@@ -1,3 +1,3 @@
 ---
-- 'Team:Fleet':
-    - 'exporter/elasticsearchexporter'
+- 'team:observablt-ci':
+    - '.github/workflows/**/*.*'

--- a/.github/workflows/ping-elastic-codeowners-prs.yml
+++ b/.github/workflows/ping-elastic-codeowners-prs.yml
@@ -1,0 +1,38 @@
+name: 'Ping Elastic code owners on PRs'
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  ping-elastic-owners:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    if: startsWith(github.event.label.name, 'team:')
+    steps:
+      - name: ping elastic code owners
+        run: |
+          set -euo pipefail
+          # Given the label with the format "team:team-name", let's extract the team name
+          # and convert it to the GitHub team name format "team-name"
+          TEAM_NAME=$(echo "${LABEL}" | sed -E 's#team:(.+)#\1#')
+
+          # For more: https://github.com/cli/cli/issues/4844
+          echo "Requesting review from code owners: ${TEAM_NAME}"
+
+          curl \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
+              -d "{\"team_reviewers\":[\"${TEAM_NAME}\"]}" \
+              | jq ".message" \
+              || echo "jq was unable to parse GitHub's response"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: ${{ github.event.label.name }}
+          PR: ${{ github.event.number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/ping-elastic-codeowners-prs.yml
+++ b/.github/workflows/ping-elastic-codeowners-prs.yml
@@ -28,7 +28,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               "https://api.github.com/repos/${REPO}/pulls/${PR}/requested_reviewers" \
-              -d "{\"team_reviewers\":[\"${TEAM_NAME}\"]}" \
+              -d "{\"reviewers\":[],\"team_reviewers\":[\"${TEAM_NAME}\"]}" \
               | jq ".message" \
               || echo "jq was unable to parse GitHub's response"
         env:


### PR DESCRIPTION
Use the path-labeller approach, similarly done in `kibana`:
- https://github.com/elastic/kibana/blob/main/.github/paths-labeller.yml

Then, use the github actions to see if any label has been added with the format `team:<team-name>` and then get the `<team-name>` and assign it as reviewer.

See [API docs](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request) to assign reviewers