### PR TITLE
[receiver/splunkenterprise]unexport Info struct

### DIFF
--- a/.chloggen/unexport_splunkenterprise2.yaml
+++ b/.chloggen/unexport_splunkenterprise2.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkenterprisereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport Info
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40267]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/splunkenterprisereceiver/search_result.go
+++ b/receiver/splunkenterprisereceiver/search_result.go
@@ -195,7 +195,7 @@ type healthDetails struct {
 }
 
 // '/services/server/info'
-type Info struct {
+type info struct {
 	Host    string      `json:"origin"`
 	Entries []infoEntry `json:"entry"`
 }
@@ -209,7 +209,7 @@ type infoContent struct {
 	Version string `json:"version"`
 }
 
-type infoDict map[any]Info
+type infoDict map[any]info
 
 // '/services/search/jobs/{search_id}'
 type searchMetaEntries struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This struct should not be exposed as part of the API. Unexporting it.
