### PR TITLE
[coralogix/exporter] Drop data after authorization or quota errors reported by the backend

### DIFF
--- a/.chloggen/40074.yaml
+++ b/.chloggen/40074.yaml
@@ -1,0 +1,42 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added a mechanism to drop telemetry data when rate limit, quota or authorization errors are encountered.
+
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40074]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Added a new configuration option to the Coralogix exporter to enable a rate limiter mechanism.
+  The rate limiter mechanism is disabled by default. It can be configured using the following configuration options:
+
+  rate_limiter:
+    enabled: true
+    threshold: 10
+    duration: 1m
+
+  Where:
+  - `enabled` is a boolean flag to enable the rate limiter mechanism.
+  - `threshold` is the number of errors to trigger the rate limiter mechanism (default: 10).
+  - `duration` is the duration of the rate limit window (default: 1 minute).
+
+  Note the number of errors is cumulative and reset after the duration has passed or a successful request is made.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -90,6 +90,11 @@ func TestLoadConfig(t *testing.T) {
 					},
 					BalancerName: "",
 				},
+				RateLimiter: RateLimiterConfig{
+					Enabled:   false,
+					Threshold: 10,
+					Duration:  time.Minute,
+				},
 			},
 		},
 		{
@@ -146,6 +151,11 @@ func TestLoadConfig(t *testing.T) {
 						"appName":      "APP_NAME",
 					},
 					BalancerName: "",
+				},
+				RateLimiter: RateLimiterConfig{
+					Enabled:   false,
+					Threshold: 10,
+					Duration:  time.Minute,
 				},
 			},
 		},

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -7,6 +7,7 @@ package coralogixexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
@@ -61,6 +62,11 @@ func createDefaultConfig() component.Config {
 		},
 		PrivateKey: "",
 		AppName:    "",
