### PR TITLE
configkafka: default compression level to 0

### DIFF
--- a/.chloggen/kafka-default-compression.yaml
+++ b/.chloggen/kafka-default-compression.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Snappy compression codec support for the Kafka exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -196,12 +196,9 @@ type ProducerConfig struct {
 
 func NewDefaultProducerConfig() ProducerConfig {
 	return ProducerConfig{
-		MaxMessageBytes: 1000000,
-		RequiredAcks:    WaitForLocal,
-		Compression:     "none",
-		CompressionParams: configcompression.CompressionParams{
-			Level: configcompression.DefaultCompressionLevel,
-		},
+		MaxMessageBytes:  1000000,
+		RequiredAcks:     WaitForLocal,
+		Compression:      "none",
 		FlushMaxMessages: 0,
 	}
 }

--- a/pkg/kafka/configkafka/config_test.go
+++ b/pkg/kafka/configkafka/config_test.go
@@ -178,9 +178,17 @@ func TestProducerConfig(t *testing.T) {
 				RequiredAcks:    0,
 				Compression:     "zstd",
 				CompressionParams: configcompression.CompressionParams{
-					Level: configcompression.DefaultCompressionLevel,
+					// zero is treated as the codec-specific default
+					Level: 0,
 				},
 				FlushMaxMessages: 2,
+			},
+		},
+		"snappy_compression": {
+			expected: ProducerConfig{
+				MaxMessageBytes: 1000000,
+				RequiredAcks:    1,
+				Compression:     "snappy",
 			},
 		},
 		"invalid_compression_level": {

--- a/pkg/kafka/configkafka/testdata/producer_config.yaml
+++ b/pkg/kafka/configkafka/testdata/producer_config.yaml
@@ -11,6 +11,8 @@ kafka/default_compression_level:
   required_acks: 0
   compression: zstd
   flush_max_messages: 2
+kafka/snappy_compression:
+  compression: snappy
 kafka/invalid_compression_level:
   max_message_bytes: 1
   required_acks: 0


### PR DESCRIPTION
#### Description

Use 0 as the default compression level, similar to confighttp. For codecs that support a level this is then converted to the codec-specific default. Without this change, compression level validation always fails for snappy.

#### Link to tracking issue

Fixes #40288

#### Testing

- Added unit tests / test cases
- Verified default for Snappy works

#### Documentation

None