### PR TITLE
[chore] gopsutilenv module

### DIFF
--- a/internal/gopsutilenv/Makefile
+++ b/internal/gopsutilenv/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/internal/gopsutilenv/go.mod
+++ b/internal/gopsutilenv/go.mod
@@ -1,0 +1,14 @@
+module github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv
+
+go 1.23.0
+
+require (
+	github.com/shirou/gopsutil/v4 v4.25.4
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/internal/gopsutilenv/go.sum
+++ b/internal/gopsutilenv/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shirou/gopsutil/v4 v4.25.4 h1:cdtFO363VEOOFrUCjZRh4XVJkb548lyF0q0uTeMqYPw=
+github.com/shirou/gopsutil/v4 v4.25.4/go.mod h1:xbuxyoZj+UsgnZrENu3lQivsngRR5BdjbJwf2fv4szA=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/gopsutilenv/gopsutilenv_linux.go
+++ b/internal/gopsutilenv/gopsutilenv_linux.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package gopsutilenv // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv"
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/shirou/gopsutil/v4/common"
+)
+
+var gopsutilEnvVars = map[common.EnvKeyType]string{
+	common.HostProcEnvKey: "/proc",
+	common.HostSysEnvKey:  "/sys",
+	common.HostEtcEnvKey:  "/etc",
+	common.HostVarEnvKey:  "/var",
+	common.HostRunEnvKey:  "/run",
+	common.HostDevEnvKey:  "/dev",
+}
+
+// This exists to validate that different components that use this module do not
+// have inconsistent root_path configurations. The root_path is passed down to gopsutil
+// through context, so it must be consistent across the process.
+var globalRootPath string
+
+func ValidateRootPath(rootPath string) error {
+	if rootPath == "" || rootPath == "/" {
+		return nil
+	}
+
+	if globalRootPath != "" && rootPath != globalRootPath {
+		return fmt.Errorf("inconsistent root_path configuration detected among components: `%s` != `%s`", globalRootPath, rootPath)
+	}
+	globalRootPath = rootPath
+
+	if _, err := os.Stat(rootPath); err != nil {
+		return fmt.Errorf("invalid root_path: %w", err)
+	}
+
+	return nil
+}
+
+func SetGoPsutilEnvVars(rootPath string) common.EnvMap {
+	m := common.EnvMap{}
+	if rootPath == "" || rootPath == "/" {
+		return m
+	}
+
+	for envVarKey, defaultValue := range gopsutilEnvVars {
+		_, ok := os.LookupEnv(string(envVarKey))
+		if ok {
+			continue // don't override if existing env var is set
+		}
+		m[envVarKey] = filepath.Join(rootPath, defaultValue)
+	}
+	return m
+}
+
+// SetGlobalRootPath mainly used for unit tests
+func SetGlobalRootPath(rootPath string) {
+	globalRootPath = rootPath
+}
+
+// copied from gopsutil:
+// GetEnvWithContext retrieves the environment variable key. If it does not exist it returns the default.
+// The context may optionally contain a map superseding os.EnvKey.
+func GetEnvWithContext(ctx context.Context, key string, dfault string, combineWith ...string) string {
+	var value string
+	if env, ok := ctx.Value(common.EnvKey).(common.EnvMap); ok {
+		value = env[common.EnvKeyType(key)]
+	}
+	if value == "" {
+		value = os.Getenv(key)
+	}
+	if value == "" {
+		value = dfault
+	}
+
+	return combine(value, combineWith)
+}
+
+func combine(value string, combineWith []string) string {
+	switch len(combineWith) {
+	case 0:
+		return value
+	case 1:
+		return filepath.Join(value, combineWith[0])
+	default:
+		all := make([]string, len(combineWith)+1)
+		all[0] = value
+		copy(all[1:], combineWith)
+		return filepath.Join(all...)
+	}
+}

