### PR TITLE
receiver/prometheus: Populate scope attributes from labels instead of otel_scope_info

### DIFF
--- a/.chloggen/prometheusreceiver_scope_attributes_spec_compliance.yaml
+++ b/.chloggen/prometheusreceiver_scope_attributes_spec_compliance.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Implement scope attributes extraction from `otel_scope_` prefixed labels to comply with updated OpenTelemetry specification"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40060]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The OpenTelemetry Prometheus specification has been updated to deprecate the `otel_scope_info` metric 
+  in favor of embedding scope attributes directly in metrics using `otel_scope_` prefixed labels.
+  A new feature gate `receiver.prometheusreceiver.RemoveScopeInfo` controls this behavior:
+  - When enabled (new behavior): scope attributes are extracted from `otel_scope_` prefixed labels on all metrics
+  - When disabled (legacy behavior): scope attributes continue to be extracted from the `otel_scope_info` metric
+  This change maintains backward compatibility while enabling compliance with the updated specification.
+  See: https://github.com/open-telemetry/opentelemetry-specification/issues/4223
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prometheusreceiver_scope_attributes_spec_compliance.yaml
+++ b/.chloggen/prometheusreceiver_scope_attributes_spec_compliance.yaml
@@ -18,11 +18,13 @@ issues: [40060]
 subtext: |
   The OpenTelemetry Prometheus specification has been updated to deprecate the `otel_scope_info` metric 
   in favor of embedding scope attributes directly in metrics using `otel_scope_` prefixed labels.
-  A new feature gate `receiver.prometheusreceiver.RemoveScopeInfo` controls this behavior:
-  - When enabled (new behavior): scope attributes are extracted from `otel_scope_` prefixed labels on all metrics
-  - When disabled (legacy behavior): scope attributes continue to be extracted from the `otel_scope_info` metric
+  This implementation always extracts scope attributes from `otel_scope_` prefixed labels on all metrics
+  and always filters these labels from datapoint attributes, regardless of the feature gate setting.
+  The feature gate `receiver.prometheusreceiver.RemoveScopeInfo` only controls `otel_scope_info` processing:
+  - When disabled: `otel_scope_info` metrics are processed for scope attributes and merged with `otel_scope_` labels.
+  - When enabled: `otel_scope_info` metrics are treated as regular metrics.
   This change maintains backward compatibility while enabling compliance with the updated specification.
-  See: https://github.com/open-telemetry/opentelemetry-specification/issues/4223
+  See: https://github.com/open-telemetry/opentelemetry-specification/pull/4505
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -153,10 +153,16 @@ This receiver accepts exemplars coming in Prometheus format and converts it to O
 This receiver drops the `target_info` prometheus metric, if present, and uses attributes on
 that metric to populate the OpenTelemetry Resource.
 
