### PR TITLE
processor/metricstarttime: offset strategy

### DIFF
--- a/.chloggen/metricstarttime_offset.yaml
+++ b/.chloggen/metricstarttime_offset.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add offset strategy
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39996]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: implements an offset strategy that computes start times as by subtracting a configurable duration from the timestamp
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/metricstarttimeprocessor/README.md
+++ b/processor/metricstarttimeprocessor/README.md
@@ -69,3 +69,16 @@ Cons:
 
 * The absolute value of counters is modified. This is generally not an issue, since counters are usually used to compute rates.
 * The initial point is dropped, which loses information.
+
+### Strategy: Fixed Offset
+
+The `offset` strategy computes missing start times for data points of any
+temporality by subtracting a configured duration from their timestamp:
+
+```yaml
+strategy: offset
+offset: <duration> | default = 1m
+```
+
+
+E.g. a datapoint at `2025-05-12T13:51:55` would receive a start time of `2025-05-12T13:50:55`.

--- a/processor/metricstarttimeprocessor/config.go
+++ b/processor/metricstarttimeprocessor/config.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/offset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
@@ -17,6 +18,7 @@ import (
 // Config holds configuration of the metric start time processor.
 type Config struct {
 	Strategy   string        `mapstructure:"strategy"`
+	Offset     time.Duration `mapstructure:"offset"`
 	GCInterval time.Duration `mapstructure:"gc_interval"`
 }
 
@@ -34,6 +36,10 @@ func (cfg *Config) Validate() error {
 	switch cfg.Strategy {
 	case truereset.Type:
 	case subtractinitial.Type:
+	case offset.Type:
+		if cfg.Offset == 0 {
+			cfg.Offset = time.Minute
+		}
 	default:
 		return fmt.Errorf("%q is not a valid strategy", cfg.Strategy)
 	}

--- a/processor/metricstarttimeprocessor/config_test.go
+++ b/processor/metricstarttimeprocessor/config_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/offset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
@@ -55,6 +56,22 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_strategy"),
 			errorMessage: "\"bad\" is not a valid strategy",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "offset-default"),
+			expected: &Config{
+				Strategy:   offset.Type,
+				Offset:     60 * time.Second,
+				GCInterval: 10 * time.Minute,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "offset-manual"),
+			expected: &Config{
+				Strategy:   offset.Type,
+				Offset:     15 * time.Second,
+				GCInterval: 10 * time.Minute,
+			},
 		},
 	}
 

--- a/processor/metricstarttimeprocessor/factory.go
+++ b/processor/metricstarttimeprocessor/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/offset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
@@ -41,6 +42,9 @@ func createMetricsProcessor(
 		adjustMetrics = adjuster.AdjustMetrics
 	case subtractinitial.Type:
 		adjuster := subtractinitial.NewAdjuster(set.TelemetrySettings, rCfg.GCInterval)
+		adjustMetrics = adjuster.AdjustMetrics
+	case offset.Type:
+		adjuster := offset.NewAdjuster(set.TelemetrySettings, rCfg.Offset)
 		adjustMetrics = adjuster.AdjustMetrics
 	}
 

