### PR TITLE
[chore] add exclusion for problematic module

### DIFF
--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -156,3 +156,5 @@ retract (
 )
 
 replace google.golang.org/genproto => google.golang.org/genproto v0.0.0-20250218202821-56aae31c358a
+
+exclude github.com/envoyproxy/go-control-plane/envoy v1.32.3

--- a/extension/observer/k8sobserver/go.sum
+++ b/extension/observer/k8sobserver/go.sum
@@ -446,7 +446,6 @@ github.com/envoyproxy/go-control-plane v0.13.0/go.mod h1:GRaKG3dwvFoTg4nj7aXdZnv
 github.com/envoyproxy/go-control-plane v0.13.1/go.mod h1:X45hY0mufo6Fd0KW3rqsGvQMw58jvjymeCzBU3mWyHw=
 github.com/envoyproxy/go-control-plane v0.13.4/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/go-control-plane/envoy v1.32.2/go.mod h1:eR2SOX2IedqlPvmiKjUH7Wu//S602JKI7HPC/L3SRq8=
-github.com/envoyproxy/go-control-plane/envoy v1.32.3/go.mod h1:F6hWupPfh75TBXGKA++MCT/CZHFq5r9/uwt/kQYkZfE=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=


### PR DESCRIPTION
The following error happens when tidying the module:

```
go: google.golang.org/grpc@v1.72.1 requires
        github.com/envoyproxy/go-control-plane@v0.13.4 requires
        github.com/envoyproxy/go-control-plane/envoy@v1.32.3: verifying go.mod: checksum mismatch
        downloaded: h1:c955gQjaXHsMxMjHjEZ7nwIzMJYxXpN+sJIGufsSbg4=
        sum.golang.org: h1:F6hWupPfh75TBXGKA++MCT/CZHFq5r9/uwt/kQYkZfE=
```
