### PR TITLE
[pkg/datadog] Switch EnableOperationAndResourceNameV2 to Beta

### DIFF
--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -123,10 +123,9 @@ func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfi
 	if !datadog.ReceiveResourceSpansV2FeatureGate.IsEnabled() {
 		acfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
-	if datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
-		acfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
-	} else {
-		logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This feature will be enabled by default in the future - if you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention.")
+	if !datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
+		acfg.Features["disable_operation_and_resource_name_logic_v2"] = struct{}{}
+		logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This flag will be made stable in a future release. If you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention. See the migration guide at https://docs.datadoghq.com/opentelemetry/guide/migrate/migrate_operation_names/")
 	}
 	if v := cfg.BucketInterval; v > 0 {
 		acfg.BucketInterval = v

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.67.0-devel.0.20250422212611-65be868f4270
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.66.0-devel.0.20250407180930-ebfcfa2817ce
-	github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce
-	github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce
+	github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa
+	github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.27.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.27.0
@@ -100,6 +100,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
@@ -125,7 +126,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.37.1 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect
-	github.com/DataDog/go-sqllexer v0.1.3 // indirect
+	github.com/DataDog/go-sqllexer v0.1.6 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -169,8 +169,8 @@ github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407
 github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:a8cPaeE65MIqcQGxZbXcd/kP2iyV/T96NLj9VRHtkQw=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:XTdVCZzQUNPDD2+bfxBxKS2j4yq20IHLigfARk1g4SQ=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:uckeYcHAkid8msRPl8G++46vWzjZP3b7YqTvldiOt1I=
-github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:SZSDR+8w0z+bZKike4z0dbdVoZPUsqqmmB3AcdomA6s=
-github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:07jphzXKrdxfBm7Wn3IAA4odJTkpxDom0O7fYUxFCvQ=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa h1:poFmdxGxOGc954jd/9XWS3MpfK37oO8bSbiRo8t6peM=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa/go.mod h1:W88l6/tojCQo+8j6fnt8kfxQ4tapxOrG2RezsuUKOZc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:+4nPzlMkq13AH8IUy+nePJsbgTHky5RBwIa2Xs3K5gc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:NY9KdZi7WDO085fQ17F5whm6C0T/MF6d+HUPyaBlfm4=
 github.com/DataDog/datadog-agent/pkg/serializer v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:X+YRGhSKl6EjYvdq2jjsKjD+DuTYCcf+gZUpxTvFwB4=
@@ -183,8 +183,10 @@ github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcf
 github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:Z6BpV3ZgUudaMl/Jo9g8KUKxerIXiqQC9bG7DZ3OZNQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:0fiM9Y+KtLsq0dgvChBRxP8GzJDf5JY3WMgqmW+1YJQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:QjpK9pb49FQncSZzHBGTdS+iZWws3waQZ/1B4EwZGU8=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:UGgBmLi/ljWUAj68RQLU4Tqob6V8fqEIdcAK78J5Yoc=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:inD7t7xiwd5qQOGlGuG2Q+IWQg2BxpCcwFEspFpN8ug=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 h1:Yb4qVoYfDEN1frsgrOxPGbZJxMmQbYZMOL7K4EhMau4=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:uZEMDpntZpvc2SWQWgZTpwCRM8m9FMfWx471/5zjZBU=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483 h1:2uOLVWRbODryW6uudR6/kYoveDYQIDAE1YRMnwbGlws=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:mV1UjI117XTvxntK7kLn3igitkj/k4LFT8r44EWkEpc=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:ke3SFXikRaTt3gmg83kBden/siQyr6u5jz6afytTbCg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:oaxs0gK3C7cezKEn+94oBUQTtO742orsCMHHKpL0VEg=
 github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:inEF3ZGKaXnwcKmqShtmZ8xadH2WmGYncdobktIfdvY=
@@ -243,8 +245,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 h1:RoH7VLzTnxHEugRPIgnGlxwDFszFGI7b3WZZUtWuPRM=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.1.3 h1:Kl2T6QVndMEZqQSY8rkoltYP+LVNaA54N+EwAMc9N5w=
-github.com/DataDog/go-sqllexer v0.1.3/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
+github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/sds v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.66.0-devel.0.20250407180930-ebfcfa2817ce
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce
+	github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa
 	github.com/DataDog/datadog-agent/pkg/status/health v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce
+	github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.37.1
@@ -149,6 +149,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
@@ -171,7 +172,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect
-	github.com/DataDog/go-sqllexer v0.1.3 // indirect
+	github.com/DataDog/go-sqllexer v0.1.6 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -186,8 +186,8 @@ github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407
 github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:a8cPaeE65MIqcQGxZbXcd/kP2iyV/T96NLj9VRHtkQw=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:XTdVCZzQUNPDD2+bfxBxKS2j4yq20IHLigfARk1g4SQ=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:uckeYcHAkid8msRPl8G++46vWzjZP3b7YqTvldiOt1I=
-github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:SZSDR+8w0z+bZKike4z0dbdVoZPUsqqmmB3AcdomA6s=
-github.com/DataDog/datadog-agent/pkg/proto v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:07jphzXKrdxfBm7Wn3IAA4odJTkpxDom0O7fYUxFCvQ=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa h1:poFmdxGxOGc954jd/9XWS3MpfK37oO8bSbiRo8t6peM=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa/go.mod h1:W88l6/tojCQo+8j6fnt8kfxQ4tapxOrG2RezsuUKOZc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:+4nPzlMkq13AH8IUy+nePJsbgTHky5RBwIa2Xs3K5gc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:NY9KdZi7WDO085fQ17F5whm6C0T/MF6d+HUPyaBlfm4=
 github.com/DataDog/datadog-agent/pkg/serializer v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:X+YRGhSKl6EjYvdq2jjsKjD+DuTYCcf+gZUpxTvFwB4=
@@ -200,8 +200,10 @@ github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcf
 github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:Z6BpV3ZgUudaMl/Jo9g8KUKxerIXiqQC9bG7DZ3OZNQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:0fiM9Y+KtLsq0dgvChBRxP8GzJDf5JY3WMgqmW+1YJQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:QjpK9pb49FQncSZzHBGTdS+iZWws3waQZ/1B4EwZGU8=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:UGgBmLi/ljWUAj68RQLU4Tqob6V8fqEIdcAK78J5Yoc=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:inD7t7xiwd5qQOGlGuG2Q+IWQg2BxpCcwFEspFpN8ug=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 h1:Yb4qVoYfDEN1frsgrOxPGbZJxMmQbYZMOL7K4EhMau4=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:uZEMDpntZpvc2SWQWgZTpwCRM8m9FMfWx471/5zjZBU=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483 h1:2uOLVWRbODryW6uudR6/kYoveDYQIDAE1YRMnwbGlws=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:mV1UjI117XTvxntK7kLn3igitkj/k4LFT8r44EWkEpc=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:ke3SFXikRaTt3gmg83kBden/siQyr6u5jz6afytTbCg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:oaxs0gK3C7cezKEn+94oBUQTtO742orsCMHHKpL0VEg=
 github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:inEF3ZGKaXnwcKmqShtmZ8xadH2WmGYncdobktIfdvY=
@@ -261,8 +263,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 h1:RoH7VLzTnxHEugRPIgnGlxwDFszFGI7b3WZZUtWuPRM=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.1.3 h1:Kl2T6QVndMEZqQSY8rkoltYP+LVNaA54N+EwAMc9N5w=
-github.com/DataDog/go-sqllexer v0.1.3/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
+github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.149
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.66.0-devel.0.20250407180930-ebfcfa2817ce
-	github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel
+	github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.125.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.125.0
@@ -98,7 +98,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.66.0-devel.0.20250407180930-ebfcfa2817ce // indirect
@@ -125,7 +126,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.37.1 // indirect
 	github.com/DataDog/datadog-go/v5 v5.6.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 // indirect
-	github.com/DataDog/go-sqllexer v0.1.3 // indirect
+	github.com/DataDog/go-sqllexer v0.1.6 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -173,8 +173,8 @@ github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407
 github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:a8cPaeE65MIqcQGxZbXcd/kP2iyV/T96NLj9VRHtkQw=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:XTdVCZzQUNPDD2+bfxBxKS2j4yq20IHLigfARk1g4SQ=
 github.com/DataDog/datadog-agent/pkg/process/util/api v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:uckeYcHAkid8msRPl8G++46vWzjZP3b7YqTvldiOt1I=
-github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel h1:/ERrlY+e3/t4t2enA7eYAcvL+OMvJIUFsJFzU/Ts9fg=
-github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel/go.mod h1:eUhWdIjBj4KqdABQkhL8h/CjMCbFhlO+Pv9EUjP3tjE=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa h1:poFmdxGxOGc954jd/9XWS3MpfK37oO8bSbiRo8t6peM=
+github.com/DataDog/datadog-agent/pkg/proto v0.67.0-devel.0.20250506152405-1c4b973c33fa/go.mod h1:W88l6/tojCQo+8j6fnt8kfxQ4tapxOrG2RezsuUKOZc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:+4nPzlMkq13AH8IUy+nePJsbgTHky5RBwIa2Xs3K5gc=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:NY9KdZi7WDO085fQ17F5whm6C0T/MF6d+HUPyaBlfm4=
 github.com/DataDog/datadog-agent/pkg/serializer v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:X+YRGhSKl6EjYvdq2jjsKjD+DuTYCcf+gZUpxTvFwB4=
@@ -187,8 +187,10 @@ github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcf
 github.com/DataDog/datadog-agent/pkg/tagset v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:Z6BpV3ZgUudaMl/Jo9g8KUKxerIXiqQC9bG7DZ3OZNQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:0fiM9Y+KtLsq0dgvChBRxP8GzJDf5JY3WMgqmW+1YJQ=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:QjpK9pb49FQncSZzHBGTdS+iZWws3waQZ/1B4EwZGU8=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:UGgBmLi/ljWUAj68RQLU4Tqob6V8fqEIdcAK78J5Yoc=
-github.com/DataDog/datadog-agent/pkg/trace v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:inD7t7xiwd5qQOGlGuG2Q+IWQg2BxpCcwFEspFpN8ug=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483 h1:Yb4qVoYfDEN1frsgrOxPGbZJxMmQbYZMOL7K4EhMau4=
+github.com/DataDog/datadog-agent/pkg/template v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:uZEMDpntZpvc2SWQWgZTpwCRM8m9FMfWx471/5zjZBU=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483 h1:2uOLVWRbODryW6uudR6/kYoveDYQIDAE1YRMnwbGlws=
+github.com/DataDog/datadog-agent/pkg/trace v0.67.0-devel.0.20250506141753-8e276a113483/go.mod h1:mV1UjI117XTvxntK7kLn3igitkj/k4LFT8r44EWkEpc=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:ke3SFXikRaTt3gmg83kBden/siQyr6u5jz6afytTbCg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.66.0-devel.0.20250407180930-ebfcfa2817ce/go.mod h1:oaxs0gK3C7cezKEn+94oBUQTtO742orsCMHHKpL0VEg=
 github.com/DataDog/datadog-agent/pkg/util/buf v0.66.0-devel.0.20250407180930-ebfcfa2817ce h1:inEF3ZGKaXnwcKmqShtmZ8xadH2WmGYncdobktIfdvY=
@@ -247,8 +249,8 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 h1:RoH7VLzTnxHEugRPIgnGlxwDFszFGI7b3WZZUtWuPRM=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.1.3 h1:Kl2T6QVndMEZqQSY8rkoltYP+LVNaA54N+EwAMc9N5w=
-github.com/DataDog/go-sqllexer v0.1.3/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.1.6 h1:skEXpWEVCpeZFIiydoIa2f2rf+ymNpjiIMqpW4w3YAk=
+github.com/DataDog/go-sqllexer v0.1.6/go.mod h1:GGpo1h9/BVSN+6NJKaEcJ9Jn44Hqc63Rakeb+24Mjgo=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -235,10 +235,9 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *dat
 			return clientutil.NewHTTPClient(cfg.ClientConfig)
 		}
 	}