--- a/processor/metricstarttimeprocessor/internal/offset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/offset/adjuster.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package offset // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/offset"
+
+import (
+	"context"
+	"iter"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const Type = "offset"
+
+type Adjuster struct {
+	set    component.TelemetrySettings
+	offset time.Duration
+}
+
+// NewAdjuster returns a new Adjuster which adjust metrics' start times based on the initial received points.
+func NewAdjuster(set component.TelemetrySettings, offset time.Duration) *Adjuster {
+	return &Adjuster{
+		set:    set,
+		offset: offset,
+	}
+}
+
+func (a *Adjuster) AdjustMetrics(_ context.Context, md pmetric.Metrics) (pmetric.Metrics, error) {
+	for m := range all(md) {
+		switch m.Type() {
+		case pmetric.MetricTypeSum:
+			for _, dp := range m.Sum().DataPoints().All() {
+				if dp.StartTimestamp() == 0 {
+					dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(a.offset))
+				}
+			}
+		case pmetric.MetricTypeGauge:
+			for _, dp := range m.Gauge().DataPoints().All() {
+				if dp.StartTimestamp() == 0 {
+					dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(a.offset))
+				}
+			}
+		case pmetric.MetricTypeHistogram:
+			for _, dp := range m.Histogram().DataPoints().All() {
+				if dp.StartTimestamp() == 0 {
+					dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(a.offset))
+				}
+			}
+		case pmetric.MetricTypeExponentialHistogram:
+			for _, dp := range m.ExponentialHistogram().DataPoints().All() {
+				if dp.StartTimestamp() == 0 {
+					dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(a.offset))
+				}
+			}
+		case pmetric.MetricTypeSummary:
+			for _, dp := range m.Summary().DataPoints().All() {
+				if dp.StartTimestamp() == 0 {
+					dp.SetStartTimestamp(dp.Timestamp() - pcommon.Timestamp(a.offset))
+				}
+			}
+		}
+	}
+	return md, nil
+}
+
+func all(md pmetric.Metrics) iter.Seq[pmetric.Metric] {
+	return func(yield func(pmetric.Metric) bool) {
+		for _, rm := range md.ResourceMetrics().All() {
+			for _, sm := range rm.ScopeMetrics().All() {
+				for _, m := range sm.Metrics().All() {
+					if !yield(m) {
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/processor/metricstarttimeprocessor/internal/offset/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/offset/adjuster_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package offset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdjuster(t *testing.T) {
+	metrics := func(start, ts pcommon.Timestamp) pmetric.Metrics {
+		md := pmetric.NewMetrics()
+		ms := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
+
+		sum := ms.AppendEmpty().SetEmptySum().DataPoints().AppendEmpty()
+		sum.SetStartTimestamp(start)
+		sum.SetTimestamp(ts)
+
+		gauge := ms.AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+		gauge.SetStartTimestamp(start)
+		gauge.SetTimestamp(ts)
+
+		histogram := ms.AppendEmpty().SetEmptyHistogram().DataPoints().AppendEmpty()
+		histogram.SetStartTimestamp(start)
+		histogram.SetTimestamp(ts)
+
+		exp := ms.AppendEmpty().SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+		exp.SetStartTimestamp(start)
+		exp.SetTimestamp(ts)
+
+		summary := ms.AppendEmpty().SetEmptySummary().DataPoints().AppendEmpty()
+		summary.SetStartTimestamp(start)
+		summary.SetTimestamp(ts)
+		return md
+	}
+
+	now := time.Now()
+	start := pcommon.NewTimestampFromTime(now.Add(-time.Minute))
+	ts := pcommon.NewTimestampFromTime(now)
+
+	adj := NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute)
+	got, err := adj.AdjustMetrics(context.TODO(), metrics(0, ts))
+	require.NoError(t, err)
+
+	want := metrics(start, ts)
+	assert.Equal(t, want.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics(), got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics())
+}

--- a/processor/metricstarttimeprocessor/testdata/config.yaml
+++ b/processor/metricstarttimeprocessor/testdata/config.yaml
@@ -11,3 +11,10 @@ metricstarttime/negative_interval:
 
 metricstarttime/invalid_strategy:
   strategy: bad
+
+metricstarttime/offset-default:
+  strategy: offset
+
+metricstarttime/offset-manual:
+  strategy: offset
+  offset: 15s


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Implements `offset` strategy that computes start times by subtracting a configurable duration from the actual timestamp

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39996

<!--Describe what testing was performed and which tests were added.-->
#### Testing
test added

<!--Describe the documentation added.-->
#### Documentation
readme updated

<!--Please delete paragraphs that you did not use before submitting.-->
