### PR TITLE
[chore] Refactor Coralogix exporter

### DIFF
--- a/exporter/coralogixexporter/go.mod
+++ b/exporter/coralogixexporter/go.mod
@@ -26,6 +26,7 @@ require (
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
 	google.golang.org/grpc v1.72.0
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
@@ -85,7 +86,6 @@ require (
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestNewLogsExporter(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		shouldError bool
+	}{
+		{
+			name: "Valid domain config",
+			cfg: &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Valid logs endpoint config",
+			cfg: &Config{
+				Logs: configgrpc.ClientConfig{
+					Endpoint: "localhost:4317",
+				},
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Missing both domain and endpoint",
+			cfg: &Config{
+				PrivateKey: "test-key",
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exp, err := newLogsExporter(tt.cfg, exportertest.NewNopSettings(exportertest.NopType))
+			if tt.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, exp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, exp)
+			}
+		})
+	}
+}
+
+func TestLogsExporter_Start(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Logs: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	assert.NotNil(t, exp.clientConn)
+	assert.NotNil(t, exp.logExporter)
+	assert.Contains(t, exp.config.Logs.Headers, "Authorization")
+
+	// Test shutdown
+	err = exp.shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestLogsExporter_EnhanceContext(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Logs: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{
+				"test-header": "test-value",
+			},
+		},
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	enhancedCtx := exp.enhanceContext(ctx)
+	assert.NotEqual(t, ctx, enhancedCtx)
+}
+
+func TestLogsExporter_PushLogs(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Logs: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	// Initialize the exporter by calling start
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// Create test logs
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs()
+	rl := resourceLogs.AppendEmpty()
+
+	resource := rl.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+
+	err = exp.pushLogs(context.Background(), logs)
+	assert.Error(t, err)
+}

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -5,76 +5,43 @@ package coralogixexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"runtime"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configopaque"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func newMetricsExporter(cfg component.Config, set exporter.Settings) (*metricsExporter, error) {
-	oCfg := cfg.(*Config)
-
-	if isEmpty(oCfg.Domain) && isEmpty(oCfg.Metrics.Endpoint) {
-		return nil, errors.New("coralogix exporter config requires `domain` or `metrics.endpoint` configuration")
+	oCfg, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
-	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
-		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
-	return &metricsExporter{config: oCfg, settings: set.TelemetrySettings, userAgent: userAgent}, nil
+	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Metrics.Endpoint, oCfg.Metrics.Headers)
+	if err != nil {
+		return nil, err
+	}
+
+	return &metricsExporter{
+		signalExporter: *signalExporter,
+	}, nil
 }
 
 type metricsExporter struct {
-	// Input configuration.
-	config *Config
-
 	metricExporter pmetricotlp.GRPCClient
-	clientConn     *grpc.ClientConn
-	callOptions    []grpc.CallOption
-
-	settings component.TelemetrySettings
-
-	// Default user-agent header.
-	userAgent string
+	signalExporter
 }
 
 func (e *metricsExporter) start(ctx context.Context, host component.Host) (err error) {
-	switch {
-	case !isEmpty(e.config.Metrics.Endpoint):
-		if e.clientConn, err = e.config.Metrics.ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
-			return err
-		}
-	case !isEmpty(e.config.Domain):
-		if e.clientConn, err = e.config.getDomainGrpcSettings().ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
-			return err
-		}
+	wrapper := &signalConfigWrapper{config: &e.config.Metrics}
+	if err := e.startSignalExporter(ctx, host, wrapper); err != nil {
+		return err
 	}
-
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
-	if e.config.Metrics.Headers == nil {
-		e.config.Metrics.Headers = make(map[string]configopaque.String)
-	}
-	e.config.Metrics.Headers["Authorization"] = configopaque.String("Bearer " + string(e.config.PrivateKey))
-
-	e.callOptions = []grpc.CallOption{
-		grpc.WaitForReady(e.config.Metrics.WaitForReady),
-	}
-
-	return
+	return nil
 }
 
 func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
@@ -102,93 +69,6 @@ func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) e
 	return nil
 }
 
