### PR TITLE
fix(splunk): treat HTTP 403 Forbidden as a permanent error

### DIFF
--- a/.chloggen/fix_splunkhec-auth-403-permanent.yaml
+++ b/.chloggen/fix_splunkhec-auth-403-permanent.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: internal/splunk
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Treat HTTP 403 Forbidden as a permanent error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39037]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Splunk responses with a 403 typically indicate an authentication or authorization issue that is not likely to be resolved by retrying.
+  - This change ensures that the error is treated as permanent to avoid unnecessary retries.
+  - This change is applicable to `splunkhecexporter`, `signalfxexporter`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -220,14 +220,15 @@ func TestConsumeMetrics(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.EqualError(t, err, errMsg)
+				assert.ErrorContains(t, err, errMsg)
 				return
 			}
 
 			if tt.wantPermanentErr {
+				errMsg = "Permanent error: " + errMsg
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
-				assert.ErrorContains(t, err, errMsg)
+				assert.EqualError(t, err, errMsg)
 				return
 			}
 
@@ -2085,7 +2086,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.EqualError(t, err, errMsg)
+				assert.ErrorContains(t, err, errMsg)
 				return
 			}
 

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -43,7 +43,7 @@ func HandleHTTPCode(resp *http.Response) error {
 		// Indicate to our caller to pause for the specified number of seconds.
 		err = exporterhelper.NewThrottleRetry(err, time.Duration(retryAfter)*time.Second)
 	// Check for permanent errors.
-	case http.StatusBadRequest, http.StatusUnauthorized:
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
 		err = consumererror.NewPermanent(err)
 	}
 


### PR DESCRIPTION
#### Description
- Splunk responses with a 403 typically indicate an authentication or authorization issue that is not likely to be resolved by retrying. This change ensures that the error is treated as permanent to avoid unnecessary retries.
- This change is applied at `internal/splunk` level
- There should be no breaking changes for `signalfxexporter`, `splunkhecexporter`

#### Link to tracking issue
Fixes #39037 

#### Testing
Added and updated tests for handling 403 permanent error

#### Documentation
https://docs.splunk.com/Documentation/Splunk/latest/Data/TroubleshootHTTPEventCollector#Possible_error_codes