### PR TITLE
[receiver/kafka][chore] delete unsupported auth method from docs

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -65,9 +65,8 @@ The following settings can be optionally configured:
   - `sasl`
     - `username`: The username to use.
     - `password`: The password to use.
-    - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM, AWS_MSK_IAM_OAUTHBEARER or PLAIN)
-    - `aws_msk.region`: AWS Region in case of AWS_MSK_IAM or AWS_MSK_IAM_OAUTHBEARER mechanism
-    - `aws_msk.broker_addr`: MSK Broker address in case of AWS_MSK_IAM mechanism
+    - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM_OAUTHBEARER or PLAIN)
+    - `aws_msk.region`: AWS Region in case of AWS_MSK_IAM_OAUTHBEARER mechanism
   - `tls` (Deprecated in v0.124.0: configure tls at the top level): this is an alias for tls at the top level.
   - `kerberos`
     - `service_name`: Kerberos service name


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Setting `auth.sasl.mechanism` as `AWS_MSK_IAM` results in an issue:
```
 Error: cannot start pipelines: failed to start "kafka" receiver: kafka: invalid configuration (The SASL mechanism configuration is invalid. Possible values are `OAUTHBEARER`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` and `GSSAPI`)
2025/06/05 13:25:30 main.go:92: application run finished with error: cannot start pipelines: failed to start "kafka" receiver: kafka: invalid configuration (The SASL mechanism configuration is invalid. Possible values are `OAUTHBEARER`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512` and `GSSAPI`)
```

`AWS_MSK_IAM` is not supported despite being referenced in some documentation.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40554


