### PR TITLE
[receiver/apachespark] Add various features

### DIFF
--- a/receiver/apachesparkreceiver/README.md
+++ b/receiver/apachesparkreceiver/README.md
@@ -40,9 +40,10 @@ The following settings are optional:
 - `start_time_epoch_limit`: Limits application scrapped by startTimeEpoch
 
 The prescedence is the following:
-1. limit
-1. start_time_epoch_limit
-1. application_names and application_ids
+1. limits:
+- count
+- start_time_epoch
+2. application_names and application_ids
 
 
 ### Example Configuration
@@ -57,8 +58,9 @@ receivers:
     - PythonLR
     application_ids:
     - application_1
-    limit: 2
-    start_time_epoch_limit: 23432433
+    limits:
+      count: 2
+      start_time_epoch: 1745976432694
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).

--- a/receiver/apachesparkreceiver/README.md
+++ b/receiver/apachesparkreceiver/README.md
@@ -36,7 +36,14 @@ The following settings are optional:
 - `endpoint`: (default = `http://localhost:4040`): Apache Spark endpoint to connect to in the form of `[http][://]{host}[:{port}]`
 - `application_names`: An array of Spark application names for which metrics should be collected. If no application names are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
 - `application_ids`: An array of Spark application ids for which metrics should be collected. If no application ids are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
-- `application_limit`: Limits the number of applications scraped from the Spark history server. If unset, all applications are scraped.
+- `limit`: Limits the number of applications scraped from the Spark history server. If unset, all applications are scraped.
+- `start_time_epoch_limit`: Limits application scrapped by startTimeEpoch
+
+The prescedence is the following:
+1. limit
+1. start_time_epoch_limit
+1. application_names and application_ids
+
 
 ### Example Configuration
 
@@ -50,7 +57,8 @@ receivers:
     - PythonLR
     application_ids:
     - application_1
-    application_limit: 2
+    limit: 2
+    start_time_epoch_limit: 23432433
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).

--- a/receiver/apachesparkreceiver/README.md
+++ b/receiver/apachesparkreceiver/README.md
@@ -36,6 +36,7 @@ The following settings are optional:
 - `endpoint`: (default = `http://localhost:4040`): Apache Spark endpoint to connect to in the form of `[http][://]{host}[:{port}]`
 - `application_names`: An array of Spark application names for which metrics should be collected. If no application names are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
 - `application_ids`: An array of Spark application ids for which metrics should be collected. If no application ids are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
+- `application_limit`: Limits the number of applications scraped from the Spark history server. If unset, all applications are scraped.
 
 ### Example Configuration
 
@@ -49,6 +50,7 @@ receivers:
     - PythonLR
     application_ids:
     - application_1
+    application_limit: 2
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).

--- a/receiver/apachesparkreceiver/README.md
+++ b/receiver/apachesparkreceiver/README.md
@@ -35,6 +35,7 @@ The following settings are optional:
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `endpoint`: (default = `http://localhost:4040`): Apache Spark endpoint to connect to in the form of `[http][://]{host}[:{port}]`
 - `application_names`: An array of Spark application names for which metrics should be collected. If no application names are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
+- `application_ids`: An array of Spark application ids for which metrics should be collected. If no application ids are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
 
 ### Example Configuration
 
@@ -46,6 +47,8 @@ receivers:
     application_names:
     - PythonStatusAPIDemo
     - PythonLR