-func (e *metricsExporter) shutdown(context.Context) error {
-	if e.clientConn == nil {
-		return nil
-	}
-	return e.clientConn.Close()
-}
-
 func (e *metricsExporter) enhanceContext(ctx context.Context) context.Context {
-	md := metadata.New(nil)
-	for k, v := range e.config.Metrics.Headers {
-		md.Set(k, string(v))
-	}
-	return metadata.NewOutgoingContext(ctx, md)
-}
-
-// Send a trace or metrics request to the server. "perform" function is expected to make
-// the actual gRPC unary call that sends the request. This function implements the
-// common OTLP logic around request handling such as retries and throttling.
-func processError(err error) error {
-	if err == nil {
-		// Request is successful, we are done.
-		return nil
-	}
-
-	// We have an error, check gRPC status code.
-
-	st := status.Convert(err)
-	if st.Code() == codes.OK {
-		// Not really an error, still success.
-		return nil
-	}
-
-	// Now, this is this a real error.
-
-	retryInfo := getRetryInfo(st)
-
-	if !shouldRetry(st.Code(), retryInfo) {
-		// It is not a retryable error, we should not retry.
-		return consumererror.NewPermanent(err)
-	}
-
-	// Check if server returned throttling information.
-	throttleDuration := getThrottleDuration(retryInfo)
-	if throttleDuration != 0 {
-		// We are throttled. Wait before retrying as requested by the server.
-		return exporterhelper.NewThrottleRetry(err, throttleDuration)
-	}
-
-	// Need to retry.
-
-	return err
-}
-
-func shouldRetry(code codes.Code, retryInfo *errdetails.RetryInfo) bool {
-	switch code {
-	case codes.Canceled,
-		codes.DeadlineExceeded,
-		codes.Aborted,
-		codes.OutOfRange,
-		codes.Unavailable,
-		codes.DataLoss:
-		// These are retryable errors.
-		return true
-	case codes.ResourceExhausted:
-		// Retry only if RetryInfo was supplied by the server.
-		// This indicates that the server can still recover from resource exhaustion.
-		return retryInfo != nil
-	}
-	// Don't retry on any other code.
-	return false
-}
-
-func getRetryInfo(status *status.Status) *errdetails.RetryInfo {
-	for _, detail := range status.Details() {
-		if t, ok := detail.(*errdetails.RetryInfo); ok {
-			return t
-		}
-	}
-	return nil
-}
-
-func getThrottleDuration(t *errdetails.RetryInfo) time.Duration {
-	if t == nil || t.RetryDelay == nil {
-		return 0
-	}
-	if t.RetryDelay.Seconds > 0 || t.RetryDelay.Nanos > 0 {
-		return time.Duration(t.RetryDelay.Seconds)*time.Second + time.Duration(t.RetryDelay.Nanos)*time.Nanosecond
-	}
-	return 0
+	return e.signalExporter.enhanceContext(ctx)
 }

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestNewMetricsExporter(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		shouldError bool
+	}{
+		{
+			name: "Valid domain config",
+			cfg: &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Valid metrics endpoint config",
+			cfg: &Config{
+				Metrics: configgrpc.ClientConfig{
+					Endpoint: "localhost:4317",
+				},
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Missing both domain and endpoint",
+			cfg: &Config{
+				PrivateKey: "test-key",
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exp, err := newMetricsExporter(tt.cfg, exportertest.NewNopSettings(exportertest.NopType))
+			if tt.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, exp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, exp)
+			}
+		})
+	}
+}
+
+func TestMetricsExporter_Start(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Metrics: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newMetricsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	assert.NotNil(t, exp.clientConn)
+	assert.NotNil(t, exp.metricExporter)
+	assert.Contains(t, exp.config.Metrics.Headers, "Authorization")
+
+	// Test shutdown
+	err = exp.shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestMetricsExporter_EnhanceContext(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Metrics: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{
+				"test-header": "test-value",
+			},
+		},
+	}
+
+	exp, err := newMetricsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	enhancedCtx := exp.enhanceContext(ctx)
+	assert.NotEqual(t, ctx, enhancedCtx)
+}
+
+func TestMetricsExporter_PushMetrics(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Metrics: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newMetricsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	// Initialize the exporter by calling start
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// Create test metrics
+	metrics := pmetric.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics()
+	rm := resourceMetrics.AppendEmpty()
+
+	resource := rm.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+
+	err = exp.pushMetrics(context.Background(), metrics)
+	assert.Error(t, err)
+}

