### PR TITLE
[receiver/faro] Ensure http server has shutdown before returning from Shutdown

### DIFF
--- a/.chloggen/wait-on-shutdown-faro.yaml
+++ b/.chloggen/wait-on-shutdown-faro.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/faro
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that the Faro receiver waits for http server shutdown to complete before exiting.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40331]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/faroreceiver/receiver.go
+++ b/receiver/faroreceiver/receiver.go
@@ -128,11 +128,11 @@ func (r *faroReceiver) startHTTPServer(ctx context.Context, host component.Host)
 
 	r.shutdownWg.Add(1)
 	go func() {
+		defer r.shutdownWg.Done()
 		if err := r.serverHTTP.Serve(listener); !errors.Is(err, http.ErrServerClosed) && err != nil {
 			r.settings.Logger.Error("Failed to start HTTP server", zap.Error(err))
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-		r.shutdownWg.Done()
 	}()
 
 	r.settings.Logger.Info("HTTP server started", zap.String("address", r.serverHTTP.Addr))

--- a/receiver/faroreceiver/receiver.go
+++ b/receiver/faroreceiver/receiver.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 
 	faro "github.com/grafana/faro/pkg/go"
 	"go.opentelemetry.io/collector/component"
@@ -56,8 +57,10 @@ func newFaroReceiver(cfg *Config, set *receiver.Settings) (*faroReceiver, error)
 }
 
 type faroReceiver struct {
-	cfg        *Config
+	cfg *Config
+
 	serverHTTP *http.Server
+	shutdownWg sync.WaitGroup
 
 	nextTraces consumer.Traces
 	nextLogs   consumer.Logs
@@ -76,10 +79,13 @@ func (r *faroReceiver) Start(ctx context.Context, host component.Host) error {
 }
 
 func (r *faroReceiver) Shutdown(ctx context.Context) error {
+	var err error
 	if r.serverHTTP != nil {
-		return r.serverHTTP.Shutdown(ctx)
+		err = r.serverHTTP.Shutdown(ctx)
 	}
-	return nil
+
+	r.shutdownWg.Wait()
+	return err
 }
 
 func (r *faroReceiver) RegisterTracesConsumer(tc consumer.Traces) {
@@ -120,11 +126,13 @@ func (r *faroReceiver) startHTTPServer(ctx context.Context, host component.Host)
 		return err
 	}
 
+	r.shutdownWg.Add(1)
 	go func() {
 		if err := r.serverHTTP.Serve(listener); !errors.Is(err, http.ErrServerClosed) && err != nil {
 			r.settings.Logger.Error("Failed to start HTTP server", zap.Error(err))
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
+		r.shutdownWg.Done()
 	}()
 
 	r.settings.Logger.Info("HTTP server started", zap.String("address", r.serverHTTP.Addr))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Use a waitgroup to ensure that the http server has shut down completely before returning in the Shutdown function.
Copied the pattern from the arrowreceiver.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40331

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Not exactly scientific, but I was able to reproduce the CI error locally by hitting 'run test' a bunch of times simultaneously in vscode, confirmed that I couldn't reproduce again with the fix.
