### PR TITLE
[chore] add @andrzej-stencel as codeowner for pkg/stanza

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -164,7 +164,7 @@ pkg/pdatatest/                                                   @open-telemetry
 pkg/pdatautil/                                                   @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                         @open-telemetry/collector-contrib-approvers @mx-psi
 pkg/sampling/                                                    @open-telemetry/collector-contrib-approvers @kentquirk @jmacd
-pkg/stanza/                                                      @open-telemetry/collector-contrib-approvers
+pkg/stanza/                                                      @open-telemetry/collector-contrib-approvers @andrzej-stencel
 pkg/stanza/fileconsumer/                                         @open-telemetry/collector-contrib-approvers @andrzej-stencel
 pkg/status/                                                      @open-telemetry/collector-contrib-approvers @mwear
 pkg/translator/azure/                                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins

--- a/pkg/stanza/metadata.yaml
+++ b/pkg/stanza/metadata.yaml
@@ -2,5 +2,6 @@ status:
   disable_codecov_badge: true
   class: pkg
   codeowners:
+    active: [andrzej-stencel]
     emeritus: [djaglowski]
     seeking_new: true


### PR DESCRIPTION
Proposing myself as codeowner of the `pkg/stanza` module.

I'm already a codeowner for `pkg/stanza/fileconsumer` and I'm vitally interested in the future of Stanza library. I also have some opinions and ideas for the evolution of the library as part of the OTel Collector that I would like to discuss and potentially implement.

Not removing the "seeking new" status, as ideally there should be more than one codeowner of such a crucial library.

My contributions to the module: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=author:andrzej-stencel+label:pkg/stanza