### PR TITLE
[receiver/cloudfoundry] unexport EnvelopeStreamFactory and UAATokenProvider

### DIFF
--- a/.chloggen/unexport_cloudfoundry.yaml
+++ b/.chloggen/unexport_cloudfoundry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cloudfoundryreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport EnvelopeStreamFactory and UAATokenProvider
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40270]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/cloudfoundryreceiver/stream.go
+++ b/receiver/cloudfoundryreceiver/stream.go
@@ -16,17 +16,17 @@ import (
 	"go.uber.org/zap"
 )
 
-type EnvelopeStreamFactory struct {
+type envelopeStreamFactory struct {
 	rlpGatewayClient *loggregator.RLPGatewayClient
 }
 
 func newEnvelopeStreamFactory(
 	ctx context.Context,
 	settings component.TelemetrySettings,
-	authTokenProvider *UAATokenProvider,
+	authTokenProvider *uaaTokenProvider,
 	httpConfig confighttp.ClientConfig,
 	host component.Host,
-) (*EnvelopeStreamFactory, error) {
+) (*envelopeStreamFactory, error) {
 	httpClient, err := httpConfig.ToClient(ctx, host, settings)
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP client for Cloud Foundry RLP Gateway: %w", err)
@@ -41,10 +41,10 @@ func newEnvelopeStreamFactory(
 		}),
 	)
 
-	return &EnvelopeStreamFactory{gatewayClient}, nil
+	return &envelopeStreamFactory{gatewayClient}, nil
 }
 
-func (rgc *EnvelopeStreamFactory) CreateMetricsStream(ctx context.Context, baseShardID string) loggregator.EnvelopeStream {
+func (rgc *envelopeStreamFactory) CreateMetricsStream(ctx context.Context, baseShardID string) loggregator.EnvelopeStream {
 	newShardID := baseShardID + "_metrics"
 	selectors := []*loggregator_v2.Selector{
 		{
@@ -65,7 +65,7 @@ func (rgc *EnvelopeStreamFactory) CreateMetricsStream(ctx context.Context, baseS
 	return stream
 }
 
-func (rgc *EnvelopeStreamFactory) CreateLogsStream(ctx context.Context, baseShardID string) loggregator.EnvelopeStream {
+func (rgc *envelopeStreamFactory) CreateLogsStream(ctx context.Context, baseShardID string) loggregator.EnvelopeStream {
 	newShardID := baseShardID + "_logs"
 	selectors := []*loggregator_v2.Selector{
 		{
@@ -83,7 +83,7 @@ func (rgc *EnvelopeStreamFactory) CreateLogsStream(ctx context.Context, baseShar
 
 type authorizationProvider struct {
 	logger            *zap.Logger
-	authTokenProvider *UAATokenProvider
+	authTokenProvider *uaaTokenProvider
 	client            *http.Client
 }
 

--- a/receiver/cloudfoundryreceiver/uaa.go
+++ b/receiver/cloudfoundryreceiver/uaa.go
@@ -17,7 +17,7 @@ const (
 	expirationTimeBuffer = -5 * time.Second
 )
 
-type UAATokenProvider struct {
+type uaaTokenProvider struct {
 	client         *uaago.Client
 	logger         *zap.Logger
 	username       string
@@ -28,7 +28,7 @@ type UAATokenProvider struct {
 	mutex          *sync.Mutex
 }
 
-func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, username string, password string) (*UAATokenProvider, error) {
+func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, username string, password string) (*uaaTokenProvider, error) {
 	client, err := uaago.NewClient(config.Endpoint)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, usernam
 
 	logger.Debug(fmt.Sprintf("creating new cloud foundry UAA token client with url %s username %s", config.Endpoint, username))
 
-	return &UAATokenProvider{
+	return &uaaTokenProvider{
 		logger:         logger,
 		client:         client,
 		username:       username,
@@ -48,7 +48,7 @@ func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, usernam
 	}, nil
 }
 
-func (utp *UAATokenProvider) ProvideToken() (string, error) {
+func (utp *uaaTokenProvider) ProvideToken() (string, error) {
 	utp.mutex.Lock()
 	defer utp.mutex.Unlock()
 


### PR DESCRIPTION
#### Description
Unexport both types as they should not be part of the component API.