### PR TITLE
kafkaexporter: Allow topics from metadata key

### DIFF
--- a/.chloggen/f_kafkaexporter-add-topic-from-metadata-key.yaml
+++ b/.chloggen/f_kafkaexporter-add-topic-from-metadata-key.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'kafkaexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow kafka exporter to produce to topics based on metadata key values"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39208]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Allows the Kafka exporter to dynamically use a signal's export target topic based
+  on the value of the pipeline's metadata, allowing dynamic signal routing.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -142,6 +142,7 @@ exporters:
 
 The destination topic can be defined in a few different ways and takes priority in the following order:
 
-1. When `topic_from_attribute` is configured, and the corresponding attribute is found on the ingested data, the value of this attribute is used.
-2. If a prior component in the collector pipeline sets the topic on the context via the `topic.WithTopic` function (from the `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic` package), the value set in the context is used.
-3. Finally, the `<signal>::topic` configuration is used for the signal-specific destination topic. If this is not explicitly configured, the `topic` configuration (deprecated in v0.124.0) is used as a fallback for all signals.
+1. When `<signal>.topic_from_metadata_key` is set to use a key from the request metadata, the value of this key is used as the signal specific topic.
+2. Otherwise, if `topic_from_attribute` is configured, and the corresponding attribute is found on the ingested data, the value of this attribute is used.
+3. If a prior component in the collector pipeline sets the topic on the context via the `topic.WithTopic` function (from the `github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic` package), the value set in the context is used.
+4. Finally, the `<signal>::topic` configuration is used for the signal-specific destination topic. If this is not explicitly configured, the `topic` configuration (deprecated in v0.124.0) is used as a fallback for all signals.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -30,12 +30,15 @@ The following settings can be optionally configured:
 - `logs`
   - `topic` (default = otlp\_logs): The name of the Kafka topic to which logs will be exported.
   - `encoding` (default = otlp\_proto): The encoding for logs. See [Supported encodings](#supported-encodings).
+  - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
 - `metrics`
   - `topic` (default = otlp\_metrics): The name of the Kafka topic from which to consume metrics.
   - `encoding` (default = otlp\_proto): The encoding for metrics. See [Supported encodings](#supported-encodings).
+  - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
 - `traces`
   - `topic` (default = otlp\_spans): The name of the Kafka topic from which to consume traces.
   - `encoding` (default = otlp\_proto): The encoding for traces. See [Supported encodings](#supported-encodings).
+  - `topic_from_metadata_key` (default = ""): The name of the metadata key whose value should be used as the message's topic. Useful to dynamically produce to topics based on request inputs. It takes precedence over `topic_from_attribute` and `topic` settings.
 - `topic` (Deprecated in v0.124.0: use `logs::topic`, `metrics::topic`, and `traces::topic`) If specified, this is used as the default topic, but will be overridden by signal-specific configuration. See [Destination Topic](#destination-topic) below for more details.
 - `topic_from_attribute` (default = ""): Specify the resource attribute whose value should be used as the message's topic. See [Destination Topic](#destination-topic) below for more details. 
 - `encoding` (Deprecated in v0.124.0: use `logs::encoding`, `metrics::encoding`, and `traces::encoding`) If specified, this is used as the default encoding, but will be overridden by signal-specific configuration. See [Supported encodings](#supported-encodings) below for more details.

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -117,6 +117,11 @@ type SignalConfig struct {
 	//  - "otlp_logs" for logs
 	Topic string `mapstructure:"topic"`
 
+	// TopicFromMetadataKey holds the name of the metadata key to use as the
+	// topic name for this signal type. If this is set, it takes precedence
+	// over the topic name set in the topic field.
+	TopicFromMetadataKey string `mapstructure:"topic_from_metadata_key"`
+
 	// Encoding holds the encoding of messages for the signal type.
 	//
 	// Defaults to "otlp_proto".

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -87,8 +87,9 @@ func TestLoadConfig(t *testing.T) {
 				ClientConfig:    configkafka.NewDefaultClientConfig(),
 				Producer:        configkafka.NewDefaultProducerConfig(),
 				Logs: SignalConfig{
-					Topic:    "legacy_topic",
-					Encoding: "otlp_proto",
+					Topic:                "legacy_topic",
+					Encoding:             "otlp_proto",
+					TopicFromMetadataKey: "metadata_key",
 				},
 				Metrics: SignalConfig{
 					Topic:    "metrics_topic",

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -151,7 +151,7 @@ func (e *kafkaTracesMessager) marshalData(td ptrace.Traces) ([]marshaler.Message
 }
 
 func (e *kafkaTracesMessager) getTopic(ctx context.Context, td ptrace.Traces) string {
-	return getTopic(ctx, &e.config, e.config.Traces.Topic, td.ResourceSpans())
+	return getTopic(ctx, e.config.Traces, e.config.TopicFromAttribute, td.ResourceSpans())
 }
 
 func (e *kafkaTracesMessager) partitionData(td ptrace.Traces) iter.Seq2[[]byte, ptrace.Traces] {
@@ -196,7 +196,7 @@ func (e *kafkaLogsMessager) marshalData(ld plog.Logs) ([]marshaler.Message, erro
 }
 
 func (e *kafkaLogsMessager) getTopic(ctx context.Context, ld plog.Logs) string {
-	return getTopic(ctx, &e.config, e.config.Logs.Topic, ld.ResourceLogs())
+	return getTopic(ctx, e.config.Logs, e.config.TopicFromAttribute, ld.ResourceLogs())
 }
 
 func (e *kafkaLogsMessager) partitionData(ld plog.Logs) iter.Seq2[[]byte, plog.Logs] {
@@ -239,7 +239,7 @@ func (e *kafkaMetricsMessager) marshalData(md pmetric.Metrics) ([]marshaler.Mess
 }
 
 func (e *kafkaMetricsMessager) getTopic(ctx context.Context, md pmetric.Metrics) string {
-	return getTopic(ctx, &e.config, e.config.Metrics.Topic, md.ResourceMetrics())
+	return getTopic(ctx, e.config.Metrics, e.config.TopicFromAttribute, md.ResourceMetrics())
 }
 
 func (e *kafkaMetricsMessager) partitionData(md pmetric.Metrics) iter.Seq2[[]byte, pmetric.Metrics] {
@@ -270,23 +270,27 @@ type resource interface {
 
 func getTopic[T resource](
 	ctx context.Context,
-	cfg *Config,
-	defaultTopic string,
+	signalCfg SignalConfig,
+	topicFromAttribute string,
 	resources resourceSlice[T],
 ) string {
-	if cfg.TopicFromAttribute != "" {
+	if k := signalCfg.TopicFromMetadataKey; k != "" {
+		if topic := client.FromContext(ctx).Metadata.Get(k); len(topic) > 0 {
+			return topic[0]
+		}
+	}
+	if topicFromAttribute != "" {
 		for i := 0; i < resources.Len(); i++ {
-			rv, ok := resources.At(i).Resource().Attributes().Get(cfg.TopicFromAttribute)
+			rv, ok := resources.At(i).Resource().Attributes().Get(topicFromAttribute)
 			if ok && rv.Str() != "" {
 				return rv.Str()
 			}
 		}
 	}
-	contextTopic, ok := topic.FromContext(ctx)
-	if ok {
-		return contextTopic
+	if topic, ok := topic.FromContext(ctx); ok {
+		return topic
 	}
-	return defaultTopic
+	return signalCfg.Topic
 }
 
 func makeSaramaMessages(messages []marshaler.Message, topic string) []*sarama.ProducerMessage {

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -23,6 +23,8 @@ kafka/legacy_topic:
   topic: legacy_topic
   metrics:
     topic: metrics_topic
+  logs:
+    topic_from_metadata_key: metadata_key
 kafka/legacy_encoding:
   encoding: legacy_encoding
   metrics:


### PR DESCRIPTION
#### Description
Introduces a new per-signal config option `topic_from_metadata_key` to allow the user to produce to topics which which can be set using parts of the request metadata. This is useful for multi-tenant use-cases.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Closes #39208

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests

<!--Describe the documentation added.-->
#### Documentation

Updated the readme with the new option.