### PR TITLE
[receiver/googlecloudmonitoring: Support distribution metric

### DIFF
--- a/.chloggen/support-ingesting-gcp-metrics-distribution.yaml
+++ b/.chloggen/support-ingesting-gcp-metrics-distribution.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudmonitoringreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for ingesting GCP Distribution metrics kind.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39600]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -206,9 +206,9 @@ func (mb *MetricsBuilder) ConvertDistributionToMetrics(metricKind metric.MetricD
 
 		// Set sum and range values
 		dp.SetSum(float64(distValue.Mean) * float64(distValue.Count))
-		if range_ := distValue.GetRange(); range_ != nil {
-			dp.SetMin(float64(range_.Min))
-			dp.SetMax(float64(range_.Max))
+		if rangeValue := distValue.GetRange(); rangeValue != nil {
+			dp.SetMin(float64(rangeValue.Min))
+			dp.SetMax(float64(rangeValue.Max))
 		}
 	}
 

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/api/metric"
 )
 
 type MetricsBuilder struct {
@@ -115,6 +116,99 @@ func (mb *MetricsBuilder) ConvertDeltaToMetrics(ts *monitoringpb.TimeSeries, m p
 			dp.SetIntValue(v.Int64Value)
 		default:
 			mb.logger.Info("Unhandled metric value type:", zap.Reflect("Type", v))
+		}
+	}
+
+	return m
+}
+
+func (mb *MetricsBuilder) ConvertDistributionToMetrics(metricKind metric.MetricDescriptor_MetricKind, ts *monitoringpb.TimeSeries, m pmetric.Metric) pmetric.Metric {
+	m.SetName(ts.GetMetric().GetType())
+	m.SetUnit(ts.GetUnit())
+	dist := m.SetEmptyHistogram()
+
+	switch metricKind {
+	case metric.MetricDescriptor_CUMULATIVE:
+		dist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	case metric.MetricDescriptor_DELTA:
+		dist.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+	default:
+		mb.logger.Warn("Unsupported metric kind:", zap.String("Metric", ts.GetMetric().GetType()))
+		return m
+	}
+
+	for _, point := range ts.GetPoints() {
+		dp := dist.DataPoints().AppendEmpty()
+
+		// Set timestamps if valid
+		if point.Interval.StartTime != nil && point.Interval.StartTime.IsValid() {
+			dp.SetStartTimestamp(pcommon.NewTimestampFromTime(point.Interval.StartTime.AsTime()))
+		}
+
+		if point.Interval.EndTime != nil && point.Interval.EndTime.IsValid() {
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(point.Interval.EndTime.AsTime()))
+		} else {
+			mb.logger.Warn("EndTime is invalid for metric:", zap.String("Metric", ts.GetMetric().GetType()))
+		}
+
+		distValue := point.Value.GetDistributionValue()
+		if distValue == nil {
+			mb.logger.Warn("Distribution value is nil for metric:", zap.String("Metric", ts.GetMetric().GetType()))
+			continue
+		}
+
+		dp.SetCount(uint64(distValue.Count))
+
+		// Handle bucket options based on type
+		if bucketOpts := distValue.BucketOptions; bucketOpts != nil {
+			if expBuckets := bucketOpts.GetExponentialBuckets(); expBuckets != nil {
+				// Initialize all buckets with zeros for exponential buckets
+				numBuckets := int(expBuckets.NumFiniteBuckets)
+				dp.BucketCounts().EnsureCapacity(numBuckets)
+				for i := 0; i < numBuckets; i++ {
+					dp.BucketCounts().Append(0)
+				}
+			} else if linearBuckets := bucketOpts.GetLinearBuckets(); linearBuckets != nil {
+				// Initialize all buckets with zeros for linear buckets
+				numBuckets := int(linearBuckets.NumFiniteBuckets)
+				dp.BucketCounts().EnsureCapacity(numBuckets)
+				for i := 0; i < numBuckets; i++ {
+					dp.BucketCounts().Append(0)
+				}
+			} else if explicitBuckets := bucketOpts.GetExplicitBuckets(); explicitBuckets != nil {
+				bounds := explicitBuckets.Bounds
+				dp.ExplicitBounds().EnsureCapacity(len(bounds))
+				for _, bucket := range bounds {
+					dp.ExplicitBounds().Append(bucket)
+				}
+			}
+		}
+
+		// Set bucket counts from the distribution data
+		if len(distValue.BucketCounts) > 0 {
+			// Update existing bucket counts instead of appending
+			for i, count := range distValue.BucketCounts {
+				if i < dp.BucketCounts().Len() {
+					dp.BucketCounts().SetAt(i, uint64(count))
+				} else {
+					// If we somehow have more counts than buckets, append the extras
+					dp.BucketCounts().Append(uint64(count))
+				}
+			}
+		}
+
+		// Set exemplars
+		if exemplars := distValue.Exemplars; exemplars != nil {
+			for _, exemplar := range exemplars {
+				dp.Exemplars().AppendEmpty().SetDoubleValue(float64(exemplar.Value))
+			}
+		}
+
+		// Set sum and range values
+		dp.SetSum(float64(distValue.Mean) * float64(distValue.Count))
+		if range_ := distValue.GetRange(); range_ != nil {
+			dp.SetMin(float64(range_.Min))
+			dp.SetMax(float64(range_.Max))
 		}
 	}
 

--- a/receiver/googlecloudmonitoringreceiver/receiver.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver.go
@@ -307,6 +307,10 @@ func (mr *monitoringReceiver) convertGCPTimeSeriesToMetrics(metrics pmetric.Metr
 	m.SetDescription(metricDesc.GetDescription())
 	m.SetUnit(metricDesc.Unit)
 
+	if metricDesc.GetValueType() == metric.MetricDescriptor_DISTRIBUTION {
+		mr.metricsBuilder.ConvertDistributionToMetrics(timeSeries.GetMetricKind(), timeSeries, m)
+		return
+	}
 	// Convert the TimeSeries to the appropriate metric type
 	switch timeSeries.GetMetricKind() {
 	case metric.MetricDescriptor_GAUGE:
@@ -315,7 +319,6 @@ func (mr *monitoringReceiver) convertGCPTimeSeriesToMetrics(metrics pmetric.Metr
 		mr.metricsBuilder.ConvertSumToMetrics(timeSeries, m)
 	case metric.MetricDescriptor_DELTA:
 		mr.metricsBuilder.ConvertDeltaToMetrics(timeSeries, m)
-	// TODO: Add support for HISTOGRAM
 	// TODO: Add support for EXPONENTIAL_HISTOGRAM
 	default:
 		metricError := fmt.Sprintf("\n Unsupported metric kind: %v\n", timeSeries.GetMetricKind())


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Support for the `DISTRIBUTION` metric kind. Learn more: https://cloud.google.com/monitoring/api/v3/kinds-and-types#metric-kinds

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39600

<!--Describe what testing was performed and which tests were added.-->
#### Testing
I've tested this patch with the following metrics:
- `run.googleapis.com/container/cpu/utilizations`
- `run.googleapis.com/container/memory/utilizations`

It likely needs broader testing—I'm happy to try it out with more relevant Google metrics.



