### PR TITLE
[receiver/windowsservice] Added receiver scrape wireframe

### DIFF
--- a/receiver/windowsservicereceiver/config.go
+++ b/receiver/windowsservicereceiver/config.go
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//revive:disable:unused-parameter
+//nolint:unused,unparam
+
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 
 import (

--- a/receiver/windowsservicereceiver/config.go
+++ b/receiver/windowsservicereceiver/config.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unused,unparam
+//nolint:unparam
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 

--- a/receiver/windowsservicereceiver/config.go
+++ b/receiver/windowsservicereceiver/config.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unparam
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 

--- a/receiver/windowsservicereceiver/factory.go
+++ b/receiver/windowsservicereceiver/factory.go
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//revive:disable:unused-parameter
+//nolint:unused,unparam
+
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 
 import (

--- a/receiver/windowsservicereceiver/factory.go
+++ b/receiver/windowsservicereceiver/factory.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unused,unparam
+//nolint:unparam
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 

--- a/receiver/windowsservicereceiver/factory.go
+++ b/receiver/windowsservicereceiver/factory.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unparam
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
 

--- a/receiver/windowsservicereceiver/go.mod
+++ b/receiver/windowsservicereceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/scraper/scraperhelper v0.128.1-0.20250610090210-188191247685
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sys v0.33.0
 )
 
 require (
@@ -55,7 +56,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.72.2 // indirect

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -1,5 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
+//revive:disable:unused-parameter
+//nolint:unused,unparam
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -3,3 +3,39 @@
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver/internal/metadata"
+)
+
+type windowsServiceScraper struct {
+	scm      serviceManager
+	settings receiver.Settings
+	conf     *Config
+	mb       *metadata.MetricsBuilder
+}
+
+func newWindowsServiceScraper(settings receiver.Settings, cfg *Config) windowsServiceScraper {
+	return windowsServiceScraper{
+		settings: settings,
+		mb:       metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),
+	}
+}
+
+func (ws *windowsServiceScraper) start(ctx context.Context, _ component.Host) (err error) {
+	return nil
+}
+
+func (ws *windowsServiceScraper) shutdown(ctx context.Context) (err error) {
+	return nil
+}
+
+func (ws *windowsServiceScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
+	return ws.mb.Emit(), nil
+}

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unused,unparam
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
@@ -17,6 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver/internal/metadata"
 )
 