+		RateLimiter: RateLimiterConfig{
+			Enabled:   false,
+			Threshold: 10,
+			Duration:  time.Minute,
+		},
 	}
 }
 

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -5,15 +5,23 @@ package coralogixexporter
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"google.golang.org/grpc"
 )
 
 func TestNewLogsExporter(t *testing.T) {
@@ -117,7 +125,6 @@ func TestLogsExporter_PushLogs(t *testing.T) {
 	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
 	require.NoError(t, err)
 
-	// Initialize the exporter by calling start
 	err = exp.start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 	defer func() {
@@ -125,7 +132,6 @@ func TestLogsExporter_PushLogs(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	// Create test logs
 	logs := plog.NewLogs()
 	resourceLogs := logs.ResourceLogs()
 	rl := resourceLogs.AppendEmpty()
@@ -135,4 +141,145 @@ func TestLogsExporter_PushLogs(t *testing.T) {
 
 	err = exp.pushLogs(context.Background(), logs)
 	assert.Error(t, err)
+}
+
+func TestLogsExporter_PushLogs_WhenCannotSend(t *testing.T) {
+	tests := []struct {
+		description string
+		enabled     bool
+	}{
+		{
+			description: "Rate limit exceeded config enabled",
+			enabled:     true,
+		},
+		{
+			description: "Rate limit exceeded config disabled",
+			enabled:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cfg := &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+				Logs: configgrpc.ClientConfig{
+					Headers: map[string]configopaque.String{},
+				},
+				RateLimiter: RateLimiterConfig{
+					Enabled:   tt.enabled,
+					Threshold: 1,
+					Duration:  time.Minute,
+				},
+			}
+
+			exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+			require.NoError(t, err)
+
+			err = exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+			defer func() {
+				err = exp.shutdown(context.Background())
+				require.NoError(t, err)
+			}()
+
+			rateLimitErr := errors.New("rate limit exceeded")
+			exp.EnableRateLimit(rateLimitErr)
+			exp.EnableRateLimit(rateLimitErr)
+
+			logs := plog.NewLogs()
+			resourceLogs := logs.ResourceLogs()
+			rl := resourceLogs.AppendEmpty()
+			resource := rl.Resource()
+			resource.Attributes().PutStr("service.name", "test-service")
+
+			err = exp.pushLogs(context.Background(), logs)
+			assert.Error(t, err)
+			if tt.enabled {
+				assert.Contains(t, err.Error(), "rate limit exceeded")
+			} else {
+				assert.Contains(t, err.Error(), "no such host")
+			}
+		})
+	}
+}
+
+type mockLogsServer struct {
+	plogotlp.UnimplementedGRPCServer
+	recvCount int
+}
+
+func (m *mockLogsServer) Export(_ context.Context, req plogotlp.ExportRequest) (plogotlp.ExportResponse, error) {
+	m.recvCount += req.Logs().LogRecordCount()
+	return plogotlp.NewExportResponse(), nil
+}
+
+func startMockOtlpLogsServer(tb testing.TB) (endpoint string, stopFn func(), srv *mockLogsServer) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("failed to listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	srv = &mockLogsServer{}
+	plogotlp.RegisterGRPCServer(grpcServer, srv)
+	go func() {
+		_ = grpcServer.Serve(ln)
+	}()
+	return ln.Addr().String(), func() {
+		grpcServer.Stop()
+		ln.Close()
+	}, srv
+}
+
+func BenchmarkLogsExporter_PushLogs(b *testing.B) {
+	endpoint, stopFn, mockSrv := startMockOtlpLogsServer(b)
+	defer stopFn()
+
+	cfg := &Config{
+		Logs: configgrpc.ClientConfig{
+			Endpoint: endpoint,
+			TLSSetting: configtls.ClientConfig{
+				Insecure: true,
+			},
+			Headers: map[string]configopaque.String{},
+		},
+		PrivateKey: "test-key",
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	if err != nil {
+		b.Fatalf("failed to create logs exporter: %v", err)
+	}
+	if err := exp.start(context.Background(), componenttest.NewNopHost()); err != nil {
+		b.Fatalf("failed to start logs exporter: %v", err)
+	}
+	defer func() {
+		_ = exp.shutdown(context.Background())
+	}()
+
+	testCases := []int{
+		100000,
+		500000,
+		1000000,
+		5000000,
+		10000000,
+		50000000,
+	}
+	for _, numLogs := range testCases {
+		b.Run("numLogs="+fmt.Sprint(numLogs), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logs := plog.NewLogs()
+				rl := logs.ResourceLogs().AppendEmpty()
+				rl.Resource().Attributes().PutStr("service.name", "benchmark-service")
+				sl := rl.ScopeLogs().AppendEmpty()
+				for j := 0; j < numLogs; j++ {
+					logRecord := sl.LogRecords().AppendEmpty()
+					logRecord.Body().SetStr("benchmark log message")
+					logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+				}
+				_ = exp.pushLogs(context.Background(), logs)
+			}
+		})
+	}
+	b.Logf("Total logs received by mock server: %d", mockSrv.recvCount)
 }

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -26,13 +26,13 @@ func newMetricsExporter(cfg component.Config, set exporter.Settings) (*metricsEx
 	}
 
 	return &metricsExporter{
-		signalExporter: *signalExporter,
+		signalExporter: signalExporter,
 	}, nil
 }
 
 type metricsExporter struct {
 	metricExporter pmetricotlp.GRPCClient
-	signalExporter
+	*signalExporter
 }
 
 func (e *metricsExporter) start(ctx context.Context, host component.Host) (err error) {
@@ -45,6 +45,10 @@ func (e *metricsExporter) start(ctx context.Context, host component.Host) (err e
 }
 
 func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if !e.canSend() {
+		return e.rateError.GetError()
+	}
+
 	rss := md.ResourceMetrics()
 	for i := 0; i < rss.Len(); i++ {
 		resourceMetric := rss.At(i)
@@ -55,7 +59,7 @@ func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) e
 
 	resp, err := e.metricExporter.Export(e.enhanceContext(ctx), pmetricotlp.NewExportRequestFromMetrics(md), e.callOptions...)
 	if err != nil {
-		return processError(err)
+		return e.processError(err)
 	}
 
 	partialSuccess := resp.PartialSuccess()

--- a/exporter/coralogixexporter/profiles_client_test.go
+++ b/exporter/coralogixexporter/profiles_client_test.go
@@ -5,15 +5,24 @@ package coralogixexporter
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/pprofile/pprofileotlp"
+	"google.golang.org/grpc"
 )
 
 func TestNewProfilesExporter(t *testing.T) {
@@ -135,4 +144,148 @@ func TestProfilesExporter_PushProfiles(t *testing.T) {
 
 	err = exp.pushProfiles(context.Background(), profiles)
 	assert.Error(t, err)
+}
+
+func TestProfilesExporter_PushProfiles_WhenCannotSend(t *testing.T) {
+	tests := []struct {
+		description string
+		enabled     bool
+	}{
+		{
+			description: "Rate limit exceeded config enabled",
+			enabled:     true,
+		},
+		{
+			description: "Rate limit exceeded config disabled",
+			enabled:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cfg := &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+				Profiles: configgrpc.ClientConfig{
+					Headers: map[string]configopaque.String{},
+				},
+				RateLimiter: RateLimiterConfig{
+					Enabled:   tt.enabled,
+					Threshold: 1,
+					Duration:  time.Minute,
+				},
+			}
+
+			exp, err := newProfilesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+			require.NoError(t, err)
+
+			err = exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+			defer func() {
+				err = exp.shutdown(context.Background())
+				require.NoError(t, err)
+			}()
+
+			rateLimitErr := errors.New("rate limit exceeded")
+			exp.EnableRateLimit(rateLimitErr)
+			exp.EnableRateLimit(rateLimitErr)
+
+			profiles := pprofile.NewProfiles()
+			resourceProfiles := profiles.ResourceProfiles()
+			rp := resourceProfiles.AppendEmpty()
+			resource := rp.Resource()
+			resource.Attributes().PutStr("service.name", "test-service")
+
+			err = exp.pushProfiles(context.Background(), profiles)
+			assert.Error(t, err)
+			if tt.enabled {
+				assert.Contains(t, err.Error(), "rate limit exceeded")
+			} else {
+				assert.Contains(t, err.Error(), "no such host")
+			}
+		})
+	}
+}
+
+type mockProfilesServer struct {
+	pprofileotlp.UnimplementedGRPCServer
+	recvCount int
+}
+
+func (m *mockProfilesServer) Export(_ context.Context, req pprofileotlp.ExportRequest) (pprofileotlp.ExportResponse, error) {
+	m.recvCount += req.Profiles().ResourceProfiles().Len()
+	return pprofileotlp.NewExportResponse(), nil
+}
+
+func startMockOtlpProfilesServer(tb testing.TB) (endpoint string, stopFn func(), srv *mockProfilesServer) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("failed to listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	srv = &mockProfilesServer{}
+	pprofileotlp.RegisterGRPCServer(grpcServer, srv)
+	go func() {
+		_ = grpcServer.Serve(ln)
+	}()
+	return ln.Addr().String(), func() {
+		grpcServer.Stop()
+		ln.Close()
+	}, srv
+}
+
+func BenchmarkProfilesExporter_PushProfiles(b *testing.B) {
+	endpoint, stopFn, mockSrv := startMockOtlpProfilesServer(b)
+	defer stopFn()
+
+	cfg := &Config{
+		Profiles: configgrpc.ClientConfig{
+			Endpoint: endpoint,
+			TLSSetting: configtls.ClientConfig{
+				Insecure: true,
+			},
+			Headers: map[string]configopaque.String{},
+		},
+		PrivateKey: "test-key",
+	}
+
+	exp, err := newProfilesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	if err != nil {
+		b.Fatalf("failed to create profiles exporter: %v", err)
+	}
+	if err := exp.start(context.Background(), componenttest.NewNopHost()); err != nil {
+		b.Fatalf("failed to start profiles exporter: %v", err)
+	}
+	defer func() {
+		_ = exp.shutdown(context.Background())
+	}()
+
+	testCases := []int{
+		100000,
+		500000,
+		1000000,
+		5000000,
+		10000000,
+		50000000,
+	}
+	for _, numProfiles := range testCases {
+		b.Run("numProfiles="+fmt.Sprint(numProfiles), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				profiles := pprofile.NewProfiles()
+				rp := profiles.ResourceProfiles().AppendEmpty()
+				rp.Resource().Attributes().PutStr("service.name", "benchmark-service")
+				sp := rp.ScopeProfiles().AppendEmpty()
+				for j := 0; j < numProfiles; j++ {
+					profile := sp.Profiles().AppendEmpty()
+					var id [16]byte
+					binary.LittleEndian.PutUint64(id[:8], uint64(j))
+					profile.SetProfileID(id)
+					profile.SetStartTime(pcommon.NewTimestampFromTime(time.Now()))
+					profile.SetDuration(1000000000) // 1 second in nanoseconds
+				}
+				_ = exp.pushProfiles(context.Background(), profiles)
+			}
+		})
+	}
+	b.Logf("Total profiles received by mock server: %d", mockSrv.recvCount)
 }

