### PR TITLE
Make receiverType private

### DIFF
--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -16,29 +16,31 @@ import (
 
 // newFactoryAdapter creates a factory for windowseventlog receiver
 func newFactoryAdapter() receiver.Factory {
-	return adapter.NewFactory(ReceiverType{}, metadata.LogsStability)
+	return adapter.NewFactory(receiverType{}, metadata.LogsStability)
 }
 
-// ReceiverType implements adapter.LogReceiverType
+// receiverType implements adapter.LogReceiverType
 // to create a file tailing receiver
-type ReceiverType struct{}
+type receiverType struct{}
+
+var _ adapter.LogReceiverType = (*receiverType)(nil)
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (f receiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (f receiverType) CreateDefaultConfig() component.Config {
 	return createDefaultConfig()
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (f receiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*WindowsLogConfig).BaseConfig
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (f receiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*WindowsLogConfig).InputConfig)
 }


### PR DESCRIPTION
Fix #40678 "these structs are not part of config and cannot be exported: ReceiverType"