--- a/exporter/coralogixexporter/retry.go
+++ b/exporter/coralogixexporter/retry.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Send a telemetry data request to the server. "perform" function is expected to make
+// the actual gRPC unary call that sends the request. This function implements the
+// common OTLP logic around request handling such as retries and throttling.
+func processError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	st := status.Convert(err)
+	if st.Code() == codes.OK {
+		return nil
+	}
+
+	retryInfo := getRetryInfo(st)
+
+	if !shouldRetry(st.Code(), retryInfo) {
+		return consumererror.NewPermanent(err)
+	}
+
+	throttleDuration := getThrottleDuration(retryInfo)
+	if throttleDuration != 0 {
+		return exporterhelper.NewThrottleRetry(err, throttleDuration)
+	}
+
+	return err
+}
+
+func shouldRetry(code codes.Code, retryInfo *errdetails.RetryInfo) bool {
+	switch code {
+	case codes.Canceled,
+		codes.DeadlineExceeded,
+		codes.Aborted,
+		codes.OutOfRange,
+		codes.Unavailable,
+		codes.DataLoss:
+		// These are retryable errors.
+		return true
+	case codes.ResourceExhausted:
+		// Retry only if RetryInfo was supplied by the server.
+		// This indicates that the server can still recover from resource exhaustion.
+		return retryInfo != nil
+	}
+	// Don't retry on any other code.
+	return false
+}
+
+func getRetryInfo(status *status.Status) *errdetails.RetryInfo {
+	for _, detail := range status.Details() {
+		if t, ok := detail.(*errdetails.RetryInfo); ok {
+			return t
+		}
+	}
+	return nil
+}
+
+func getThrottleDuration(t *errdetails.RetryInfo) time.Duration {
+	if t == nil || t.RetryDelay == nil {
+		return 0
+	}
+	if t.RetryDelay.Seconds > 0 || t.RetryDelay.Nanos > 0 {
+		return time.Duration(t.RetryDelay.Seconds)*time.Second + time.Duration(t.RetryDelay.Nanos)*time.Nanosecond
+	}
+	return 0
+}