-It drops `otel_scope_name` and `otel_scope_version` labels, if present, from metrics, and uses them to populate
-the OpenTelemetry Instrumentation Scope name and version. It drops the `otel_scope_info` metric,
-and uses attributes (other than `otel_scope_name` and `otel_scope_version`) to populate Scope
-Attributes.
+It always extracts scope attributes from `otel_scope_` prefixed labels on metrics. Labels with the 
+`otel_scope_name`, `otel_scope_version`, and `otel_scope_schema_url` prefixes are used to populate the 
+OpenTelemetry Instrumentation Scope identity, while other `otel_scope_` prefixed labels become Scope Attributes.
+All `otel_scope_` labels are filtered from the metric datapoint attributes.
+
+The processing of `otel_scope_info` metrics is controlled by the `receiver.prometheusreceiver.RemoveScopeInfo` 
+feature gate:
+- When disabled: `otel_scope_info` metrics are processed for scope attributes and merged with 
+  any `otel_scope_` labels, with `otel_scope_` labels taking precedence in conflicts.
+- When enabled: `otel_scope_info` metrics are treated as regular metrics and not processed for scope attributes.
 
 ## Prometheus API Server
 The Prometheus API server can be enabled to host info about the Prometheus targets, config, service discovery, and metrics. The `server_config` can be specified using the OpenTelemetry confighttp package. An example configuration would be:

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -360,6 +360,13 @@ func populateAttributes(mType pmetric.MetricType, ls labels.Labels, dest pcommon
 		if j < len(names) && l.Name == names[j] {
 			return
 		}
+
+		// When removeScopeInfo feature gate is enabled, filter out otel_scope_ prefixed labels
+		// as they are now extracted as scope attributes instead of datapoint attributes
+		if RemoveScopeInfoGate.IsEnabled() && strings.HasPrefix(l.Name, "otel_scope_") {
+			return
+		}
+
 		if l.Value == "" {
 			// empty label values should be omitted
 			return

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -361,9 +361,7 @@ func populateAttributes(mType pmetric.MetricType, ls labels.Labels, dest pcommon
 			return
 		}
 
-		// When removeScopeInfo feature gate is enabled, filter out otel_scope_ prefixed labels
-		// as they are now extracted as scope attributes instead of datapoint attributes
-		if RemoveScopeInfoGate.IsEnabled() && strings.HasPrefix(l.Name, "otel_scope_") {
+		if strings.HasPrefix(l.Name, "otel_scope_") {
 			return
 		}
 

--- a/receiver/prometheusreceiver/internal/transaction_bench_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_bench_test.go
@@ -4,7 +4,6 @@
 package internal
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func createBenchmarkTransaction(tb testing.TB) *transaction {
 	)
 
 	scrapeCtx := scrape.ContextWithMetricMetadataStore(
-		scrape.ContextWithTarget(context.Background(), target),
+		scrape.ContextWithTarget(tb.Context(), target),
 		testMetadataStore(testMetadata))
 
 	return newTransaction(

--- a/receiver/prometheusreceiver/internal/transaction_bench_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_bench_test.go
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// createBenchmarkTransaction creates a transaction for benchmark testing
+func createBenchmarkTransaction(tb testing.TB) *transaction {
+	target := scrape.NewTarget(
+		labels.FromMap(map[string]string{
+			model.InstanceLabel: "localhost:8080",
+		}),
+		&config.ScrapeConfig{},
+		map[model.LabelName]model.LabelValue{
+			model.AddressLabel: "address:8080",
+			model.SchemeLabel:  "http",
+		},
+		nil,
+	)
+
+	scrapeCtx := scrape.ContextWithMetricMetadataStore(
+		scrape.ContextWithTarget(context.Background(), target),
+		testMetadataStore(testMetadata))
+
+	return newTransaction(
+		scrapeCtx,
+		&startTimeAdjuster{startTime: startTimestamp},
+		new(consumertest.MetricsSink),
+		labels.EmptyLabels(),
+		receivertest.NewNopSettings(receivertest.NopType),
+		nopObsRecv(tb),
+		false, // trimSuffixes
+		false, // enableNativeHistograms
+	)
+}
+
+// createTestLabels creates various types of prometheus labels for benchmarking
+func createTestLabels(metricName string, additionalLabels ...string) labels.Labels {
+	lbls := []string{
+		model.MetricNameLabel, metricName,
+		model.JobLabel, "benchmark-job",
+		model.InstanceLabel, "localhost:8080",
+	}
+	lbls = append(lbls, additionalLabels...)
+	return labels.FromStrings(lbls...)
+}
+
+// BenchmarkTransactionAppendAndCommit benchmarks the core processing pipeline (Append + Commit)
+func BenchmarkTransactionAppendAndCommit(b *testing.B) {
+	b.Run("Floats", func(b *testing.B) {
+		benchmarkFloat(b)
+	})
+	b.Run("Histogram", func(b *testing.B) {
+		benchmarkHistogram(b)
+	})
+}
+
+func benchmarkFloat(b *testing.B) {
+	tr := createBenchmarkTransaction(b)
+	metricName := "metric"
+	labels := []string{"method", "GET", "status", "200"}
+	lbls := createTestLabels(metricName, labels...)
+	timestamp := time.Now().Unix() * 1000
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := tr.Append(0, lbls, timestamp, float64(i))
+		require.NoError(b, err)
+
+		targetInfoLabels := createTestLabels("target_info",
+			"version", "1.2.3",
+			"service_name", "benchmark-service",
+			"environment", "test")
+		_, err = tr.Append(0, targetInfoLabels, timestamp, 1.0)
+		require.NoError(b, err)
+
+		scopeInfoLabels := createTestLabels("otel_scope_info",
+			"otel_scope_name", "benchmark-scope",
+			"otel_scope_version", "1.0.0",
+			"otel_scope_schema_url", "https://example.com/schema",
+			"custom_attr", "benchmark_value")
+		_, err = tr.Append(0, scopeInfoLabels, timestamp, 1.0)
+		require.NoError(b, err)
+
+		newScopeLabels := createTestLabels(metricName+"_with_scope_labels",
+			append(labels,
+				"otel_scope_name", "benchmark-scope",
+				"otel_scope_version", "1.0.0",
+				"otel_scope_schema_url", "https://example.com/schema",
+				"otel_scope_custom_attr", "benchmark_value")...)
+		_, err = tr.Append(0, newScopeLabels, timestamp, float64(i))
+		require.NoError(b, err)
+	}
+
+	err := tr.Commit()
+	require.NoError(b, err)
+}
+
+func benchmarkHistogram(b *testing.B) {
+	tr := createBenchmarkTransaction(b)
+
+	// Create histogram buckets
+	buckets := []string{
+		"le", "0.1",
+		"le", "0.5",
+		"le", "1.0",
+		"le", "5.0",
+		"le", "+Inf",
+	}
+
+	timestamp := time.Now().Unix() * 1000
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		targetInfoLabels := createTestLabels("target_info",
+			"version", "2.1.0",
+			"service_name", "web-api",
+			"environment", "production",
+			"region", "us-west-2")
+		_, err := tr.Append(0, targetInfoLabels, timestamp, 1.0)
+		require.NoError(b, err)
+
+		scopeInfoLabels := createTestLabels("otel_scope_info",
+			"otel_scope_name", "http-server",
+			"otel_scope_version", "2.1.0",
+			"otel_scope_schema_url", "https://opentelemetry.io/schemas/1.17.0",
+			"service_name", "web-api")
+		_, err = tr.Append(0, scopeInfoLabels, timestamp, 1.0)
+		require.NoError(b, err)
+
+		for j := 0; j < len(buckets); j += 2 {
+			lbls := createTestLabels("http_duration_bucket", "method", "GET", buckets[j], buckets[j+1])
+			_, err = tr.Append(0, lbls, timestamp, float64(i*10+j/2))
+			require.NoError(b, err)
+		}
+
+		sumLabels := createTestLabels("http_duration_sum", "method", "GET")
+		_, err = tr.Append(0, sumLabels, timestamp, float64(i*100))
+		require.NoError(b, err)
+
+		countLabels := createTestLabels("http_duration_count", "method", "GET")
+		_, err = tr.Append(0, countLabels, timestamp, float64(i*20))
+		require.NoError(b, err)
+
+		newScopeBucketLabels := createTestLabels("request_duration_bucket_with_scope",
+			"method", "POST",
+			"le", "1.0",
+			"otel_scope_name", "http-server",
+			"otel_scope_version", "2.1.0",
+			"otel_scope_schema_url", "https://opentelemetry.io/schemas/1.17.0",
+			"otel_scope_service_name", "web-api")
+		_, err = tr.Append(0, newScopeBucketLabels, timestamp, float64(i*5))
+		require.NoError(b, err)
+	}
+
+	err := tr.Commit()
+	require.NoError(b, err)
+}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -735,13 +735,13 @@ func TestAppendHistogramCTZeroSample(t *testing.T) {
 	)
 }
 
-func nopObsRecv(t *testing.T) *receiverhelper.ObsReport {
+func nopObsRecv(tb testing.TB) *receiverhelper.ObsReport {
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             component.MustNewID("prometheus"),
 		Transport:              transport,
 		ReceiverCreateSettings: receivertest.NewNopSettings(receivertest.NopType),
 	})
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return obsrecv
 }
 


### PR DESCRIPTION
#### Description
This PR is a PoC for the spec change described at https://github.com/open-telemetry/opentelemetry-specification/issues/4223.

In the specification change, it's proposed that Prometheus exporters stop generating the metric `otel_scope_info` with all the scope attributes and instead add all scope information as labels, turning the Scope information "identifying".

For the receiver, this means that Scope should no longer be populated from the `otel_scope_info` but should instead be looked for metrics with the same labels prefixed with `otel_scope_`.

For users who still haven't updated to newer versions of the SDK that adhere to the spec change, ignoring the `otel_scope_info` metric would be a breaking change from this receiver's perspective. For that reason, this change is being made through feature flags.

If an exporter exposes `otel_scope_info` and the feature gate `receiver.prometheusreceiver.RemoteScopeInfo` is enabled, then `otel_scope_info` will be transformed into a metric like all others instead of being cached and used to generate ScopeMetrics information

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41502