### PR TITLE
prometheusreceiver: fix created timestamp conversion from ms to s

### DIFF
--- a/.chloggen/prometheus-ct-hot-fix.yaml
+++ b/.chloggen/prometheus-ct-hot-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Convert ms to s when setting start time on the metric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39912]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -36,13 +36,16 @@ type metricFamily struct {
 // a couple data complexValue (buckets and count/sum), a group of a metric family always share a same set of tags. for
 // simple types like counter and gauge, each data point is a group of itself
 type metricGroup struct {
-	mtype          pmetric.MetricType
-	ts             int64
-	ls             labels.Labels
-	count          float64
-	hasCount       bool
-	sum            float64
-	hasSum         bool
+	mtype    pmetric.MetricType
+	ts       int64
+	ls       labels.Labels
+	count    float64
+	hasCount bool
+	sum      float64
+	hasSum   bool
+	// This corresponds to the `_created` sample found from the metric parsing.
+	// - https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#timestamps
+	// - https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1
 	createdSeconds float64
 	value          float64
 	hValue         *histogram.Histogram
@@ -425,6 +428,9 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 	return nil
 }
 
+// addCreationTimestamp updates the metric group cache with the created timestamp for the group.
+// The parser gets the created time in ms however and we must convert it to seconds here.
+// - https://github.com/prometheus/prometheus/blob/2bf6f4c9dcbb1ad2e8fef70c6a48d8fc44a7f57c/model/textparse/interface.go#L77-L80
 func (mf *metricFamily) addCreationTimestamp(seriesRef uint64, ls labels.Labels, atMs, ctMs int64) {
 	mg := mf.loadMetricGroupOrCreate(seriesRef, ls, atMs)
 	mg.createdSeconds = float64(ctMs) / 1000.0

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -36,19 +36,19 @@ type metricFamily struct {
 // a couple data complexValue (buckets and count/sum), a group of a metric family always share a same set of tags. for
 // simple types like counter and gauge, each data point is a group of itself
 type metricGroup struct {
-	mtype        pmetric.MetricType
-	ts           int64
-	ls           labels.Labels
-	count        float64
-	hasCount     bool
-	sum          float64
-	hasSum       bool
-	created      float64
-	value        float64
-	hValue       *histogram.Histogram
-	fhValue      *histogram.FloatHistogram
-	complexValue []*dataPoint
-	exemplars    pmetric.ExemplarSlice
+	mtype          pmetric.MetricType
+	ts             int64
+	ls             labels.Labels
+	count          float64
+	hasCount       bool
+	sum            float64
+	hasSum         bool
+	createdSeconds float64
+	value          float64
+	hValue         *histogram.Histogram
+	fhValue        *histogram.FloatHistogram
+	complexValue   []*dataPoint
+	exemplars      pmetric.ExemplarSlice
 }
 
 func newMetricFamily(metricName string, mc scrape.MetricMetadataStore, logger *zap.Logger) *metricFamily {
@@ -143,8 +143,8 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 
 	// The timestamp MUST be in retrieved from milliseconds and converted to nanoseconds.
 	tsNanos := timestampFromMs(mg.ts)
-	if mg.created != 0 {
-		point.SetStartTimestamp(timestampFromFloat64(mg.created))
+	if mg.createdSeconds != 0 {
+		point.SetStartTimestamp(timestampFromFloat64(mg.createdSeconds))
 	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
@@ -221,8 +221,8 @@ func (mg *metricGroup) toExponentialHistogramDataPoints(dest pmetric.Exponential
 	}
 
 	tsNanos := timestampFromMs(mg.ts)
-	if mg.created != 0 {
-		point.SetStartTimestamp(timestampFromFloat64(mg.created))
+	if mg.createdSeconds != 0 {
+		point.SetStartTimestamp(timestampFromFloat64(mg.createdSeconds))
 	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
@@ -315,8 +315,8 @@ func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 	// The timestamp MUST be in retrieved from milliseconds and converted to nanoseconds.
 	tsNanos := timestampFromMs(mg.ts)
 	point.SetTimestamp(tsNanos)
-	if mg.created != 0 {
-		point.SetStartTimestamp(timestampFromFloat64(mg.created))
+	if mg.createdSeconds != 0 {
+		point.SetStartTimestamp(timestampFromFloat64(mg.createdSeconds))
 	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
@@ -329,8 +329,8 @@ func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
 	point := dest.AppendEmpty()
 	// gauge/undefined types have no start time.
 	if mg.mtype == pmetric.MetricTypeSum {
-		if mg.created != 0 {
-			point.SetStartTimestamp(timestampFromFloat64(mg.created))
+		if mg.createdSeconds != 0 {
+			point.SetStartTimestamp(timestampFromFloat64(mg.createdSeconds))
 		} else if !removeStartTimeAdjustment.IsEnabled() {
 			// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 			point.SetStartTimestamp(tsNanos)
@@ -398,7 +398,7 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 			mg.count = v
 			mg.hasCount = true
 		case metricName == mf.metadata.Metric+metricSuffixCreated:
-			mg.created = v
+			mg.createdSeconds = v
 		default:
 			boundary, err := getBoundary(mf.mtype, ls)
 			if err != nil {
@@ -408,11 +408,11 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 		}
 	case pmetric.MetricTypeExponentialHistogram:
 		if metricName == mf.metadata.Metric+metricSuffixCreated {
-			mg.created = v
+			mg.createdSeconds = v
 		}
 	case pmetric.MetricTypeSum:
 		if metricName == mf.metadata.Metric+metricSuffixCreated {
-			mg.created = v
+			mg.createdSeconds = v
 		} else {
 			mg.value = v
 		}
@@ -425,9 +425,9 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 	return nil
 }
 
-func (mf *metricFamily) addCreationTimestamp(seriesRef uint64, ls labels.Labels, atMs, created int64) {
+func (mf *metricFamily) addCreationTimestamp(seriesRef uint64, ls labels.Labels, atMs, ctMs int64) {
 	mg := mf.loadMetricGroupOrCreate(seriesRef, ls, atMs)
-	mg.created = float64(created)
+	mg.createdSeconds = float64(ctMs) / 1000.0
 }
 
 func (mf *metricFamily) addExponentialHistogramSeries(seriesRef uint64, metricName string, ls labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) error {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -669,18 +669,20 @@ func TestAppendCTZeroSample(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
 
+	var atMs, ctMs int64
+	atMs, ctMs = 200, 100
 	_, err := tr.AppendCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
 		model.JobLabel, "test",
 		model.MetricNameLabel, "counter_test",
-	), 200, 100)
+	), atMs, ctMs)
 	assert.NoError(t, err)
 
 	_, err = tr.Append(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
 		model.JobLabel, "test",
 		model.MetricNameLabel, "counter_test",
-	), 200, 100)
+	), atMs, 100)
 	assert.NoError(t, err)
 
 	assert.NoError(t, tr.Commit())
@@ -692,7 +694,7 @@ func TestAppendCTZeroSample(t *testing.T) {
 	require.Equal(t, 1, mds[0].MetricCount())
 	require.Equal(
 		t,
-		pcommon.Timestamp(100000000000),
+		pcommon.NewTimestampFromTime(time.UnixMilli(ctMs)),
 		mds[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).StartTimestamp(),
 	)
 }
@@ -701,18 +703,20 @@ func TestAppendHistogramCTZeroSample(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
 
+	var atMs, ctMs int64
+	atMs, ctMs = 200, 100
 	_, err := tr.AppendHistogramCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
 		model.JobLabel, "test",
 		model.MetricNameLabel, "hist_test_bucket",
-	), 200, 100, nil, nil)
+	), atMs, ctMs, nil, nil)
 	assert.NoError(t, err)
 
 	_, err = tr.AppendHistogram(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
 		model.JobLabel, "test",
 		model.MetricNameLabel, "hist_test_bucket",
-	), 200, tsdbutil.GenerateTestHistogram(1), tsdbutil.GenerateTestFloatHistogram(1))
+	), atMs, tsdbutil.GenerateTestHistogram(1), tsdbutil.GenerateTestFloatHistogram(1))
 
 	assert.NoError(t, err)
 
@@ -725,7 +729,7 @@ func TestAppendHistogramCTZeroSample(t *testing.T) {
 	require.Equal(t, 1, mds[0].MetricCount())
 	require.Equal(
 		t,
-		pcommon.Timestamp(100000000000),
+		pcommon.NewTimestampFromTime(time.UnixMilli(ctMs)),
 		mds[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).ExponentialHistogram().DataPoints().At(0).StartTimestamp(),
 	)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Set the start time appropriately when Append.*CTZeroSample is called. Also rename so units are clearer in the definition

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39912.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added more clarity to the unit tests.

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
