### PR TITLE
[cmd/opampsupervisor] fix: Report RemoteConfigStatus on startup if present

### DIFF
--- a/.chloggen/supervisor-reports-remote-cfg-on-startup.yaml
+++ b/.chloggen/supervisor-reports-remote-cfg-on-startup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "opampsupervisor"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "If there is a remote config, the supervisor now reports the remote config as applied and the correct hash on startup."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40233]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -457,6 +457,7 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 
 	// create server
 	var agentConfig atomic.Value
+	var remoteConfigStatus atomic.Value
 	server := newOpAMPServer(
 		t,
 		defaultConnectingHandler,
@@ -468,7 +469,9 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 						agentConfig.Store(string(config.Body))
 					}
 				}
-
+				if message.RemoteConfigStatus != nil {
+					remoteConfigStatus.Store(message.RemoteConfigStatus)
+				}
 				return &protobufs.ServerToAgent{}
 			},
 		})
@@ -526,6 +529,12 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 
 		return n != 0
 	}, 20*time.Second, 500*time.Millisecond, "Log never appeared in output")
+
+	// verify that the supervisor reports the remote config as applied and the correct hash
+	require.Eventually(t, func() bool {
+		status := remoteConfigStatus.Load().(*protobufs.RemoteConfigStatus)
+		return status != nil && status.Status == protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED && bytes.Equal(status.LastRemoteConfigHash, hash)
+	}, 20*time.Second, 500*time.Millisecond, "Remote config status never became applied")
 }
 
 func TestSupervisorStartsWithNoOpAMPServer(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -625,6 +625,9 @@ func (s *Supervisor) startOpAMPClient() error {
 		return fmt.Errorf("unsupported scheme in server endpoint: %q", parsedURL.Scheme)
 	}
 
+	// load the remote config, this is needed for start settings
+	s.loadRemoteConfig()
+
 	s.telemetrySettings.Logger.Debug("Connecting to OpAMP server...", zap.String("endpoint", s.config.Server.Endpoint), zap.Any("headers", s.config.Server.Headers))
 	settings := types.StartSettings{
 		OpAMPServerURL: s.config.Server.Endpoint,
@@ -1055,8 +1058,8 @@ func (s *Supervisor) composeAgentConfigFiles() []byte {
 	return b
 }
 
-func (s *Supervisor) loadAndWriteInitialMergedConfig() error {
-	var lastRecvRemoteConfig, lastRecvOwnTelemetryConfig []byte
+func (s *Supervisor) loadRemoteConfig() {
+	var lastRecvRemoteConfig []byte
 	var err error
 
 	if s.config.Capabilities.AcceptsRemoteConfig {
@@ -1079,6 +1082,11 @@ func (s *Supervisor) loadAndWriteInitialMergedConfig() error {
 	} else {
 		s.telemetrySettings.Logger.Debug("Remote config is not supported, will not attempt to load config from fil")
 	}
+}
+
+func (s *Supervisor) loadAndWriteInitialMergedConfig() error {
+	var lastRecvOwnTelemetryConfig []byte
+	var err error
 
 	if s.config.Capabilities.ReportsOwnMetrics || s.config.Capabilities.ReportsOwnTraces || s.config.Capabilities.ReportsOwnLogs {
 		// Try to load the last received own metrics config if it exists.

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -631,6 +631,15 @@ func (s *Supervisor) startOpAMPClient() error {
 		Header:         s.config.Server.Headers,
 		TLSConfig:      tlsConfig,
 		InstanceUid:    types.InstanceUid(s.persistentState.InstanceID),
+		RemoteConfigStatus: func() *protobufs.RemoteConfigStatus {
+			if s.remoteConfig != nil {
+				return &protobufs.RemoteConfigStatus{
+					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
+					LastRemoteConfigHash: s.remoteConfig.GetConfigHash(),
+				}
+			}
+			return nil
+		}(),
 		Callbacks: types.Callbacks{
 			OnConnect: func(_ context.Context) {
 				s.telemetrySettings.Logger.Debug("Connected to the server.")

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -283,6 +283,7 @@ service:
 			})
 			s.agentDescription = agentDesc
 
+			s.loadRemoteConfig()
 			require.NoError(t, s.createTemplates())
 			require.NoError(t, s.loadAndWriteInitialMergedConfig())
 
@@ -1585,6 +1586,7 @@ service:
 
 		s.agentDescription = agentDesc
 
+		s.loadRemoteConfig()
 		require.NoError(t, s.createTemplates())
 		require.NoError(t, s.loadAndWriteInitialMergedConfig())
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The OpAMP Client `StartSettings` include an initial [RemoteConfigStatus](https://github.com/open-telemetry/opamp-go/blob/main/client/types/startsettings.go#L40) that can be reported on startup. In the event it is unset/nil, OpAMP servers will respond with a RemoteConfig message to the supervisor. However, when the supervisor receives this message and it's the same config it is already running the collector with, it has nothing to do so it drops the message. This causes the OpAMP server to continually send more RemoteConfig messages because the supervisor hasn't reported a status since startup.

This PR sets this initial RemoteConfigStatus if we have one present. Made a slight refactor to how we load the initial config. Pulled out the remote config loading into it's own function that is called during the client start. This has no affect on the config loading.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated an e2e test testing supervisor&collector start up when there's a remote config present to also check the remote config message that is sent.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
