### PR TITLE
[chore] Fix config example

### DIFF
--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -281,7 +281,6 @@ The processor can be configured to set the
 
 ```yaml
 k8sattributes:
-k8sattributes/2:
   auth_type: "serviceAccount"
   passthrough: false
   filter:


### PR DESCRIPTION
This PR fixes the config example which might be misleading. 

The existing example includes a `k8sattributes` processor instance which is empty (fall backs to default) and a one `k8sattributes/2` with actually configuration. I think we can remove the "empty" one since it doesn't serve much as an example.
