### PR TITLE
[chore] remove stable processor.resourcedetection.hostCPUSteppingAsString featuregate

### DIFF
--- a/.chloggen/remove_hostcpustepping_asstring.yaml
+++ b/.chloggen/remove_hostcpustepping_asstring.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the stable processor.resourcedetection.hostCPUSteppingAsString featuregate
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40569]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: It was supposed to be removed in v0.110.0.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/shirou/gopsutil/v4/cpu"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
 	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
@@ -20,15 +19,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/system"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system/internal/metadata"
-)
-
-var _ = featuregate.GlobalRegistry().MustRegister(
-	"processor.resourcedetection.hostCPUSteppingAsString",
-	featuregate.StageStable,
-	featuregate.WithRegisterDescription("Change type of host.cpu.stepping to string."),
-	featuregate.WithRegisterFromVersion("v0.95.0"),
-	featuregate.WithRegisterToVersion("v0.110.0"),
-	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/664"),
 )
 
 const (


### PR DESCRIPTION
#### Description

It should have been removed in v0.110.0.