+    application_ids:
+    - application_1
 ```
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).

--- a/receiver/apachesparkreceiver/config.go
+++ b/receiver/apachesparkreceiver/config.go
@@ -21,15 +21,20 @@ const (
 
 var errInvalidEndpoint = errors.New("'endpoint' must be in the form of <scheme>://<hostname>:<port>")
 
+// Define limits for applications scapping
+type ConfigLimits struct {
+	Count          int   `mapstructure:"count"`
+	StartTimeEpoch int64 `mapstructure:"start_time_epoch"`
+}
+
 // Config defines the configuration for the various elements of the receiver agent.
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig  `mapstructure:",squash"`
 	confighttp.ClientConfig        `mapstructure:",squash"`
-	ApplicationNames               []string `mapstructure:"application_names"`
-	ApplicationIds                 []string `mapstructure:"application_ids"`
-	Limit                          int      `mapstructure:"limit"`
-	StartTimeEpochLimit            int64    `mapstructure:"start_time_epoch_limit"`
+	ApplicationNames               []string     `mapstructure:"application_names"`
+	ApplicationIds                 []string     `mapstructure:"application_ids"`
+	Limits                         ConfigLimits `mapstructure:"limits"`
 }
 
 // Validate validates missing and invalid configuration fields.

--- a/receiver/apachesparkreceiver/config.go
+++ b/receiver/apachesparkreceiver/config.go
@@ -28,7 +28,8 @@ type Config struct {
 	confighttp.ClientConfig        `mapstructure:",squash"`
 	ApplicationNames               []string `mapstructure:"application_names"`
 	ApplicationIds                 []string `mapstructure:"application_ids"`
-	ApplicationLimit               int      `mapstructure:"application_limit"`
+	Limit                          int      `mapstructure:"limit"`
+	StartTimeEpochLimit            int64    `mapstructure:"start_time_epoch_limit"`
 }
 
 // Validate validates missing and invalid configuration fields.

--- a/receiver/apachesparkreceiver/config.go
+++ b/receiver/apachesparkreceiver/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	metadata.MetricsBuilderConfig  `mapstructure:",squash"`
 	confighttp.ClientConfig        `mapstructure:",squash"`
 	ApplicationNames               []string `mapstructure:"application_names"`
+	ApplicationIds                 []string `mapstructure:"application_ids"`
 }
 
 // Validate validates missing and invalid configuration fields.

--- a/receiver/apachesparkreceiver/config.go
+++ b/receiver/apachesparkreceiver/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	confighttp.ClientConfig        `mapstructure:",squash"`
 	ApplicationNames               []string `mapstructure:"application_names"`
 	ApplicationIds                 []string `mapstructure:"application_ids"`
+	ApplicationLimit               int      `mapstructure:"application_limit"`
 }
 
 // Validate validates missing and invalid configuration fields.

--- a/receiver/apachesparkreceiver/config_test.go
+++ b/receiver/apachesparkreceiver/config_test.go
@@ -49,27 +49,21 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestCreateDefaultConfig(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-	assert.NotNil(t, cfg, "failed to create default config")
-
-	// Assert that the default collection interval is set
-	defaultConfig, ok := cfg.(*Config)
-	require.True(t, ok, "expected config to be of type *Config")
-	assert.Equal(t, defaultCollectionInterval, defaultConfig.CollectionInterval)
-	assert.Equal(t, defaultEndpoint, defaultConfig.Endpoint)
-	assert.NotNil(t, defaultConfig.ApplicationNames)
-	assert.Empty(t, defaultConfig.ApplicationNames)
-	assert.NotNil(t, defaultConfig.ApplicationIds)
-	assert.Empty(t, defaultConfig.ApplicationIds)
-}
-
 func TestApplicationLimitConfig(t *testing.T) {
 	cfg := &Config{}
 	// Default should be zero (unlimited)
-	assert.Equal(t, 0, cfg.ApplicationLimit)
+	assert.Equal(t, 0, cfg.Limit)
 
-	cfg.ApplicationLimit = 2
-	assert.Equal(t, 2, cfg.ApplicationLimit)
+	cfg.Limit = 2
+	assert.Equal(t, 2, cfg.Limit)
+}
+
+func TestStartTimeEpochLimitConfig(t *testing.T) {
+	cfg := &Config{}
+	// Default should be zero
+	assert.Equal(t, int64(0), cfg.StartTimeEpochLimit)
+
+	// Set a specific value
+	cfg.StartTimeEpochLimit = 1680000000
+	assert.Equal(t, int64(1680000000), cfg.StartTimeEpochLimit)
 }

--- a/receiver/apachesparkreceiver/config_test.go
+++ b/receiver/apachesparkreceiver/config_test.go
@@ -6,6 +6,7 @@ package apachesparkreceiver // import "github.com/open-telemetry/opentelemetry-c
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
@@ -46,4 +47,20 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateDefaultConfig(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	assert.NotNil(t, cfg, "failed to create default config")
+
+	// Assert that the default collection interval is set
+	defaultConfig, ok := cfg.(*Config)
+	require.True(t, ok, "expected config to be of type *Config")
+	assert.Equal(t, defaultCollectionInterval, defaultConfig.CollectionInterval)
+	assert.Equal(t, defaultEndpoint, defaultConfig.Endpoint)
+	assert.NotNil(t, defaultConfig.ApplicationNames)
+	assert.Empty(t, defaultConfig.ApplicationNames)
+	assert.NotNil(t, defaultConfig.ApplicationIds)
+	assert.Empty(t, defaultConfig.ApplicationIds)
 }

--- a/receiver/apachesparkreceiver/config_test.go
+++ b/receiver/apachesparkreceiver/config_test.go
@@ -64,3 +64,12 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NotNil(t, defaultConfig.ApplicationIds)
 	assert.Empty(t, defaultConfig.ApplicationIds)
 }
+
+func TestApplicationLimitConfig(t *testing.T) {
+	cfg := &Config{}
+	// Default should be zero (unlimited)
+	assert.Equal(t, 0, cfg.ApplicationLimit)
+
+	cfg.ApplicationLimit = 2
+	assert.Equal(t, 2, cfg.ApplicationLimit)
+}

--- a/receiver/apachesparkreceiver/internal/models/application.go
+++ b/receiver/apachesparkreceiver/internal/models/application.go
@@ -3,8 +3,22 @@
 
 package models // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver/internal/models"
 
+type Attempts struct {
+	StartTime        string `json:"startTime"`
+	EndTime          string `json:"endTime"`
+	LastUpdated      string `json:"lastUpdated"`
+	Duration         int64  `json:"duration"`
+	SparkUser        string `json:"sparkUser"`
+	Completed        bool   `json:"completed"`
+	AppSparkVersion  string `json:"appSparkVersion"`
+	EndTimeEpoch     int64  `json:"endTimeEpoch"`
+	StartTimeEpoch   int64  `json:"startTimeEpoch"`
+	LastUpdatedEpoch int64  `json:"lastUpdatedEpoch"`
+}
+
 // Applications represents the json returned by the api/v1/applications endpoint
 type Application struct {
-	ApplicationID string `json:"id"`
-	Name          string `json:"name"`
+	ApplicationID string     `json:"id"`
+	Name          string     `json:"name"`
+	Attempts      []Attempts `json:"attempts,omitempty"`
 }

--- a/receiver/apachesparkreceiver/scraper.go
+++ b/receiver/apachesparkreceiver/scraper.go
@@ -97,6 +97,11 @@ func (s *sparkScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 		}
 	}
 
+	// Limit scapped applications if ApplicationLimit is set
+	if s.config.ApplicationLimit > 0 && len(allowedApps) > s.config.ApplicationLimit {
+		allowedApps = allowedApps[:s.config.ApplicationLimit]
+	}
+
 	// Get stats from the 'metrics' endpoint
 	clusterStats, err := s.client.ClusterStats()
 	if err != nil {

--- a/receiver/apachesparkreceiver/scraper.go
+++ b/receiver/apachesparkreceiver/scraper.go
@@ -63,21 +63,21 @@ func (s *sparkScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 
 	// Limit the number of applications checked
 	appsToCheck := apps
-	if s.config.Limit > 0 && len(apps) > s.config.Limit {
-		appsToCheck = apps[:s.config.Limit]
+	if s.config.Limits.Count > 0 && len(apps) > s.config.Limits.Count {
+		appsToCheck = apps[:s.config.Limits.Count]
 	}
 
-	// Filter out any applications older than StartTimeEpochLimit
+	// Filter out any applications older than StartTimeEpoch
 	var recentApps []models.Application
-	if s.config.StartTimeEpochLimit == 0 {
+	if s.config.Limits.StartTimeEpoch == 0 {
 		recentApps = appsToCheck
 	} else {
-	startTimeEpochLimit:
+	startTimeEpoch:
 		for _, app := range appsToCheck {
 			for _, attempt := range app.Attempts {
-				if s.config.StartTimeEpochLimit < attempt.StartTimeEpoch {
+				if s.config.Limits.StartTimeEpoch < attempt.StartTimeEpoch {
 					recentApps = append(recentApps, app)
-					break startTimeEpochLimit
+					break startTimeEpoch
 				}
 			}
 		}

--- a/receiver/apachesparkreceiver/scraper_test.go
+++ b/receiver/apachesparkreceiver/scraper_test.go
@@ -339,7 +339,9 @@ func TestScraper(t *testing.T) {
 				ControllerConfig: scraperhelper.ControllerConfig{
 					CollectionInterval: defaultCollectionInterval,
 				},
-				Limit:                1,
+				Limits: {
+					Count: 1,
+				},
 				ClientConfig:         clientConfig,
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 			},
@@ -390,7 +392,9 @@ func TestScraper(t *testing.T) {
 				ControllerConfig: scraperhelper.ControllerConfig{
 					CollectionInterval: defaultCollectionInterval,
 				},
-				StartTimeEpochLimit:  100000,
+				Limits: {
+					StartTimeEpoch: 100000,
+				},
 				ClientConfig:         clientConfig,
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 			},

--- a/receiver/apachesparkreceiver/scraper_test.go
+++ b/receiver/apachesparkreceiver/scraper_test.go
@@ -288,7 +288,109 @@ func TestScraper(t *testing.T) {
 				ControllerConfig: scraperhelper.ControllerConfig{
 					CollectionInterval: defaultCollectionInterval,
 				},
-				ApplicationIds:       []string{"app-123"},
+				ApplicationIds:       []string{"local-1682603253681"},
+				ClientConfig:         clientConfig,
+				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Successfully allowing apps by Limit",
+			setupMockClient: func(t *testing.T) client {
+				mockClient := mocks.MockClient{}
+				data := loadAPIResponseData(t, clusterStatsResponseFile)
+				var clusterStats *models.ClusterProperties
+				err := json.Unmarshal(data, &clusterStats)
+				require.NoError(t, err)
+				mockClient.On("ClusterStats").Return(clusterStats, nil)
+
+				data = loadAPIResponseData(t, appsStatsResponseFile)
+				var apps []models.Application
+				err = json.Unmarshal(data, &apps)
+				require.NoError(t, err)
+				mockClient.On("Applications").Return(apps, nil)
+
+				data = loadAPIResponseData(t, stagesStatsResponseFile)
+				var stages []models.Stage
+				err = json.Unmarshal(data, &stages)
+				require.NoError(t, err)
+				mockClient.On("StageStats", mock.Anything).Return(stages, nil)
+
+				data = loadAPIResponseData(t, executorsStatsResponseFile)
+				var executors []models.Executor
+				err = json.Unmarshal(data, &executors)
+				require.NoError(t, err)
+				mockClient.On("ExecutorStats", mock.Anything).Return(executors, nil)
+
+				data = loadAPIResponseData(t, jobsStatsResponseFile)
+				var jobs []models.Job
+				err = json.Unmarshal(data, &jobs)
+				require.NoError(t, err)
+				mockClient.On("JobStats", mock.Anything).Return(jobs, nil)
+				return &mockClient
+			},
+			expectedMetricGen: func(t *testing.T) pmetric.Metrics {
+				goldenPath := filepath.Join("testdata", "expected_metrics", "metrics_golden.yaml")
+				expectedMetrics, err := golden.ReadMetrics(goldenPath)
+				require.NoError(t, err)
+				return expectedMetrics
+			},
+			config: &Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: defaultCollectionInterval,
+				},
+				Limit:                1,
+				ClientConfig:         clientConfig,
+				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Successfully allowing apps by StartTimeEpochLimit",
+			setupMockClient: func(t *testing.T) client {
+				mockClient := mocks.MockClient{}
+				data := loadAPIResponseData(t, clusterStatsResponseFile)
+				var clusterStats *models.ClusterProperties
+				err := json.Unmarshal(data, &clusterStats)
+				require.NoError(t, err)
+				mockClient.On("ClusterStats").Return(clusterStats, nil)
+
+				data = loadAPIResponseData(t, appsStatsResponseFile)
+				var apps []models.Application
+				err = json.Unmarshal(data, &apps)
+				require.NoError(t, err)
+				mockClient.On("Applications").Return(apps, nil)
+
+				data = loadAPIResponseData(t, stagesStatsResponseFile)
+				var stages []models.Stage
+				err = json.Unmarshal(data, &stages)
+				require.NoError(t, err)
+				mockClient.On("StageStats", mock.Anything).Return(stages, nil)
+
+				data = loadAPIResponseData(t, executorsStatsResponseFile)
+				var executors []models.Executor
+				err = json.Unmarshal(data, &executors)
+				require.NoError(t, err)
+				mockClient.On("ExecutorStats", mock.Anything).Return(executors, nil)
+
+				data = loadAPIResponseData(t, jobsStatsResponseFile)
+				var jobs []models.Job
+				err = json.Unmarshal(data, &jobs)
+				require.NoError(t, err)
+				mockClient.On("JobStats", mock.Anything).Return(jobs, nil)
+				return &mockClient
+			},
+			expectedMetricGen: func(t *testing.T) pmetric.Metrics {
+				goldenPath := filepath.Join("testdata", "expected_metrics", "metrics_golden.yaml")
+				expectedMetrics, err := golden.ReadMetrics(goldenPath)
+				require.NoError(t, err)
+				return expectedMetrics
+			},
+			config: &Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: defaultCollectionInterval,
+				},
+				StartTimeEpochLimit:  100000,
 				ClientConfig:         clientConfig,
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 			},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add application ids filter and other features.

Based on #39936

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->


<!--Describe what testing was performed and which tests were added.-->
#### Testing
Run manualily and added unit tests.

<!--Describe the documentation added.-->
#### Documentation
It is possible to scrape by application name but not by id.
Add limit by count and by  time.
Other changes.

```yaml
  apachespark:
    collection_interval: 60s
    endpoint: http://spark:4040
    application_ids:
      - "spark-1234"
    limis:
      count: 100
```