-	if datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
-		acfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
-	} else {
-		params.Logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This feature will be enabled by default in the future - if you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention.")
+	if !datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
+		acfg.Features["disable_operation_and_resource_name_logic_v2"] = struct{}{}
+		params.Logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This flag will be made stable in a future release. If you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention. See the migration guide at https://docs.datadoghq.com/opentelemetry/guide/migrate/migrate_operation_names/")
 	}
 	if v := cfg.Traces.GetFlushInterval(); v > 0 {
 		acfg.TraceWriter.FlushPeriodSeconds = v

--- a/pkg/datadog/gates.go
+++ b/pkg/datadog/gates.go
@@ -17,7 +17,7 @@ var ReceiveResourceSpansV2FeatureGate = featuregate.GlobalRegistry().MustRegiste
 // OperationAndResourceNameV2FeatureGate is a feature gate that enables enhanced span operation name and resource names in Datadog exporter and connector
 var OperationAndResourceNameV2FeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"datadog.EnableOperationAndResourceNameV2",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, datadogexporter and datadogconnector use improved logic to compute operation name and resource name."),
 	featuregate.WithRegisterFromVersion("v0.118.0"),
 )


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Switch datadog.EnableOperationAndResourceNameV2 to Beta. This changes how Datadog exporter and connector compute the proprietary Datadog operation name from attributes on OTLP spans.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
