### PR TITLE
[cmd/opampsupervisor] Fix merging lists when using local config

### DIFF
--- a/.chloggen/opampsupervisor-fix-local-config.yaml
+++ b/.chloggen/opampsupervisor-fix-local-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix slice merging when using local configuration files
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/opampsupervisor-fix-local-config.yaml
+++ b/.chloggen/opampsupervisor-fix-local-config.yaml
@@ -10,7 +10,7 @@ component: cmd/opampsupervisor
 note: Fix slice merging when using local configuration files
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [39947]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/opampsupervisor/testdata/collector/simple_pipeline_env.yaml
+++ b/cmd/opampsupervisor/testdata/collector/simple_pipeline_env.yaml
@@ -8,7 +8,12 @@ exporters:
   file:
     path: ${OUT_FILE}
 
+extensions:
+  health_check/e2e:
+    endpoint: "localhost:${HEALTHCHECK_PORT}"
+
 service:
+  extensions: [health_check/e2e]
   pipelines:
     logs:
       receivers: [filelog]

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_exec_config.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_exec_config.yaml
@@ -19,3 +19,4 @@ agent:
   env:
     OUT_FILE: '{{.outputLogFile}}'
     IN_FILE: '{{.inputLogFile}}'
+    HEALTHCHECK_PORT: '{{.healthcheckPort}}'


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

With https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38671, we supply the local config to the Collector in two places:
1. The effective (merged) config
2. A list of files passed through `--config` flags to the Collector.

While the second approach is preferable in the long term, we have to manually merge the config for now since the Collector doesn't support merging lists in config without a feature gate enabled. This PR therefore opts for the first option until we enable this feature gate.

Fixes #39931