### PR TITLE
kafkaexporter: Include all kafka producer errors

### DIFF
--- a/.chloggen/f_include-more-kafka-error-details.yaml
+++ b/.chloggen/f_include-more-kafka-error-details.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Include all unique producer error messages in the error message"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [12312]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Before this change, the error message only included the first unique producer error message.
+  Now, it includes all unique producer error messages.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/f_include-more-kafka-error-details.yaml
+++ b/.chloggen/f_include-more-kafka-error-details.yaml
@@ -10,7 +10,7 @@ component: kafkaexporter
 note: "Include all unique producer error messages in the error message"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [12312]
+issues: [40282]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.


### PR DESCRIPTION
#### Description
Updates the kafka exporter error handling to include all the returned unique kafka producer errors, not just the first one.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
No open issue, but I think it was also noticed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38608/files#r2076631211.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests.

<!--Describe the documentation added.-->
#### Documentation

N/A
