### PR TITLE
[processor/filter] Create `WithAdditional*Funcs` factory options and `Validate*Conditions` to provide additional OTTL funcs programatically.

### DIFF
--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -61,6 +61,13 @@ func StandardResourceFuncs() map[string]ottl.Factory[ottlresource.TransformConte
 	return ottlfuncs.StandardConverters[ottlresource.TransformContext]()
 }
 
+func MergeAdditionalFuncs[T any](m map[string]ottl.Factory[T], additionalFuncs []ottl.Factory[T]) map[string]ottl.Factory[T] {
+	for _, f := range additionalFuncs {
+		m[f.Name()] = f
+	}
+	return m
+}
+
 type hasAttributeOnDatapointArguments struct {
 	Key         string
 	ExpectedVal string

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -12,19 +12,76 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/metadata"
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
+type filterProcessorFactory struct {
+	additionalLogFunctions    []ottl.Factory[ottllog.TransformContext]
+	additionalSpanFunctions   []ottl.Factory[ottlspan.TransformContext]
+	additionalMetricFunctions []ottl.Factory[ottlmetric.TransformContext]
+}
+
+// FactoryOption applies changes to filterProcessorFactory.
+type FactoryOption func(factory *filterProcessorFactory)
+
+// defaultAdditionalMetricFunctions returns an empty slice of ottl function factories.
+func defaultAdditionalMetricFunctions() []ottl.Factory[ottlmetric.TransformContext] {
+	return []ottl.Factory[ottlmetric.TransformContext]{}
+}
+
+// defaultAdditionalLogFunctions returns an empty slice of ottl function factories.
+func defaultAdditionalLogFunctions() []ottl.Factory[ottllog.TransformContext] {
+	return []ottl.Factory[ottllog.TransformContext]{}
+}
+
+// defaultAdditionalSpanFunctions returns an empty slice of ottl function factories.
+func defaultAdditionalSpanFunctions() []ottl.Factory[ottlspan.TransformContext] {
+	return []ottl.Factory[ottlspan.TransformContext]{}
+}
+
+// WithAdditionalMetricFunctions adds ottl metric functions to resulting processor
+func WithAdditionalMetricFunctions(metricFunctions []ottl.Factory[ottlmetric.TransformContext]) FactoryOption {
+	return func(factory *filterProcessorFactory) {
+		factory.additionalMetricFunctions = metricFunctions
+	}
+}
+
+// WithAdditionalLogFunctions adds ottl log functions to resulting processor
+func WithAdditionalLogFunctions(logFunctions []ottl.Factory[ottllog.TransformContext]) FactoryOption {
+	return func(factory *filterProcessorFactory) {
+		factory.additionalLogFunctions = logFunctions
+	}
+}
+
+// WithAdditionalSpanFunctions adds ottl span functions to resulting processor
+func WithAdditionalSpanFunctions(spanFunctions []ottl.Factory[ottlspan.TransformContext]) FactoryOption {
+	return func(factory *filterProcessorFactory) {
+		factory.additionalSpanFunctions = spanFunctions
+	}
+}
+
 // NewFactory returns a new factory for the Filter processor.
-func NewFactory() processor.Factory {
+func NewFactory(options ...FactoryOption) processor.Factory {
+	f := &filterProcessorFactory{
+		additionalMetricFunctions: defaultAdditionalMetricFunctions(),
+		additionalLogFunctions:    defaultAdditionalLogFunctions(),
+		additionalSpanFunctions:   defaultAdditionalSpanFunctions(),
+	}
+	for _, o := range options {
+		o(f)
+	}
+
 	return processor.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		processor.WithMetrics(createMetricsProcessor, metadata.MetricsStability),
-		processor.WithLogs(createLogsProcessor, metadata.LogsStability),
-		processor.WithTraces(createTracesProcessor, metadata.TracesStability),
+		processor.WithMetrics(f.createMetricsProcessor, metadata.MetricsStability),
+		processor.WithLogs(f.createLogsProcessor, metadata.LogsStability),
+		processor.WithTraces(f.createTracesProcessor, metadata.TracesStability),
 	)
 }
 
@@ -34,13 +91,13 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createMetricsProcessor(
+func (f *filterProcessorFactory) createMetricsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (processor.Metrics, error) {
-	fp, err := newFilterMetricProcessor(set, cfg.(*Config))
+	fp, err := newFilterMetricProcessor(set, cfg.(*Config), f.additionalMetricFunctions...)
 	if err != nil {
 		return nil, err
 	}
@@ -53,13 +110,13 @@ func createMetricsProcessor(
 		processorhelper.WithCapabilities(processorCapabilities))
 }
 
-func createLogsProcessor(
+func (f *filterProcessorFactory) createLogsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
 ) (processor.Logs, error) {
-	fp, err := newFilterLogsProcessor(set, cfg.(*Config))
+	fp, err := newFilterLogsProcessor(set, cfg.(*Config), f.additionalLogFunctions...)
 	if err != nil {
 		return nil, err
 	}
@@ -72,13 +129,13 @@ func createLogsProcessor(
 		processorhelper.WithCapabilities(processorCapabilities))
 }
 
-func createTracesProcessor(
+func (f *filterProcessorFactory) createTracesProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
-	fp, err := newFilterSpansProcessor(set, cfg.(*Config))
+	fp, err := newFilterSpansProcessor(set, cfg.(*Config), f.additionalSpanFunctions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description
Create `WithAdditionalMetricFunctions`, `WithAdditionalSpanFunctions` and `WithAdditionalLogFunctions` factory options to add custom OTTL functions for logs, metrics or traces to the resulting processor. Also created the `Config` methods `ValidateMetricConditions`, `ValidateLogConditions` and `ValidateSpanConditions` to enable users to validate configs with the additional OTTL functions.

Some details about the solution :

- To create a custom `filter` processor the user needs to create `NewFactory` and `Config.Validate` providing the additional OTTL functions.
- Since, as far as i understand, the collector design doesn't let the `Config` to access the processor `Factory`, the `Config.Validate` method can't access the additional OTTL functions from the `Factory`. I circumvented this issue by creating the `Validate*Conditions` helper functions which can be used to create a custom `Config.Validate` method to validate with the additional ottl functions.
- This is a result of the discussion in this thread : https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39641#discussion_r2081450587
- This is intended for developers of Opentelemetry Collector Distributions.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39698

**Note : There is a similar followup proposed update for the `processor/filter`.**

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- TODO

<!--Describe the documentation added.-->
#### Documentation
- TODO

<!--Please delete paragraphs that you did not use before submitting.-->
