### PR TITLE
[chore] Add Andrew Wilkins as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/open-telemetry/teams/collector-contrib-triagers))
 
+- [Andrew Wilkins](https://github.com/axw), Elastic
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace
 - [Israel Blancas](https://github.com/iblancasa), Coralogix


### PR DESCRIPTION
This PR proposes to promote Andrew Wilkins as a triager for this repository.

Andrew has been active and his input has helped many PRs in the past months. He is also a regular attendee of APAC SIG meetings, where he has helped community members.

Andrew has agreed to take this additional responsibility (@axw please comment and confirm you are still open to this proposal), and has cautioned that this is an additional workload that might prove a challenge given his many commitments. This is understood by maintainers, and as all work on open source, it is based on a voluntary basis and we are grateful for any help.