### PR TITLE
Support `num_workers` when `batcher::enabled`: true

### DIFF
--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -202,7 +202,6 @@ func (s *syncBulkIndexerSession) Add(ctx context.Context, index string, docID st
 	case s.s.items <- doc:
 		return nil
 	}
-
 }
 
 // End is a no-op.

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -136,7 +136,14 @@ func (s *syncBulkIndexer) StartSession(ctx context.Context) bulkIndexerSession {
 
 	s.wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
-		bulkIndexer, _ := docappender.NewBulkIndexer(s.bulkIndexerCfg)
+		bulkIndexer, err := docappender.NewBulkIndexer(s.bulkIndexerCfg)
+		if err != nil {
+			// This should never happen in practice:
+			// NewBulkIndexer should only fail if the
+			// config is invalid, and we expect it to
+			// always be valid at this point.
+			return errBulkIndexerSession{err: err}
+		}
 		worker := &syncBulkIndexerWorker{
 			indexer:               bulkIndexer,
 			items:                 s.items,
@@ -204,7 +211,7 @@ func (s *syncBulkIndexerSession) End() {
 }
 
 // Flush flushes documents added to the bulk indexer session.
-func (s *syncBulkIndexerSession) Flush(ctx context.Context) error {
+func (s *syncBulkIndexerSession) Flush(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds support for `num_workers` configuration when `batcher::enabled` is true.
Previously, it was only supported when batcher was disabled (a.k.a asynchronous indexing)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
TODO

<!--Describe the documentation added.-->
#### Documentation
TODO

<!--Please delete paragraphs that you did not use before submitting.-->
