### PR TITLE
[chore] Add link to Expr language playground for receivercreator docs

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -84,6 +84,10 @@ manually setting it like the above example, the observer endpoint target value
 will automatically be sourced. If no `endpoint` field is available you are
 required to specify any necessary fields.
 
+To develop, test or debug [expvar
+syntax](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md)
+based expressions use [Expr language playground](https://expr-lang.org/playground).
+
 **receivers.resource_attributes**
 
 ```yaml


### PR DESCRIPTION
This PR adds a link to Epxr language playground within `receivercreator` docs so as users can leverage this to test their expressions.