### PR TITLE
[pkg/stanza]  Fix gzip files not being read if nonstandard format (WIP)

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -85,10 +85,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 		// For gzip files, we track offset based on decompressed bytes read
 		// The offset will be updated by the scanner as it reads tokens
 		defer func() {
-			// Only update to EOF if we've actually read everything
-			if r.Offset >= currentEOF {
-				r.Offset = currentEOF
-			}
+			r.Offset = currentEOF
 		}()
 	default:
 		r.reader = r.file
@@ -142,9 +139,9 @@ func (r *Reader) createGzipReader() (int64, error) {
 		zap.Int64("offset", r.Offset),
 		zap.Error(err))
 
-	if _, err := r.file.Seek(0, 0); err != nil {
-		r.set.Logger.Error("failed to seek to start of file", zap.Error(err))
-		return 0, err
+	if _, seekErr := r.file.Seek(0, 0); seekErr != nil {
+		r.set.Logger.Error("failed to seek to start of file", zap.Error(seekErr))
+		return 0, seekErr
 	}
 
 	// create a new gzip reader from the start of the file

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -168,7 +168,7 @@ func (r *Reader) createGzipReader() (int64, error) {
 				toRead = bytesToSkip
 			}
 			n, err := gzipReader.Read(buf[:toRead])
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				r.set.Logger.Error("failed to skip bytes in gzip reader", zap.Error(err))
 				return 0, err
 			}

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -340,7 +340,7 @@ func TestGzipReadFallback(t *testing.T) {
 	// Create a test file with some content
 	content := "test line 1\ntest line 2\ntest line 3\n"
 	tempPath := filepath.Join(tempDir, "test.log")
-	err := os.WriteFile(tempPath, []byte(content), 0x600)
+	err := os.WriteFile(tempPath, []byte(content), 0600)
 	require.NoError(t, err)
 
 	// Create a gzipped version of the file
@@ -384,7 +384,7 @@ func TestGzipReadFallback(t *testing.T) {
 	require.NotEmpty(t, secondToken)
 	require.Equal(t, []byte("test line 2"), secondToken)
 
-	// Read the rest of the content
+	// Read the rest of the content in the sink
 	thirdToken := sink.NextToken(t)
 	require.NotEmpty(t, thirdToken)
 	require.Equal(t, []byte("test line 3"), thirdToken)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Work in Progress but was noticing some weird behavior with `pkg/stanza`'s capability on reading gzipped files

```yaml
# This configuration is managed by Bindplane.
# Configuration: CloudTrail_test:23
receivers:
    filelog/source1_01JWS1EGG8EWTQ98KX096RPASN:
        compression: 'gzip'
        delete_after_read: false
        force_flush_period: 1s
        include:
          - /Users/keithschmitt/resources/*.gz
        include_file_name: true
        include_file_name_resolved: false
        include_file_path: false
        include_file_path_resolved: false
        max_concurrent_files: 1024
        poll_interval: 500ms
        retry_on_failure:
            enabled: true
        start_at: beginning
        # storage: file_storage
exporters:
    file/DevNull: 
      path: /Users/keithschmitt/bp_resources/test.txt
service:
    extensions:
        - file_storage
    pipelines:
        logs/source1_01JWS1EGG8EWTQ98KX096RPASN__DevNull-0:
            receivers:
                - filelog/source1_01JWS1EGG8EWTQ98KX096RPASN
            processors: []
            exporters:
                - file/DevNull
    telemetry:
        metrics:
            readers:
                - pull:
                    exporter:
                        prometheus:
                            host: localhost
                            port: 8888
extensions:
    file_storage:
        directory: /Users/keithschmitt/bp_resources/storage
        timeout: 1s

```

Was noticing that for nonstandard gzipped file(or maybe custom compressed, still not sure) from AWS CloudTraill were never ingesting, I did some digging and realized that it was never getting ingested via the filelogreceiver. 

What was interesting was if I downloaded the file and `gunzip file.json.gz` => `vim file.json` (modify a character) => `gzip file.json` it was properly parsed with the old implementation. This lead me to believe that the file must be customly compressed but is still a valid gzip.

```sh
➜ gzip -l /Users/keithschmitt/bp_resources/776660375188_CloudTrail_us-east-1_20250602T1905Z_mZfBOuEMPCmhbWpK.json.gz
  compressed uncompressed  ratio uncompressed_name
        1488         5956  75.0% /Users/keithschmitt/bp_resources/776660375188_CloudTrail_us-east-1_20250602T1905Z_mZfBOuEMPCmhbWpK.json
```

- This PR improves the gzip file reading behavior in the file consumer by:
- Fixing incorrect offset tracking for gzip files by tracking decompressed bytes instead of file position
- Optimizing buffer allocation by using file size information
- Improving error handling and logging for gzip operations

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

The test verifies that:
- We correctly read gzipped content
- We properly handle offset tracking
- We don't read more data than necessary
- We correctly emit tokens in order

<!--Describe the documentation added.-->
#### Documentation

Deeper code level change... user impacts for n

<!--Please delete paragraphs that you did not use before submitting.-->
