### PR TITLE
[receiver/sqlserver] Properly parse scientific notation numbers to ints

### DIFF
--- a/.chloggen/sqlserver_scientific_notation.yaml
+++ b/.chloggen/sqlserver_scientific_notation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Properly parse numbers stored in scientific notation to integers
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39124]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -160,7 +160,7 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) er
 
 	var errs []error
 	now := pcommon.NewTimestampFromTime(time.Now())
-	var val float64
+	var val any
 	for i, row := range rows {
 		rb := s.mb.NewResourceBuilder()
 		rb.SetSqlserverComputerName(row[computerNameKey])
@@ -169,20 +169,20 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) er
 		rb.SetServerAddress(s.config.Server)
 		rb.SetServerPort(int64(s.config.Port))
 
-		val, err = strconv.ParseFloat(row[readLatencyMsKey], 64)
+		val, err = retrieveFloat(row, readLatencyMsKey)
 		if err != nil {
 			err = fmt.Errorf("row %d: %w", i, err)
 			errs = append(errs, err)
 		} else {
-			s.mb.RecordSqlserverDatabaseLatencyDataPoint(now, val/1e3, row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionRead)
+			s.mb.RecordSqlserverDatabaseLatencyDataPoint(now, val.(float64)/1e3, row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionRead)
 		}
 
-		val, err = strconv.ParseFloat(row[writeLatencyMsKey], 64)
+		val, err = retrieveFloat(row, writeLatencyMsKey)
 		if err != nil {
 			err = fmt.Errorf("row %d: %w", i, err)
 			errs = append(errs, err)
 		} else {
-			s.mb.RecordSqlserverDatabaseLatencyDataPoint(now, val/1e3, row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionWrite)
+			s.mb.RecordSqlserverDatabaseLatencyDataPoint(now, val.(float64)/1e3, row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionWrite)
 		}
 
 		errs = append(errs, s.mb.RecordSqlserverDatabaseOperationsDataPoint(now, row[readCountKey], row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionRead))
@@ -253,210 +253,210 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 
 		switch row[counterKey] {
 		case activeTempTables:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, activeTempTables)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverTableCountDataPoint(now, val, metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
+				s.mb.RecordSqlserverTableCountDataPoint(now, val.(int64), metadata.AttributeTableStateActive, metadata.AttributeTableStatusTemporary)
 			}
 		case backupRestoreThroughputPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, backupRestoreThroughputPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDatabaseBackupOrRestoreRateDataPoint(now, val)
+				s.mb.RecordSqlserverDatabaseBackupOrRestoreRateDataPoint(now, val.(float64))
 			}
 		case batchRequestRate:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, batchRequestRate)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverBatchRequestRateDataPoint(now, val)
+				s.mb.RecordSqlserverBatchRequestRateDataPoint(now, val.(float64))
 			}
 		case bufferCacheHitRatio:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bufferCacheHitRatio)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverPageBufferCacheHitRatioDataPoint(now, val)
+				s.mb.RecordSqlserverPageBufferCacheHitRatioDataPoint(now, val.(float64))
 			}
 		case bytesReceivedFromReplicaPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val, metadata.AttributeReplicaDirectionReceive)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionReceive)
 			}
 		case bytesSentForReplicaPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, bytesReceivedFromReplicaPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val, metadata.AttributeReplicaDirectionTransmit)
+				s.mb.RecordSqlserverReplicaDataRateDataPoint(now, val.(float64), metadata.AttributeReplicaDirectionTransmit)
 			}
 		case diskReadIOThrottled:
 			errs = append(errs, s.mb.RecordSqlserverResourcePoolDiskThrottledReadRateDataPoint(now, row[valueKey]))
 		case diskWriteIOThrottled:
 			errs = append(errs, s.mb.RecordSqlserverResourcePoolDiskThrottledWriteRateDataPoint(now, row[valueKey]))
 		case executionErrors:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, executionErrors)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val)