--- a/exporter/coralogixexporter/retry_test.go
+++ b/exporter/coralogixexporter/retry_test.go
@@ -1,0 +1,207 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestProcessError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "nil error returns nil",
+			err:      nil,
+			expected: nil,
+		},
+		{
+			name:     "non-gRPC error returns permanent error",
+			err:      errors.New("some error"),
+			expected: consumererror.NewPermanent(errors.New("some error")),
+		},
+		{
+			name:     "OK status returns nil",
+			err:      status.Error(codes.OK, "ok"),
+			expected: nil,
+		},
+		{
+			name:     "permanent error returns permanent error",
+			err:      status.Error(codes.InvalidArgument, "invalid argument"),
+			expected: consumererror.NewPermanent(status.Error(codes.InvalidArgument, "invalid argument")),
+		},
+		{
+			name:     "retryable error returns original error",
+			err:      status.Error(codes.Unavailable, "unavailable"),
+			expected: status.Error(codes.Unavailable, "unavailable"),
+		},
+		{
+			name: "throttled error returns throttle retry",
+			err:  status.Error(codes.ResourceExhausted, "resource exhausted"),
+			expected: func() error {
+				st := status.New(codes.ResourceExhausted, "resource exhausted")
+				st, _ = st.WithDetails(&errdetails.RetryInfo{
+					RetryDelay: durationpb.New(time.Second),
+				})
+				return exporterhelper.NewThrottleRetry(st.Err(), time.Second)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := processError(tt.err)
+			if tt.expected == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				if consumererror.IsPermanent(err) {
+					assert.True(t, consumererror.IsPermanent(err))
+				} else {
+					assert.Contains(t, err.Error(), tt.expected.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestShouldRetry(t *testing.T) {
+	tests := []struct {
+		name      string
+		code      codes.Code
+		retryInfo *errdetails.RetryInfo
+		expected  bool
+	}{
+		{
+			name:      "Canceled is retryable",
+			code:      codes.Canceled,
+			retryInfo: nil,
+			expected:  true,
+		},
+		{
+			name:      "DeadlineExceeded is retryable",
+			code:      codes.DeadlineExceeded,
+			retryInfo: nil,
+			expected:  true,
+		},
+		{
+			name:      "Unavailable is retryable",
+			code:      codes.Unavailable,
+			retryInfo: nil,
+			expected:  true,
+		},
+		{
+			name:      "ResourceExhausted without retry info is not retryable",
+			code:      codes.ResourceExhausted,
+			retryInfo: nil,
+			expected:  false,
+		},
+		{
+			name: "ResourceExhausted with retry info is retryable",
+			code: codes.ResourceExhausted,
+			retryInfo: &errdetails.RetryInfo{
+				RetryDelay: durationpb.New(time.Second),
+			},
+			expected: true,
+		},
+		{
+			name:      "InvalidArgument is not retryable",
+			code:      codes.InvalidArgument,
+			retryInfo: nil,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldRetry(tt.code, tt.retryInfo)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetRetryInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   *status.Status
+		expected *errdetails.RetryInfo
+	}{
+		{
+			name:     "status without retry info returns nil",
+			status:   status.New(codes.OK, "ok"),
+			expected: nil,
+		},
+		{
+			name: "status with retry info returns retry info",
+			status: func() *status.Status {
+				st := status.New(codes.ResourceExhausted, "resource exhausted")
+				st, _ = st.WithDetails(&errdetails.RetryInfo{
+					RetryDelay: durationpb.New(time.Second),
+				})
+				return st
+			}(),
+			expected: &errdetails.RetryInfo{
+				RetryDelay: durationpb.New(time.Second),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getRetryInfo(tt.status)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else if assert.NotNil(t, result) {
+				assert.Equal(t, tt.expected.RetryDelay, result.RetryDelay)
+			}
+		})
+	}
+}
+
+func TestGetThrottleDuration(t *testing.T) {
+	tests := []struct {
+		name      string
+		retryInfo *errdetails.RetryInfo
+		expected  time.Duration
+	}{
+		{
+			name:      "nil retry info returns 0",
+			retryInfo: nil,
+			expected:  0,
+		},
+		{
+			name: "nil retry delay returns 0",
+			retryInfo: &errdetails.RetryInfo{
+				RetryDelay: nil,
+			},
+			expected: 0,
+		},
+		{
+			name: "valid retry delay returns correct duration",
+			retryInfo: &errdetails.RetryInfo{
+				RetryDelay: durationpb.New(time.Second + 500*time.Millisecond),
+			},
+			expected: time.Second + 500*time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getThrottleDuration(tt.retryInfo)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	exp "go.opentelemetry.io/collector/exporter"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// signalConfigWrapper wraps configgrpc.ClientConfig to implement signalConfig interface
+type signalConfigWrapper struct {
+	config *configgrpc.ClientConfig
+}
+
+func (w *signalConfigWrapper) ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, opts ...configgrpc.ToClientConnOption) (*grpc.ClientConn, error) {
+	return w.config.ToClientConn(ctx, host, settings, opts...)
+}
+
+func (w *signalConfigWrapper) GetWaitForReady() bool {
+	return w.config.WaitForReady
+}
+
+func (w *signalConfigWrapper) GetEndpoint() string {
+	return w.config.Endpoint
+}
+
+func newSignalExporter(oCfg *Config, set exp.Settings, signalEndpoint string, headers map[string]configopaque.String) (*signalExporter, error) {
+	if isEmpty(oCfg.Domain) && isEmpty(signalEndpoint) {
+		return nil, errors.New("coralogix exporter config requires `domain` or `logs.endpoint` configuration")
+	}
+
+	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
+		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
+
+	md := metadata.New(nil)
+	for k, v := range headers {
+		md.Set(k, string(v))
+	}
+
+	return &signalExporter{
+		config:    oCfg,
+		settings:  set.TelemetrySettings,
+		userAgent: userAgent,
+		metadata:  md,
+	}, nil
+}
+
+type signalConfig interface {
+	ToClientConn(ctx context.Context, host component.Host, settings component.TelemetrySettings, opts ...configgrpc.ToClientConnOption) (*grpc.ClientConn, error)
+	GetWaitForReady() bool
+	GetEndpoint() string
+}
+
+type signalExporter struct {
+	// Input configuration.
+	config *Config
+
+	clientConn  *grpc.ClientConn
+	callOptions []grpc.CallOption
+
+	settings component.TelemetrySettings
+
+	// Default user-agent header.
+	userAgent string
+
+	// Cached metadata for outgoing context
+	metadata metadata.MD
+}
+
+func (e *signalExporter) shutdown(_ context.Context) error {
+	if e.clientConn == nil {
+		return nil
+	}
+	return e.clientConn.Close()
+}
+
+func (e *signalExporter) enhanceContext(ctx context.Context) context.Context {
+	if len(e.metadata) == 0 {
+		return ctx
+	}
+
+	return metadata.NewOutgoingContext(ctx, e.metadata)
+}
+
+func (e *signalExporter) startSignalExporter(ctx context.Context, host component.Host, signalConfig signalConfig) (err error) {
+	switch {
+	case !isEmpty(signalConfig.GetEndpoint()):
+		if e.clientConn, err = signalConfig.ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
+			return err
+		}
+	case !isEmpty(e.config.Domain):
+		if e.clientConn, err = e.config.getDomainGrpcSettings().ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
+			return err
+		}
+	}
+
+	if signalConfigWrapper, ok := signalConfig.(*signalConfigWrapper); ok {
+		if signalConfigWrapper.config.Headers == nil {
+			signalConfigWrapper.config.Headers = make(map[string]configopaque.String)
+		}
+		signalConfigWrapper.config.Headers["Authorization"] = configopaque.String("Bearer " + string(e.config.PrivateKey))
+	}
+
+	e.callOptions = []grpc.CallOption{
+		grpc.WaitForReady(signalConfig.GetWaitForReady()),
+	}
+
+	return nil
+}

--- a/exporter/coralogixexporter/signals_test.go
+++ b/exporter/coralogixexporter/signals_test.go
@@ -1,0 +1,237 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	exp "go.opentelemetry.io/collector/exporter"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestSignalConfigWrapper(t *testing.T) {
+	config := &configgrpc.ClientConfig{
+		Endpoint:     "test-endpoint:4317",
+		WaitForReady: true,
+	}
+	wrapper := &signalConfigWrapper{config: config}
+
+	t.Run("GetEndpoint", func(t *testing.T) {
+		assert.Equal(t, "test-endpoint:4317", wrapper.GetEndpoint())
+	})
+
+	t.Run("GetWaitForReady", func(t *testing.T) {
+		assert.True(t, wrapper.GetWaitForReady())
+	})
+
+	t.Run("ToClientConn", func(_ *testing.T) {
+		ctx := context.Background()
+		host := &mockHost{}
+		settings := component.TelemetrySettings{}
+
+		conn, _ := wrapper.ToClientConn(ctx, host, settings)
+		if conn != nil {
+			_ = conn.Close()
+			// Wait for the connection to be fully closed
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			conn.WaitForStateChange(ctx, connectivity.Ready)
+		}
+		// No assertion on error, just ensure call is safe
+	})
+}
+
+func TestNewSignalExporter(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		settings       exp.Settings
+		signalEndpoint string
+		headers        map[string]configopaque.String
+		wantErr        bool
+	}{
+		{
+			name:           "valid config with domain",
+			config:         &Config{Domain: "test-domain"},
+			settings:       exp.Settings{},
+			signalEndpoint: "",
+			headers:        nil,
+			wantErr:        false,
+		},
+		{
+			name:           "valid config with signal endpoint",
+			config:         &Config{},
+			settings:       exp.Settings{},
+			signalEndpoint: "test-endpoint:4317",
+			headers:        nil,
+			wantErr:        false,
+		},
+		{
+			name:           "invalid config - no domain or endpoint",
+			config:         &Config{},
+			settings:       exp.Settings{},
+			signalEndpoint: "",
+			headers:        nil,
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter, err := newSignalExporter(tt.config, tt.settings, tt.signalEndpoint, tt.headers)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, exporter)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, exporter)
+				assert.Equal(t, tt.config, exporter.config)
+			}
+		})
+	}
+}
+
+func TestSignalExporter_Shutdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		exporter *signalExporter
+		wantErr  bool
+	}{
+		{
+			name:     "nil client connection",
+			exporter: &signalExporter{},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.exporter.shutdown(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSignalExporter_EnhanceContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		exporter *signalExporter
+		wantMD   metadata.MD
+	}{
+		{
+			name:     "empty metadata",
+			exporter: &signalExporter{},
+			wantMD:   nil,
+		},
+		{
+			name: "with metadata",
+			exporter: &signalExporter{
+				metadata: metadata.New(map[string]string{
+					"key": "value",
+				}),
+			},
+			wantMD: metadata.New(map[string]string{
+				"key": "value",
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			enhancedCtx := tt.exporter.enhanceContext(ctx)
+
+			if tt.wantMD == nil {
+				md, ok := metadata.FromOutgoingContext(enhancedCtx)
+				assert.False(t, ok)
+				assert.Nil(t, md)
+			} else {
+				md, ok := metadata.FromOutgoingContext(enhancedCtx)
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantMD, md)
+			}
+		})
+	}
+}
+
+func TestSignalExporter_StartSignalExporter(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       *Config
+		signalConfig signalConfig
+	}{
+		{
+			name:   "valid signal endpoint",
+			config: &Config{},
+			signalConfig: &signalConfigWrapper{
+				config: &configgrpc.ClientConfig{
+					Endpoint: "test-endpoint:4317",
+				},
+			},
+		},
+		{
+			name: "valid domain",
+			config: &Config{
+				Domain:     "test-domain",
+				PrivateKey: configopaque.String("test-key"),
+			},
+			signalConfig: &signalConfigWrapper{
+				config: &configgrpc.ClientConfig{},
+			},
+		},
+		{
+			name:   "no endpoint or domain",
+			config: &Config{},
+			signalConfig: &signalConfigWrapper{
+				config: &configgrpc.ClientConfig{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(_ *testing.T) {
+			exporter := &signalExporter{
+				config:   tt.config,
+				settings: component.TelemetrySettings{},
+			}
+
+			_ = exporter.startSignalExporter(context.Background(), &mockHost{}, tt.signalConfig)
+			if exporter.clientConn != nil {
+				_ = exporter.clientConn.Close()
+				// Wait for the connection to be fully closed
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				exporter.clientConn.WaitForStateChange(ctx, connectivity.Ready)
+			}
+			// No assertion on error, just ensure call is safe and close connection to avoid goroutine leaks
+		})
+	}
+}
+
+// mockHost implements component.Host interface for testing
+type mockHost struct{}
+
+func (m *mockHost) ReportFatalError(_ error) {}
+func (m *mockHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+	return nil
+}
+
+func (m *mockHost) GetExtensions() map[component.ID]component.Component {
+	return nil
+}
+
+func (m *mockHost) GetExporters() map[component.Type]map[component.ID]component.Component {
+	return nil
+}

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -5,34 +5,14 @@ package coralogixexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"runtime"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
-
-type tracesExporter struct {
-	// Input configuration.
-	config *Config
-
-	traceExporter ptraceotlp.GRPCClient
-	clientConn    *grpc.ClientConn
-	callOptions   []grpc.CallOption
-
-	settings component.TelemetrySettings
-
-	// Default user-agent header.
-	userAgent string
-}
 
 func newTracesExporter(cfg component.Config, set exporter.Settings) (*tracesExporter, error) {
 	oCfg, ok := cfg.(*Config)
@@ -40,37 +20,27 @@ func newTracesExporter(cfg component.Config, set exporter.Settings) (*tracesExpo
 		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
 
-	if isEmpty(oCfg.Domain) && isEmpty(oCfg.Traces.Endpoint) {
-		return nil, errors.New("coralogix exporter config requires `domain` or `traces.endpoint` configuration")
+	signalExporter, err := newSignalExporter(oCfg, set, oCfg.Traces.Endpoint, oCfg.Traces.Headers)
+	if err != nil {
+		return nil, err
 	}
-	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
-		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
-	return &tracesExporter{config: oCfg, settings: set.TelemetrySettings, userAgent: userAgent}, nil
+	return &tracesExporter{
+		signalExporter: *signalExporter,
+	}, nil
+}
+
+type tracesExporter struct {
+	traceExporter ptraceotlp.GRPCClient
+	signalExporter
 }
 
 func (e *tracesExporter) start(ctx context.Context, host component.Host) (err error) {
-	switch {
-	case !isEmpty(e.config.Traces.Endpoint):
-		if e.clientConn, err = e.config.Traces.ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
-			return err
-		}
-	case !isEmpty(e.config.Domain):
-		if e.clientConn, err = e.config.getDomainGrpcSettings().ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
-			return err
-		}
+	wrapper := &signalConfigWrapper{config: &e.config.Traces}
+	if err := e.startSignalExporter(ctx, host, wrapper); err != nil {
+		return err
 	}
-
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)
-	if e.config.Traces.Headers == nil {
-		e.config.Traces.Headers = make(map[string]configopaque.String)
-	}
-	e.config.Traces.Headers["Authorization"] = configopaque.String("Bearer " + string(e.config.PrivateKey))
-
-	e.callOptions = []grpc.CallOption{
-		grpc.WaitForReady(e.config.Traces.WaitForReady),
-	}
-
 	return nil
 }
 
@@ -99,17 +69,6 @@ func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error
 	return nil
 }
 
-func (e *tracesExporter) shutdown(context.Context) error {
-	if e.clientConn == nil {
-		return nil
-	}
-	return e.clientConn.Close()
-}
-
 func (e *tracesExporter) enhanceContext(ctx context.Context) context.Context {
-	md := metadata.New(nil)
-	for k, v := range e.config.Traces.Headers {
-		md.Set(k, string(v))
-	}
-	return metadata.NewOutgoingContext(ctx, md)
+	return e.signalExporter.enhanceContext(ctx)
 }

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -1,0 +1,138 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestNewTracesExporter(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		shouldError bool
+	}{
+		{
+			name: "Valid domain config",
+			cfg: &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Valid traces endpoint config",
+			cfg: &Config{
+				Traces: configgrpc.ClientConfig{
+					Endpoint: "localhost:4317",
+				},
+				PrivateKey: "test-key",
+			},
+			shouldError: false,
+		},
+		{
+			name: "Missing both domain and endpoint",
+			cfg: &Config{
+				PrivateKey: "test-key",
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exp, err := newTracesExporter(tt.cfg, exportertest.NewNopSettings(exportertest.NopType))
+			if tt.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, exp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, exp)
+			}
+		})
+	}
+}
+
+func TestTracesExporter_Start(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Traces: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	assert.NotNil(t, exp.clientConn)
+	assert.NotNil(t, exp.traceExporter)
+	assert.Contains(t, exp.config.Traces.Headers, "Authorization")
+
+	// Test shutdown
+	err = exp.shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTracesExporter_EnhanceContext(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Traces: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{
+				"test-header": "test-value",
+			},
+		},
+	}
+
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	enhancedCtx := exp.enhanceContext(ctx)
+	assert.NotEqual(t, ctx, enhancedCtx)
+}
+
+func TestTracesExporter_PushTraces(t *testing.T) {
+	cfg := &Config{
+		Domain:     "test.domain.com",
+		PrivateKey: "test-key",
+		Traces: configgrpc.ClientConfig{
+			Headers: map[string]configopaque.String{},
+		},
+	}
+
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	// Initialize the exporter by calling start
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	// Create test traces
+	traces := ptrace.NewTraces()
+	resourceSpans := traces.ResourceSpans()
+	rs := resourceSpans.AppendEmpty()
+
+	resource := rs.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+
+	err = exp.pushTraces(context.Background(), traces)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
#### Description

Some refactoring for the Coralogix exporter:
- Unify signal logic in a single place
- Moved some helpers to `retry` file
- Added unit tests