--- a/exporter/coralogixexporter/ratelimit.go
+++ b/exporter/coralogixexporter/ratelimit.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type rateError struct {
+	rateLimited atomic.Bool
+	enabled     bool
+	state       atomic.Pointer[rateErrorState]
+	errorCount  atomic.Int32
+	threshold   int
+	duration    time.Duration
+}
+
+type rateErrorState struct {
+	timestamp time.Time
+	err       error
+}
+
+func (r *rateError) isRateLimited() bool {
+	if !r.enabled {
+		return false
+	}
+
+	if r.rateLimited.Load() {
+		return true
+	}
+
+	r.errorCount.Store(0) // reset the error count
+	return false
+}
+
+// canDisableRateLimit checks if we can disable the limiter in the exporter.
+func (r *rateError) canDisableRateLimit() bool {
+	return time.Since(r.state.Load().timestamp) > r.duration
+}
+
+func (r *rateError) enableRateLimit(err error) {
+	r.errorCount.Add(1)
+	if r.errorCount.Load() < int32(r.threshold) {
+		return
+	}
+
+	now := time.Now()
+	r.state.Store(&rateErrorState{
+		timestamp: now,
+		err:       err,
+	})
+	r.rateLimited.Store(true)
+}
+
+func (r *rateError) disableRateLimit() {
+	r.errorCount.Store(0)
+	r.rateLimited.Store(false)
+}
+
+func (r *rateError) GetError() error {
+	return r.state.Load().err
+}

