### PR TITLE
[receiver/statsd] allow customizing `metric_type` attribute name 

### DIFF
--- a/.chloggen/feature_statsdreceiver-custom-metrictype-attr.yaml
+++ b/.chloggen/feature_statsdreceiver-custom-metrictype-attr.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow customizing metric_type attribute name when enable_metric_type=true
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40339]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -34,6 +34,8 @@ The Following settings are optional:
 
 - `enable_metric_type: true`(default value is false): Enable the statsd receiver to be able to emit the metric type(gauge, counter, timer(in the future), histogram(in the future)) as a label.
 
+- `metric_type_attribute`: The name of the attribute that will be added to the metrics if `enable_metric_type` is true. If not set "metric_type" will be used as the attribute name.
+
 - `enable_ip_only_aggregation` (default value is false): Enables metric aggregation on `Client+IP` only. Normally, aggregation is performed on `Client+IP+Port`. This setting is useful when the client sends metrics from a random ports or the receiver should aggregate metrics from the same client but different ports.
 
 - `enable_simple_tags: true`(default value is false): Enable parsing tags that do not have a value, e.g. `#mykey` instead of `#mykey:myvalue`. DogStatsD supports such tagging.

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	EnableMetricType        bool                             `mapstructure:"enable_metric_type"`
 	EnableSimpleTags        bool                             `mapstructure:"enable_simple_tags"`
 	IsMonotonicCounter      bool                             `mapstructure:"is_monotonic_counter"`
+	MetricTypeAttribute     string                           `mapstructure:"metric_type_attribute"`
 	TimerHistogramMapping   []protocol.TimerHistogramMapping `mapstructure:"timer_histogram_mapping"`
 	// Will only be used when transport set to 'unixgram'.
 	SocketPermissions os.FileMode `mapstructure:"socket_permissions"`
@@ -34,6 +35,10 @@ func (c *Config) Validate() error {
 
 	if c.AggregationInterval <= 0 {
 		errs = multierr.Append(errs, errors.New("aggregation_interval must be a positive duration"))
+	}
+
+	if c.EnableMetricType && c.MetricTypeAttribute == "" {
+		errs = multierr.Append(errs, errors.New("metric_type_attribute cannot be set to empty when enable_metric_type is true"))
 	}
 
 	var TimerHistogramMappingMissingObjectName bool

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -44,6 +44,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				SocketPermissions:   0o622,
 				AggregationInterval: 70 * time.Second,
+				EnableMetricType:    false,
+				MetricTypeAttribute: "metric_type",
 				TimerHistogramMapping: []protocol.TimerHistogramMapping{
 					{
 						StatsdType:   "histogram",
@@ -191,6 +193,15 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expectedErr: negativeAggregationIntervalErr,
+		},
+		{
+			name: "emptyMetricTypeAttribute",
+			cfg: &Config{
+				AggregationInterval: 10,
+				EnableMetricType:    true,
+				MetricTypeAttribute: "",
+			},
+			expectedErr: "metric_type_attribute cannot be set to empty when enable_metric_type is true",
 		},
 	}
 

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -20,8 +20,9 @@ import (
 const (
 	defaultBindEndpoint        = "localhost:8125"
 	defaultAggregationInterval = 60 * time.Second
-	defaultEnableMetricType    = false
 	defaultIsMonotonicCounter  = false
+	defaultEnableMetricType    = false
+	defaultMetricTypeAttribute = "metric_type"
 	defaultSocketPermissions   = os.FileMode(0o622)
 )
 
@@ -45,6 +46,7 @@ func createDefaultConfig() component.Config {
 		AggregationInterval:   defaultAggregationInterval,
 		EnableMetricType:      defaultEnableMetricType,
 		IsMonotonicCounter:    defaultIsMonotonicCounter,
+		MetricTypeAttribute:   defaultMetricTypeAttribute,
 		TimerHistogramMapping: defaultTimerHistogramMapping,
 		SocketPermissions:     defaultSocketPermissions,
 	}

--- a/receiver/statsdreceiver/internal/parser/parser.go
+++ b/receiver/statsdreceiver/internal/parser/parser.go
@@ -14,7 +14,7 @@ import (
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
-	Initialize(enableMetricType bool, enableSimpleTags bool, isMonotonicCounter bool, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping) error
+	Initialize(enableSimpleTags bool, isMonotonicCounter bool, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping, metricTypeAttribute string) error
 	GetMetrics() []BatchMetrics
 	Aggregate(line string, addr net.Addr) error
 }

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -303,7 +303,7 @@ func Test_ParseMessageToMetric(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, false, false)
+			got, err := parseMessageToMetric(tt.input, disabledTypeAttribute, false)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
@@ -330,7 +330,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				false,
 				"c", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"counter"},
 				0,
 			),
