### PR TITLE
[receiver/prometheusreceiver]: Allow to configure EnableCreatedTimest…

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
+	// EnableCreatedTimestampZeroIngestion - enables TODO!
+	EnableCreatedTimestampZeroIngestion bool `mapstructure:"enable_created_timestamp_zero_ingestion"`
+
 	// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
 	ReportExtraScrapeMetrics bool `mapstructure:"report_extra_scrape_metrics"`
 

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -120,6 +120,20 @@ func TestValidateConfigWithScrapeConfigFiles(t *testing.T) {
 	require.NoError(t, xconfmap.Validate(cfg))
 }
 
+func TestValidateConfigEnableCreatedTimestampZeroIngestion(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config_enable_created_timestamp_zero_ingestion.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
+	require.NoError(t, err)
+	require.NoError(t, sub.Unmarshal(cfg))
+
+	require.NoError(t, xconfmap.Validate(cfg))
+	assert.False(t, cfg.(*Config).EnableCreatedTimestampZeroIngestion)
+}
+
 func TestLoadConfigFailsOnUnknownSection(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "invalid-config-section.yaml"))
 	require.NoError(t, err)

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -53,6 +53,7 @@ func createDefaultConfig() component.Config {
 		PrometheusConfig: &PromConfig{
 			GlobalConfig: promconfig.DefaultGlobalConfig,
 		},
+		EnableCreatedTimestampZeroIngestion: true,
 	}
 }
 

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -190,7 +190,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, logger *slog.L
 		HTTPClientOptions: []commonconfig.HTTPClientOption{
 			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
 		},
-		EnableCreatedTimestampZeroIngestion: true,
+		EnableCreatedTimestampZeroIngestion: r.cfg.EnableCreatedTimestampZeroIngestion,
 	}
 
 	if enableNativeHistogramsGate.IsEnabled() {

--- a/receiver/prometheusreceiver/testdata/config_enable_created_timestamp_zero_ingestion.yaml
+++ b/receiver/prometheusreceiver/testdata/config_enable_created_timestamp_zero_ingestion.yaml
@@ -1,0 +1,5 @@
+prometheus:
+  enable_created_timestamp_zero_ingestion: false
+  config:
+      scrape_config_files:
+        - ./testdata/scrape-config.yaml


### PR DESCRIPTION
Allow to configure EnableCreatedTimestampZeroIngestion in prometheus receiver

#### Description

This PR fixes a perfomance regression described [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40379)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [40379](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40379)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Configuration tests.

<!--Describe the documentation added.-->
#### Documentation

not applicable
