### PR TITLE
[chore] Add missing approver to auto_assign

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -12,6 +12,7 @@ assigneeGroups:
   approvers_maintainers:
     # Approvers
     - ArthurSens
+    - braydonk
     - ChrsMark
     - crobert-1
     # - dashpole on leave


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This was missed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39814, updated list matches [approver and maintainer list](https://github.com/open-telemetry/opentelemetry-collector-contrib?tab=readme-ov-file#contributing).