### PR TITLE
[exporter/awss3exporter] substitute resource attributes in s3_partition_format and file_prefix

### DIFF
--- a/exporter/awss3exporter/config.go
+++ b/exporter/awss3exporter/config.go
@@ -55,6 +55,18 @@ const (
 type ResourceAttrsToS3 struct {
 	// S3Prefix indicates the mapping of the key (directory) prefix used for writing into the bucket to a specific resource attribute value.
 	S3Prefix string `mapstructure:"s3_prefix"`
+	// S3PartitionFormat is used to provide the rollup on how data is written.
+	// If overrides the value in S3UploaderConfig.S3PartitionFormat.
+	// In addition to the format supported by S3UploaderConfig.S3PartitionFormat it also
+	// supports bracketed shell-style variable substitutions (${var}), where the variables are resource attribute names.
+	S3PartitionFormat string `mapstructure:"s3_partition_format"`
+	// FilePrefix is the filename prefix used for the file to avoid any potential collisions.
+	// If overrides the value in S3UploaderConfig.FilePrefix.
+	// It supports bracketed shell-style variable substitutions (${var}), where the variables are resource attribute names.
+	FilePrefix string `mapstructure:"file_prefix"`
+	// UnknownAttributePlaceholder is the placeholder used for missing attributes specified in S3PartitionFormat.
+	// If unset "_unknown_" is used.
+	UnknownAttributePlaceholder string `mapstructure:"unknown_attribute_placeholder"`
 }
 
 // Config contains the main configuration options for the s3 exporter

--- a/exporter/awss3exporter/exporter_test.go
+++ b/exporter/awss3exporter/exporter_test.go
@@ -9,26 +9,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter/internal/upload"
 )
 
 var (
 	s3PrefixKey    = "_sourceHost"
-	overridePrefix = "host"
-	testLogs       = []byte(fmt.Sprintf(`{"resourceLogs":[{"resource":{"attributes":[{"key":"_sourceCategory","value":{"stringValue":"logfile"}},{"key":"%s","value":{"stringValue":"%s"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"observedTimeUnixNano":"1654257420681895000","body":{"stringValue":"2022-06-03 13:57:00.62739 +0200 CEST m=+14.018296742 log entry14"},"attributes":[{"key":"log.file.path_resolved","value":{"stringValue":"logwriter/data.log"}}],"traceId":"","spanId":""}]}],"schemaUrl":"https://opentelemetry.io/schemas/1.6.1"}]}`, s3PrefixKey, overridePrefix))
+	prefixValue = "host"
+	testLogs       = []byte(fmt.Sprintf(`{"resourceLogs":[{"resource":{"attributes":[{"key":"_sourceCategory","value":{"stringValue":"logfile"}},{"key":"%s","value":{"stringValue":"%s"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"observedTimeUnixNano":"1654257420681895000","body":{"stringValue":"2022-06-03 13:57:00.62739 +0200 CEST m=+14.018296742 log entry14"},"attributes":[{"key":"log.file.path_resolved","value":{"stringValue":"logwriter/data.log"}}],"traceId":"","spanId":""}]}],"schemaUrl":"https://opentelemetry.io/schemas/1.6.1"}]}`, s3PrefixKey, prefixValue))
 )
 
-type TestWriter struct {
-	t *testing.T
-}
+type TestWriter func(context.Context, []byte, pcommon.Map) error
 
