### PR TITLE
[pkg/datadog] expose forwarder methods through Serializer interface

### DIFF
--- a/.chloggen/jackgopack4-pkg-datadog-Serializer-interface.yaml
+++ b/.chloggen/jackgopack4-pkg-datadog-Serializer-interface.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exposes 'SerializerWithForwarder' interface to allow for direct interaction with the underlying forwarder's lifecycle methods.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40637]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -47,6 +47,9 @@ type forwarderWithLifecycle interface {
 // Compile-time check to ensure DefaultForwarder implements ForwarderWithLifecycle
 var _ forwarderWithLifecycle = (*defaultforwarder.DefaultForwarder)(nil)
 
+// Compile-time check to ensure datadogSerializer implements SerializerWithForwarder
+var _ SerializerWithForwarder = (*datadogSerializer)(nil)
+
 // datadogSerializer is a concrete implementation of SerializerWithForwarder that wraps
 // a MetricSerializer and provides access to the underlying forwarder's lifecycle methods
 type datadogSerializer struct {

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -26,6 +26,49 @@ import (
 // This allows for flexible configuration by different modules.
 type ConfigOption func(pkgconfigmodel.Config)
 
+// SerializerWithForwarder is an interface that extends the MetricSerializer interface
+// with ability to interact directly with the underlying forwarder's lifecycle methods.
+type SerializerWithForwarder interface {
+	serializer.MetricSerializer
+	Start() error
+	State() uint32
+	Stop()
+}
+
+// forwarderWithLifecycle extends the defaultforwarder.Forwarder interface
+// with lifecycle management methods
+type forwarderWithLifecycle interface {
+	defaultforwarder.Forwarder
+	Start() error
+	State() uint32
+	Stop()
+}
+
+// Compile-time check to ensure DefaultForwarder implements ForwarderWithLifecycle
+var _ forwarderWithLifecycle = (*defaultforwarder.DefaultForwarder)(nil)
+
+// datadogSerializer is a concrete implementation of SerializerWithForwarder that wraps
+// a MetricSerializer and provides access to the underlying forwarder's lifecycle methods
+type datadogSerializer struct {
+	serializer.MetricSerializer
+	forwarder forwarderWithLifecycle
+}
+
+// Start delegates to the underlying forwarder's Start method
+func (ds *datadogSerializer) Start() error {
+	return ds.forwarder.Start()
+}
+
+// State delegates to the underlying forwarder's State method
+func (ds *datadogSerializer) State() uint32 {
+	return ds.forwarder.State()
+}
+
+// Stop delegates to the underlying forwarder's Stop method
+func (ds *datadogSerializer) Stop() {
+	ds.forwarder.Stop()
+}
+
 // NewLogComponent creates a new log component for collector that uses the provided telemetry settings.
 func NewLogComponent(set component.TelemetrySettings) corelog.Component {
 	zlog := &ZapLogger{
@@ -35,10 +78,15 @@ func NewLogComponent(set component.TelemetrySettings) corelog.Component {
 }
 
 // NewSerializerComponent creates a new serializer that serializes and compresses payloads prior to being forwarded
-func NewSerializerComponent(cfg coreconfig.Component, logger corelog.Component, hostname string) serializer.MetricSerializer {
+func NewSerializerComponent(cfg coreconfig.Component, logger corelog.Component, hostname string) SerializerWithForwarder {
 	forwarder := newForwarderComponent(cfg, logger)
 	compressor := zlib.New()
-	return serializer.NewSerializer(forwarder, nil, compressor, cfg, logger, hostname)
+	metricSerializer := serializer.NewSerializer(forwarder, nil, compressor, cfg, logger, hostname)
+
+	return &datadogSerializer{
+		MetricSerializer: metricSerializer,
+		forwarder:        forwarder,
+	}
 }
 
 // NewConfigComponent creates a new Datadog agent config component with the given options.
@@ -72,6 +120,7 @@ func WithForwarderConfig() ConfigOption {
 		pkgconfig.Set("forwarder_backoff_base", 2, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("forwarder_backoff_max", 64, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("forwarder_recovery_interval", 2, pkgconfigmodel.SourceDefault)
+		pkgconfig.Set("forwarder_http_protocol", "auto", pkgconfigmodel.SourceDefault)
 	}
 }
 
@@ -161,7 +210,7 @@ func setProxyFromEnv(config pkgconfigmodel.Config) {
 }
 
 // newForwarderComponent creates a new forwarder that sends payloads to Datadog backend
-func newForwarderComponent(cfg coreconfig.Component, log corelog.Component) defaultforwarder.Forwarder {
+func newForwarderComponent(cfg coreconfig.Component, log corelog.Component) forwarderWithLifecycle {
 	keysPerDomain := map[string][]pkgconfigutils.APIKeys{
 		"https://api." + cfg.GetString("site"): {pkgconfigutils.NewAPIKeys("api_key", cfg.GetString("api_key"))},
 	}

--- a/pkg/datadog/agentcomponents/agentcomponents_test.go
+++ b/pkg/datadog/agentcomponents/agentcomponents_test.go
@@ -449,7 +449,7 @@ func TestAgentComponents_NewSerializer(t *testing.T) {
 	// Create a config component
 	configComponent := NewConfigComponent(configOptions...)
 
-	// Call NewSerializer - now creates forwarder and compressor internally
+	// Call NewSerializer - now returns SerializerWithForwarder
 	serializer := NewSerializerComponent(configComponent, zlog, "test-hostname")
 
 	// Assert that the returned serializer is not nil
@@ -457,6 +457,96 @@ func TestAgentComponents_NewSerializer(t *testing.T) {
 
 	// Assert that serializer implements MetricSerializer interface by calling a method
 	assert.True(t, serializer.AreSeriesEnabled() || !serializer.AreSeriesEnabled()) // Just testing interface compliance
+}
+
+func TestSerializerWithForwarder_LifecycleMethods(t *testing.T) {
+	// Create a zap logger for testing
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	zlog := &ZapLogger{
+		Logger: logger,
+	}
+
+	configOptions := []ConfigOption{
+		WithAPIConfig(&datadogconfig.Config{
+			API: datadogconfig.APIConfig{
+				Key:  configopaque.String("test-api-key-123"),
+				Site: "datadoghq.com",
+			},
+		}),
+		WithForwarderConfig(),
+		WithPayloadsConfig(),
+	}
+	configComponent := NewConfigComponent(configOptions...)
+
+	// Create the serializer
+	serializer := NewSerializerComponent(configComponent, zlog, "test-hostname")
+	require.NotNil(t, serializer)
+
+	// Test that it implements SerializerWithForwarder
+	serializerWithForwarder, ok := serializer.(SerializerWithForwarder)
+	require.True(t, ok, "Expected serializer to implement SerializerWithForwarder interface")
+
+	// Test initial state - should be stopped
+	assert.Equal(t, defaultforwarder.Stopped, serializerWithForwarder.State())
+
+	// Test Start method
+	err = serializerWithForwarder.Start()
+	assert.NoError(t, err, "Start should succeed")
+	assert.Equal(t, defaultforwarder.Started, serializerWithForwarder.State())
+
+	// Test that we can call Start again (should return error or be idempotent)
+	err = serializerWithForwarder.Start()
+	assert.Error(t, err, "Starting an already started forwarder should return an error")
+
+	// Test Stop method
+	serializerWithForwarder.Stop()
+	assert.Equal(t, defaultforwarder.Stopped, serializerWithForwarder.State())
+
+	// Test that we can stop again (should be safe)
+	serializerWithForwarder.Stop() // Should not panic
+}
+
+func TestForwarderWithLifecycle_CompileTimeCheck(t *testing.T) {
+	// This test verifies that our compile-time check works correctly
+	// If DefaultForwarder doesn't implement ForwarderWithLifecycle,
+	// the compilation would fail at the var _ ForwarderWithLifecycle line
+
+	// Create a minimal setup to verify the interface works
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	zlog := &ZapLogger{Logger: logger}
+
+	configOptions := []ConfigOption{
+		WithAPIConfig(&datadogconfig.Config{
+			API: datadogconfig.APIConfig{
+				Key:  configopaque.String("abcdef1234567890"),
+				Site: "datadoghq.com",
+			},
+		}),
+		WithForwarderConfig(),
+	}
+	configComponent := NewConfigComponent(configOptions...)
+
+	// This should return ForwarderWithLifecycle
+	forwarder := newForwarderComponent(configComponent, zlog)
+	require.NotNil(t, forwarder)
+
+	// Lifecycle methods
+	assert.Equal(t, defaultforwarder.Stopped, forwarder.State())
+
+	err = forwarder.Start()
+	assert.NoError(t, err)
+	assert.Equal(t, defaultforwarder.Started, forwarder.State())
+
+	// Test that it implements both Forwarder and lifecycle methods
+	// Forwarder interface methods
+	err = forwarder.SubmitV1Series(nil, nil)
+	assert.NoError(t, err) // Should not panic, may return error
+
+	forwarder.Stop()
+	assert.Equal(t, defaultforwarder.Stopped, forwarder.State())
 }
 
 func TestAgentComponents_NewLogComponent(t *testing.T) {
@@ -492,30 +582,25 @@ func TestNewForwarderComponent(t *testing.T) {
 		name     string
 		site     string
 		apiKey   string
-		validate func(t *testing.T, forwarder defaultforwarder.Forwarder, cfg coreconfig.Component)
+		validate func(t *testing.T, forwarder forwarderWithLifecycle, cfg coreconfig.Component)
 	}{
 		{
 			name:   "basic forwarder creation",
 			site:   "datadoghq.com",
 			apiKey: "test-api-key-123",
-			validate: func(t *testing.T, forwarder defaultforwarder.Forwarder, _ coreconfig.Component) {
+			validate: func(t *testing.T, forwarder forwarderWithLifecycle, _ coreconfig.Component) {
 				// Test that forwarder is not nil
 				assert.NotNil(t, forwarder)
 
-				// Test that we can cast to concrete type to access state
-				df, ok := forwarder.(*defaultforwarder.DefaultForwarder)
-				assert.True(t, ok, "Expected forwarder to be *DefaultForwarder")
-				assert.NotNil(t, df)
-
 				// Test that the forwarder is in stopped state initially
-				assert.Equal(t, defaultforwarder.Stopped, df.State())
+				assert.Equal(t, defaultforwarder.Stopped, forwarder.State())
 			},
 		},
 		{
 			name:   "different site configuration",
 			site:   "datadoghq.eu",
 			apiKey: "eu-api-key-456",
-			validate: func(t *testing.T, forwarder defaultforwarder.Forwarder, cfg coreconfig.Component) {
+			validate: func(t *testing.T, forwarder forwarderWithLifecycle, cfg coreconfig.Component) {
 				assert.NotNil(t, forwarder)
 
 				// Verify the site was configured correctly
@@ -527,7 +612,7 @@ func TestNewForwarderComponent(t *testing.T) {
 			name:   "empty api key",
 			site:   "datadoghq.com",
 			apiKey: "",
-			validate: func(t *testing.T, forwarder defaultforwarder.Forwarder, cfg coreconfig.Component) {
+			validate: func(t *testing.T, forwarder forwarderWithLifecycle, cfg coreconfig.Component) {
 				assert.NotNil(t, forwarder)
 				assert.Empty(t, cfg.GetString("api_key"))
 			},
@@ -591,20 +676,16 @@ func TestNewForwarderComponent_Internal(t *testing.T) {
 	// Validate the forwarder was created
 	require.NotNil(t, forwarder)
 
-	// Cast to concrete type to test internals
-	df, ok := forwarder.(*defaultforwarder.DefaultForwarder)
-	require.True(t, ok, "Expected forwarder to be *DefaultForwarder")
-
 	// Test internal state
-	assert.Equal(t, defaultforwarder.Stopped, df.State())
+	assert.Equal(t, defaultforwarder.Stopped, forwarder.State())
 
 	// Test that we can start and stop the forwarder (this tests internal configuration)
-	err = df.Start()
+	err = forwarder.Start()
 	assert.NoError(t, err)
-	assert.Equal(t, defaultforwarder.Started, df.State())
+	assert.Equal(t, defaultforwarder.Started, forwarder.State())
 
-	df.Stop()
-	assert.Equal(t, defaultforwarder.Stopped, df.State())
+	forwarder.Stop()
+	assert.Equal(t, defaultforwarder.Stopped, forwarder.State())
 }
 
 func TestNewForwarderComponent_KeysPerDomainConfiguration(t *testing.T) {
@@ -635,13 +716,11 @@ func TestNewForwarderComponent_KeysPerDomainConfiguration(t *testing.T) {
 	forwarder := newForwarderComponent(configComponent, logComponent)
 	require.NotNil(t, forwarder)
 
-	// Test that the forwarder can be started (which validates internal configuration)
-	df := forwarder.(*defaultforwarder.DefaultForwarder)
-	err = df.Start()
+	err = forwarder.Start()
 	assert.NoError(t, err)
 
 	// Clean up
-	df.Stop()
+	forwarder.Stop()
 }
 
 func TestNewForwarderComponent_DisableAPIKeyChecking(t *testing.T) {
@@ -668,12 +747,11 @@ func TestNewForwarderComponent_DisableAPIKeyChecking(t *testing.T) {
 	// The function should set DisableAPIKeyChecking to true
 	// We can verify this by checking that the forwarder starts successfully
 	// even with potentially invalid keys, since API key validation is disabled
-	df := forwarder.(*defaultforwarder.DefaultForwarder)
-	err = df.Start()
+	err = forwarder.Start()
 	assert.NoError(t, err, "Forwarder should start successfully with DisableAPIKeyChecking=true")
 
 	// Clean up
-	df.Stop()
+	forwarder.Stop()
 }
 
 func TestNewForwarderComponent_ForwarderInterface(t *testing.T) {
@@ -698,8 +776,7 @@ func TestNewForwarderComponent_ForwarderInterface(t *testing.T) {
 
 	// Test a few method calls that shouldn't panic (though they may return errors)
 	// Since these require the forwarder to be started, we'll start it first
-	df := forwarder.(*defaultforwarder.DefaultForwarder)
-	err = df.Start()
+	err = forwarder.Start()
 	require.NoError(t, err)
 
 	// These method calls validate that the interface is properly implemented
@@ -711,5 +788,5 @@ func TestNewForwarderComponent_ForwarderInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	// Clean up
-	df.Stop()
+	forwarder.Stop()
 }

--- a/pkg/datadog/agentcomponents/agentcomponents_test.go
+++ b/pkg/datadog/agentcomponents/agentcomponents_test.go
@@ -484,28 +484,24 @@ func TestSerializerWithForwarder_LifecycleMethods(t *testing.T) {
 	serializer := NewSerializerComponent(configComponent, zlog, "test-hostname")
 	require.NotNil(t, serializer)
 
-	// Test that it implements SerializerWithForwarder
-	serializerWithForwarder, ok := serializer.(SerializerWithForwarder)
-	require.True(t, ok, "Expected serializer to implement SerializerWithForwarder interface")
-
 	// Test initial state - should be stopped
-	assert.Equal(t, defaultforwarder.Stopped, serializerWithForwarder.State())
+	assert.Equal(t, defaultforwarder.Stopped, serializer.State())
 
 	// Test Start method
-	err = serializerWithForwarder.Start()
+	err = serializer.Start()
 	assert.NoError(t, err, "Start should succeed")
-	assert.Equal(t, defaultforwarder.Started, serializerWithForwarder.State())
+	assert.Equal(t, defaultforwarder.Started, serializer.State())
 
 	// Test that we can call Start again (should return error or be idempotent)
-	err = serializerWithForwarder.Start()
+	err = serializer.Start()
 	assert.Error(t, err, "Starting an already started forwarder should return an error")
 
 	// Test Stop method
-	serializerWithForwarder.Stop()
-	assert.Equal(t, defaultforwarder.Stopped, serializerWithForwarder.State())
+	serializer.Stop()
+	assert.Equal(t, defaultforwarder.Stopped, serializer.State())
 
 	// Test that we can stop again (should be safe)
-	serializerWithForwarder.Stop() // Should not panic
+	serializer.Stop() // Should not panic
 }
 
 func TestForwarderWithLifecycle_CompileTimeCheck(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds `SerializerWithForwarder` interface to `pkg/datadog/agentcomponents` to allow for interaction with underlying Forwarder's methods
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to #40560, #40556

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated unit tests

<!--Describe the documentation added.-->
#### Documentation
.chloggen for api
<!--Please delete paragraphs that you did not use before submitting.-->
