### PR TITLE
[chore] Remove matrix from scoped-tests to unblock CI

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -55,11 +55,7 @@ jobs:
   scoped-tests:
     needs: changedfiles
     if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ windows-latest ]
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     steps:
       - name: Echo changed files
         shell: bash


### PR DESCRIPTION
Once we have more options, we can move them to another job like scoped-tests-matrix as done for the unittest job

This should resolve https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40080