### PR TITLE
[cmd/opampsupervisor] chore: Store RemoteConfigStatus in persistent state

### DIFF
--- a/.chloggen/supervisor-persistently-stores-remotecfgstatus.yaml
+++ b/.chloggen/supervisor-persistently-stores-remotecfgstatus.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Supervisor now persists the remote config status to disk. This allows more accurate reporting of the remote config status. Also reports healthy status when not running the agent due to empty config (previous performance optimization).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40467]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -457,7 +457,6 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 
 	// create server
 	var agentConfig atomic.Value
-	var remoteConfigStatus atomic.Value
 	server := newOpAMPServer(
 		t,
 		defaultConnectingHandler,
@@ -468,9 +467,6 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 					if config != nil {
 						agentConfig.Store(string(config.Body))
 					}
-				}
-				if message.RemoteConfigStatus != nil {
-					remoteConfigStatus.Store(message.RemoteConfigStatus)
 				}
 				return &protobufs.ServerToAgent{}
 			},
@@ -501,12 +497,6 @@ func TestSupervisorStartsCollectorWithRemoteConfigAndExecParams(t *testing.T) {
 	defer s.Shutdown()
 
 	waitForSupervisorConnection(server.supervisorConnected, true)
-
-	// verify that the supervisor reports the remote config as applied and the correct hash
-	require.Eventually(t, func() bool {
-		status := remoteConfigStatus.Load().(*protobufs.RemoteConfigStatus)
-		return status != nil && status.Status == protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED && bytes.Equal(status.LastRemoteConfigHash, hash)
-	}, 20*time.Second, 500*time.Millisecond, "Remote config status never became applied")
 
 	for _, port := range []int{healthcheckPort, secondHealthcheckPort} {
 		require.Eventually(t, func() bool {
@@ -1364,6 +1354,7 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 	tempDir := t.TempDir()
 
 	var agentConfig atomic.Value
+	var initialRemoteConfigStatus atomic.Value
 	initialServer := newOpAMPServer(
 		t,
 		defaultConnectingHandler,
@@ -1375,6 +1366,9 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 						agentConfig.Store(string(config.Body))
 					}
 				}
+				if message.RemoteConfigStatus != nil {
+					initialRemoteConfigStatus.Store(message.RemoteConfigStatus)
+				}
 				return &protobufs.ServerToAgent{}
 			},
 		})
@@ -1385,16 +1379,16 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 
 	waitForSupervisorConnection(initialServer.supervisorConnected, true)
 
-	cfg, hash, _, _ := createSimplePipelineCollectorConf(t)
+	simplePipelineCFG, simplePipelineHash, _, _ := createSimplePipelineCollectorConf(t)
 
 	initialServer.sendToSupervisor(&protobufs.ServerToAgent{
 		RemoteConfig: &protobufs.AgentRemoteConfig{
 			Config: &protobufs.AgentConfigMap{
 				ConfigMap: map[string]*protobufs.AgentConfigFile{
-					"": {Body: cfg.Bytes()},
+					"": {Body: simplePipelineCFG.Bytes()},
 				},
 			},
-			ConfigHash: hash,
+			ConfigHash: simplePipelineHash,
 		},
 	})
 
@@ -1404,10 +1398,17 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 		return err == nil
 	}, 5*time.Second, 250*time.Millisecond, "Config file was not written to persistent storage directory")
 
+	// wait for remote config status to be applied
+	require.Eventually(t, func() bool {
+		status := initialRemoteConfigStatus.Load().(*protobufs.RemoteConfigStatus)
+		return status != nil && status.Status == protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED && bytes.Equal(status.LastRemoteConfigHash, simplePipelineHash)
+	}, 20*time.Second, 500*time.Millisecond, "Initial remote config never became applied")
+
 	agentConfig.Store("")
 	s.Shutdown()
 	initialServer.shutdown()
 
