### PR TITLE
[chore] [basicauthextension] fix flaky tests

### DIFF
--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -54,7 +54,7 @@ func TestBasicAuth_Valid(t *testing.T) {
 		require.NoError(t, err)
 	}
 	htpasswdFile := filepath.Join(t.TempDir(), ".htpasswd")
-	err := os.WriteFile(htpasswdFile, buf.Bytes(), 0644)
+	err := os.WriteFile(htpasswdFile, buf.Bytes(), 0o600)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -151,7 +151,7 @@ func TestBasicAuth_HtpasswdInlinePrecedence(t *testing.T) {
 	t.Parallel()
 
 	htpasswdFile := filepath.Join(t.TempDir(), ".htpasswd")
-	err := os.WriteFile(htpasswdFile, []byte("username:fromfile"), 0644)
+	err := os.WriteFile(htpasswdFile, []byte("username:fromfile"), 0o600)
 	require.NoError(t, err)
 
 	ext, err := newServerAuthExtension(&Config{

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -4,11 +4,13 @@
 package basicauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,20 +47,21 @@ var credentials = [][]string{
 
 func TestBasicAuth_Valid(t *testing.T) {
 	t.Parallel()
-	f, err := os.CreateTemp(t.TempDir(), ".htpasswd")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
 
+	var buf bytes.Buffer
 	for _, c := range credentials {
-		_, err = fmt.Fprintf(f, "%s:%s\n", c[0], c[1])
+		_, err := fmt.Fprintf(&buf, "%s:%s\n", c[0], c[1])
 		require.NoError(t, err)
 	}
+	htpasswdFile := filepath.Join(t.TempDir(), ".htpasswd")
+	err := os.WriteFile(htpasswdFile, buf.Bytes(), 0644)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
 	ext, err := newServerAuthExtension(&Config{
 		Htpasswd: &HtpasswdSettings{
-			File: f.Name(),
+			File: htpasswdFile,
 		},
 	})
 	require.NoError(t, err)
@@ -146,16 +149,14 @@ func TestBasicAuth_InvalidFormat(t *testing.T) {
 
 func TestBasicAuth_HtpasswdInlinePrecedence(t *testing.T) {
 	t.Parallel()
-	f, err := os.CreateTemp(t.TempDir(), ".htpasswd")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
 
-	_, err = f.WriteString("username:fromfile")
+	htpasswdFile := filepath.Join(t.TempDir(), ".htpasswd")
+	err := os.WriteFile(htpasswdFile, []byte("username:fromfile"), 0644)
 	require.NoError(t, err)
 
 	ext, err := newServerAuthExtension(&Config{
 		Htpasswd: &HtpasswdSettings{
-			File:   f.Name(),
+			File:   htpasswdFile,
 			Inline: "username:frominline",
 		},
 	})


### PR DESCRIPTION
#### Description

Don't keep the .htpasswd test data files open, as this will cause the test to fail on Windows during teardown, when it attempts to remove the temp dir. On Windows, by default, a file cannot be removed while it is open.

#### Link to tracking issue
Fixes #40405

#### Testing

I used Wine to reproduce this locally:
 - `GOOS=windows go test -c`
 - `wine ./basicauthextension.test.exe -test.v -test.failfast -test.count=1000 -test.run=TestBasicAuth_HtpasswdInlinePrecedence`

#### Documentation

N/A