+				s.mb.RecordSqlserverDatabaseExecutionErrorsDataPoint(now, val.(int64))
 			}
 		case freeListStalls:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, freeListStalls)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverPageBufferCacheFreeListStallsRateDataPoint(now, val)
+				s.mb.RecordSqlserverPageBufferCacheFreeListStallsRateDataPoint(now, val.(int64))
 			}
 		case fullScansPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, fullScansPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDatabaseFullScanRateDataPoint(now, val)
+				s.mb.RecordSqlserverDatabaseFullScanRateDataPoint(now, val.(float64))
 			}
 		case freeSpaceInTempdb:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, freeSpaceInTempdb)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDatabaseTempdbSpaceDataPoint(now, val, metadata.AttributeTempdbStateFree)
+				s.mb.RecordSqlserverDatabaseTempdbSpaceDataPoint(now, val.(int64), metadata.AttributeTempdbStateFree)
 			}
 		case indexSearchesPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, indexSearchesPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverIndexSearchRateDataPoint(now, val)
+				s.mb.RecordSqlserverIndexSearchRateDataPoint(now, val.(float64))
 			}
 		case lockTimeoutsPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, lockTimeoutsPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverLockTimeoutRateDataPoint(now, val)
+				s.mb.RecordSqlserverLockTimeoutRateDataPoint(now, val.(float64))
 			}
 		case lockWaits:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, lockWaits)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverLockWaitRateDataPoint(now, val)
+				s.mb.RecordSqlserverLockWaitRateDataPoint(now, val.(float64))
 			}
 		case loginsPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, loginsPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverLoginRateDataPoint(now, val)
+				s.mb.RecordSqlserverLoginRateDataPoint(now, val.(float64))
 			}
 		case logoutPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, logoutPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverLogoutRateDataPoint(now, val)
+				s.mb.RecordSqlserverLogoutRateDataPoint(now, val.(float64))
 			}
 		case memoryGrantsPending:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, memoryGrantsPending)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverMemoryGrantsPendingCountDataPoint(now, val)
+				s.mb.RecordSqlserverMemoryGrantsPendingCountDataPoint(now, val.(int64))
 			}
 		case mirrorWritesTransactionPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, mirrorWritesTransactionPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverTransactionMirrorWriteRateDataPoint(now, val)
+				s.mb.RecordSqlserverTransactionMirrorWriteRateDataPoint(now, val.(float64))
 			}
 		case numberOfDeadlocksPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, numberOfDeadlocksPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDeadlockRateDataPoint(now, val)
+				s.mb.RecordSqlserverDeadlockRateDataPoint(now, val.(float64))
 			}
 		case pageLookupsPerSec:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, pageLookupsPerSec)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val)
+				s.mb.RecordSqlserverPageLookupRateDataPoint(now, val.(float64))
 			}
 		case processesBlocked:
 			errs = append(errs, s.mb.RecordSqlserverProcessesBlockedDataPoint(now, row[valueKey]))
 		case sqlCompilationRate:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, sqlCompilationRate)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverBatchSQLCompilationRateDataPoint(now, val)
+				s.mb.RecordSqlserverBatchSQLCompilationRateDataPoint(now, val.(float64))
 			}
 		case sqlReCompilationsRate:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, sqlReCompilationsRate)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverBatchSQLRecompilationRateDataPoint(now, val)
+				s.mb.RecordSqlserverBatchSQLRecompilationRateDataPoint(now, val.(float64))
 			}
 		case transactionDelay:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, transactionDelay)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverTransactionDelayDataPoint(now, val)
+				s.mb.RecordSqlserverTransactionDelayDataPoint(now, val.(float64))
 			}
 		case userConnCount:
-			val, err := strconv.ParseInt(row[valueKey], 10, 64)
+			val, err := retrieveInt(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, userConnCount)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverUserConnectionCountDataPoint(now, val)
+				s.mb.RecordSqlserverUserConnectionCountDataPoint(now, val.(int64))
 			}
 		case usedMemory:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, usedMemory)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverMemoryUsageDataPoint(now, val)
