### PR TITLE
[chore] remove unused fillLogThree method

### DIFF
--- a/internal/coreinternal/testdata/log.go
+++ b/internal/coreinternal/testdata/log.go
@@ -83,15 +83,6 @@ func fillLogTwo(log plog.LogRecord) {
 	log.Body().SetStr("something happened")
 }
 
-func fillLogThree(log plog.LogRecord) {
-	log.SetTimestamp(TestLogTimestamp)
-	log.SetDroppedAttributesCount(1)
-	log.SetSeverityNumber(plog.SeverityNumberWarn)
-	log.SetSeverityText("Warning")
-
-	log.Body().SetStr("something else happened")
-}
-
 func GenerateLogsManyLogRecordsSameResource(count int) plog.Logs {
 	ld := GenerateLogsOneEmptyLogRecord()
 	logs := ld.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()


### PR DESCRIPTION
Running the linter here fails because this method is unused.