### PR TITLE
[cmd/opampsupervisor] Use `service.telemetry` configs for supervisor telemetry

### DIFF
--- a/.chloggen/supervisor-use-telemetry-structs.yaml
+++ b/.chloggen/supervisor-use-telemetry-structs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use service.telemetry structs for the supervisor's own telemetry.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40375]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -15,13 +15,11 @@ import (
 	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/service/telemetry"
-	config "go.opentelemetry.io/contrib/otelconf/v0.3.0"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -227,26 +225,11 @@ type AgentDescription struct {
 }
 
 type Telemetry struct {
-	// TODO: Add more telemetry options
-	// Issue here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35582
-	Logs    Logs                   `mapstructure:"logs"`
-	Metrics Metrics                `mapstructure:"metrics"`
-	Traces  telemetry.TracesConfig `mapstructure:"traces"`
+	Logs    telemetry.LogsConfig    `mapstructure:"logs"`
+	Metrics telemetry.MetricsConfig `mapstructure:"metrics"`
+	Traces  telemetry.TracesConfig  `mapstructure:"traces"`
 
 	Resource map[string]*string `mapstructure:"resource"`
-}
-
-type Logs struct {
-	Level       zapcore.Level `mapstructure:"level"`
-	OutputPaths []string      `mapstructure:"output_paths"`
-	// Processors allow configuration of log record processors to emit logs to
-	// any number of supported backends.
-	Processors []config.LogRecordProcessor `mapstructure:"processors,omitempty"`
-}
-
-type Metrics struct {
-	Level   configtelemetry.Level `mapstructure:"level"`
-	Readers []config.MetricReader `mapstructure:"readers"`
 }
 
 // DefaultSupervisor returns the default supervisor config
@@ -287,7 +270,7 @@ func DefaultSupervisor() Supervisor {
 			PassthroughLogs:         false,
 		},
 		Telemetry: Telemetry{
-			Logs: Logs{
+			Logs: telemetry.LogsConfig{
 				Level:       zapcore.InfoLevel,
 				OutputPaths: []string{"stderr"},
 			},

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/service/telemetry"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -583,7 +584,7 @@ telemetry:
 						PassthroughLogs:         true,
 					},
 					Telemetry: Telemetry{
-						Logs: Logs{
+						Logs: telemetry.LogsConfig{
 							Level:       zapcore.WarnLevel,
 							OutputPaths: []string{"stdout"},
 						},

--- a/cmd/opampsupervisor/supervisor/telemetry/logger.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/logger.go
@@ -4,12 +4,11 @@
 package telemetry
 
 import (
+	"go.opentelemetry.io/collector/service/telemetry"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 )
 
-func NewLogger(cfg config.Logs) (*zap.Logger, error) {
+func NewLogger(cfg telemetry.LogsConfig) (*zap.Logger, error) {
 	zapCfg := zap.NewProductionConfig()
 
 	zapCfg.Level = zap.NewAtomicLevelAt(cfg.Level)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
For configuring the supervisor's own telemetry, we've been using the same fields and types as the structs found in "go.opentelemetry.io/collector/service/telemetry" (i.e. what the collector also uses) but not the actual structs themselves (except for Traces).

This updates the Logs and Metrics sections to use their respective config structs. This should not cause any breaking changes because the types and field names are the same.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