+				s.mb.RecordSqlserverMemoryUsageDataPoint(now, val.(float64))
 			}
 		case versionStoreSize:
-			val, err := strconv.ParseFloat(row[valueKey], 64)
+			val, err := retrieveFloat(row, valueKey)
 			if err != nil {
 				err = fmt.Errorf("failed to parse valueKey for row %d: %w in %s", i, err, versionStoreSize)
 				errs = append(errs, err)
 			} else {
-				s.mb.RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint(now, val)
+				s.mb.RecordSqlserverDatabaseTempdbVersionStoreSizeDataPoint(now, val.(float64))
 			}
 		}
 
@@ -831,11 +831,25 @@ func vanillaRetriever(row sqlquery.StringMap, columnName string) (any, error) {
 
 func retrieveInt(row sqlquery.StringMap, columnName string) (any, error) {
 	var err error
-	result := 0
+	var result int64
 	if row[columnName] != "" {
-		result, err = strconv.Atoi(row[columnName])
+		result, err = strconv.ParseInt(row[columnName], 10, 64)
+		if err != nil {
+			// SQL Server stores large integers in scientific e notation
+			// (eg 123456 is stored as 1.23456e+5)
+			// This value cannot be parsed by strconv.ParseInt, but is successfully
+			// parsed by strconv.ParseFloat. The goal is here to convert to int
+			// even if the stored value is in scientific e notation.
+			var resultFloat float64
+			resultFloat, err = strconv.ParseFloat(row[columnName], 64)
+			if err == nil {
+				result = int64(resultFloat)
+			}
+		}
+	} else {
+		err = fmt.Errorf("no value found for column %s", columnName)
 	}
-	return int64(result), err
+	return result, err
 }
 
 func retrieveIntAndConvert(convert func(int64) any) func(row sqlquery.StringMap, columnName string) (any, error) {
@@ -851,6 +865,8 @@ func retrieveFloat(row sqlquery.StringMap, columnName string) (any, error) {
 	var result float64
 	if row[columnName] != "" {
 		result, err = strconv.ParseFloat(row[columnName], 64)
+	} else {
+		err = fmt.Errorf("no value found for column %s", columnName)
 	}
 	return result, err
 }

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -39,7 +39,7 @@ resourceMetrics:
           - description: Number of execution errors.
             gauge:
               dataPoints:
-                - asInt: 1048
+                - asInt: 18256656
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: sqlserver.database.execution.errors
@@ -900,7 +900,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: 61824
+                - asInt: 18256656
                   attributes:
                     - key: tempdb.state
                       value:

--- a/receiver/sqlserverreceiver/testdata/perfCounterQueryData.txt
+++ b/receiver/sqlserverreceiver/testdata/perfCounterQueryData.txt
@@ -28,7 +28,7 @@
       "object":"SQLServer:Access Methods",
       "sql_instance":"8cac97ac9b8f",
       "computer_name":"abcde",
-      "value":"1048"
+      "value":"1.8256656e+07"
    },
    {
       "counter":"Index Searches/sec",
@@ -2708,7 +2708,7 @@
       "object":"SQLServer:Transactions",
       "sql_instance":"8cac97ac9b8f",
       "computer_name":"abcde",
-      "value":"61824"
+      "value":"1.8256656e+07"
    },
    {
       "counter":"Version Store Size (KB)",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
SQL Server stores large integers in scientific e notation. `strconv.ParseInt` fails to parse this and raises an error, as seen in the original filed issue. For our use case, we still want these to be considered valid integers, so before failing entirely, attempt to parse to float and convert to integer.

This change also uses already existing methods, `retrieveInt` and `retrieveFloat` to be able to re-use the parsing functionality. The original issue was only for `sqlserver.database.tempdb.space`, but I believe this issue is relevant for all metrics of type `int`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39124

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Changed test values of a couple integers to ensure new functionality works. The changed values broke tests on `main` in the same way the filed bug shows, but tests are passing with this change.