### PR TITLE
[chore] remove stable exporter.googlecloud.OTLPDirect feature gate

### DIFF
--- a/.chloggen/remove_googlecloud_otlpdirect.yaml
+++ b/.chloggen/remove_googlecloud_otlpdirect.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the stable exporter.googlecloud.OTLPDirect featuregate
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [17192]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: It was supposed to be removed in v0.69.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -24,14 +24,6 @@ const (
 	defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
 )
 
-var _ = featuregate.GlobalRegistry().MustRegister(
-	"exporter.googlecloud.OTLPDirect",
-	featuregate.StageStable,
-	featuregate.WithRegisterDescription("When enabled, the googlecloud exporter translates pdata directly to google cloud monitoring's types, rather than first translating to opencensus."),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7132"),
-	featuregate.WithRegisterToVersion("v0.69.0"),
-)
-
 var customMonitoredResourcesGate = featuregate.GlobalRegistry().MustRegister(
 	"exporter.googlecloud.CustomMonitoredResources",
 	featuregate.StageAlpha,


### PR DESCRIPTION
#### Description

This feature-gate should have been removed a long time ago.  This is cleaning it up.

@braydonk @ridwanmsharif 