### PR TITLE
[pkg/datadog] Switch EnableOperationAndResourceNameV2 to Beta

### DIFF
--- a/.chloggen/ibraheem_enable-datadog-operation-names-v2-by-default.yaml
+++ b/.chloggen/ibraheem_enable-datadog-operation-names-v2-by-default.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Swtich feature gate datadog.EnableOperationAndResourceNameV2 to beta. This gate affects exporter/datadog and connector/datadog. It modifies the logic for computing operation names from OTLP spans to produce shorter, more readable names and improve alignment with OpenTelemetry specifications.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39895]

--- a/.chloggen/ibraheem_enable-datadog-operation-names-v2-by-default.yaml
+++ b/.chloggen/ibraheem_enable-datadog-operation-names-v2-by-default.yaml
@@ -7,7 +7,9 @@ change_type: breaking
 component: pkg/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Swtich feature gate datadog.EnableOperationAndResourceNameV2 to beta. This gate affects exporter/datadog and connector/datadog. It modifies the logic for computing operation names from OTLP spans to produce shorter, more readable names and improve alignment with OpenTelemetry specifications.
+note: Switch feature gate datadog.EnableOperationAndResourceNameV2 to beta. This gate affects exporter/datadog and connector/datadog. It modifies the logic for computing operation names from OTLP spans to produce shorter, more readable names and improve alignment with OpenTelemetry specifications.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [39895]
+
+subtext: Please see the migration guide for more details. https://docs.datadoghq.com/opentelemetry/migrate/migrate_operation_names/?tab=opentelemetrycollector

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -126,7 +126,7 @@ func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfi
 	if datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 		acfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	} else {
-		logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This feature will be enabled by default in the future - if you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention.")
+		logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This flag will be made stable in a future release. If you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention. See the migration guide at https://docs.datadoghq.com/opentelemetry/guide/migrate/migrate_operation_names/")
 	}
 	if v := cfg.BucketInterval; v > 0 {
 		acfg.BucketInterval = v

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -238,7 +238,7 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *dat
 	if datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 		acfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	} else {
-		params.Logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This feature will be enabled by default in the future - if you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention.")
+		params.Logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. This flag will be made stable in a future release. If you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention. See the migration guide at https://docs.datadoghq.com/opentelemetry/guide/migrate/migrate_operation_names/")
 	}
 	if v := cfg.Traces.GetFlushInterval(); v > 0 {
 		acfg.TraceWriter.FlushPeriodSeconds = v

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -444,17 +444,17 @@ func testPushTraceDataNewEnvConvention(t *testing.T, enableReceiveResourceSpansV
 	assert.Equal(t, "new_env", traces.TracerPayloads[0].GetEnv())
 }
 
-func TestPushTraceData_OperationAndResourceName(t *testing.T) {
+func TestPushTraceDataOperationAndResourceName(t *testing.T) {
 	t.Run("OperationAndResourceNameV1", func(t *testing.T) {
-		testPushTraceData_OperationAndResourceName(t, false)
+		testPushTraceDataOperationAndResourceName(t, false)
 	})
 
 	t.Run("OperationAndResourceNameV2", func(t *testing.T) {
-		testPushTraceData_OperationAndResourceName(t, true)
+		testPushTraceDataOperationAndResourceName(t, true)
 	})
 }
 
-func testPushTraceData_OperationAndResourceName(t *testing.T, enableOperationAndResourceNameV2 bool) {
+func testPushTraceDataOperationAndResourceName(t *testing.T, enableOperationAndResourceNameV2 bool) {
 	if !enableOperationAndResourceNameV2 {
 		prevVal := pkgdatadog.OperationAndResourceNameV2FeatureGate.IsEnabled()
 		require.NoError(t, featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", false))

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -446,15 +446,16 @@ func testPushTraceDataNewEnvConvention(t *testing.T, enableReceiveResourceSpansV
 
 func TestPushTraceDataOperationAndResourceName(t *testing.T) {
 	t.Run("OperationAndResourceNameV1", func(t *testing.T) {
-		testPushTraceDataOperationAndResourceName(t, false)
+		subtestPushTraceDataOperationAndResourceName(t, false)
 	})
 
 	t.Run("OperationAndResourceNameV2", func(t *testing.T) {
-		testPushTraceDataOperationAndResourceName(t, true)
+		subtestPushTraceDataOperationAndResourceName(t, true)
 	})
 }
 
-func testPushTraceDataOperationAndResourceName(t *testing.T, enableOperationAndResourceNameV2 bool) {
+func subtestPushTraceDataOperationAndResourceName(t *testing.T, enableOperationAndResourceNameV2 bool) {
+	t.Helper()
 	if !enableOperationAndResourceNameV2 {
 		prevVal := pkgdatadog.OperationAndResourceNameV2FeatureGate.IsEnabled()
 		require.NoError(t, featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", false))

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -444,10 +444,23 @@ func testPushTraceDataNewEnvConvention(t *testing.T, enableReceiveResourceSpansV
 	assert.Equal(t, "new_env", traces.TracerPayloads[0].GetEnv())
 }
 
-func TestPushTraceData_OperationAndResourceNameV2(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", true)
-	if err != nil {
-		t.Fatal(err)
+func TestPushTraceData_OperationAndResourceName(t *testing.T) {
+	t.Run("OperationAndResourceNameV1", func(t *testing.T) {
+		testPushTraceData_OperationAndResourceName(t, false)
+	})
+
+	t.Run("OperationAndResourceNameV2", func(t *testing.T) {
+		testPushTraceData_OperationAndResourceName(t, true)
+	})
+}
+
+func testPushTraceData_OperationAndResourceName(t *testing.T, enableOperationAndResourceNameV2 bool) {
+	if !enableOperationAndResourceNameV2 {
+		prevVal := pkgdatadog.OperationAndResourceNameV2FeatureGate.IsEnabled()
+		require.NoError(t, featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", false))
+		defer func() {
+			require.NoError(t, featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", prevVal))
+		}()
 	}
 	tracesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.TraceEndpoint, ReqChan: make(chan []byte)}
 	server := testutil.DatadogServerMock(tracesRec.HandlerFunc)
@@ -486,7 +499,11 @@ func TestPushTraceData_OperationAndResourceNameV2(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(slurp, &traces))
 	assert.Len(t, traces.TracerPayloads, 1)
 	assert.Equal(t, "new_env", traces.TracerPayloads[0].GetEnv())
-	assert.Equal(t, "server.request", traces.TracerPayloads[0].Chunks[0].Spans[0].Name)
+	if enableOperationAndResourceNameV2 {
+		assert.Equal(t, "server.request", traces.TracerPayloads[0].Chunks[0].Spans[0].Name)
+	} else {
+		assert.Equal(t, "opentelemetry.server", traces.TracerPayloads[0].Chunks[0].Spans[0].Name)
+	}
 }
 
 func TestResRelatedAttributesInSpanAttributes_ReceiveResourceSpansV2Enabled(t *testing.T) {

--- a/pkg/datadog/gates.go
+++ b/pkg/datadog/gates.go
@@ -17,7 +17,7 @@ var ReceiveResourceSpansV2FeatureGate = featuregate.GlobalRegistry().MustRegiste
 // OperationAndResourceNameV2FeatureGate is a feature gate that enables enhanced span operation name and resource names in Datadog exporter and connector
 var OperationAndResourceNameV2FeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"datadog.EnableOperationAndResourceNameV2",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, datadogexporter and datadogconnector use improved logic to compute operation name and resource name."),
 	featuregate.WithRegisterFromVersion("v0.118.0"),
 )


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Switch datadog.EnableOperationAndResourceNameV2 to Beta. This changes how Datadog exporter and connector compute the proprietary Datadog operation name from attributes on OTLP spans.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Ran collector locally, verified new logic enabled by default

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
