### PR TITLE
Promote receiver.prometheusreceiver.RemoveLegacyResourceAttributes feature gate to stable

### DIFF
--- a/.chloggen/stable_removelegacyresource.yaml
+++ b/.chloggen/stable_removelegacyresource.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the receiver.prometheusreceiver.RemoveLegacyResourceAttributes featuregate to stable
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40572]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: It has been beta since v0.126.0
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -90,12 +90,6 @@ prometheus --config.file=prom.yaml
 "--feature-gates=receiver.prometheusreceiver.EnableNativeHistograms"
 ```
 
-- `receiver.prometheusreceiver.RemoveLegacyResourceAttributes`: Remove `net.host.name`, `net.host.port`, and `http.scheme` resource attributes, which are redundant with the new `server.address`, `server.port`, and `url.scheme` attributes.
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.RemoveLegacyResourceAttributes"
-```
-
 - `receiver.prometheusreceiver.RemoveStartTimeAdjustment`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
 
 ```shell

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -13,14 +13,13 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.25.0"
 )
 
-const removeOldSemconvFeatureGateID = "receiver.prometheusreceiver.RemoveLegacyResourceAttributes"
-
-var removeOldSemconvFeatureGate = featuregate.GlobalRegistry().MustRegister(
-	removeOldSemconvFeatureGateID,
-	featuregate.StageBeta,
+var _ = featuregate.GlobalRegistry().MustRegister(
+	"receiver.prometheusreceiver.RemoveLegacyResourceAttributes",
+	featuregate.StageStable,
 	featuregate.WithRegisterFromVersion("v0.101.0"),
 	featuregate.WithRegisterDescription("When enabled, the net.host.name, net.host.port, and http.scheme resource attributes are no longer added to metrics. Use server.address, server.port, and url.scheme instead."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32814"),
+	featuregate.WithRegisterToVersion("v0.130.0"),
 )
 
 // isDiscernibleHost checks if a host can be used as a value for the 'host.name' key.
@@ -52,16 +51,9 @@ func CreateResource(job, instance string, serviceDiscoveryLabels labels.Labels) 
 	attrs := resource.Attributes()
 	attrs.PutStr(string(conventions.ServiceNameKey), job)
 	if isDiscernibleHost(host) {
-		if !removeOldSemconvFeatureGate.IsEnabled() {
-			attrs.PutStr(string(conventions.NetHostNameKey), host)
-		}
 		attrs.PutStr(string(conventions.ServerAddressKey), host)
 	}
 	attrs.PutStr(string(conventions.ServiceInstanceIDKey), instance)
-	if !removeOldSemconvFeatureGate.IsEnabled() {
-		attrs.PutStr(string(conventions.NetHostPortKey), port)
-		attrs.PutStr(string(conventions.HTTPSchemeKey), serviceDiscoveryLabels.Get(model.SchemeLabel))
-	}
 	attrs.PutStr(string(conventions.ServerPortKey), port)
 	attrs.PutStr(string(conventions.URLSchemeKey), serviceDiscoveryLabels.Get(model.SchemeLabel))
 

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 )
 
 type jobInstanceDefinition struct {
@@ -73,36 +71,16 @@ func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, hasHost bool)
 	return resource
 }
 
-func makeResourceWithJobInstanceSchemeDuplicate(def *jobInstanceDefinition, hasHost bool) pcommon.Resource {
-	resource := pcommon.NewResource()
-	attrs := resource.Attributes()
-	// Using hardcoded values to assert on outward expectations so that
-	// when variables change, these tests will fail and we'll have reports.
-	attrs.PutStr("service.name", def.job)
-	if hasHost {
-		attrs.PutStr("net.host.name", def.host)
-		attrs.PutStr("server.address", def.host)
-	}
-	attrs.PutStr("service.instance.id", def.instance)
-	attrs.PutStr("net.host.port", def.port)
-	attrs.PutStr("http.scheme", def.scheme)
-	attrs.PutStr("server.port", def.port)
-	attrs.PutStr("url.scheme", def.scheme)
-	return resource
-}
-
 func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 	tests := []struct {
-		name, job                   string
-		instance                    string
-		sdLabels                    labels.Labels
-		removeOldSemconvFeatureGate bool
-		want                        pcommon.Resource
+		name, job string
+		instance  string
+		sdLabels  labels.Labels
+		want      pcommon.Resource
 	}{
 		{
 			name: "all attributes proper",
 			job:  "job", instance: "hostname:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, true),
@@ -110,7 +88,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "missing port",
 			job:  "job", instance: "myinstance", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "https"}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance", "myinstance", "https", "",
 			}, true),
@@ -118,7 +95,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "blank scheme",
 			job:  "job", instance: "myinstance:443", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance:443", "myinstance", "", "443",
 			}, true),
@@ -126,7 +102,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "blank instance, blank scheme",
 			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "", "",
 			}, true),
@@ -134,7 +109,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "blank instance, non-blank scheme",
 			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "http", "",
 			}, true),
@@ -142,7 +116,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "0.0.0.0 address",
 			job:  "job", instance: "0.0.0.0:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "0.0.0.0:8888", "", "http", "8888",
 			}, false),
@@ -150,57 +123,7 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		{
 			name: "localhost",
 			job:  "job", instance: "localhost:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			removeOldSemconvFeatureGate: true,
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
-				"job", "localhost:8888", "", "http", "8888",
-			}, false),
-		},
-		{
-			name: "all attributes proper with duplicates",
-			job:  "job", instance: "hostname:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "hostname:8888", "hostname", "http", "8888",
-			}, true),
-		},
-		{
-			name: "missing port with duplicates",
-			job:  "job", instance: "myinstance", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "https"}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "myinstance", "myinstance", "https", "",
-			}, true),
-		},
-		{
-			name: "blank scheme with duplicates",
-			job:  "job", instance: "myinstance:443", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "myinstance:443", "myinstance", "", "443",
-			}, true),
-		},
-		{
-			name: "blank instance, blank scheme with duplicates",
-			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "", "", "", "",
-			}, true),
-		},
-		{
-			name: "blank instance, non-blank scheme with duplicates",
-			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "", "", "http", "",
-			}, true),
-		},
-		{
-			name: "0.0.0.0 address with duplicates",
-			job:  "job", instance: "0.0.0.0:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
-				"job", "0.0.0.0:8888", "", "http", "8888",
-			}, false),
-		},
-		{
-			name: "localhost with duplicates",
-			job:  "job", instance: "localhost:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
-			want: makeResourceWithJobInstanceSchemeDuplicate(&jobInstanceDefinition{
 				"job", "localhost:8888", "", "http", "8888",
 			}, false),
 		},
@@ -216,7 +139,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "DaemonSet"},
 				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -240,7 +162,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "ReplicaSet"},
 				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -264,7 +185,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "StatefulSet"},
 				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -288,7 +208,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "Job"},
 				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -312,7 +231,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "CronJob"},
 				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -330,7 +248,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__scheme__", Value: "http"},
 				labels.Label{Name: "__meta_kubernetes_node_name", Value: "k8s-node-123"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -343,7 +260,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				labels.Label{Name: "__scheme__", Value: "http"},
 				labels.Label{Name: "__meta_kubernetes_endpoint_node_name", Value: "k8s-node-123"},
 			),
-			removeOldSemconvFeatureGate: true,
 			want: makeK8sResource(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, &k8sResourceDefinition{
@@ -354,7 +270,6 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testutil.SetFeatureGateForTest(t, removeOldSemconvFeatureGate, tt.removeOldSemconvFeatureGate)
 			got := CreateResource(tt.job, tt.instance, tt.sdLabels)
 			require.Equal(t, tt.want.Attributes().AsRaw(), got.Attributes().AsRaw())
 		})


### PR DESCRIPTION
#### Description

This feature gate removes legacy resource attributes that were removed from the semconv a long time ago.

Users can easily rename the new attributes using the transform processor.

It has been in beta since v0.126.0

cc @ArthurSens 