-func (testWriter *TestWriter) Upload(_ context.Context, buf []byte, uploadOpts *upload.UploadOptions) error {
-	assert.Equal(testWriter.t, testLogs, buf)
-	assert.Equal(testWriter.t, &upload.UploadOptions{OverridePrefix: ""}, uploadOpts)
-	return nil
+func (testWriter TestWriter) Upload(ctx context.Context, buf []byte, attrs pcommon.Map) error {
+	return testWriter(ctx, buf, attrs)
 }
 
 func getTestLogs(tb testing.TB) plog.Logs {
@@ -40,9 +35,16 @@ func getTestLogs(tb testing.TB) plog.Logs {
 
 func getLogExporter(t *testing.T) *s3Exporter {
 	marshaler, _ := newMarshaler("otlp_json", zap.NewNop())
+	testWriter := TestWriter(func(ctx context.Context, buf []byte, attrs pcommon.Map) error {
+		assert.Equal(t, testLogs, buf)
+		val, ok := attrs.Get(s3PrefixKey)
+		assert.True(t, ok)
+		assert.Equal(t, prefixValue, val.AsString())
+		return nil
+	})
 	exporter := &s3Exporter{
 		config:    createDefaultConfig().(*Config),
-		uploader:  &TestWriter{t},
+		uploader:  testWriter,
 		logger:    zap.NewNop(),
 		marshaler: marshaler,
 	}
@@ -52,34 +54,5 @@ func getLogExporter(t *testing.T) *s3Exporter {
 func TestLog(t *testing.T) {
 	logs := getTestLogs(t)
 	exporter := getLogExporter(t)
-	assert.NoError(t, exporter.ConsumeLogs(context.Background(), logs))
-}
-
-type TestWriterWithResourceAttrs struct {
-	t *testing.T
-}
-
-func (testWriterWO *TestWriterWithResourceAttrs) Upload(_ context.Context, buf []byte, uploadOpts *upload.UploadOptions) error {
-	assert.Equal(testWriterWO.t, testLogs, buf)
-	assert.Equal(testWriterWO.t, &upload.UploadOptions{OverridePrefix: overridePrefix}, uploadOpts)
-	return nil
-}
-
-func getLogExporterWithResourceAttrs(t *testing.T) *s3Exporter {
-	marshaler, _ := newMarshaler("otlp_json", zap.NewNop())
-	config := createDefaultConfig().(*Config)
-	config.ResourceAttrsToS3.S3Prefix = s3PrefixKey
-	exporter := &s3Exporter{
-		config:    config,
-		uploader:  &TestWriterWithResourceAttrs{t},
-		logger:    zap.NewNop(),
-		marshaler: marshaler,
-	}
-	return exporter
-}
-
-func TestLogWithResourceAttrs(t *testing.T) {
-	logs := getTestLogs(t)
-	exporter := getLogExporterWithResourceAttrs(t)
 	assert.NoError(t, exporter.ConsumeLogs(context.Background(), logs))
 }

--- a/exporter/awss3exporter/internal/subst/subst.go
+++ b/exporter/awss3exporter/internal/subst/subst.go
@@ -1,0 +1,25 @@
+package subst
+
+import (
+	"maps"
+	"regexp"
+	"slices"
+)
+
+var re = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+func Subst(txt string, f func(key string) string) string {
+	return re.ReplaceAllStringFunc(txt, func(m string) string {
+		key := m[2 : len(m)-1]
+		return f(key)
+	})
+}
+
+func Vars(txt string) []string {
+	vars := map[string]bool{}
+	m := re.FindAllStringSubmatch(txt, -1)
+	for _, s := range m {
+		vars[s[1]] = true
+	}
+	return slices.Sorted(maps.Keys(vars))
+}

--- a/exporter/awss3exporter/internal/subst/subst_test.go
+++ b/exporter/awss3exporter/internal/subst/subst_test.go
@@ -1,0 +1,26 @@
+package subst
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubst(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{
+		"attr.Val_1": "v1",
+		"attr.Val_2": "v2",
+	}
+
+	s := Subst("foo/${attr.Val_1}/bar/${attr.Val_2}/baz", func(key string) string {
+		return vars[key]
+	})
+	assert.Equal(t, "foo/v1/bar/v2/baz", s)
+}
+
+func TestVars(t *testing.T) {
+	v := Vars("foo/${var1}/bar/${var2}/baz/${var1}")
+	assert.Equal(t, []string{"var1", "var2"}, v)
+}


### PR DESCRIPTION
#### Description
Add `resource_attrs_to_s3/s3_partition_format` and `resource_attrs_to_s3/file_prefix` to enable using resource attribute substitutions in S3 paths, similar to `resource_attrs_to_s3/s3_prefix`.

#### Testing
* Added unit tests for the new configuration fields

#### Documentation
TODO: will add if the approach is accepted.
