### PR TITLE
[exporter/coralogix] Fix missing header causing authentication errors

### DIFF
--- a/.chloggen/40330.yaml
+++ b/.chloggen/40330.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Authorization header not being set in metadata.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40330]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -6,6 +6,7 @@
 | Stability     | [alpha]: profiles   |
 |               | [beta]: traces, metrics, logs   |
 | Distributions | [contrib] |
+| Warnings      | [Authentication issues in v0.127.0](#warnings) |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fcoralogix%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fcoralogix) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fcoralogix%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fcoralogix) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=exporter_coralogix)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=exporter_coralogix&displayType=list) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@povilasv](https://www.github.com/povilasv), [@iblancasa](https://www.github.com/iblancasa), [@douglascamata](https://www.github.com/douglascamata) |
@@ -324,6 +325,28 @@ service:
       receivers: [filelog/nginx, filelog/access-log]
       exporters: [coralogix]
 ```
+
+## Warnings
+### Authentication issues in v0.127.0
+
+Version 0.127.0 introduced a regression in the Coralogix exporter. As a consequence, it requires an updated authentication configuration to ensure proper telemetry data transmission to Coralogix. If you're using this version, please modify your configuration to include the authentication headers as shown below:
+
+```yaml
+coralogix:
+  traces:
+    headers:
+      "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
+  metrics:
+    headers:
+      "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
+  logs:
+    headers:
+      "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
+```
+
+This configuration ensures proper authentication with the Coralogix backend.
+Prior versions (v0.126.0 and earlier) and subsequent versions (v0.128.0 and later) are not affected by this authentication issue.
+
 
 ### Need help?
 

--- a/exporter/coralogixexporter/metadata.yaml
+++ b/exporter/coralogixexporter/metadata.yaml
@@ -8,6 +8,7 @@ status:
   distributions: [contrib]
   codeowners:
     active: [povilasv, iblancasa, douglascamata]
+  warnings: ["Authentication issues in v0.127.0"]
 
 tests:
   config:

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -120,6 +120,10 @@ func (e *signalExporter) startSignalExporter(ctx context.Context, host component
 			signalConfigWrapper.config.Headers = make(map[string]configopaque.String)
 		}
 		signalConfigWrapper.config.Headers["Authorization"] = configopaque.String("Bearer " + string(e.config.PrivateKey))
+
+		for k, v := range signalConfigWrapper.config.Headers {
+			e.metadata.Set(k, string(v))
+		}
 	}
 
 	e.callOptions = []grpc.CallOption{


### PR DESCRIPTION
#### Link to tracking issue
Fixes #40330

#### Testing
- Added new unit tests
- Manual test with the Coralogix backend

Workaround tested with:
```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:4318

exporters:
  coralogix:
    traces:
      headers:
        "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
    metrics:
      headers:
        "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
    logs:
      headers:
        "Authorization": "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
    application_name: otel
    application_name_attributes:
      - service.name
      - k8s.namespace.name
      - service.namespace
    sending_queue:
      enabled: true
      sizer: "items"
      num_consumers: 10
      queue_size: 25000
      batch:
        flush_timeout: 1s
        min_size: 1024
        max_size: 2048
    domain: eu2.coralogix.com
    subsystem_name: k8s-saas
    subsystem_name_attributes:
      - subsystem.name
    private_key: ${env:CORALOGIX_PRIVATE_KEY}

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [coralogix]
    metrics:
      receivers: [otlp]
      exporters: [coralogix]
    logs:
      receivers: [otlp]
      exporters: [coralogix]

```