### PR TITLE
[exporter/elasticsearch] fix panic when encoding scope attributes

### DIFF
--- a/.chloggen/37701-fix-es-exporter-scope-attr-panic.yaml
+++ b/.chloggen/37701-fix-es-exporter-scope-attr-panic.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix panic when encoding non-string scope attributes."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37701]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -449,11 +449,12 @@ func durationAsMicroseconds(start, end time.Time) int64 {
 
 func scopeToAttributes(scope pcommon.InstrumentationScope) pcommon.Map {
 	attrs := pcommon.NewMap()
+
+	scope.Attributes().CopyTo(attrs)
+
 	attrs.PutStr("name", scope.Name())
 	attrs.PutStr("version", scope.Version())
-	for k, v := range scope.Attributes().AsRaw() {
-		attrs.PutStr(k, v.(string))
-	}
+
 	return attrs
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Previously, the code attempted to cast scope attribute values to strings, leading to a panic when incompatible types were encountered.

When mapping scope to attributes, instead of trying to cast them to string now it just creates a new Map for the attributes and copies the cope entries to the new map. This avoids any cast and preserves the original types.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37701

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Run the exporter with the config that originally causes the panic, see config below.
Running it on main will panic, running it on this PR will not panic.

```
./bin/otelcontribcol_linux_amd64 --config otel-test.yaml
```

```
receivers:
  hostmetrics:
    metadata_collection_interval: 1s
    scrapers:
      cpu: {}

exporters:
  elasticsearch:
    mapping:
      mode: none
    endpoint: <redacted>
    user: <redacted>
    password: <redacted>
    flush:
      interval: 1s

service:
  pipelines:
    logs:
      receivers: [hostmetrics]
      processors: []
      exporters: [elasticsearch]

```

<!--Describe the documentation added.-->
#### Documentation

N/A
<!--Please delete paragraphs that you did not use before submitting.-->
