### PR TITLE
[cmd/opampsupervisor] add config to validate the config

### DIFF
--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -190,6 +190,7 @@ type Agent struct {
 	ConfigFiles             []string          `mapstructure:"config_files"`
 	Arguments               []string          `mapstructure:"args"`
 	Env                     map[string]string `mapstructure:"env"`
+	ValidateConfig          bool              `mapstructure:"validate"`
 }
 
 func (a Agent) Validate() error {


### PR DESCRIPTION
#### Description

Adds the ability for users to configure the opamp supervisor to call the collector's `validate` command to report any errors via the supervisor's logs

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