--- a/exporter/coralogixexporter/ratelimit_test.go
+++ b/exporter/coralogixexporter/ratelimit_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+package coralogixexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateError_ErrorCountReset(t *testing.T) {
+	re := &rateError{
+		threshold: 5,
+		enabled:   true,
+	}
+	assert.Equal(t, int32(0), re.errorCount.Load())
+
+	for i := 0; i < 5; i++ {
+		re.enableRateLimit(nil)
+	}
+	assert.Equal(t, int32(5), re.errorCount.Load())
+
+	re.rateLimited.Store(false)
+	re.isRateLimited()
+
+	assert.Equal(t, int32(0), re.errorCount.Load())
+}
+
+func TestRateError_ErrorCountNotResetWhenRateLimited(t *testing.T) {
+	re := &rateError{
+		threshold: 1,
+		enabled:   true,
+	}
+
+	for i := 0; i < re.threshold; i++ {
+		re.enableRateLimit(nil)
+	}
+
+	initialCount := re.errorCount.Load()
+	re.isRateLimited()
+
+	assert.Equal(t, initialCount, re.errorCount.Load())
+}

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -12,9 +12,13 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	exp "go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // signalConfigWrapper wraps configgrpc.ClientConfig to implement signalConfig interface
@@ -52,6 +56,11 @@ func newSignalExporter(oCfg *Config, set exp.Settings, signalEndpoint string, he
 		settings:  set.TelemetrySettings,
 		userAgent: userAgent,
 		metadata:  md,
+		rateError: rateError{
+			enabled:   oCfg.RateLimiter.Enabled,
+			threshold: oCfg.RateLimiter.Threshold,
+			duration:  oCfg.RateLimiter.Duration,
+		},
 	}, nil
 }
 
