### PR TITLE
[testbed] Increase memory limit for TestMetric10kDPS/STEF

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -79,7 +79,7 @@ func TestMetric10kDPS(t *testing.T) {
 			receiver: datareceivers.NewStefDataReceiver(testutil.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 60,
-				ExpectedMaxRAM: 100,
+				ExpectedMaxRAM: 150,
 			},
 		},
 	}


### PR DESCRIPTION
This is a new test and the limit wasn't set correctly in the initial commit. I set the limit to 1.5 x of the locally observed maximum. I will watch how much it consumes on github actions and if necessary will adjust as needed.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40206
