### PR TITLE
[chore] [pkg/stanza/fileconsumer] fix flaky sink timeout tests

### DIFF
--- a/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
@@ -24,7 +24,7 @@ func TestNextToken(t *testing.T) {
 }
 
 func TestNextTokenTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for _, c := range testCalls {
 		token := s.NextToken(t)
 		assert.Equal(t, c.Body, token)
@@ -46,7 +46,7 @@ func TestNextTokens(t *testing.T) {
 }
 
 func TestNextTokensTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for i := 0; i < 5; i++ {
 		tokens := s.NextTokens(t, 2)
 		assert.Equal(t, testCalls[2*i].Body, tokens[0])
@@ -69,7 +69,7 @@ func TestNextCall(t *testing.T) {
 }
 
 func TestNextCallTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for _, c := range testCalls {
 		token, attributes := s.NextCall(t)
 		require.Equal(t, c.Body, token)
@@ -90,7 +90,7 @@ func TestExpectToken(t *testing.T) {
 }
 
 func TestExpectTokenTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for _, c := range testCalls {
 		s.ExpectToken(t, c.Body)
 	}
@@ -109,7 +109,7 @@ func TestExpectTokens(t *testing.T) {
 }
 
 func TestExpectTokensTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for i := 0; i < 5; i++ {
 		s.ExpectTokens(t, testCalls[2*i].Body, testCalls[2*i+1].Body)
 	}
@@ -128,7 +128,7 @@ func TestExpectCall(t *testing.T) {
 }
 
 func TestExpectCallTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	for _, c := range testCalls {
 		s.ExpectCall(t, c.Body, c.Attributes)
 	}
@@ -152,7 +152,7 @@ func TestExpectCalls(t *testing.T) {
 }
 
 func TestExpectCallsTimeout(t *testing.T) {
-	s, testCalls := sinkTest(t, WithTimeout(10*time.Millisecond))
+	s, testCalls := sinkTest(t, WithTimeout(30*time.Millisecond))
 	testCallsOutOfOrder := make([]emit.Token, 0, 10)
 	for i := 0; i < len(testCalls); i += 2 {
 		testCallsOutOfOrder = append(testCallsOutOfOrder, testCalls[i])


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39950 by increasing timeout from 10 ms to 30 ms.