@@ -75,6 +84,8 @@ type signalExporter struct {
 
 	// Cached metadata for outgoing context
 	metadata metadata.MD
+
+	rateError rateError
 }
 
 func (e *signalExporter) shutdown(_ context.Context) error {
@@ -116,4 +127,52 @@ func (e *signalExporter) startSignalExporter(ctx context.Context, host component
 	}
 
 	return nil
+}
+
+func (e *signalExporter) EnableRateLimit(err error) {
+	e.rateError.enableRateLimit(consumererror.NewPermanent(err))
+}
+
+func (e *signalExporter) canSend() bool {
+	if !e.rateError.isRateLimited() {
+		return true
+	}
+
+	if e.rateError.canDisableRateLimit() {
+		e.rateError.disableRateLimit()
+		return true
+	}
+
+	return false
+}
+
+// processError implements the common OTLP logic around request handling such as retries and throttling.
+// Send a telemetry data request to the server. "perform" function is expected to make
+// the actual gRPC unary call that sends the request.
+func (e *signalExporter) processError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	st := status.Convert(err)
+	if st.Code() == codes.OK {
+		return nil
+	}
+
+	retryInfo := getRetryInfo(st)
+
+	shouldRetry, shouldFlagRateLimit := shouldRetry(st.Code(), retryInfo)
+	if !shouldRetry {
+		if shouldFlagRateLimit {
+			e.EnableRateLimit(err)
+		}
+		return consumererror.NewPermanent(err)
+	}
+
+	throttleDuration := getThrottleDuration(retryInfo)
+	if throttleDuration != 0 {
+		return exporterhelper.NewThrottleRetry(err, throttleDuration)
+	}
+
+	return err
 }

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -5,15 +5,23 @@ package coralogixexporter
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
 )
 
 func TestNewTracesExporter(t *testing.T) {
@@ -135,4 +143,147 @@ func TestTracesExporter_PushTraces(t *testing.T) {
 
 	err = exp.pushTraces(context.Background(), traces)
 	assert.Error(t, err)
+}
+
+func TestTracesExporter_PushTraces_WhenCannotSend(t *testing.T) {
+	tests := []struct {
+		description   string
+		configEnabled bool
+	}{
+		{
+			description:   "Rate limit exceeded config enabled",
+			configEnabled: true,
+		},
+		{
+			description:   "Rate limit exceeded config disabled",
+			configEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cfg := &Config{
+				Domain:     "test.domain.com",
+				PrivateKey: "test-key",
+				Traces: configgrpc.ClientConfig{
+					Headers: map[string]configopaque.String{},
+				},
+				RateLimiter: RateLimiterConfig{
+					Enabled:   tt.configEnabled,
+					Threshold: 1,
+					Duration:  time.Minute,
+				},
+			}
+
+			exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+			require.NoError(t, err)
+
+			err = exp.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err)
+			defer func() {
+				err = exp.shutdown(context.Background())
+				require.NoError(t, err)
+			}()
+
+			rateLimitErr := errors.New("rate limit exceeded")
+			exp.EnableRateLimit(rateLimitErr)
+			exp.EnableRateLimit(rateLimitErr)
+
+			traces := ptrace.NewTraces()
+			resourceSpans := traces.ResourceSpans()
+			rs := resourceSpans.AppendEmpty()
+			resource := rs.Resource()
+			resource.Attributes().PutStr("service.name", "test-service")
+
+			err = exp.pushTraces(context.Background(), traces)
+			assert.Error(t, err)
+			if tt.configEnabled {
+				assert.Contains(t, err.Error(), rateLimitErr.Error())
+			} else {
+				assert.Contains(t, err.Error(), "no such host")
+			}
+		})
+	}
+}
+
+type mockTracesServer struct {
+	ptraceotlp.UnimplementedGRPCServer
+	recvCount int
+}
+
+func (m *mockTracesServer) Export(_ context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
+	m.recvCount += req.Traces().ResourceSpans().Len()
+	return ptraceotlp.NewExportResponse(), nil
+}
+
+func startMockOtlpTracesServer(tb testing.TB) (endpoint string, stopFn func(), srv *mockTracesServer) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("failed to listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	srv = &mockTracesServer{}
+	ptraceotlp.RegisterGRPCServer(grpcServer, srv)
+	go func() {
+		_ = grpcServer.Serve(ln)
+	}()
+	return ln.Addr().String(), func() {
+		grpcServer.Stop()
+		ln.Close()
+	}, srv
+}
+
+func BenchmarkTracesExporter_PushTraces(b *testing.B) {
+	endpoint, stopFn, mockSrv := startMockOtlpTracesServer(b)
+	defer stopFn()
+
+	cfg := &Config{
+		Traces: configgrpc.ClientConfig{
+			Endpoint: endpoint,
+			TLSSetting: configtls.ClientConfig{
+				Insecure: true,
+			},
+			Headers: map[string]configopaque.String{},
+		},
+		PrivateKey: "test-key",
+	}
+
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	if err != nil {
+		b.Fatalf("failed to create traces exporter: %v", err)
+	}
+	if err := exp.start(context.Background(), componenttest.NewNopHost()); err != nil {
+		b.Fatalf("failed to start traces exporter: %v", err)
+	}
+	defer func() {
+		_ = exp.shutdown(context.Background())
+	}()
+
+	testCases := []int{
+		100000,
+		500000,
+		1000000,
+		5000000,
+		10000000,
+		50000000,
+	}
+	for _, numTraces := range testCases {
+		b.Run("numTraces="+fmt.Sprint(numTraces), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				traces := ptrace.NewTraces()
+				rs := traces.ResourceSpans().AppendEmpty()
+				rs.Resource().Attributes().PutStr("service.name", "benchmark-service")
+				ss := rs.ScopeSpans().AppendEmpty()
+				for j := 0; j < numTraces; j++ {
+					span := ss.Spans().AppendEmpty()
+					span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+					span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+					span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+					span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
+				}
+				_ = exp.pushTraces(context.Background(), traces)
+			}
+		})
+	}
+	b.Logf("Total traces received by mock server: %d", mockSrv.recvCount)
 }


### PR DESCRIPTION
#### Description
Drop telemetry data during 1 minute window when authorization or quota errors are returned by the backend.

Merge after #40044.

#### Link to tracking issue
Fixes #40074

#### Testing
- Added new unit tests
