### PR TITLE
[testbed] fix typo in TestLogOtlpSendingQueue

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -221,7 +221,7 @@ func TestLogOtlpSendingQueue(t *testing.T) {
     retry_on_failure:
       enabled: true
 `)
-	otlpreceiver10.WithQueue(`
+	otlpreceiver100.WithQueue(`
     sending_queue:
       enabled: true
       queue_size: 100


### PR DESCRIPTION
#### Description
Fixes a typo found when reviewing the testbed test code.
