### PR TITLE
promote the processor.resourcedetection.removeGCPFaasID feature gate to beta

### DIFF
--- a/.chloggen/remove_gcpfaasid_beta.yaml
+++ b/.chloggen/remove_gcpfaasid_beta.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the processor.resourcedetection.removeGCPFaasID feature gate to beta.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40601]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The faas.id attribute is replaced by the faas.instance attribute. |
+  This disables detection of the faas.id resource attribute by default. |
+  Re-enable by disabling the processor.resourcedetection.removeGCPFaasID feature gate.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -26,7 +26,7 @@ const (
 
 var removeGCPFaasID = featuregate.GlobalRegistry().MustRegister(
 	"processor.resourcedetection.removeGCPFaasID",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("Remove faas.id from the GCP detector. Use faas.instance instead."),
 	featuregate.WithRegisterFromVersion("v0.87.0"))
 


### PR DESCRIPTION
#### Description

This feature gate has been in alpha since v0.87.0.  It is just an attribute rename to keep up with semconv, so it should be low-impact for users.
