### PR TITLE
[chore][exporter/datadog] shorten internal metrics interval in tests

### DIFF
--- a/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
@@ -26,6 +26,7 @@ service:
       level: "basic"
       readers:
         - periodic:
+            interval: 5000 # milliseconds
             exporter:
               otlp:
                 protocol: http/protobuf

--- a/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
@@ -26,6 +26,7 @@ service:
       level: "basic"
       readers:
         - periodic:
+            interval: 5000 # milliseconds
             exporter:
               otlp:
                 protocol: http/protobuf


### PR DESCRIPTION
#### Description
Set interval of internal metrics periodic reader to 5s. Default is 60s which is too long for the tests.

#### Link to tracking issue
Fixes #40012

