### PR TITLE
[receiver/sqlserver] export host.name in the attribute resources

### DIFF
--- a/.chloggen/export-host-name-in-resources-attributes.yaml
+++ b/.chloggen/export-host-name-in-resources-attributes.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlserverreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: export `host.name` as resource attributes for metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40576]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  in the metadata file, the `host.name` resource attribute is defined for metrics, but it is not exported in reality. this fixed 
+  the issue and export it as a resource attribute.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -176,6 +176,7 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) er
 		rb.SetSqlserverInstanceName(row[instanceNameKey])
 		rb.SetServerAddress(s.config.Server)
 		rb.SetServerPort(int64(s.config.Port))
+		rb.SetHostName(s.config.Server)
 
 		val, err = retrieveFloat(row, readLatencyMsKey)
 		if err != nil {
@@ -262,6 +263,7 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 		rb.SetSqlserverInstanceName(row[instanceNameKey])
 		rb.SetServerAddress(s.config.Server)
 		rb.SetServerPort(int64(s.config.Port))
+		rb.SetHostName(s.config.Server)
 
 		switch row[counterKey] {
 		case activeTempTables:
@@ -535,6 +537,7 @@ func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context
 		rb.SetSqlserverInstanceName(row[instanceNameKey])
 		rb.SetServerAddress(s.config.Server)
 		rb.SetServerPort(int64(s.config.Port))
+		rb.SetHostName(s.config.Server)
 
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbOnline], metadata.AttributeDatabaseStatusOnline))
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbRestoring], metadata.AttributeDatabaseStatusRestoring))
@@ -574,6 +577,7 @@ func (s *sqlServerScraperHelper) recordDatabaseWaitMetrics(ctx context.Context) 
 		rb.SetSqlserverInstanceName(row[instanceNameKey])
 		rb.SetServerAddress(s.config.Server)
 		rb.SetServerPort(int64(s.config.Port))
+		rb.SetHostName(s.config.Server)
 
 		val, err = retrieveFloat(row, waitTimeMs)
 		if err != nil {

--- a/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -137,6 +140,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -273,6 +279,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -409,6 +418,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -545,6 +557,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -681,6 +696,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -817,6 +835,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -953,6 +974,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1089,6 +1113,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1225,6 +1252,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1361,6 +1391,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1410,414 +1443,6 @@ resourceMetrics:
                     - key: physical_filename
                       value:
                         stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: By
-          - description: Total time that the users waited for I/O issued on this file.
-            name: sqlserver.database.latency
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0.001
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: s
-          - description: The number of operations issued on the file.
-            name: sqlserver.database.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{operations}'
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: server.address
-          value:
-            stringValue: 0.0.0.0
-        - key: server.port
-          value:
-            intValue: "1433"
-        - key: sqlserver.database.name
-          value:
-            stringValue: tempdb
-        - key: sqlserver.instance.name
-          value:
-            stringValue: 8cac97ac9b8f
-    scopeMetrics:
-      - metrics:
-          - description: The number of bytes of I/O on this file.
-            name: sqlserver.database.io
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "90112"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: By
-          - description: Total time that the users waited for I/O issued on this file.
-            name: sqlserver.database.latency
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: s
-          - description: The number of operations issued on the file.
-            name: sqlserver.database.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{operations}'
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: server.address
-          value:
-            stringValue: 0.0.0.0
-        - key: server.port
-          value:
-            intValue: "1433"
-        - key: sqlserver.database.name
-          value:
-            stringValue: tempdb
-        - key: sqlserver.instance.name
-          value:
-            stringValue: 8cac97ac9b8f
-    scopeMetrics:
-      - metrics:
-          - description: The number of bytes of I/O on this file.
-            name: sqlserver.database.io
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "90112"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: By
-          - description: Total time that the users waited for I/O issued on this file.
-            name: sqlserver.database.latency
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: s
-          - description: The number of operations issued on the file.
-            name: sqlserver.database.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{operations}'
-        scope:
-          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: server.address
-          value:
-            stringValue: 0.0.0.0
-        - key: server.port
-          value:
-            intValue: "1433"
-        - key: sqlserver.database.name
-          value:
-            stringValue: tempdb
-        - key: sqlserver.instance.name
-          value:
-            stringValue: 8cac97ac9b8f
-    scopeMetrics:
-      - metrics:
-          - description: The number of bytes of I/O on this file.
-            name: sqlserver.database.io
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "90112"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -1837,6 +1462,423 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
+        - key: server.address
+          value:
+            stringValue: 0.0.0.0
+        - key: server.port
+          value:
+            intValue: "1433"
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
+        - key: server.address
+          value:
+            stringValue: 0.0.0.0
+        - key: server.port
+          value:
+            intValue: "1433"
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
+        - key: server.address
+          value:
+            stringValue: 0.0.0.0
+        - key: server.port
+          value:
+            intValue: "1433"
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.001
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
                         stringValue: tempdev7
                     - key: physical_filename
                       value:
@@ -1905,6 +1947,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -25,6 +28,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -49,6 +55,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -77,6 +86,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -105,6 +117,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -129,6 +144,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -153,6 +171,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -181,6 +202,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -205,6 +229,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -233,6 +260,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -257,6 +287,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -282,6 +315,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -306,6 +342,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -330,6 +369,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -354,6 +396,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -378,6 +423,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -402,6 +450,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -426,6 +477,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -450,6 +504,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -474,6 +531,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -498,6 +558,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -530,6 +593,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -554,6 +620,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -578,6 +647,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -602,6 +674,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -626,6 +701,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -650,6 +728,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -674,6 +755,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -698,6 +782,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -723,6 +810,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -748,6 +838,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -772,6 +865,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -800,6 +896,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -824,6 +923,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -852,6 +954,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -880,6 +985,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -904,6 +1012,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -932,6 +1043,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -956,6 +1070,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -981,6 +1098,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1005,6 +1125,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1029,6 +1152,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1053,6 +1179,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1082,6 +1211,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1106,6 +1238,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -1132,6 +1267,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0

--- a/receiver/sqlserverreceiver/testdata/expectedProperties.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedProperties.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0

--- a/receiver/sqlserverreceiver/testdata/expectedWaitStats.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedWaitStats.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -37,6 +40,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -73,6 +79,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -109,6 +118,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -145,6 +157,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -181,6 +196,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -217,6 +235,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -253,6 +274,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -289,6 +313,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -325,6 +352,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -361,6 +391,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -397,6 +430,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -433,6 +469,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -469,6 +508,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -505,6 +547,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -541,6 +586,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -577,6 +625,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -613,6 +664,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -649,6 +703,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -685,6 +742,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -721,6 +781,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -757,6 +820,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -793,6 +859,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0
@@ -829,6 +898,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: 0.0.0.0
         - key: server.address
           value:
             stringValue: 0.0.0.0


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
part of #40141

the `host.name` attribute is specified in the metadata but it is actually not exported. so this pr fixes this issue and export `host.name` in resource attributes.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
