### PR TITLE
[pkg/experimentalmetricmetadata] Add missing otel.entity.type fields to delete events

### DIFF
--- a/.chloggen/fix-experimental-entity-delete-events.yaml
+++ b/.chloggen/fix-experimental-entity-delete-events.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/experimentalmetricmetadata
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add missing otel.entity.type field to the delete events
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40279]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/experimentalmetricmetadata/entity_events.go
+++ b/pkg/experimentalmetricmetadata/entity_events.go
@@ -195,3 +195,18 @@ func (s EntityStateDetails) Interval() time.Duration {
 type EntityDeleteDetails struct {
 	orig plog.LogRecord
 }
+
+// EntityType returns the type of the entity.
+// TODO: Move the entity type methods to EntityEvent as they are needed for both EntityState and EntityDelete events.
+func (d EntityDeleteDetails) EntityType() string {
+	t, ok := d.orig.Attributes().Get(semconvOtelEntityType)
+	if !ok {
+		return ""
+	}
+	return t.Str()
+}
+
+// SetEntityType sets the type of the entity.
+func (d EntityDeleteDetails) SetEntityType(t string) {
+	d.orig.Attributes().PutStr(semconvOtelEntityType, t)
+}

--- a/pkg/experimentalmetricmetadata/entity_events_test.go
+++ b/pkg/experimentalmetricmetadata/entity_events_test.go
@@ -44,11 +44,13 @@ func Test_Entity_Delete(t *testing.T) {
 
 	event := slice.AppendEmpty()
 	event.ID().PutStr("k8s.node.uid", "abc")
-	event.SetEntityDelete()
+	deleteEvent := event.SetEntityDelete()
+	deleteEvent.SetEntityType("k8s.node")
 
 	actual := slice.At(0)
 
 	assert.Equal(t, EventTypeDelete, actual.EventType())
+	assert.Equal(t, "k8s.node", event.EntityDeleteDetails().EntityType())
 	v, ok := actual.ID().Get("k8s.node.uid")
 	assert.True(t, ok)
 	assert.Equal(t, "abc", v.Str())
@@ -75,7 +77,8 @@ func Test_EntityEventsSlice_ConvertAndMoveToLogs(t *testing.T) {
 
 	event = slice.AppendEmpty()
 	event.ID().PutStr("k8s.node.uid", "abc")
-	event.SetEntityDelete()
+	deleteEvent := event.SetEntityDelete()
+	deleteEvent.SetEntityType("k8s.node")
 
 	// Convert to logs.
 	logs := slice.ConvertAndMoveToLogs()
@@ -112,6 +115,7 @@ func Test_EntityEventsSlice_ConvertAndMoveToLogs(t *testing.T) {
 	assert.Equal(
 		t, map[string]any{
 			semconvOtelEntityEventName: semconvEventEntityEventDelete,
+			semconvOtelEntityType:      "k8s.node",
 			semconvOtelEntityID:        map[string]any{"k8s.node.uid": "abc"},
 		}, attrs,
 	)

--- a/receiver/k8sclusterreceiver/internal/metadata/entities.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/entities.go
@@ -21,7 +21,8 @@ func GetEntityEvents(oldMetadata, newMetadata map[metadataPkg.ResourceID]*Kubern
 			entityEvent := out.AppendEmpty()
 			entityEvent.SetTimestamp(timestamp)
 			entityEvent.ID().PutStr(oldObj.ResourceIDKey, string(oldObj.ResourceID))
-			entityEvent.SetEntityDelete()
+			deleteEvent := entityEvent.SetEntityDelete()
+			deleteEvent.SetEntityType(oldObj.EntityType)
 		}
 	}
 

--- a/receiver/k8sclusterreceiver/internal/metadata/entities.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/entities.go
@@ -21,8 +21,7 @@ func GetEntityEvents(oldMetadata, newMetadata map[metadataPkg.ResourceID]*Kubern
 			entityEvent := out.AppendEmpty()
 			entityEvent.SetTimestamp(timestamp)
 			entityEvent.ID().PutStr(oldObj.ResourceIDKey, string(oldObj.ResourceID))
-			deleteEvent := entityEvent.SetEntityDelete()
-			deleteEvent.SetEntityType(oldObj.EntityType)
+			entityEvent.SetEntityDelete()
 		}
 	}
 


### PR DESCRIPTION
Add missing `otel.entity.type` field to the delete events. The type along with the set of identifying attributes forms an entity identity. So it has to be present in all types of entity events. This change adds new fields to the `EntityDeleteDetails`, but the entity type fields will be moved to the event level in the next PR to avoid redundancy in the API