### PR TITLE
[cmd/opampsupervisor] Fix data race on `Supervisor.lastHealthFromClient`

### DIFF
--- a/.chloggen/supervisor-last-health-datarace.yaml
+++ b/.chloggen/supervisor-last-health-datarace.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data race on access to `Supervisor.lastHealthFromClient`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40207]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/supervisor-last-health-datarace.yaml
+++ b/.chloggen/supervisor-last-health-datarace.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: cmd/opampsupervisor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix data race on access to `Supervisor.lastHealthFromClient`
+note: Fix race condition where the Supervisor could report the wrong health status
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [40207]

--- a/cmd/opampsupervisor/Makefile
+++ b/cmd/opampsupervisor/Makefile
@@ -2,4 +2,4 @@ include ../../Makefile.Common
 
 e2e-test:
 	make -C ../../ otelcontribcol
-	go test -v --tags=e2e .
+	go test -v -race --tags=e2e .

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1262,6 +1262,13 @@ func TestSupervisorRestartCommand(t *testing.T) {
 		},
 	})
 
+	// Here we will wait for the supervisor connection to go away and come back.
+	// This helps us check that the restart logic is actually restarting the agent.
+	// Note: this also helps the data race detector confirm that access to the
+	// [Supervisor.lastHealthFromClient] has to be synchronized to prevent races.
+	waitForSupervisorConnection(server.supervisorConnected, false)
+	waitForSupervisorConnection(server.supervisorConnected, true)
+
 	server.sendToSupervisor(&protobufs.ServerToAgent{
 		Flags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 	})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes a data race on access to `Supervisor.lastHealthFromClient` by changing the field from its original type to something wrapped by `atomic.Pointer[T]`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40207

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Modified the `e2e_test` Make target to run the tests with the race detector enabled.
- Modified the `TestSupervisorRestartCommand` test in `e2e_test.go` in a way that not only covers better the functionality under test, but also let the test race detector identify the issue.