### PR TITLE
[chore][receiver/sqlquery] Update README datasource documentation

### DIFF
--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -30,11 +30,14 @@ The configuration supports the following top-level fields:
 - `datasource`(required): The datasource value passed to [sql.Open](https://pkg.go.dev/database/sql#Open). This is
   a driver-specific string usually consisting of at least a database name and connection information. This is sometimes
   referred to as the "connection string" in driver documentation. Examples:
-  - [postgres](https://github.com/lib/pq) - `host=localhost port=5432 user=username password=user_password sslmode=disable`
+  - [hdb](github.com/SAP/go-hdb) - `hdb://<USER>:<PASSWORD>@something.hanacloud.ondemand.com:443?TLSServerName=something.hanacloud.ondemand.com`
   - [mysql](https://github.com/go-sql-driver/mysql) - `username:user_password@tcp(localhost:3306)/db_name`
   - [oracle](https://github.com/sijms/go-ora) - `oracle://username:user_password@localhost:1521/FREEPDB1`
-  - [sqlserver](https://github.com/go-sql-driver/mysql) - `sqlserver://username:user_password@localhost:1433?database=db_name`
-  - [sapAse](https://github.com/thda/tds) - `tds://username:user_password@localhost:5000/db_name`
+  - [postgres](https://github.com/lib/pq) - `host=localhost port=5432 user=username password=user_password sslmode=disable`
+  - [snowflake](github.com/snowflakedb/gosnowflake) - `username[:password]@<account_identifier>/dbname/schemaname[?param1=value&...&paramN=valueN]`
+  - [sqlserver](github.com/microsoft/go-mssqldb) - `sqlserver://username:user_password@localhost:1433?database=db_name`
+  - [tds](https://github.com/thda/tds) - `tds://username:user_password@localhost:5000/db_name`
+
 - `queries`(required): A list of queries, where a query is a sql statement and one or more `logs` and/or `metrics` sections (details below).
 - `collection_interval`(optional): The time interval between query executions. Defaults to _10s_.
 - `storage` (optional, default `""`): The ID of a [storage][storage_extension] extension to be used to [track processed results](#tracking-processed-results).

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -30,12 +30,12 @@ The configuration supports the following top-level fields:
 - `datasource`(required): The datasource value passed to [sql.Open](https://pkg.go.dev/database/sql#Open). This is
   a driver-specific string usually consisting of at least a database name and connection information. This is sometimes
   referred to as the "connection string" in driver documentation. Examples:
-  - [hdb](github.com/SAP/go-hdb) - `hdb://<USER>:<PASSWORD>@something.hanacloud.ondemand.com:443?TLSServerName=something.hanacloud.ondemand.com`
+  - [hdb](https://github.com/SAP/go-hdb) - `hdb://<USER>:<PASSWORD>@something.hanacloud.ondemand.com:443?TLSServerName=something.hanacloud.ondemand.com`
   - [mysql](https://github.com/go-sql-driver/mysql) - `username:user_password@tcp(localhost:3306)/db_name`
   - [oracle](https://github.com/sijms/go-ora) - `oracle://username:user_password@localhost:1521/FREEPDB1`
   - [postgres](https://github.com/lib/pq) - `host=localhost port=5432 user=username password=user_password sslmode=disable`
-  - [snowflake](github.com/snowflakedb/gosnowflake) - `username[:password]@<account_identifier>/dbname/schemaname[?param1=value&...&paramN=valueN]`
-  - [sqlserver](github.com/microsoft/go-mssqldb) - `sqlserver://username:user_password@localhost:1433?database=db_name`
+  - [snowflake](https://github.com/snowflakedb/gosnowflake) - `username[:password]@<account_identifier>/dbname/schemaname[?param1=value&...&paramN=valueN]`
+  - [sqlserver](https://github.com/microsoft/go-mssqldb) - `sqlserver://username:user_password@localhost:1433?database=db_name`
   - [tds](https://github.com/thda/tds) - `tds://username:user_password@localhost:5000/db_name`
 
 - `queries`(required): A list of queries, where a query is a sql statement and one or more `logs` and/or `metrics` sections (details below).


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This is a documentation-only change, filling out the `datasource` config option examples section of the README to have an example for each DB driver. Driver links are taken from [go.mod](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c08a5c55a6035fa4519d0ee3578ee496bf8480f3/receiver/sqlqueryreceiver/go.mod#L26).

This also fixes the link for the SQL Server driver.