+//nolint:unused
 type windowsServiceScraper struct {
 	scm      serviceManager
 	settings receiver.Settings
@@ -24,6 +24,7 @@ type windowsServiceScraper struct {
 	mb       *metadata.MetricsBuilder
 }
 
+//nolint:unused
 func newWindowsServiceScraper(settings receiver.Settings, cfg *Config) windowsServiceScraper {
 	return windowsServiceScraper{
 		settings: settings,
@@ -31,14 +32,17 @@ func newWindowsServiceScraper(settings receiver.Settings, cfg *Config) windowsSe
 	}
 }
 
+//nolint:unused
 func (ws *windowsServiceScraper) start(ctx context.Context, _ component.Host) (err error) {
 	return nil
 }
 
+//nolint:unused
 func (ws *windowsServiceScraper) shutdown(ctx context.Context) (err error) {
 	return nil
 }
 
+//nolint:unused
 func (ws *windowsServiceScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	return ws.mb.Emit(), nil
 }

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -25,7 +25,7 @@ type windowsServiceScraper struct {
 }
 
 //nolint:unused
-func newWindowsServiceScraper(settings receiver.Settings, cfg *Config) windowsServiceScraper {
+func newWindowsServiceScraper(settings receiver.Settings, _ *Config) windowsServiceScraper {
 	return windowsServiceScraper{
 		settings: settings,
 		mb:       metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -33,16 +33,16 @@ func newWindowsServiceScraper(settings receiver.Settings, _ *Config) windowsServ
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) start(ctx context.Context, _ component.Host) (err error) {
+func (ws *windowsServiceScraper) start(_ context.Context, _ component.Host) (err error) {
 	return nil
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) shutdown(ctx context.Context) (err error) {
+func (ws *windowsServiceScraper) shutdown(_ context.Context) (err error) {
 	return nil
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
+func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 	return ws.mb.Emit(), nil
 }

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -1,5 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
+//revive:disable:unused-parameter
+//nolint:unused,unparam
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -3,3 +3,43 @@
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import (
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+/*
+* Functions and structs which are used to interact with the Windows service api.
+*
+* Primary functions are connecting to the Service Control Manager (SCM) to gather service information on scrape.
+*
+* Docs may be found at https://learn.microsoft.com/en-us/windows/win32/services/services
+* and "https://learn.microsoft.com/en-us/windows/win32/api/winsvc/"
+**/
+
+// service manager "client"
+type serviceManager struct {
+	handle windows.Handle // handle to SCM database
+}
+
+// get SCM database handle
+func scmConnect() (*serviceManager, error) {
+	var h windows.Handle
+	return &serviceManager{
+		h,
+	}, nil
+}
+
+func (sm *serviceManager) disconnect() error {
+	return nil
+}
+
+func (sm *serviceManager) listServices() ([]string, error) {
+	var s []string
+	return s, nil
+}
+
+func (sm *serviceManager) openService() (*mgr.Service, error) {
+	return nil, nil
+}

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unused,unparam
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
@@ -22,11 +21,15 @@ import (
 **/
 
 // service manager "client"
+//
+//nolint:unused
 type serviceManager struct {
 	handle windows.Handle // handle to SCM database
 }
 
 // get SCM database handle
+//
+//nolint:unused
 func scmConnect() (*serviceManager, error) {
 	var h windows.Handle
 	return &serviceManager{
@@ -34,15 +37,18 @@ func scmConnect() (*serviceManager, error) {
 	}, nil
 }
 
+//nolint:unused
 func (sm *serviceManager) disconnect() error {
 	return nil
 }
 
+//nolint:unused
 func (sm *serviceManager) listServices() ([]string, error) {
 	var s []string
 	return s, nil
 }
 
+//nolint:unused
 func (sm *serviceManager) openService() (*mgr.Service, error) {
 	return nil, nil
 }

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -29,7 +29,7 @@ type serviceManager struct {
 
 // get SCM database handle
 //
-//nolint:unused
+//nolint:unused,unparam
 func scmConnect() (*serviceManager, error) {
 	var h windows.Handle
 	return &serviceManager{

--- a/receiver/windowsservicereceiver/winservice.go
+++ b/receiver/windowsservicereceiver/winservice.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
+
+import "golang.org/x/sys/windows/svc/mgr"
+
+/**
+* Windows Service representation and associated functions. These handle
+* interacting with the SCM and martialing service information returned by the
+* windows api calls.
+**/
+
+// receiver representation of a service
+type winService struct {
+	service       *mgr.Service
+	serviceStatus uint32
+	startType     uint32
+}
+
+func getService(mgr *serviceManager, sname string) (*winService, error) {
+	return &winService{}, nil
+}
+
+func (w *winService) getStatus() error {
+	return nil
+}
+
+func (w *winService) getConfig() error {
+	return nil
+}

--- a/receiver/windowsservicereceiver/winservice.go
+++ b/receiver/windowsservicereceiver/winservice.go
@@ -1,5 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
+//revive:disable:unused-parameter
+//nolint:unused
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"

--- a/receiver/windowsservicereceiver/winservice.go
+++ b/receiver/windowsservicereceiver/winservice.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //revive:disable:unused-parameter
-//nolint:unused
 //go:build windows
 
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"
@@ -16,20 +15,25 @@ import "golang.org/x/sys/windows/svc/mgr"
 **/
 
 // receiver representation of a service
+//
+//nolint:unused
 type winService struct {
 	service       *mgr.Service
 	serviceStatus uint32
 	startType     uint32
 }
 
+//nolint:unused
 func getService(mgr *serviceManager, sname string) (*winService, error) {
 	return &winService{}, nil
 }
 
+//nolint:unused
 func (w *winService) getStatus() error {
 	return nil
 }
 
+//nolint:unused
 func (w *winService) getConfig() error {
 	return nil
 }

--- a/receiver/windowsservicereceiver/winservice_test.go
+++ b/receiver/windowsservicereceiver/winservice_test.go
@@ -1,0 +1,5 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+
+package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"


### PR DESCRIPTION
#### Description
This PR adds the outline for the scraping functionality to the Windows Service receiver. This outlines the intended structure including how the receiver will access the win32 api and serialize the results. The actual implementation details will be submitted in a separate PR once the approach and framework is agreed upon.

The primary motivation for breaking the PRs up like this is to prevent scope creep and keep code light and easy to review.

#### Link to tracking issue
Fixes [38619](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38619)

#### Testing
No testing required at this point.

#### Documentation
README.md included as well as scratch notes on the components.