+	var remoteConfigStatus atomic.Value
 	newServer := newOpAMPServer(
 		t,
 		defaultConnectingHandler,
@@ -1418,6 +1419,9 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 					if config != nil {
 						agentConfig.Store(string(config.Body))
 					}
+				}
+				if message.RemoteConfigStatus != nil {
+					remoteConfigStatus.Store(message.RemoteConfigStatus)
 				}
 				return &protobufs.ServerToAgent{}
 			},
@@ -1434,6 +1438,12 @@ func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
 	newServer.sendToSupervisor(&protobufs.ServerToAgent{
 		Flags: uint64(protobufs.ServerToAgentFlags_ServerToAgentFlags_ReportFullState),
 	})
+
+	// verify that the supervisor reports the existing remote config status
+	require.Eventually(t, func() bool {
+		status := remoteConfigStatus.Load().(*protobufs.RemoteConfigStatus)
+		return status != nil && status.Status == protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED && bytes.Equal(status.LastRemoteConfigHash, simplePipelineHash)
+	}, 20*time.Second, 500*time.Millisecond, "Remote config status never became applied")
 
 	// Check that the new Supervisor instance starts with the configuration from the last received remote config
 	require.Eventually(t, func() bool {

--- a/cmd/opampsupervisor/supervisor/persistence.go
+++ b/cmd/opampsupervisor/supervisor/persistence.go
@@ -78,10 +78,10 @@ func (p *persistentState) writeState() error {
 // loadOrCreatePersistentState attempts to load the persistent state from disk. If it doesn't
 // exist, a new persistent state file is created.
 func loadOrCreatePersistentState(file string, logger *zap.Logger) (*persistentState, error) {
-	state, err := loadPersistentState(file)
+	state, err := loadPersistentState(file, logger)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return createNewPersistentState(file)
+		return createNewPersistentState(file, logger)
 	case err != nil:
 		return nil, err
 	default:
@@ -89,7 +89,7 @@ func loadOrCreatePersistentState(file string, logger *zap.Logger) (*persistentSt
 	}
 }
 
-func loadPersistentState(file string) (*persistentState, error) {
+func loadPersistentState(file string, logger *zap.Logger) (*persistentState, error) {
 	var state *persistentState
 
 	by, err := os.ReadFile(file)
@@ -102,11 +102,12 @@ func loadPersistentState(file string) (*persistentState, error) {
 	}
 
 	state.configPath = file
+	state.logger = logger
 
 	return state, nil
 }
 
-func createNewPersistentState(file string) (*persistentState, error) {
+func createNewPersistentState(file string, logger *zap.Logger) (*persistentState, error) {
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, err
@@ -115,6 +116,7 @@ func createNewPersistentState(file string) (*persistentState, error) {
 	p := &persistentState{
 		InstanceID: id,
 		configPath: file,
+		logger:     logger,
 	}
 
 	return p, p.writeState()

--- a/cmd/opampsupervisor/supervisor/persistence.go
+++ b/cmd/opampsupervisor/supervisor/persistence.go
@@ -4,25 +4,66 @@
 package supervisor
 
 import (
+	"encoding/hex"
 	"errors"
 	"os"
 
 	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
 // persistentState represents persistent state for the supervisor
 type persistentState struct {
-	InstanceID uuid.UUID `yaml:"instance_id"`
+	InstanceID             uuid.UUID           `yaml:"instance_id"`
+	LastRemoteConfigStatus *RemoteConfigStatus `yaml:"last_remote_config_status"`
 
 	// Path to the config file that the state should be saved to.
 	// This is not marshaled.
-	configPath string `yaml:"-"`
+	configPath string      `yaml:"-"`
+	logger     *zap.Logger `yaml:"-"`
+}
+
+// RemoteConfigStatus is a custom struct that is used to marshal/unmarshal the remote config status.
+// LastRemoteConfigHash is a hex encoded string of the last remote config hash for human readability.
+type RemoteConfigStatus struct {
+	// Status is the status of the last remote config.
+	Status protobufs.RemoteConfigStatuses `yaml:"status"`
+	// LastRemoteConfigHash is a hex encoded string of the last remote config hash for human readability.
+	LastRemoteConfigHash string `yaml:"last_remote_config_hash"`
+	// ErrorMessage is the error message of the last remote config.
+	ErrorMessage string `yaml:"error_message"`
 }
 
 func (p *persistentState) SetInstanceID(id uuid.UUID) error {
 	p.InstanceID = id
 	return p.writeState()
+}
+
+func (p *persistentState) SetLastRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	p.LastRemoteConfigStatus = &RemoteConfigStatus{
+		Status:               status.Status,
+		LastRemoteConfigHash: hex.EncodeToString(status.LastRemoteConfigHash),
+		ErrorMessage:         status.ErrorMessage,
+	}
+	return p.writeState()
+}
+
+func (p *persistentState) GetLastRemoteConfigStatus() *protobufs.RemoteConfigStatus {
+	if p.LastRemoteConfigStatus == nil {
+		return nil
+	}
+	lastRemoteConfigHash, err := hex.DecodeString(p.LastRemoteConfigStatus.LastRemoteConfigHash)
+	if err != nil {
+		p.logger.Error("Failed to decode last remote config hash, returning empty status", zap.Error(err))
+		return nil
+	}
+	return &protobufs.RemoteConfigStatus{
+		Status:               p.LastRemoteConfigStatus.Status,
+		LastRemoteConfigHash: lastRemoteConfigHash,
+		ErrorMessage:         p.LastRemoteConfigStatus.ErrorMessage,
+	}
 }
 
 func (p *persistentState) writeState() error {
@@ -36,7 +77,7 @@ func (p *persistentState) writeState() error {
 
 // loadOrCreatePersistentState attempts to load the persistent state from disk. If it doesn't
 // exist, a new persistent state file is created.
-func loadOrCreatePersistentState(file string) (*persistentState, error) {
+func loadOrCreatePersistentState(file string, logger *zap.Logger) (*persistentState, error) {
 	state, err := loadPersistentState(file)
 	switch {
 	case errors.Is(err, os.ErrNotExist):

--- a/cmd/opampsupervisor/supervisor/persistence_test.go
+++ b/cmd/opampsupervisor/supervisor/persistence_test.go
@@ -4,36 +4,54 @@
 package supervisor
 
 import (
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestCreateOrLoadPersistentState(t *testing.T) {
 	t.Run("Creates a new state file if it does not exist", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "state.yaml")
-		state, err := loadOrCreatePersistentState(f)
+		state, err := loadOrCreatePersistentState(f, zap.NewNop())
 		require.NoError(t, err)
 
-		// instance ID should be populated
+		// instance ID should be populated && remote config status should be nil
 		require.NotEqual(t, uuid.Nil, state.InstanceID)
+		require.Nil(t, state.LastRemoteConfigStatus)
 		require.FileExists(t, f)
 	})
 
 	t.Run("loads state from file if it exists", func(t *testing.T) {
 		f := filepath.Join(t.TempDir(), "state.yaml")
 
-		err := os.WriteFile(f, []byte(`instance_id: "018feed6-905b-7aa6-ba37-b0eec565de03"`), 0o600)
+		lastRemoteConfigHash, err := hex.DecodeString("259ac3f596a87e6b8ca3b431908ac237ed8ae86128274da7911fcbedb93186a3")
 		require.NoError(t, err)
 
-		state, err := loadOrCreatePersistentState(f)
+		err = os.WriteFile(f, []byte(`
+instance_id: "018feed6-905b-7aa6-ba37-b0eec565de03"
+last_remote_config_status:
+  status: 3
+  last_remote_config_hash: 259ac3f596a87e6b8ca3b431908ac237ed8ae86128274da7911fcbedb93186a3
+  error_message: "test error message"`), 0o600)
+
+		require.NoError(t, err)
+
+		state, err := loadOrCreatePersistentState(f, zap.NewNop())
 		require.NoError(t, err)
 
 		// instance ID should be populated with value from file
 		require.Equal(t, uuid.MustParse("018feed6-905b-7aa6-ba37-b0eec565de03"), state.InstanceID)
+		require.Equal(t, &protobufs.RemoteConfigStatus{
+			Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
+			LastRemoteConfigHash: lastRemoteConfigHash,
+			ErrorMessage:         "test error message",
+		}, state.GetLastRemoteConfigStatus())
 		require.FileExists(t, f)
 	})
 }
@@ -58,4 +76,32 @@ func TestPersistentState_SetInstanceID(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, newUUID, loadedState.InstanceID)
+}
+
+func TestPersistentState_SetLastRemoteConfigStatus(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "state.yaml")
+	state, err := createNewPersistentState(f)
+	require.NoError(t, err)
+
+	require.Nil(t, state.LastRemoteConfigStatus)
+	require.FileExists(t, f)
+
+	lastRemoteConfigHash, err := hex.DecodeString("259ac3f596a87e6b8ca3b431908ac237ed8ae86128274da7911fcbedb93186a3")
+	require.NoError(t, err)
+
+	err = state.SetLastRemoteConfigStatus(&protobufs.RemoteConfigStatus{
+		Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
+		LastRemoteConfigHash: lastRemoteConfigHash,
+	})
+	require.NoError(t, err)
+
+	// Test that loading the state after setting the last remote config status has the new status
+	loadedState, err := loadPersistentState(f)
+	require.NoError(t, err)
+
+	require.Equal(t, &protobufs.RemoteConfigStatus{
+		Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
+		LastRemoteConfigHash: lastRemoteConfigHash,
+	}, loadedState.GetLastRemoteConfigStatus())
+	require.FileExists(t, f)
 }

--- a/cmd/opampsupervisor/supervisor/persistence_test.go
+++ b/cmd/opampsupervisor/supervisor/persistence_test.go
@@ -58,7 +58,7 @@ last_remote_config_status:
 
 func TestPersistentState_SetInstanceID(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "state.yaml")
-	state, err := createNewPersistentState(f)
+	state, err := createNewPersistentState(f, zap.NewNop())
 	require.NoError(t, err)
 
 	// instance ID should be populated
@@ -72,7 +72,7 @@ func TestPersistentState_SetInstanceID(t *testing.T) {
 	require.Equal(t, newUUID, state.InstanceID)
 
 	// Test that loading the state after setting the instance ID has the new instance ID
-	loadedState, err := loadPersistentState(f)
+	loadedState, err := loadPersistentState(f, zap.NewNop())
 	require.NoError(t, err)
 
 	require.Equal(t, newUUID, loadedState.InstanceID)
@@ -80,7 +80,7 @@ func TestPersistentState_SetInstanceID(t *testing.T) {
 
 func TestPersistentState_SetLastRemoteConfigStatus(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "state.yaml")
-	state, err := createNewPersistentState(f)
+	state, err := createNewPersistentState(f, zap.NewNop())
 	require.NoError(t, err)
 
 	require.Nil(t, state.LastRemoteConfigStatus)
@@ -96,7 +96,7 @@ func TestPersistentState_SetLastRemoteConfigStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that loading the state after setting the last remote config status has the new status
-	loadedState, err := loadPersistentState(f)
+	loadedState, err := loadPersistentState(f, zap.NewNop())
 	require.NoError(t, err)
 
 	require.Equal(t, &protobufs.RemoteConfigStatus{

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -303,7 +303,7 @@ func initTelemetrySettings(logger *zap.Logger, cfg config.Telemetry) (telemetryS
 
 func (s *Supervisor) Start() error {
 	var err error
-	s.persistentState, err = loadOrCreatePersistentState(s.persistentStateFilePath())
+	s.persistentState, err = loadOrCreatePersistentState(s.persistentStateFilePath(), s.telemetrySettings.Logger)
 	if err != nil {
 		return err
 	}
@@ -625,24 +625,13 @@ func (s *Supervisor) startOpAMPClient() error {
 		return fmt.Errorf("unsupported scheme in server endpoint: %q", parsedURL.Scheme)
 	}
 
-	// load the remote config, this is needed for start settings
-	s.loadRemoteConfig()
-
 	s.telemetrySettings.Logger.Debug("Connecting to OpAMP server...", zap.String("endpoint", s.config.Server.Endpoint), zap.Any("headers", s.config.Server.Headers))
 	settings := types.StartSettings{
-		OpAMPServerURL: s.config.Server.Endpoint,
-		Header:         s.config.Server.Headers,
-		TLSConfig:      tlsConfig,
-		InstanceUid:    types.InstanceUid(s.persistentState.InstanceID),
-		RemoteConfigStatus: func() *protobufs.RemoteConfigStatus {
-			if s.remoteConfig != nil {
-				return &protobufs.RemoteConfigStatus{
-					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
-					LastRemoteConfigHash: s.remoteConfig.GetConfigHash(),
-				}
-			}
-			return nil
-		}(),
+		OpAMPServerURL:     s.config.Server.Endpoint,
+		Header:             s.config.Server.Headers,
+		TLSConfig:          tlsConfig,
+		InstanceUid:        types.InstanceUid(s.persistentState.InstanceID),
+		RemoteConfigStatus: s.persistentState.GetLastRemoteConfigStatus(),
 		Callbacks: types.Callbacks{
 			OnConnect: func(_ context.Context) {
 				s.telemetrySettings.Logger.Info("Connected to the server.")
@@ -1058,53 +1047,18 @@ func (s *Supervisor) composeAgentConfigFiles() []byte {
 	return b
 }
 
-func (s *Supervisor) loadRemoteConfig() {
-	var lastRecvRemoteConfig []byte
-	var err error
-
-	if s.config.Capabilities.AcceptsRemoteConfig {
-		// Try to load the last received remote config if it exists.
-		lastRecvRemoteConfig, err = os.ReadFile(filepath.Join(s.config.Storage.Directory, lastRecvRemoteConfigFile))
-		switch {
-		case err == nil:
-			config := &protobufs.AgentRemoteConfig{}
-			err = proto.Unmarshal(lastRecvRemoteConfig, config)
-			if err != nil {
-				s.telemetrySettings.Logger.Error("Cannot parse last received remote config", zap.Error(err))
-			} else {
-				s.remoteConfig = config
-			}
-		case errors.Is(err, os.ErrNotExist):
-			s.telemetrySettings.Logger.Info("No last received remote config found")
-		default:
-			s.telemetrySettings.Logger.Error("error while reading last received config", zap.Error(err))
-		}
-	} else {
-		s.telemetrySettings.Logger.Debug("Remote config is not supported, will not attempt to load config from fil")
-	}
-}
-
+// loadAndWriteInitialMergedConfig loads and writes the initial config by
+// merging the last received remote config, last received own metrics config,
+// and any local configs.
 func (s *Supervisor) loadAndWriteInitialMergedConfig() error {
-	var lastRecvOwnTelemetryConfig []byte
-	var err error
+	// load the last received remote config
+	s.loadRemoteConfig()
 
-	if s.config.Capabilities.ReportsOwnMetrics || s.config.Capabilities.ReportsOwnTraces || s.config.Capabilities.ReportsOwnLogs {
-		// Try to load the last received own metrics config if it exists.
-		lastRecvOwnTelemetryConfig, err = os.ReadFile(filepath.Join(s.config.Storage.Directory, lastRecvOwnTelemetryConfigFile))
-		if err == nil {
-			set := &protobufs.ConnectionSettingsOffers{}
-			err = proto.Unmarshal(lastRecvOwnTelemetryConfig, set)
-			if err != nil {
-				s.telemetrySettings.Logger.Error("Cannot parse last received own telemetry config", zap.Error(err))
-			} else {
-				s.setupOwnTelemetry(context.Background(), set)
-			}
-		}
-	} else {
-		s.telemetrySettings.Logger.Debug("Own metrics is not supported, will not attempt to load config from file")
-	}
+	// load the last received own telemetry config
+	s.loadLastReceivedOwnTelemetryConfig()
 
-	_, err = s.composeMergedConfig(s.remoteConfig)
+	// compose the initial merged config
+	_, err := s.composeMergedConfig(s.remoteConfig)
 	if err != nil {
 		return fmt.Errorf("could not compose initial merged config: %w", err)
 	}
@@ -1116,6 +1070,56 @@ func (s *Supervisor) loadAndWriteInitialMergedConfig() error {
 	}
 
 	return nil
+}
+
+// loadRemoteConfig loads the last received remote config from file if the capability is supported.
+func (s *Supervisor) loadRemoteConfig() {
+	if !s.config.Capabilities.AcceptsRemoteConfig {
+		s.telemetrySettings.Logger.Debug("Remote config is not supported, will not attempt to load config from file")
+		return
+	}
+
+	// Try to load the last received remote config if it exists.
+	var lastRecvRemoteConfig []byte
+	var err error
+	lastRecvRemoteConfig, err = os.ReadFile(filepath.Join(s.config.Storage.Directory, lastRecvRemoteConfigFile))
+	switch {
+	case err == nil:
+		config := &protobufs.AgentRemoteConfig{}
+		err = proto.Unmarshal(lastRecvRemoteConfig, config)
+		if err != nil {
+			s.telemetrySettings.Logger.Error("Cannot parse last received remote config", zap.Error(err))
+		} else {
+			s.remoteConfig = config
+		}
+	case errors.Is(err, os.ErrNotExist):
+		s.telemetrySettings.Logger.Info("No last received remote config found")
+	default:
+		s.telemetrySettings.Logger.Error("error while reading last received config", zap.Error(err))
+	}
+}
+
+// loadLastReceivedOwnTelemetryConfig loads the last received own telemetry config from file if the capability is supported.
+func (s *Supervisor) loadLastReceivedOwnTelemetryConfig() {
+	// If none of the own telemetry capabilities are supported, do nothing.
+	if !(s.config.Capabilities.ReportsOwnMetrics || s.config.Capabilities.ReportsOwnTraces || s.config.Capabilities.ReportsOwnLogs) {
+		s.telemetrySettings.Logger.Debug("Own metrics is not supported, will not attempt to load config from file")
+		return
+	}
+
+	// Try to load the last received own metrics config if it exists.
+	var lastRecvOwnTelemetryConfig []byte
+	var err error
+	lastRecvOwnTelemetryConfig, err = os.ReadFile(filepath.Join(s.config.Storage.Directory, lastRecvOwnTelemetryConfigFile))
+	if err == nil {
+		set := &protobufs.ConnectionSettingsOffers{}
+		err = proto.Unmarshal(lastRecvOwnTelemetryConfig, set)
+		if err != nil {
+			s.telemetrySettings.Logger.Error("Cannot parse last received own telemetry config", zap.Error(err))
+		} else {
+			s.setupOwnTelemetry(context.Background(), set)
+		}
+	}
 }
 
 // createEffectiveConfigMsg create an EffectiveConfig with the content of the
@@ -1332,7 +1336,7 @@ func (s *Supervisor) runAgentProcess() {
 		_, err := s.startAgent()
 		if err != nil {
 			s.telemetrySettings.Logger.Error("starting agent failed", zap.Error(err))
-			s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
+			s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
 		}
 	}
 
@@ -1360,13 +1364,14 @@ func (s *Supervisor) runAgentProcess() {
 			status, err := s.startAgent()
 			if err != nil {
 				s.telemetrySettings.Logger.Error("starting agent with new config failed", zap.Error(err))
-				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
+				s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
 			}
 
 			if status == agentNotStarting {
-				// not starting agent because of nop config, clear timer
+				// not starting agent because of nop config, clear timer, report applied status, report healthy status
 				configApplyTimeoutTimer.Stop()
-				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
+				s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
+				s.opampClient.SetHealth(&protobufs.ComponentHealth{Healthy: true, LastError: ""})
 			}
 
 		case <-s.commander.Exited():
@@ -1402,15 +1407,15 @@ func (s *Supervisor) runAgentProcess() {
 			_, err := s.startAgent()
 			if err != nil {
 				s.telemetrySettings.Logger.Error("restarting agent failed", zap.Error(err))
-				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
+				s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
 			}
 
 		case <-configApplyTimeoutTimer.C:
 			lastHealth := s.lastHealthFromClient.Load()
 			if lastHealth == nil || !lastHealth.Healthy {
-				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, "Config apply timeout exceeded")
+				s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, "Config apply timeout exceeded")
 			} else {
-				s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
+				s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED, "")
 			}
 
 		case <-s.doneChan:
@@ -1528,16 +1533,23 @@ func (s *Supervisor) saveLastReceivedOwnTelemetrySettings(set *protobufs.Connect
 	return os.WriteFile(filepath.Join(s.config.Storage.Directory, filePath), cfg, 0o600)
 }
 
-func (s *Supervisor) reportConfigStatus(status protobufs.RemoteConfigStatuses, errorMessage string) {
+// saveAndReportConfigStatus saves the config status to the persistent state and reports it to the server.
+func (s *Supervisor) saveAndReportConfigStatus(status protobufs.RemoteConfigStatuses, errorMessage string) {
 	if !s.config.Capabilities.ReportsRemoteConfig {
 		s.telemetrySettings.Logger.Debug("supervisor is not configured to report remote config status")
 	}
-	err := s.opampClient.SetRemoteConfigStatus(&protobufs.RemoteConfigStatus{
+	rcs := &protobufs.RemoteConfigStatus{
 		LastRemoteConfigHash: s.remoteConfig.GetConfigHash(),
 		Status:               status,
 		ErrorMessage:         errorMessage,
-	})
-	if err != nil {
+	}
+
+	// save status to persistent state
+	if err := s.persistentState.SetLastRemoteConfigStatus(rcs); err != nil {
+		s.telemetrySettings.Logger.Error("Could not save last remote config status", zap.Error(err))
+	}
+	// report status to server
+	if err := s.opampClient.SetRemoteConfigStatus(rcs); err != nil {
 		s.telemetrySettings.Logger.Error("Could not report OpAMP remote config status", zap.Error(err))
 	}
 }
@@ -1617,11 +1629,11 @@ func (s *Supervisor) processRemoteConfigMessage(msg *protobufs.AgentRemoteConfig
 	configChanged, err := s.composeMergedConfig(s.remoteConfig)
 	if err != nil {
 		s.telemetrySettings.Logger.Error("Error composing merged config. Reporting failed remote config status.", zap.Error(err))
-		s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
+		s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED, err.Error())
 	}
 	if configChanged {
 		// only report applying if the config has changed and will run agent with new config
-		s.reportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLYING, "")
+		s.saveAndReportConfigStatus(protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLYING, "")
 	}
 
 	return configChanged

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -283,7 +283,6 @@ service:
 			})
 			s.agentDescription = agentDesc
 
-			s.loadRemoteConfig()
 			require.NoError(t, s.createTemplates())
 			require.NoError(t, s.loadAndWriteInitialMergedConfig())
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- The last reported RemoteConfigStatus should be stored in the persistent state so that on startup we can more accurately report this. Currently it just reports the hash of the remote config that's on disk and an "Applied" status which may not always be accurate.
- When we opt to not run the collector because we have an empty config map (performance optimization) we should also be reporting a "Healthy" status since this is what the collector would do if it were ran.
- Small refactor to the "loadAndWriteInitialMergedConfig" function pulling out the own telemetry config generation. Additionally this function is handling loading the remote config since we no longer need to do so on startup with the status being stored in the persistent state.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Unit tests updated
- e2e updated

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
