### PR TITLE
Support named encoding extensions in Kafka receiver and exporter

### DIFF
--- a/.chloggen/kafka-encoding-name.yaml
+++ b/.chloggen/kafka-encoding-name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver, kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for named encoding extensions in kafkareceiver and kafkaexporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40142]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/marshaler.go
+++ b/exporter/kafkaexporter/marshaler.go
@@ -97,12 +97,11 @@ func loadEncodingExtension[T any](host component.Host, encoding, signalType stri
 	return marshaler, nil
 }
 
-// encodingToComponentID converts an encoding string to a component ID using the given encoding as type.
+// encodingToComponentID attempts to parse the encoding string as a component ID.
 func encodingToComponentID(encoding string) (*component.ID, error) {
-	componentType, err := component.NewType(encoding)
-	if err != nil {
-		return nil, fmt.Errorf("invalid component type: %w", err)
+	var id component.ID
+	if err := id.UnmarshalText([]byte(encoding)); err != nil {
+		return nil, fmt.Errorf("invalid component ID: %w", err)
 	}
-	id := component.NewID(componentType)
 	return &id, nil
 }

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -34,6 +34,17 @@ func TestGetLogsMarshaler(t *testing.T) {
 	require.Len(t, messages, 1)
 	assert.Equal(t, "overridden", string(messages[0].Value))
 
+	// Verify named extensions are supported.
+	m = mustGetLogsMarshaler(t, "otlp_proto/alice", extensionsHost{
+		component.MustNewIDWithName("otlp_proto", "alice"): plogMarshalerFuncExtension(func(plog.Logs) ([]byte, error) {
+			return []byte("bob"), nil
+		}),
+	})
+	messages, err = m.MarshalLogs(plog.NewLogs())
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "bob", string(messages[0].Value))
+
 	// Specifying an extension for a different type should fail fast.
 	m, err = getLogsMarshaler("otlp_proto", extensionsHost{
 		component.MustNewID("otlp_proto"): struct{ component.Component }{},

--- a/receiver/kafkareceiver/encoding.go
+++ b/receiver/kafkareceiver/encoding.go
@@ -127,12 +127,11 @@ func loadEncodingExtension[T any](host component.Host, encoding, signalType stri
 	return unmarshaler, nil
 }
 
-// encodingToComponentID converts an encoding string to a component ID using the given encoding as type.
+// encodingToComponentID attempts to parse the encoding string as a component ID.
 func encodingToComponentID(encoding string) (*component.ID, error) {
-	componentType, err := component.NewType(encoding)
-	if err != nil {
+	var id component.ID
+	if err := id.UnmarshalText([]byte(encoding)); err != nil {
 		return nil, fmt.Errorf("%w: %w", errInvalidComponentType, err)
 	}
-	id := component.NewID(componentType)
 	return &id, nil
 }

--- a/receiver/kafkareceiver/encoding_test.go
+++ b/receiver/kafkareceiver/encoding_test.go
@@ -163,6 +163,12 @@ func TestNewLogsUnmarshalerExtension(t *testing.T) {
 	})
 	assert.Equal(t, &customLogsUnmarshalerExtension, u)
 
+	// Verify extensions can be named.
+	u = mustNewLogsUnmarshaler(t, "otlp_proto/alice", extensionsHost{
+		component.MustNewIDWithName("otlp_proto", "alice"): &customLogsUnmarshalerExtension,
+	})
+	assert.Equal(t, &customLogsUnmarshalerExtension, u)
+
 	// Specifying an extension for a different type should fail fast.
 	u, err := newLogsUnmarshaler("not_logs", settings, extensionsHost{
 		component.MustNewID("not_logs"): &customTracesUnmarshalerExtension,


### PR DESCRIPTION
#### Description

Fix the Kafka receiver and exporter to support encoding extensions with a custom name, e.g. "otlp_encoding/json" rather than assuming it is only a type, e.g. "otlp_encoding".

Note: in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39809/files#r2069988901 it was suggested that we use `component.ID` in the config struct. That won't work for the Kafka receiver since it also has built-in encodings that are invalid component IDs. It could work for the exporter, but I have opted to keep the code consistent instead.

#### Link to tracking issue

Fixes #40142

#### Testing

Added tests.

#### Documentation

None