### PR TITLE
[cmd/opampsupervisor] Supervisor reports last collector STDERR message

### DIFF
--- a/.chloggen/supervisor-reports-last-collector-stderr.yaml
+++ b/.chloggen/supervisor-reports-last-collector-stderr.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Supervisor reports last error from the agent in the stderr logs.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39954]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -1384,8 +1384,7 @@ func (s *Supervisor) runAgentProcess() {
 
 			if exitCode == 1 {
 				// get last log line from the agent logs
-				lastError := s.commander.LastErr()
-				if lastError != "" {
+				if lastError := s.commander.LastErr(); lastError != "" {
 					s.telemetrySettings.Logger.Debug("Last error from the agent", zap.String("last_agent_error", lastError))
 					errMsg = fmt.Sprintf("%s: \n%s", errMsg, lastError)
 				} else {
@@ -1422,8 +1421,9 @@ func (s *Supervisor) runAgentProcess() {
 			lastHealth := s.lastHealthFromClient.Load()
 			if lastHealth == nil || !lastHealth.Healthy {
 				errMsg := "Config apply timeout exceeded"
-				if s.commander.LastErr() != "" {
-					errMsg = fmt.Sprintf("%s: \n%s", errMsg, s.commander.LastErr())
+				if lastError := s.commander.LastErr(); lastError != "" {
+					s.telemetrySettings.Logger.Debug("Last error from the agent", zap.String("last_agent_error", lastError))
+					errMsg = fmt.Sprintf("%s: \n%s", errMsg, lastError)
 				}
 				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, errMsg)
 			} else {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
If the supervisor receives a "bad" remote config (collector is unable to start or fails shortly after) and starts the collector with it, the supervisor reports a "Failed" RemoteConfigStatus and an error. This error is usually either "Config apply timeout exceeded" or "Agent process PID=1234 exited unexpectedly, exit code=1. Will restart in a bit...". 

This error isn't very descriptive though as to why the collector failed and requires retrieving the collector's log to determine the root issue. In situations where these logs aren't accessible it makes debugging very difficult if not impossible. 

This PR changes how the collector process is ran so that we can keep track of the last message the collector writes to STDERR. Whenever the collector process fails, we include this last error message with the supervisor's description of the issue.

For example, if the failure is an unrecognized component in the config, this is the error reported to the OpAMP server:
```
"Config apply timeout exceeded: \nerror decoding 'exporters': unknown type: \"doesntexist\" for id: \"doesntexist\" (valid values: [file opensearch rabbitmq sapm signalfx splunk_hec nop alertmanager alibabacloud_logservice datadog elasticsearch googlecloud googlecloudpubsub sumologic azureblob influxdb sentry syslog zipkin otlphttp dataset stef debug awss3 awsxray azuredataexplorer honeycombmarker kafka logzio opencensus awscloudwatchlogs awsemf azuremonitor bmchelix loki mezmo prometheus pulsar carbon clickhouse tencentcloud_logservice otlp awskinesis doris googlemanagedprometheus loadbalancing logicmonitor otelarrow prometheusremotewrite cassandra coralogix])"
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing
E2E test for restarting after a bad config is updated to check for an error message.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
