### PR TITLE
Add slash to libhoney paths

### DIFF
--- a/.chloggen/libhoney_clarify.yaml
+++ b/.chloggen/libhoney_clarify.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: libhoneyreceiver
+note: Handle paths without slashes at the end by adding them
+issues: [40070]
+subtext: 
+change_logs: [user]

--- a/receiver/libhoneyreceiver/README.md
+++ b/receiver/libhoneyreceiver/README.md
@@ -67,7 +67,7 @@ The following setting is required for refinery traffic since:
 ### Telemetry data types supported
 
 It will subscribe to the Traces and Logs signals but accept traffic destined for either pipeline using one http receiver
-component. Libhoney doesnot differentiate between the two so the receiver will identify which pipeline to deliver the 
+component. Libhoney does not differentiate between the two so the receiver will identify which pipeline to deliver the 
 spans or log records to.
 
 No support for metrics since they'd look just like logs.

--- a/receiver/libhoneyreceiver/config.go
+++ b/receiver/libhoneyreceiver/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
@@ -76,5 +77,10 @@ func sanitizeURLPath(urlPath string) (string, error) {
 	if !path.IsAbs(u.Path) {
 		u.Path = "/" + u.Path
 	}
+
+	if !strings.HasSuffix(u.Path, "/") {
+		u.Path = u.Path + "/"
+	}
+
 	return u.Path, nil
 }

--- a/receiver/libhoneyreceiver/config.go
+++ b/receiver/libhoneyreceiver/config.go
@@ -79,7 +79,7 @@ func sanitizeURLPath(urlPath string) (string, error) {
 	}
 
 	if !strings.HasSuffix(u.Path, "/") {
-		u.Path = u.Path + "/"
+		u.Path += "/"
 	}
 
 	return u.Path, nil

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -253,7 +253,7 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 	}
 
 	noErrors := []byte(`{"errors":[]}`)
-	writeResponse(resp, enc.ContentType(), http.StatusAccepted, noErrors)
+	writeResponse(resp, enc.ContentType(), http.StatusOK, noErrors)
 }
 
 func readContentType(resp http.ResponseWriter, req *http.Request) (encoder.Encoder, bool) {

--- a/receiver/libhoneyreceiver/receiver_test.go
+++ b/receiver/libhoneyreceiver/receiver_test.go
@@ -43,6 +43,15 @@ func TestNewLibhoneyReceiver(t *testing.T) {
 			config:    nil,
 			wantError: false,
 		},
+		{
+			name: "config_without_trailing_slashes",
+			config: &Config{
+				HTTP: &HTTPConfig{
+					TracesURLPaths: []string{"/1/events"},
+				},
+			},
+			wantError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -99,7 +108,7 @@ func TestLibhoneyReceiver_HandleEvent(t *testing.T) {
 				},
 			},
 			contentType:    "application/json",
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name: "valid_msgpack_event",
@@ -114,7 +123,7 @@ func TestLibhoneyReceiver_HandleEvent(t *testing.T) {
 				},
 			},
 			contentType:    "application/msgpack",
-			expectedStatus: http.StatusAccepted,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "invalid_content_type",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a slash to the end of the `traces_url_paths:` so that libhoney appending datasets will always work regardless of whether the user adds the slash or not. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40070

<!--Describe what testing was performed and which tests were added.-->
#### Testing

curling a simple json object into the libhoney receiver to see that it doesn't return a 404 error.

<!--Describe the documentation added.-->
#### Documentation

No changes to the documentation because it is handled in the configuration parser now.

<!--Please delete paragraphs that you did not use before submitting.-->