--- a/internal/gopsutilenv/gopsutilenv_linux_test.go
+++ b/internal/gopsutilenv/gopsutilenv_linux_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package gopsutilenv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootPaths(t *testing.T) {
+	tests := []struct {
+		testName string
+		rootPath string
+		errMsg   string
+	}{
+		{
+			testName: "valid path",
+			rootPath: "testdata",
+		},
+		{
+			testName: "empty path",
+			rootPath: "",
+		},
+		{
+			testName: "root path",
+			rootPath: "/",
+		},
+		{
+			testName: "invalid path",
+			rootPath: "invalidpath",
+			errMsg:   "invalid root_path: stat invalidpath: no such file or directory",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			err := ValidateRootPath(test.rootPath)
+			if test.errMsg != "" {
+				assert.EqualError(t, err, test.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			t.Cleanup(func() { SetGlobalRootPath("") })
+		})
+	}
+}
+
+func TestInconsistentRootPaths(t *testing.T) {
+	SetGlobalRootPath("foo")
+	err := ValidateRootPath("testdata")
+	assert.EqualError(t, err, "inconsistent root_path configuration detected among components: `foo` != `testdata`")
+
+	t.Cleanup(func() { SetGlobalRootPath("") })
+}
+
+func TestSetGoPsutilEnvVars(t *testing.T) {
+	envMap := SetGoPsutilEnvVars("testdata")
+	expectedEnvMap := common.EnvMap{
+		common.HostDevEnvKey:  "testdata/dev",
+		common.HostEtcEnvKey:  "testdata/etc",
+		common.HostRunEnvKey:  "testdata/run",
+		common.HostSysEnvKey:  "testdata/sys",
+		common.HostVarEnvKey:  "testdata/var",
+		common.HostProcEnvKey: "testdata/proc",
+	}
+	assert.Equal(t, expectedEnvMap, envMap)
+	ctx := context.WithValue(context.Background(), common.EnvKey, envMap)
+	assert.Equal(t, "testdata/proc", GetEnvWithContext(ctx, string(common.HostProcEnvKey), "default"))
+	assert.Equal(t, "testdata/sys", GetEnvWithContext(ctx, string(common.HostSysEnvKey), "default"))
+	assert.Equal(t, "testdata/etc", GetEnvWithContext(ctx, string(common.HostEtcEnvKey), "default"))
+	assert.Equal(t, "testdata/var", GetEnvWithContext(ctx, string(common.HostVarEnvKey), "default"))
+	assert.Equal(t, "testdata/run", GetEnvWithContext(ctx, string(common.HostRunEnvKey), "default"))
+	assert.Equal(t, "testdata/dev", GetEnvWithContext(ctx, string(common.HostDevEnvKey), "default"))
+
+	t.Cleanup(func() { SetGlobalRootPath("") })
+}
+
+func TestGetEnvWithContext(t *testing.T) {
+	envMap := SetGoPsutilEnvVars("testdata")
+
+	ctxEnv := context.WithValue(context.Background(), common.EnvKey, envMap)
+	assert.Equal(t, "testdata/proc", GetEnvWithContext(ctxEnv, string(common.HostProcEnvKey), "default"))
+	assert.Equal(t, "testdata/sys", GetEnvWithContext(ctxEnv, string(common.HostSysEnvKey), "default"))
+	assert.Equal(t, "testdata/etc", GetEnvWithContext(ctxEnv, string(common.HostEtcEnvKey), "default"))
+	assert.Equal(t, "testdata/var", GetEnvWithContext(ctxEnv, string(common.HostVarEnvKey), "default"))
+	assert.Equal(t, "testdata/run", GetEnvWithContext(ctxEnv, string(common.HostRunEnvKey), "default"))
+	assert.Equal(t, "testdata/dev", GetEnvWithContext(ctxEnv, string(common.HostDevEnvKey), "default"))
+
+	assert.Equal(t, "/default", GetEnvWithContext(context.Background(), string(common.HostProcEnvKey), "/default"))
+	assert.Equal(t, "/default/foo", GetEnvWithContext(context.Background(), string(common.HostProcEnvKey), "/default", "foo"))
+	assert.Equal(t, "/default/foo/bar", GetEnvWithContext(context.Background(), string(common.HostProcEnvKey), "/default", "foo", "bar"))
+
+	t.Cleanup(func() { SetGlobalRootPath("") })
+}
+
+func TestSetGoPsutilEnvVarsInvalidRootPath(t *testing.T) {
+	err := ValidateRootPath("invalidpath")
+	assert.EqualError(t, err, "invalid root_path: stat invalidpath: no such file or directory")
+
+	t.Cleanup(func() { SetGlobalRootPath("") })
+}

--- a/internal/gopsutilenv/gopsutilenv_others.go
+++ b/internal/gopsutilenv/gopsutilenv_others.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package gopsutilenv // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv"
+
+import (
+	"context"
+	"errors"
+
+	"github.com/shirou/gopsutil/v4/common"
+)
+
+func ValidateRootPath(rootPath string) error {
+	if rootPath == "" {
+		return nil
+	}
+	return errors.New("root_path is supported on linux only")
+}
+
+func SetGoPsutilEnvVars(_ string) (common.EnvMap, error) {
+	return common.EnvMap{}, nil
+}
+
+func GetEnvWithContext(_ context.Context, _ string, dfault string, _ ...string) string {
+	return dfault
+}
+
+func SetGlobalRootPath(_ string) {
+}

--- a/internal/gopsutilenv/gopsutilenv_others_test.go
+++ b/internal/gopsutilenv/gopsutilenv_others_test.go
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package gopsutilenv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootPathNotAllowedOnOS(t *testing.T) {
+	assert.Error(t, ValidateRootPath("testdata"))
+}
+
+func TestRootPathUnset(t *testing.T) {
+	assert.NoError(t, ValidateRootPath(""))
+}
+
+func TestGetEnvWithContext(t *testing.T) {
+	val := GetEnvWithContext(context.Background(), string(common.HostProcEnvKey), "default")
+	assert.Equal(t, "default", val)
+}

--- a/internal/gopsutilenv/testdata/.gitignore
+++ b/internal/gopsutilenv/testdata/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this .gitignore file
+!.gitignore

--- a/internal/tidylist/tidylist.txt
+++ b/internal/tidylist/tidylist.txt
@@ -198,6 +198,7 @@ internal/aws/k8s
 internal/aws/xray/testdata/sampleapp
 internal/aws/xray/testdata/sampleserver
 internal/collectd
+internal/gopsutilenv
 internal/kubelet
 internal/sqlquery
 internal/tools

--- a/versions.yaml
+++ b/versions.yaml
@@ -143,6 +143,7 @@ module-sets:
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka


### PR DESCRIPTION
#### Description
Extracts and improves the gopsutilenv logic from hostmetrics receiver and move it to its own module
This will be used by hostmetrics , signalfx exporter and/or any components that uses gopsutil with non-standard root fs

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40110

#### Testing
expanded the unit tests
