### PR TITLE
[chore] [resourcedetection] Remove imds client retry settings from EKS detector

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -380,23 +380,6 @@ In this example, the env variable `K8S_NODE_NAME` will hold the actual node name
                 fieldPath: spec.nodeName
 ```
 
-#### IMDS client 
-These options are available to configure the IMDS client:
-
-- `max_attempts`: The maximum number of attempts to make when calling the IMDS endpoint. The default is 3.
-- `max_backoff`: The maximum backoff time to use when retrying a request. The default is 20 seconds.
-
-```yaml
-processors:
-  resourcedetection/eks:
-    detectors: [eks]
-    timeout: 15s
-    override: false
-    eks:
-      max_attempts: 10
-      max_backoff: 5m
-```
-
 ### AWS Lambda
 
 Uses the AWS Lambda [runtime environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)

--- a/processor/resourcedetectionprocessor/internal/aws/eks/config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/config.go
@@ -4,24 +4,16 @@
 package eks // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/eks"
 
 import (
-	"time"
-
-	"github.com/aws/aws-sdk-go-v2/aws/retry"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/eks/internal/metadata"
 )
 
 type Config struct {
 	ResourceAttributes metadata.ResourceAttributesConfig `mapstructure:"resource_attributes"`
 	NodeFromEnvVar     string                            `mapstructure:"node_from_env_var"`
-	MaxAttempts        int                               `mapstructure:"max_attempts"`
-	MaxBackoff         time.Duration                     `mapstructure:"max_backoff"`
 }
 
 func CreateDefaultConfig() Config {
 	return Config{
 		ResourceAttributes: metadata.DefaultResourceAttributesConfig(),
-		MaxBackoff:         retry.DefaultMaxBackoff,
-		MaxAttempts:        retry.DefaultMaxAttempts,
 	}
 }

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
@@ -196,16 +196,13 @@ func (e eksDetectorUtils) getAWSConfig(ctx context.Context, checkAccess bool) (a
 		return aws.Config{}, err
 	}
 
-	maxAttempts := e.cfg.MaxAttempts
 	if checkAccess {
-		maxAttempts = imdsCheckMaxRetry
+		awsConfig.Retryer = func() aws.Retryer {
+			return retry.NewStandard(func(options *retry.StandardOptions) {
+				options.MaxAttempts = imdsCheckMaxRetry
+			})
+		}
 	}
 
-	awsConfig.Retryer = func() aws.Retryer {
-		return retry.NewStandard(func(options *retry.StandardOptions) {
-			options.MaxAttempts = maxAttempts
-			options.MaxBackoff = e.cfg.MaxBackoff
-		})
-	}
 	return awsConfig, nil
 }

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -366,8 +366,6 @@ func (m *mockDetectorUtils) getAWSConfig(_ context.Context, _ bool) (aws.Config,
 func TestDetect(t *testing.T) {
 	// Minimal config for detector
 	cfg := Config{
-		MaxAttempts: 2,
-		MaxBackoff:  0,
 		ResourceAttributes: metadata.ResourceAttributesConfig{
 			K8sClusterName: metadata.ResourceAttributeConfig{Enabled: true},
 			HostName:       metadata.ResourceAttributeConfig{Enabled: true},


### PR DESCRIPTION

#### Description
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40205
As part of the original PR review, we decided to not include the imds client's retry settings
