### PR TITLE
[receiver/snowflake] Add prescrape check

### DIFF
--- a/.chloggen/40418-conversionerror-bugfix.yaml
+++ b/.chloggen/40418-conversionerror-bugfix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snowflakereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixes bug regarding a bad type conversion and adds guard rails to prevent future similar bugs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40418]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/40418-conversionerror-bugfix.yaml
+++ b/.chloggen/40418-conversionerror-bugfix.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: snowflakereceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: fixes bug regarding a bad type conversion and adds guard rails to prevent future similar bugs
+note: adds a pre-scrape check to see if metrics are enabled.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [40418]

--- a/receiver/snowflakereceiver/scraper.go
+++ b/receiver/snowflakereceiver/scraper.go
@@ -107,6 +107,10 @@ func (s *snowflakeMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, 
 }
 
 func (s *snowflakeMetricsScraper) scrapeBillingMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeBillingCloudServiceTotal.Enabled && !s.conf.Metrics.SnowflakeBillingTotalCreditTotal.Enabled && !s.conf.Metrics.SnowflakeBillingVirtualWarehouseTotal.Enabled {
+		return
+	}
+
 	billingMetrics, err := s.client.FetchBillingMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -121,6 +125,10 @@ func (s *snowflakeMetricsScraper) scrapeBillingMetrics(ctx context.Context, t pc
 }
 
 func (s *snowflakeMetricsScraper) scrapeWarehouseBillingMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeBillingWarehouseTotalCreditTotal.Enabled && !s.conf.Metrics.SnowflakeBillingWarehouseCloudServiceTotal.Enabled && !s.conf.Metrics.SnowflakeBillingWarehouseVirtualWarehouseTotal.Enabled {
+		return
+	}
+
 	warehouseBillingMetrics, err := s.client.FetchWarehouseBillingMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -135,6 +143,10 @@ func (s *snowflakeMetricsScraper) scrapeWarehouseBillingMetrics(ctx context.Cont
 }
 
 func (s *snowflakeMetricsScraper) scrapeLoginMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeLoginsTotal.Enabled {
+		return
+	}
+
 	loginMetrics, err := s.client.FetchLoginMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -147,6 +159,9 @@ func (s *snowflakeMetricsScraper) scrapeLoginMetrics(ctx context.Context, t pcom
 }
 
 func (s *snowflakeMetricsScraper) scrapeHighLevelQueryMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeQueryExecuted.Enabled && !s.conf.Metrics.SnowflakeQueryBlocked.Enabled && !s.conf.Metrics.SnowflakeQueryQueuedOverload.Enabled && !s.conf.Metrics.SnowflakeQueryQueuedProvision.Enabled {
+		return
+	}
 	highLevelQueryMetrics, err := s.client.FetchHighLevelQueryMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -162,6 +177,18 @@ func (s *snowflakeMetricsScraper) scrapeHighLevelQueryMetrics(ctx context.Contex
 }
 
 func (s *snowflakeMetricsScraper) scrapeDBMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeDatabaseQueryCount.Enabled && !s.conf.Metrics.SnowflakeDatabaseBytesScannedAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueryBytesDeletedAvg.Enabled && !s.conf.Metrics.SnowflakeQueryBytesSpilledLocalAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueryBytesSpilledRemoteAvg.Enabled && !s.conf.Metrics.SnowflakeQueryBytesWrittenAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueryCompilationTimeAvg.Enabled && !s.conf.Metrics.SnowflakeQueryDataScannedCacheAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueryExecutionTimeAvg.Enabled && !s.conf.Metrics.SnowflakeQueryPartitionsScannedAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueuedOverloadTimeAvg.Enabled && !s.conf.Metrics.SnowflakeQueuedProvisioningTimeAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeQueuedRepairTimeAvg.Enabled && !s.conf.Metrics.SnowflakeRowsInsertedAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeRowsDeletedAvg.Enabled && !s.conf.Metrics.SnowflakeRowsProducedAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeRowsUnloadedAvg.Enabled && !s.conf.Metrics.SnowflakeRowsUpdatedAvg.Enabled &&
+		!s.conf.Metrics.SnowflakeTotalElapsedTimeAvg.Enabled {
+		return
+	}
 	DBMetrics, err := s.client.FetchDbMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -192,6 +219,10 @@ func (s *snowflakeMetricsScraper) scrapeDBMetrics(ctx context.Context, t pcommon
 }
 
 func (s *snowflakeMetricsScraper) scrapeSessionMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeSessionIDCount.Enabled {
+		return
+	}
+
 	sessionMetrics, err := s.client.FetchSessionMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -204,6 +235,10 @@ func (s *snowflakeMetricsScraper) scrapeSessionMetrics(ctx context.Context, t pc
 }
 
 func (s *snowflakeMetricsScraper) scrapeSnowpipeMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakePipeCreditsUsedTotal.Enabled {
+		return
+	}
+
 	snowpipeMetrics, err := s.client.FetchSnowpipeMetrics(ctx)
 	if err != nil {
 		errs <- err
@@ -216,6 +251,10 @@ func (s *snowflakeMetricsScraper) scrapeSnowpipeMetrics(ctx context.Context, t p
 }
 
 func (s *snowflakeMetricsScraper) scrapeStorageMetrics(ctx context.Context, t pcommon.Timestamp, errs chan<- error) {
+	if !s.conf.Metrics.SnowflakeStorageStorageBytesTotal.Enabled && !s.conf.Metrics.SnowflakeStorageStageBytesTotal.Enabled && !s.conf.Metrics.SnowflakeStorageFailsafeBytesTotal.Enabled {
+		return
+	}
+
 	storageMetrics, err := s.client.FetchStorageMetrics(ctx)
 	if err != nil {
 		errs <- err


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added a pre-scrape check to make sure that metrics which arent configured aren't being scraped when they don't need to be. Previously every metric would be collected from the snowflake instance and then filtered at the emit step, this should improve performance somewhat in cases where entire requests dont need to be made (and their resulting sql queries dont need to be run).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Partially fixes [40418](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40418)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
All unit tests pass as they did before.

<!--Describe the documentation added.-->
#### Documentation
no api changes needed to be documented.