@@ -344,7 +344,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				false,
 				"c",
 				0.1,
-				[]string{"key", "metric_type"},
+				[]string{"key", defaultTypeAttribute},
 				[]string{"value", "counter"},
 				0,
 			),
@@ -358,7 +358,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				false,
 				"c",
 				0.8,
-				[]string{"key", "metric_type"},
+				[]string{"key", defaultTypeAttribute},
 				[]string{"value", "counter"},
 				0,
 			),
@@ -372,7 +372,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				false,
 				"c",
 				0.8,
-				[]string{"key", "key2", "metric_type"},
+				[]string{"key", "key2", defaultTypeAttribute},
 				[]string{"value", "value2", "counter"},
 				0,
 			),
@@ -385,7 +385,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				false,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -398,7 +398,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				false,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -417,7 +417,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				false,
 				"g",
 				0.1,
-				[]string{"key", "metric_type"},
+				[]string{"key", defaultTypeAttribute},
 				[]string{"value", "gauge"},
 				0,
 			),
@@ -431,7 +431,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				false,
 				"g",
 				0.8,
-				[]string{"key", "key2", "metric_type"},
+				[]string{"key", "key2", defaultTypeAttribute},
 				[]string{"value", "value2", "gauge"},
 				0,
 			),
@@ -444,7 +444,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				true,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -457,7 +457,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				-42,
 				true,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -470,7 +470,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				true,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -483,7 +483,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				-42,
 				true,
 				"g", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"gauge"},
 				0,
 			),
@@ -496,7 +496,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				-42,
 				true,
 				"ms", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"timing"},
 				0,
 			),
@@ -509,7 +509,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				false,
 				"h", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"histogram"},
 				0,
 			),
@@ -522,7 +522,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 				42,
 				false,
 				"d", 0,
-				[]string{"metric_type"},
+				[]string{defaultTypeAttribute},
 				[]string{"distribution"},
 				0,
 			),
