### PR TITLE
[collectdreceiver] ensure HTTP server exits before Shutdown returns

### DIFF
--- a/.chloggen/collectdreceiver-wait-shutdown.yaml
+++ b/.chloggen/collectdreceiver-wait-shutdown.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: collectdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure the receiver closes its port when shutting down quickly after starting.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40406]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Note that due to the nature of the timing issue this is extremely unlikely to affect a real user,
+  and really only likely to occur in unit tests.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
#### Description

If Shutdown is called immediately after Start, then it can happen that the HTTP server's Shutdown method returns before the Server method is called. In this case, the listener may remain active, and causes test failures like this:

```
=== RUN   TestComponentLifecycle
=== RUN   TestComponentLifecycle/metrics-lifecycle
    generated_component_test.go:67: 
                Error Trace:    /home/andrew/projects/opentelemetry-collector-contrib/receiver/collectdreceiver/generated_component_test.go:67
                Error:          Received unexpected error:
                                listen tcp 127.0.0.1:8081: bind: address already in use
                Test:           TestComponentLifecycle/metrics-lifecycle
--- FAIL: TestComponentLifecycle (0.00s)
    --- FAIL: TestComponentLifecycle/metrics-lifecycle (0.00s)
```

To address that, add a WaitGroup to ensure the Serve method is called and returns before the receiver's Shutdown method returns.

#### Link to tracking issue

Fixes #40406

#### Testing

Run the unit tests. They were reliably failing for me before, now they do not.

#### Documentation

N/A