@@ -531,7 +531,7 @@ func Test_ParseMessageToMetricWithMetricType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, true, false)
+			got, err := parseMessageToMetric(tt.input, defaultTypeAttribute, false)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
@@ -596,7 +596,7 @@ func Test_ParseMessageToMetricWithSimpleTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseMessageToMetric(tt.input, false, true)
+			got, err := parseMessageToMetric(tt.input, disabledTypeAttribute, true)
 
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
@@ -1050,7 +1050,7 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(false, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+			assert.NoError(t, p.Initialize(false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, disabledTypeAttribute))
 			p.lastIntervalTime = time.Unix(611, 0)
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			addrKey := newNetAddr(addr)
@@ -1103,52 +1103,52 @@ func TestStatsDParser_AggregateByAddress(t *testing.T) {
 			expectedGauges: []map[statsDMetricDescription]pmetric.ScopeMetrics{
 				{
 					testDescription("statsdTestMetric1", "g",
-						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+						[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 						testStatsDMetric(
 							"statsdTestMetric1",
 							10102,
 							false,
 							"g",
 							0,
-							[]string{"mykey", "metric_type"},
+							[]string{"mykey", defaultTypeAttribute},
 							[]string{"myvalue", "gauge"},
 							0,
 						), time.Unix(711, 0)),
 					testDescription("statsdTestMetric2", "g",
-						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+						[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 						testStatsDMetric(
 							"statsdTestMetric2",
 							507,
 							false,
 							"g",
 							0,
-							[]string{"mykey", "metric_type"},
+							[]string{"mykey", defaultTypeAttribute},
 							[]string{"myvalue", "gauge"},
 							0,
 						), time.Unix(711, 0)),
 				},
 				{
 					testDescription("statsdTestMetric1", "g",
-						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+						[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 						testStatsDMetric(
 							"statsdTestMetric1",
 							10102,
 							false,
 							"g",
 							0,
-							[]string{"mykey", "metric_type"},
+							[]string{"mykey", defaultTypeAttribute},
 							[]string{"myvalue", "gauge"},
 							0,
 						), time.Unix(711, 0)),
 					testDescription("statsdTestMetric2", "g",
-						[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+						[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 						testStatsDMetric(
 							"statsdTestMetric2",
 							507,
 							false,
 							"g",
 							0,
-							[]string{"mykey", "metric_type"},
+							[]string{"mykey", defaultTypeAttribute},
 							[]string{"myvalue", "gauge"},
 							0,
 						), time.Unix(711, 0)),
@@ -1159,7 +1159,7 @@ func TestStatsDParser_AggregateByAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(true, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+			assert.NoError(t, p.Initialize(true, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, defaultTypeAttribute))
 			p.lastIntervalTime = time.Unix(611, 0)
 			for i, addr := range tt.addresses {
 				for _, line := range tt.input[i] {
@@ -1180,11 +1180,12 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
-		input            []string
-		expectedGauges   map[statsDMetricDescription]pmetric.ScopeMetrics
-		expectedCounters map[statsDMetricDescription]pmetric.ScopeMetrics
-		err              error
+		name                  string
+		input                 []string
+		expectedGauges        map[statsDMetricDescription]pmetric.ScopeMetrics
+		expectedCounters      map[statsDMetricDescription]pmetric.ScopeMetrics
+		expectedTypeAttribute string
+		err                   error
 	}{
 		{
 			name: "gauge plus",
@@ -1197,35 +1198,35 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 				"statsdTestMetric2:+5|g|#mykey:myvalue",
 				"statsdTestMetric2:+500|g|#mykey:myvalue",
 			},
+			expectedTypeAttribute: defaultTypeAttribute,
 			expectedGauges: map[statsDMetricDescription]pmetric.ScopeMetrics{
 				testDescription("statsdTestMetric1", "g",
-					[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+					[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 					testStatsDMetric(
 						"statsdTestMetric1",
 						10102,
 						false,
 						"g",
 						0,
-						[]string{"mykey", "metric_type"},
+						[]string{"mykey", defaultTypeAttribute},
 						[]string{"myvalue", "gauge"},
 						0,
 					), time.Unix(711, 0)),
 				testDescription("statsdTestMetric2", "g",
-					[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+					[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"}): buildGaugeMetric(
 					testStatsDMetric(
 						"statsdTestMetric2",
 						507,
 						false,
 						"g",
 						0,
-						[]string{"mykey", "metric_type"},
+						[]string{"mykey", defaultTypeAttribute},
 						[]string{"myvalue", "gauge"},
 						0,
 					), time.Unix(711, 0)),
 			},
 			expectedCounters: map[statsDMetricDescription]pmetric.ScopeMetrics{},
 		},
-
 		{
 			name: "counter with increment and sample rate",
 			input: []string{
@@ -1234,29 +1235,107 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricDescription]pmetric.ScopeMetrics{},
+			expectedTypeAttribute: defaultTypeAttribute,
+			expectedGauges:        map[statsDMetricDescription]pmetric.ScopeMetrics{},
 			expectedCounters: map[statsDMetricDescription]pmetric.ScopeMetrics{
 				testDescription("statsdTestMetric1", "c",
-					[]string{"mykey", "metric_type"}, []string{"myvalue", "counter"}): buildCounterMetric(
+					[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "counter"}): buildCounterMetric(
 					testStatsDMetric(
 						"statsdTestMetric1",
 						7000,
 						false,
 						"c",
 						0,
-						[]string{"mykey", "metric_type"},
+						[]string{"mykey", defaultTypeAttribute},
 						[]string{"myvalue", "counter"},
 						0,
 					), false),
 				testDescription("statsdTestMetric2", "c",
-					[]string{"mykey", "metric_type"}, []string{"myvalue", "counter"}): buildCounterMetric(
+					[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "counter"}): buildCounterMetric(
 					testStatsDMetric(
 						"statsdTestMetric2",
 						50,
 						false,
 						"c",
 						0,
-						[]string{"mykey", "metric_type"},
+						[]string{"mykey", defaultTypeAttribute},
+						[]string{"myvalue", "counter"},
+						0,
+					), false),
+			},
+		},
+		{
+			name: "gauge plus - custom attribute",
+			input: []string{
+				"statsdTestMetric1:1|g|#mykey:myvalue",
+				"statsdTestMetric2:2|g|#mykey:myvalue",
+				"statsdTestMetric1:+1|g|#mykey:myvalue",
+				"statsdTestMetric1:+100|g|#mykey:myvalue",
+				"statsdTestMetric1:+10000|g|#mykey:myvalue",
+				"statsdTestMetric2:+5|g|#mykey:myvalue",
+				"statsdTestMetric2:+500|g|#mykey:myvalue",
+			},
+			expectedTypeAttribute: "custom_attribute",
+			expectedGauges: map[statsDMetricDescription]pmetric.ScopeMetrics{
+				testDescription("statsdTestMetric1", "g",
+					[]string{"mykey", "custom_attribute"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+					testStatsDMetric(
+						"statsdTestMetric1",
+						10102,
+						false,
+						"g",
+						0,
+						[]string{"mykey", "custom_attribute"},
+						[]string{"myvalue", "gauge"},
+						0,
+					), time.Unix(711, 0)),
+				testDescription("statsdTestMetric2", "g",
+					[]string{"mykey", "custom_attribute"}, []string{"myvalue", "gauge"}): buildGaugeMetric(
+					testStatsDMetric(
+						"statsdTestMetric2",
+						507,
+						false,
+						"g",
+						0,
+						[]string{"mykey", "custom_attribute"},
+						[]string{"myvalue", "gauge"},
+						0,
+					), time.Unix(711, 0)),
+			},
+			expectedCounters: map[statsDMetricDescription]pmetric.ScopeMetrics{},
+		},
+		{
+			name: "counter with increment and sample rate - custom attribute",
+			input: []string{
+				"statsdTestMetric1:3000|c|#mykey:myvalue",
+				"statsdTestMetric1:4000|c|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+			},
+			expectedTypeAttribute: "custom_attribute",
+			expectedGauges:        map[statsDMetricDescription]pmetric.ScopeMetrics{},
+			expectedCounters: map[statsDMetricDescription]pmetric.ScopeMetrics{
+				testDescription("statsdTestMetric1", "c",
+					[]string{"mykey", "custom_attribute"}, []string{"myvalue", "counter"}): buildCounterMetric(
+					testStatsDMetric(
+						"statsdTestMetric1",
+						7000,
+						false,
+						"c",
+						0,
+						[]string{"mykey", "custom_attribute"},
+						[]string{"myvalue", "counter"},
+						0,
+					), false),
+				testDescription("statsdTestMetric2", "c",
+					[]string{"mykey", "custom_attribute"}, []string{"myvalue", "counter"}): buildCounterMetric(
+					testStatsDMetric(
+						"statsdTestMetric2",
+						50,
+						false,
+						"c",
+						0,
+						[]string{"mykey", "custom_attribute"},
 						[]string{"myvalue", "counter"},
 						0,
 					), false),
@@ -1267,7 +1346,7 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(true, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+			assert.NoError(t, p.Initialize(true, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, tt.expectedTypeAttribute))
 			p.lastIntervalTime = time.Unix(611, 0)
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			addrKey := newNetAddr(addr)
@@ -1337,7 +1416,7 @@ func TestStatsDParser_AggregateWithIsMonotonicCounter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(false, false, true, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+			assert.NoError(t, p.Initialize(false, true, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, disabledTypeAttribute))
 			p.lastIntervalTime = time.Unix(611, 0)
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			addrKey := newNetAddr(addr)
@@ -1464,7 +1543,7 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(false, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "summary"}, {StatsdType: "histogram", ObserverType: "summary", Summary: protocol.SummaryConfig{Percentiles: []float64{0, 95, 99}}}}))
+			assert.NoError(t, p.Initialize(false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "summary"}, {StatsdType: "histogram", ObserverType: "summary", Summary: protocol.SummaryConfig{Percentiles: []float64{0, 95, 99}}}}, disabledTypeAttribute))
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			addrKey := newNetAddr(addr)
 			for _, line := range tt.input {
@@ -1481,7 +1560,8 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 
 func TestStatsDParser_Initialize(t *testing.T) {
 	p := &StatsDParser{}
-	assert.NoError(t, p.Initialize(true, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+	customTypeAttribute := "custom_metric_type"
+	assert.NoError(t, p.Initialize(false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, customTypeAttribute))
 	teststatsdDMetricdescription := statsDMetricDescription{
 		name:       "test",
 		metricType: "g",
@@ -1494,47 +1574,48 @@ func TestStatsDParser_Initialize(t *testing.T) {
 	p.instrumentsByAddress[addrKey] = instrument
 	assert.Len(t, p.instrumentsByAddress, 1)
 	assert.Len(t, p.instrumentsByAddress[addrKey].gauges, 1)
+	assert.Equal(t, customTypeAttribute, p.metricTypeAttribute)
 	assert.Equal(t, protocol.GaugeObserver, p.timerEvents.method)
 	assert.Equal(t, protocol.GaugeObserver, p.histogramEvents.method)
 }
 
 func TestStatsDParser_GetMetricsWithMetricType(t *testing.T) {
 	p := &StatsDParser{}
-	assert.NoError(t, p.Initialize(true, false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}))
+	assert.NoError(t, p.Initialize(false, false, false, []protocol.TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}}, defaultTypeAttribute))
 	instrument := newInstruments(nil)
 	instrument.gauges[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] = buildGaugeMetric(
+		[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"})] = buildGaugeMetric(
 		testStatsDMetric(
 			"testGauge1",
 			1,
 			false,
 			"g",
 			0,
-			[]string{"mykey", "metric_type"},
+			[]string{"mykey", defaultTypeAttribute},
 			[]string{"myvalue", "gauge"},
 			0,
 		), time.Unix(711, 0))
 	instrument.gauges[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"})] = buildGaugeMetric(
+		[]string{"mykey2", defaultTypeAttribute}, []string{"myvalue2", "gauge"})] = buildGaugeMetric(
 		testStatsDMetric(
 			"statsdTestMetric1",
 			10102,
 			false,
 			"g",
 			0,
-			[]string{"mykey2", "metric_type"},
+			[]string{"mykey2", defaultTypeAttribute},
 			[]string{"myvalue2", "gauge"},
 			0,
 		), time.Unix(711, 0))
 	instrument.counters[testDescription("statsdTestMetric1", "g",
-		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] = buildCounterMetric(
+		[]string{"mykey", defaultTypeAttribute}, []string{"myvalue", "gauge"})] = buildCounterMetric(
 		testStatsDMetric(
 			"statsdTestMetric1",
 			10102,
 			false,
 			"g",
 			0,
-			[]string{"mykey", "metric_type"},
+			[]string{"mykey", defaultTypeAttribute},
 			[]string{"myvalue", "gauge"},
 			0,
 		), false)
@@ -1545,7 +1626,7 @@ func TestStatsDParser_GetMetricsWithMetricType(t *testing.T) {
 			false,
 			"ms",
 			0,
-			[]string{"mykey2", "metric_type"},
+			[]string{"mykey2", defaultTypeAttribute},
 			[]string{"myvalue2", "gauge"},
 			0,
 		), time.Unix(711, 0)))
@@ -1613,7 +1694,7 @@ func TestStatsDParser_Mappings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &StatsDParser{}
 
-			assert.NoError(t, p.Initialize(false, false, false, false, tc.mapping))
+			assert.NoError(t, p.Initialize(false, false, false, tc.mapping, disabledTypeAttribute))
 
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			assert.NoError(t, p.Aggregate("H:10|h", addr))
@@ -1646,11 +1727,12 @@ func TestStatsDParser_ScopeIsIncluded(t *testing.T) {
 	}
 	testAddress, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 
-	err := p.Initialize(true, false, false, false,
+	err := p.Initialize(true, false, false,
 		[]protocol.TimerHistogramMapping{
 			{StatsdType: "timer", ObserverType: "summary"},
 			{StatsdType: "histogram", ObserverType: "histogram"},
 		},
+		defaultTypeAttribute,
 	)
 	require.NoError(t, err)
 	require.NoError(t, p.Aggregate("test.metric:1|c", testAddress))
@@ -1915,7 +1997,7 @@ func TestStatsDParser_AggregateTimerWithHistogram(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := &StatsDParser{}
-			assert.NoError(t, p.Initialize(false, false, false, false, tt.mapping))
+			assert.NoError(t, p.Initialize(false, false, false, tt.mapping, disabledTypeAttribute))
 			addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 			for _, line := range tt.input {
 				err = p.Aggregate(line, addr)
@@ -1937,11 +2019,12 @@ func TestStatsDParser_IPOnlyAggregation(t *testing.T) {
 	testAddr01, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
 	testAddr02, _ := net.ResolveUDPAddr("udp", "1.2.3.4:8765")
 
-	err := p.Initialize(true, false, false, true,
+	err := p.Initialize(false, false, true,
 		[]protocol.TimerHistogramMapping{
 			{StatsdType: "timer", ObserverType: "summary"},
 			{StatsdType: "histogram", ObserverType: "histogram"},
 		},
+		defaultTypeAttribute,
 	)
 
 	require.NoError(t, err)

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -108,12 +108,18 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 	r.server = server
 	transferChan := make(chan transport.Metric, 10)
 	ticker := time.NewTicker(r.config.AggregationInterval)
+	metricTypeAttribute := r.config.MetricTypeAttribute
+
+	if !r.config.EnableMetricType {
+		metricTypeAttribute = ""
+	}
+
 	err = r.parser.Initialize(
-		r.config.EnableMetricType,
 		r.config.EnableSimpleTags,
 		r.config.IsMonotonicCounter,
 		r.config.EnableIPOnlyAggregation,
 		r.config.TimerHistogramMapping,
+		metricTypeAttribute,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Currently the receiver allows annotating the `metric_type` by setting `enable_metric_type` to `true`. This attribute might be in use by an application and should be customizable.

This PR introduces a new `metric_type_attribute` which allows using a custom attribute name for users that may be already be using `metric_type` for their metrics.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
No tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a couple of test cases which validate the attribute is set to the custom name, the case where the attribute is unset is already thoroughly tested.

<!--Describe the documentation added.-->
#### Documentation

Documented the new `metric_type_attribute`in the README.me

<!--Please delete paragraphs that you did not use before submitting.-->
