### PR TITLE
[receiver/googlecloudmonitoring] Add support for delta distributions

### DIFF
--- a/.chloggen/googlecloudmonitoringreceiver-add-support-for-distributions.yaml
+++ b/.chloggen/googlecloudmonitoringreceiver-add-support-for-distributions.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: googlecloudmonitoringreceiver
+note: Add support for converting Google Cloud monitoring delta distribution metrics to OpenTelemetry histograms.
+issues: [39600]

--- a/receiver/googlecloudmonitoringreceiver/go.mod
+++ b/receiver/googlecloudmonitoringreceiver/go.mod
@@ -3,6 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/google
 go 1.23.0
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.34.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/component/componenttest v0.128.1-0.20250610090210-188191247685
@@ -22,11 +24,13 @@ require (
 	cloud.google.com/go/auth v0.16.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.128.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1-0.20250610090210-188191247685 // indirect
@@ -79,3 +83,9 @@ require (
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden

--- a/receiver/googlecloudmonitoringreceiver/go.sum
+++ b/receiver/googlecloudmonitoringreceiver/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.7.0 h1:PBWF+iiAerVNe8UCHxdOt6eHLVc3ydFeO
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 cloud.google.com/go/monitoring v1.24.2 h1:5OTsoJ1dXYIiMiuL+sYscLc9BumrL3CarVLL7dd7lHM=
 cloud.google.com/go/monitoring v1.24.2/go.mod h1:x7yzPWcgDRnPEv3sI+jJGBkwl5qINf+6qY4eq0I9B4U=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -422,8 +422,9 @@ func (mb *MetricsBuilder) convertDistributionExemplarAttachmentSpanContext(sourc
 			zap.String("parsed trace ID", string(traceIDRaw)),
 			zap.Error(err),
 		)
+	} else {
+		targetExemplarDataPoint.SetTraceID(pcommon.TraceID(traceID))
 	}
-	targetExemplarDataPoint.SetTraceID(pcommon.TraceID(traceID))
 	_, err = hex.Decode(spanID, spanIDRaw)
 	if err != nil {
 		mb.logger.Debug(
@@ -432,8 +433,9 @@ func (mb *MetricsBuilder) convertDistributionExemplarAttachmentSpanContext(sourc
 			zap.String("parsed span ID", string(spanIDRaw)),
 			zap.Error(err),
 		)
+	} else {
+		targetExemplarDataPoint.SetSpanID(pcommon.SpanID(spanID))
 	}
-	targetExemplarDataPoint.SetSpanID(pcommon.SpanID(spanID))
 }
 
 func (mb *MetricsBuilder) convertDistributionExemplarAttachmentDroppedLabels(sourceValue *anypb.Any, targetExemplarDataPoint *pmetric.Exemplar) {
@@ -443,6 +445,7 @@ func (mb *MetricsBuilder) convertDistributionExemplarAttachmentDroppedLabels(sou
 			"Failed to convert dropped labels from Google Cloud Monitoring distribution data point exemplar attachment",
 			zap.Error(err),
 		)
+		return
 	}
 	targetDroppedLabels := make(map[string]any, len(sourceDroppedLabels.Label))
 	for k, v := range sourceDroppedLabels.Label {

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -224,8 +224,10 @@ func (mb *MetricsBuilder) ConvertDistributionToMetrics(ts *monitoringpb.TimeSeri
 		}
 
 		countTotal := uint64(0)
+		sourceBucketCounts := sourceValue.GetDistributionValue().GetBucketCounts()
 		targetBucketCounts := targetDataPoint.BucketCounts()
-		for _, bucketCount := range sourceValue.GetDistributionValue().GetBucketCounts() {
+		targetBucketCounts.EnsureCapacity(len(sourceBucketCounts))
+		for _, bucketCount := range sourceBucketCounts {
 			if bucketCount >= 0 {
 				targetBucketCounts.Append(uint64(bucketCount))
 				countTotal += uint64(bucketCount)
@@ -305,6 +307,7 @@ func (mb *MetricsBuilder) convertDistributionDataPointLinearBuckets(
 
 	// bucket 0: [-infinity, offset) and
 	// buckets 1 - N-1: [offset + (width * (i - 1)), offset + (width * i))
+	targetDataPoint.ExplicitBounds().EnsureCapacity(int(numFiniteBuckets) + 1)
 	for i := 0; i <= int(numFiniteBuckets); i++ {
 		targetDataPoint.ExplicitBounds().Append(offset + width*float64(i))
 	}
@@ -356,6 +359,7 @@ func (mb *MetricsBuilder) convertDistributionDataPointExponentialBuckets(
 
 	// bucket 0: [-infinity, offset) and
 	// buckets 1 - N-1: [offset + (width * (i - 1)), offset + (width * i))
+	targetDataPoint.ExplicitBounds().EnsureCapacity(int(numFiniteBuckets) + 1)
 	for i := 0; i <= int(numFiniteBuckets); i++ {
 		targetDataPoint.ExplicitBounds().Append(scale * math.Pow(growthFactor, float64(i)))
 	}

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -4,15 +4,33 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver/internal"
 
 import (
+	"encoding/hex"
+	"math"
+	"reflect"
+	"regexp"
+	"strconv"
+	"time"
+
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/api/distribution"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type MetricsBuilder struct {
 	logger *zap.Logger
 }
+
+const (
+	spanContextTypeURL   = "type.googleapis.com/google.monitoring.v3.SpanContext"
+	droppedLabelsTypeURL = "type.googleapis.com/google.monitoring.v3.DroppedLabels"
+)
+
+var spanNameRegex = regexp.MustCompile("projects/[^/]*/traces/(?P<traceId>[[:alnum:]]*)/spans/(?P<spanId>[[:alnum:]]*)")
 
 func NewMetricsBuilder(logger *zap.Logger) *MetricsBuilder {
 	return &MetricsBuilder{
@@ -119,4 +137,338 @@ func (mb *MetricsBuilder) ConvertDeltaToMetrics(ts *monitoringpb.TimeSeries, m p
 	}
 
 	return m
+}
+
+// ConvertDistributionToMetrics converts from Google cloud monitoring distributions to OpenTelemetry histograms.
+// See https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#Distribution for information on distribution metrics.
+func (mb *MetricsBuilder) ConvertDistributionToMetrics(ts *monitoringpb.TimeSeries, m pmetric.Metric) pmetric.Metric {
+	m.SetName(ts.GetMetric().GetType())
+	m.SetUnit(ts.GetUnit())
+	histogram := m.SetEmptyHistogram()
+	histogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+	// Note: Google cloud monitoring distributions use inclusive lower bound and exclusive upper bound (see
+	// https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#bucketoptions), while OpenTelemetry histograms use
+	// exclusive lower bounds and inclusive upper bounds. For the conversion, we are deliberately ignoring this discrepancy in
+	// accordance with https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram-bucket-inclusivity, quote:
+	// > Importers and exporters working with OpenTelemetry Metrics data are meant to disregard this specification when
+	// > translating to and from histogram formats that use inclusive lower bounds and exclusive upper bounds.
+
+	metricAttributes := convertDistributionLabels(ts.GetMetric().GetLabels())
+	for _, sourceDataPoint := range ts.GetPoints() {
+		sourceValue := sourceDataPoint.GetValue()
+		if sourceValue == nil {
+			mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, missing value.", zap.String("name", ts.Metric.Type))
+			continue
+		}
+		distributionValue := sourceValue.GetDistributionValue()
+		if distributionValue == nil {
+			mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, missing distribution value.", zap.String("name", ts.Metric.Type))
+			continue
+		}
+		bucketOptions := distributionValue.GetBucketOptions()
+		if bucketOptions == nil {
+			mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, missing bucket options", zap.String("name", ts.Metric.Type))
+			continue
+		}
+		interval := sourceDataPoint.GetInterval()
+		if interval == nil {
+			mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, missing interval", zap.String("name", ts.Metric.Type))
+			continue
+		}
+
+		targetDataPoint := histogram.DataPoints().AppendEmpty()
+		startTime := sourceDataPoint.GetInterval().GetStartTime()
+		if startTime != nil && startTime.IsValid() {
+			targetDataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime.AsTime()))
+		} else {
+			mb.logger.Debug("Invalid or absent start time on Google Cloud Monitoring distribution data point:", zap.String("Metric", ts.Metric.Type))
+		}
+		endTime := sourceDataPoint.GetInterval().GetEndTime()
+		if endTime != nil && endTime.IsValid() {
+			targetDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(endTime.AsTime()))
+		} else {
+			mb.logger.Debug("Invalid or absent end time on Google Cloud Monitoring distribution data point:", zap.String("Metric", ts.Metric.Type))
+			// fall back to the current time stamp if no timestamp is available on the source data point
+			targetDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		}
+
+		metricAttributes.CopyTo(targetDataPoint.Attributes())
+
+		mb.convertExemplars(distributionValue, &targetDataPoint)
+
+		switch bucketOptions.Options.(type) {
+		case *distribution.Distribution_BucketOptions_ExplicitBuckets:
+			mb.convertDistributionDataPointExplicitBuckets(
+				ts.Metric.Type,
+				bucketOptions.GetExplicitBuckets(),
+				&targetDataPoint,
+			)
+		case *distribution.Distribution_BucketOptions_LinearBuckets:
+			mb.convertDistributionDataPointLinearBuckets(
+				ts.Metric.Type,
+				bucketOptions.GetLinearBuckets(),
+				&targetDataPoint,
+			)
+		case *distribution.Distribution_BucketOptions_ExponentialBuckets:
+			mb.convertDistributionDataPointExponentialBuckets(
+				ts.Metric.Type,
+				bucketOptions.GetExponentialBuckets(),
+				&targetDataPoint,
+			)
+		default:
+			mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point: Unsupported bucket option type",
+				zap.String("name", ts.Metric.Type),
+				zap.String("bucket option type)",
+					reflect.TypeOf(bucketOptions.Options).String(),
+				))
+			continue
+		}
+
+		countTotal := uint64(0)
+		for _, bucketCount := range sourceValue.GetDistributionValue().GetBucketCounts() {
+			if bucketCount >= 0 {
+				targetDataPoint.BucketCounts().Append(uint64(bucketCount))
+				countTotal += uint64(bucketCount)
+			}
+			// silently ignore negative counts, a bucket count should never be negative
+		}
+		targetDataPoint.SetCount(countTotal)
+	}
+
+	return m
+}
+
+func convertDistributionLabels(sourceLabels map[string]string) pcommon.Map {
+	metricAttributes := pcommon.NewMap()
+	metricAttributes.EnsureCapacity(len(sourceLabels))
+	for k, v := range sourceLabels {
+		metricAttributes.PutStr(k, v)
+	}
+	return metricAttributes
+}
+
+func (mb *MetricsBuilder) convertDistributionDataPointExplicitBuckets(
+	metricType string,
+	buckets *distribution.Distribution_BucketOptions_Explicit,
+	targetDataPoint *pmetric.HistogramDataPoint,
+) {
+	bounds := buckets.GetBounds()
+	if len(bounds) == 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point with explicit bucket type and zero buckets",
+			zap.String("name", metricType),
+		)
+		return
+	}
+	targetDataPoint.ExplicitBounds().FromRaw(buckets.GetBounds())
+	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+}
+
+func (mb *MetricsBuilder) convertDistributionDataPointLinearBuckets(
+	metricType string,
+	buckets *distribution.Distribution_BucketOptions_Linear,
+	targetDataPoint *pmetric.HistogramDataPoint,
+) {
+	numFiniteBuckets := buckets.GetNumFiniteBuckets()
+	if numFiniteBuckets < 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, number of finite buckets not within allowed range (must by >= 0)",
+			zap.String("name", metricType),
+			zap.Int32("number of finite buckets", numFiniteBuckets),
+		)
+		return
+	}
+	offset := buckets.GetOffset()
+	if offset < 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, offset is not within allowed range (must >= 0)",
+			zap.String("name", metricType),
+			zap.Float64("offset", offset),
+		)
+		return
+	}
+	width := buckets.GetWidth()
+	if width <= 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, scale is not within allowed range (must be > 0)",
+			zap.String("name", metricType),
+			zap.Float64("width", width),
+		)
+		return
+	}
+
+	// See https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#linear:
+	// There are numFiniteBuckets + 2 (= N) buckets. Bucket i has the following boundaries:
+	// Lower bound (1 <= i < N): offset + (width * (i - 1)).
+	// Upper bound (0 <= i < N-1): offset + (width * i).
+
+	// bucket 0: [-infinity, offset) and
+	// buckets 1 - N-1: [offset + (width * (i - 1)), offset + (width * i))
+	for i := 0; i <= int(numFiniteBuckets); i++ {
+		targetDataPoint.ExplicitBounds().Append(offset + width*float64(i))
+	}
+	// bucket N: [offset + (width * (N - 1)), +infinity)
+	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+}
+
+func (mb *MetricsBuilder) convertDistributionDataPointExponentialBuckets(
+	metricType string,
+	buckets *distribution.Distribution_BucketOptions_Exponential,
+	targetDataPoint *pmetric.HistogramDataPoint,
+) {
+	// Note: This method converts a distribution with exponential buckets to an OpenTelemetry histogram with explicit bounds.
+	// An obvious alternative would be to convert it to an exponential histogram. However, this cannot be done without loss of
+	// precision. An OpenTelemetry exponential histograms sets the boundary for bucket i at (2^(2^(-scale)))^i, with scale being
+	// an integer. Google Cloud Monitoring exponential buckets use a floating point scale and growth factor and set the boundary
+	// at scale * (growthFactor ^ i). Depending on the chosen scale and growth factor, even the best approximation of the
+	// Google Cloud Monitoring bucket boundaries might deviate from the actual boundaries significantly. Therefore, we instead
+	// convert the exponential distribution to a plain OpenTelemetry histogram with explicit bounds. This choice trades payload
+	// size for precision (that is, we avoid loss of precision/information by accepting a larger payload size).
+	numFiniteBuckets := buckets.GetNumFiniteBuckets()
+	if numFiniteBuckets < 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, number of finite buckets not within allowed range (must by >= 0)",
+			zap.String("name", metricType),
+			zap.Int32("number of finite buckets", numFiniteBuckets),
+		)
+		return
+	}
+	growthFactor := buckets.GetGrowthFactor()
+	if growthFactor <= 1.0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, growth factor is not within allowed range (must by > 1)",
+			zap.String("name", metricType),
+			zap.Float64("growth factor", growthFactor),
+		)
+		return
+	}
+	scale := buckets.GetScale()
+	if scale <= 0 {
+		mb.logger.Debug("Cannot transform Google Cloud Monitoring distribution data point, scale is not within allowed range (must be > 0)",
+			zap.String("name", metricType),
+			zap.Float64("scale", scale),
+		)
+		return
+	}
+
+	// See https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#exponential:
+	// There are numFiniteBuckets + 2 (= N) buckets. Bucket i has the following boundaries:
+	// Lower bound (1 <= i < N): scale * (growthFactor ^ (i - 1)).
+	// Upper bound (0 <= i < N-1): scale * (growthFactor ^ i).
+
+	// bucket 0: [-infinity, offset) and
+	// buckets 1 - N-1: [offset + (width * (i - 1)), offset + (width * i))
+	for i := 0; i <= int(numFiniteBuckets); i++ {
+		targetDataPoint.ExplicitBounds().Append(scale * math.Pow(growthFactor, float64(i)))
+	}
+	// bucket N: [offset + (width * (N - 1)), +infinity)
+	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+}
+
+func (mb *MetricsBuilder) convertExemplars(distributionValue *distribution.Distribution, targetDataPoint *pmetric.HistogramDataPoint) {
+	sourceExemplars := distributionValue.GetExemplars()
+	if len(sourceExemplars) > 0 {
+		targetDataPoint.Exemplars().EnsureCapacity(len(sourceExemplars))
+		for _, sourceExemplar := range sourceExemplars {
+			targetExemplarDataPoint := targetDataPoint.Exemplars().AppendEmpty()
+			targetExemplarDataPoint.SetTimestamp(pcommon.NewTimestampFromTime(sourceExemplar.GetTimestamp().AsTime()))
+			targetExemplarDataPoint.SetDoubleValue(sourceExemplar.GetValue())
+			sourceAttachments := sourceExemplar.GetAttachments()
+			for attachmentIdx, sourceAttachment := range sourceAttachments {
+				if sourceAttachment == nil {
+					continue
+				}
+				value := sourceAttachment.GetValue()
+				if len(value) == 0 {
+					// skip attachments with nil or empty value
+					continue
+				}
+				typeURL := sourceAttachment.GetTypeUrl()
+				switch typeURL {
+				case spanContextTypeURL:
+					mb.convertDistributionExemplarAttachmentSpanContext(value, &targetExemplarDataPoint)
+				case droppedLabelsTypeURL:
+					mb.convertDistributionExemplarAttachmentDroppedLabels(sourceAttachment, &targetExemplarDataPoint)
+				default:
+					mb.convertArbitraryAttachment(typeURL, attachmentIdx, sourceAttachment, &targetExemplarDataPoint)
+				}
+			}
+		}
+	}
+}
+
+func (mb *MetricsBuilder) convertDistributionExemplarAttachmentSpanContext(sourceValueBytes []byte, targetExemplarDataPoint *pmetric.Exemplar) {
+	matches := spanNameRegex.FindSubmatch(sourceValueBytes)
+	if matches == nil || len(matches) != 3 {
+		mb.logger.Debug(
+			"Failed to parse span context from Google Cloud Monitoring distribution data point exemplar attachment, value did not match the expected format "+spanNameRegex.String(),
+			zap.String("attachment value", string(sourceValueBytes)),
+		)
+		return
+	}
+	traceIDRaw := matches[1]
+	spanIDRaw := matches[2]
+	traceID := make([]byte, 16)
+	spanID := make([]byte, 8)
+	_, err := hex.Decode(traceID, traceIDRaw)
+	if err != nil {
+		mb.logger.Debug(
+			"Failed to convert trace ID from span context of from Google Cloud Monitoring distribution data point exemplar attachment",
+			zap.String("attachment value", string(sourceValueBytes)),
+			zap.String("parsed trace ID", string(traceIDRaw)),
+			zap.Error(err),
+		)
+	}
+	targetExemplarDataPoint.SetTraceID(pcommon.TraceID(traceID))
+	_, err = hex.Decode(spanID, spanIDRaw)
+	if err != nil {
+		mb.logger.Debug(
+			"Failed to convert span ID from span context of from Google Cloud Monitoring distribution data point exemplar attachment",
+			zap.String("attachment value", string(sourceValueBytes)),
+			zap.String("parsed span ID", string(spanIDRaw)),
+			zap.Error(err),
+		)
+	}
+	targetExemplarDataPoint.SetSpanID(pcommon.SpanID(spanID))
+}
+
+func (mb *MetricsBuilder) convertDistributionExemplarAttachmentDroppedLabels(sourceValue *anypb.Any, targetExemplarDataPoint *pmetric.Exemplar) {
+	sourceDroppedLabels := monitoringpb.DroppedLabels{}
+	if err := anypb.UnmarshalTo(sourceValue, &sourceDroppedLabels, proto.UnmarshalOptions{}); err != nil {
+		mb.logger.Debug(
+			"Failed to convert dropped labels from Google Cloud Monitoring distribution data point exemplar attachment",
+			zap.Error(err),
+		)
+	}
+	targetDroppedLabels := make(map[string]any, len(sourceDroppedLabels.Label))
+	for k, v := range sourceDroppedLabels.Label {
+		targetDroppedLabels[k] = v
+	}
+	if err := targetExemplarDataPoint.FilteredAttributes().PutEmptyMap(droppedLabelsTypeURL).FromRaw(targetDroppedLabels); err != nil {
+		mb.logger.Debug(
+			"Failed to set dropped labels in Google Cloud Monitoring distribution data point exemplar",
+			zap.Error(err),
+		)
+	}
+}
+
+func (mb *MetricsBuilder) convertArbitraryAttachment(
+	typeURL string,
+	attachmentIdx int,
+	sourceValue *anypb.Any,
+	targetExemplarDataPoint *pmetric.Exemplar,
+) {
+	var attachmentKey string
+	if typeURL == "" {
+		attachmentKey = "attachment_" + strconv.Itoa(attachmentIdx)
+	} else {
+		attachmentKey = typeURL + "_" + strconv.Itoa(attachmentIdx)
+	}
+
+	// The source attachment can be any arbitrary protobuf message, so we (somewhat arbitrarily) convert it to JSON and store it
+	// the resulting byte slice in the target data point.
+	jsonBytes, err := protojson.Marshal(sourceValue)
+	if err != nil {
+		mb.logger.Debug(
+			"Failed to deserialize an exemplar attachment protobuf message in a Google Cloud Monitoring distribution data point",
+			zap.Error(err),
+		)
+	}
+	targetAttachmentBytes := targetExemplarDataPoint.FilteredAttributes().PutEmptyBytes(attachmentKey)
+	targetAttachmentBytes.FromRaw(jsonBytes)
 }

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -259,7 +259,7 @@ func (mb *MetricsBuilder) convertDistributionDataPointExplicitBuckets(
 		return
 	}
 	targetDataPoint.ExplicitBounds().FromRaw(buckets.GetBounds())
-	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+	// Note: There is also an implicit overflow bucket with boundary +Inf.
 }
 
 func (mb *MetricsBuilder) convertDistributionDataPointLinearBuckets(
@@ -302,8 +302,7 @@ func (mb *MetricsBuilder) convertDistributionDataPointLinearBuckets(
 	for i := 0; i <= int(numFiniteBuckets); i++ {
 		targetDataPoint.ExplicitBounds().Append(offset + width*float64(i))
 	}
-	// bucket N: [offset + (width * (N - 1)), +infinity)
-	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+	// bucket N: implicit overflow bucket [offset + (width * (N - 1)), +infinity)
 }
 
 func (mb *MetricsBuilder) convertDistributionDataPointExponentialBuckets(
@@ -354,8 +353,7 @@ func (mb *MetricsBuilder) convertDistributionDataPointExponentialBuckets(
 	for i := 0; i <= int(numFiniteBuckets); i++ {
 		targetDataPoint.ExplicitBounds().Append(scale * math.Pow(growthFactor, float64(i)))
 	}
-	// bucket N: [offset + (width * (N - 1)), +infinity)
-	targetDataPoint.ExplicitBounds().Append(math.Inf(1))
+	// bucket N: implicit overflow bucket [offset + (width * (N - 1)), +infinity)
 }
 
 func (mb *MetricsBuilder) convertExemplars(distributionValue *distribution.Distribution, targetDataPoint *pmetric.HistogramDataPoint) {

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -334,9 +334,9 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDa
 	mb := NewMetricsBuilder(logger)
 
 	sourceBucketCountsAllDataPoints := [][]int64{
-		{5, 10, 15, 11},
-		{6, 11, 16, 12},
-		{7, 12, 17, 13},
+		{5, 0, 15, 11},
+		{6, -1, 16, 12},
+		{7, 0, 17, 13},
 	}
 	boundsAllDataPoints := [][]float64{
 		{11.1, 22.2, 33.3},
@@ -400,12 +400,16 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDa
 
 		assert.Equal(t, 13+60*int64(i), targetDataPoint.StartTimestamp().AsTime().Unix())
 		assert.Equal(t, 13+60*int64(i+1), targetDataPoint.Timestamp().AsTime().Unix())
-		assert.Equal(t, uint64(41+4*i), targetDataPoint.Count())
+		assert.Equal(t, 31+3*i, int(targetDataPoint.Count()))
 
 		bucketCounts := targetDataPoint.BucketCounts()
 		require.Equal(t, len(sourceBucketCountsAllDataPoints[i]), bucketCounts.Len())
-		for i, countValue := range sourceBucketCountsAllDataPoints[i] {
-			assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+		for i, sourceCountValue := range sourceBucketCountsAllDataPoints[i] {
+			if sourceCountValue < 0 {
+				assert.Equal(t, uint64(0), bucketCounts.At(i))
+			} else {
+				assert.Equal(t, uint64(sourceCountValue), bucketCounts.At(i))
+			}
 		}
 
 		bounds := targetDataPoint.ExplicitBounds()

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -1,0 +1,756 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/api/distribution"
+	"google.golang.org/genproto/googleapis/api/metric"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestConvertGaugeToMetrics_ValidGaugePoints(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	ts := &monitoringpb.TimeSeries{
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 10},
+					EndTime:   &timestamppb.Timestamp{Seconds: 20},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 42.0},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertGaugeToMetrics(ts, m)
+
+	assert.Equal(t, 1, m.Gauge().DataPoints().Len())
+	dp := m.Gauge().DataPoints().At(0)
+	assert.Equal(t, int64(10), dp.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(20), dp.Timestamp().AsTime().Unix())
+	assert.Equal(t, 42.0, dp.DoubleValue())
+}
+
+func TestConvertGaugeToMetrics_InvalidEndTime(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	ts := &monitoringpb.TimeSeries{
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 10},
+					EndTime:   nil,
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 100},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertGaugeToMetrics(ts, m)
+
+	assert.Equal(t, 1, m.Gauge().DataPoints().Len())
+	dp := m.Gauge().DataPoints().At(0)
+	assert.Equal(t, int64(10), dp.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(100), dp.IntValue())
+}
+
+func TestConvertDistributionToMetrics_NoDataPoints(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{},
+	}
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+	require.Equal(t, 0, m.Histogram().DataPoints().Len())
+}
+
+func TestConvertDistributionToMetrics_InvalidConversion_NoInterval(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{},
+		Points: []*monitoringpb.Point{
+			{
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: 0,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_ExplicitBuckets{
+									ExplicitBuckets: &distribution.Distribution_BucketOptions_Explicit{
+										Bounds: []float64{},
+									},
+								},
+							},
+							BucketCounts: []int64{},
+						},
+					},
+				},
+			},
+		},
+	}
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+	require.Equal(t, 0, m.Histogram().DataPoints().Len())
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_WithExemplars(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceProjectID := "test-project"
+	sourceTraceID := "1234567890abcdef1234567890abcdef"
+	sourceSpanID := "abcdef1234567890"
+	sourceSpanName := fmt.Sprintf("projects/%s/traces/%s/spans/%s", sourceProjectID, sourceTraceID, sourceSpanID)
+	sourceExemplarAttachmentTraceContext, err := anypb.New(&monitoringpb.SpanContext{
+		SpanName: sourceSpanName,
+	})
+	require.NoError(t, err)
+	sourceDroppedLabels := map[string]string{
+		"dropped_key_1": "dropped value 1",
+		"dropped_key_2": "dropped value 2",
+	}
+	sourceExemplarAttachmentDroppedLabels, err := anypb.New(&monitoringpb.DroppedLabels{
+		Label: sourceDroppedLabels,
+	})
+	require.NoError(t, err)
+	sourceArbitraryValue, err := structpb.NewValue(map[string]any{
+		"string": "value",
+		"number": 13,
+	})
+	require.NoError(t, err)
+	exemplarAttachmentArbitrary, err := anypb.New(sourceArbitraryValue)
+	require.NoError(t, err)
+
+	sourceBucketCounts := []int64{
+		5,  // [-inifinity, 11.1)
+		10, // [11.1, 22.2)
+		15, // [22.2, 33)
+		11, // [33.3, +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{
+			Labels: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_ExplicitBuckets{
+									ExplicitBuckets: &distribution.Distribution_BucketOptions_Explicit{
+										Bounds: []float64{11.1, 22.2, 33.3},
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+
+							Exemplars: []*distribution.Distribution_Exemplar{
+								{
+									Timestamp:   &timestamppb.Timestamp{Seconds: 22},
+									Value:       15.5,
+									Attachments: []*anypb.Any{sourceExemplarAttachmentTraceContext, sourceExemplarAttachmentDroppedLabels},
+								},
+								{
+									Timestamp:   &timestamppb.Timestamp{Seconds: 33},
+									Value:       23.3,
+									Attachments: []*anypb.Any{exemplarAttachmentArbitrary},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 2, attributes.Len())
+	attr, ok := attributes.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, "value1", attr.Str())
+	attr, ok = attributes.Get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, "value2", attr.Str())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(41), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 4, bounds.Len())
+	assert.Equal(t, 11.1, bounds.At(0))
+	assert.Equal(t, 22.2, bounds.At(1))
+	assert.Equal(t, 33.3, bounds.At(2))
+	assert.True(t, math.IsInf(bounds.At(3), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+
+	targetExemplars := targetDataPoint.Exemplars()
+	require.Equal(t, 2, targetExemplars.Len())
+	targetExemplar1 := targetExemplars.At(0)
+	assert.Equal(t, pmetric.ExemplarValueTypeDouble, targetExemplar1.ValueType())
+	assert.Equal(t, float64(15.5), targetExemplar1.DoubleValue())
+	assert.False(t, targetExemplar1.TraceID().IsEmpty())
+	assert.Equal(t, sourceTraceID, targetExemplar1.TraceID().String())
+	assert.False(t, targetExemplar1.SpanID().IsEmpty())
+	assert.Equal(t, sourceSpanID, targetExemplar1.SpanID().String())
+	targetExemplar1FilteredAttributes := targetExemplar1.FilteredAttributes()
+	assert.Equal(t, 1, targetExemplar1FilteredAttributes.Len())
+	targetDroppedLabelsAttr, ok := targetExemplar1FilteredAttributes.Get("type.googleapis.com/google.monitoring.v3.DroppedLabels")
+	assert.True(t, ok)
+	targetDroppedLabelsMap := targetDroppedLabelsAttr.Map()
+	assert.Equal(t, 2, targetDroppedLabelsMap.Len())
+	dl1, ok := targetDroppedLabelsMap.Get("dropped_key_1")
+	require.True(t, ok)
+	assert.Equal(t, "dropped value 1", dl1.Str())
+	dl2, ok := targetDroppedLabelsMap.Get("dropped_key_2")
+	require.True(t, ok)
+	assert.Equal(t, "dropped value 2", dl2.Str())
+	targetExemplar2 := targetExemplars.At(1)
+	assert.Equal(t, pmetric.ExemplarValueTypeDouble, targetExemplar2.ValueType())
+	assert.Equal(t, float64(23.3), targetExemplar2.DoubleValue())
+	targetExemplar2FilteredAttributes := targetExemplar2.FilteredAttributes()
+	targetArbitraryAttachmentAttr, ok := targetExemplar2FilteredAttributes.Get("type.googleapis.com/google.protobuf.Value_0")
+	assert.True(t, ok)
+	jsonBytes := targetArbitraryAttachmentAttr.Bytes()
+	assert.NotNil(t, jsonBytes)
+	var targetArbitraryAttachmentAsMap map[string]any
+	err = json.Unmarshal(jsonBytes.AsRaw(), &targetArbitraryAttachmentAsMap)
+	require.NoError(t, err)
+	assert.Equal(t, "value", targetArbitraryAttachmentAsMap["value"].(map[string]any)["string"])
+	assert.Equal(t, float64(13), targetArbitraryAttachmentAsMap["value"].(map[string]any)["number"])
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCounts := []int64{
+		5,  // [-inifinity, 22.2)
+		11, // [22.2, +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_ExplicitBuckets{
+									ExplicitBuckets: &distribution.Distribution_BucketOptions_Explicit{
+										Bounds: []float64{22.2},
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 0, attributes.Len())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(16), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 2, bounds.Len())
+	assert.Equal(t, 22.2, bounds.At(0))
+	assert.True(t, math.IsInf(bounds.At(1), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCountsAllDataPoints := [][]int64{
+		{5, 10, 15, 11},
+		{6, 11, 16, 12},
+		{7, 12, 17, 13},
+	}
+	boundsAllDataPoints := [][]float64{
+		{11.1, 22.2, 33.3},
+		{111.1, 122.2, 133.3},
+		{211.1, 222.2, 233.3},
+	}
+	sourceCountTotalAllDataPoints := []int64{0, 0, 0}
+	for i, sourceBucketCountsForDataPoint := range sourceBucketCountsAllDataPoints {
+		for _, bucketCount := range sourceBucketCountsForDataPoint {
+			sourceCountTotalAllDataPoints[i] += bucketCount
+		}
+	}
+	dataPoints := make([]*monitoringpb.Point, 0, len(sourceBucketCountsAllDataPoints))
+	for i := range sourceBucketCountsAllDataPoints {
+		dataPoints = append(dataPoints, &monitoringpb.Point{
+			Interval: &monitoringpb.TimeInterval{
+				StartTime: &timestamppb.Timestamp{Seconds: 13 + int64(i)*60},
+				EndTime:   &timestamppb.Timestamp{Seconds: 13 + int64(i+1)*60},
+			},
+			Value: &monitoringpb.TypedValue{
+				Value: &monitoringpb.TypedValue_DistributionValue{
+					DistributionValue: &distribution.Distribution{
+						Count: sourceCountTotalAllDataPoints[i],
+						BucketOptions: &distribution.Distribution_BucketOptions{
+							Options: &distribution.Distribution_BucketOptions_ExplicitBuckets{
+								ExplicitBuckets: &distribution.Distribution_BucketOptions_Explicit{
+									Bounds: boundsAllDataPoints[i],
+								},
+							},
+						},
+						BucketCounts: sourceBucketCountsAllDataPoints[i],
+					},
+				},
+			},
+		})
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{
+			Labels: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		Points: dataPoints,
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 3, histogram.DataPoints().Len())
+
+	for i := 0; i < histogram.DataPoints().Len(); i++ {
+		targetDataPoint := histogram.DataPoints().At(i)
+		attributes := targetDataPoint.Attributes()
+		require.Equal(t, 2, attributes.Len())
+		attr, ok := attributes.Get("key1")
+		assert.True(t, ok)
+		assert.Equal(t, "value1", attr.Str())
+		attr, ok = attributes.Get("key2")
+		assert.True(t, ok)
+		assert.Equal(t, "value2", attr.Str())
+
+		assert.Equal(t, 13+60*int64(i), targetDataPoint.StartTimestamp().AsTime().Unix())
+		assert.Equal(t, 13+60*int64(i+1), targetDataPoint.Timestamp().AsTime().Unix())
+		assert.Equal(t, uint64(41+4*i), targetDataPoint.Count())
+
+		bucketCounts := targetDataPoint.BucketCounts()
+		require.Equal(t, len(sourceBucketCountsAllDataPoints[i]), bucketCounts.Len())
+		for i, countValue := range sourceBucketCountsAllDataPoints[i] {
+			assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+		}
+
+		bounds := targetDataPoint.ExplicitBounds()
+		require.Equal(t, 4, bounds.Len())
+		assert.Equal(t, boundsAllDataPoints[i][0], bounds.At(0))
+		assert.Equal(t, boundsAllDataPoints[i][1], bounds.At(1))
+		assert.Equal(t, boundsAllDataPoints[i][2], bounds.At(2))
+		assert.True(t, math.IsInf(bounds.At(3), 1))
+
+		assert.False(t, targetDataPoint.HasSum())
+		assert.False(t, targetDataPoint.HasMin())
+		assert.False(t, targetDataPoint.HasMax())
+		assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	}
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCounts := []int64{
+		5,  // [-infinity, 11.1)
+		10, // [11.1, 18.8)
+		15, // [18.8, 26.5)
+		11, // [26.5 +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{
+			Labels: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_LinearBuckets{
+									LinearBuckets: &distribution.Distribution_BucketOptions_Linear{
+										// [-infinity, 11.1), [11.1, 18.8), [18.8, 26.5), [26.5 +infinity)
+										NumFiniteBuckets: 2,
+										Offset:           11.1,
+										Width:            7.7,
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 2, attributes.Len())
+	attr, ok := attributes.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, "value1", attr.Str())
+	attr, ok = attributes.Get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, "value2", attr.Str())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(41), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 4, bounds.Len())
+	assert.Equal(t, 11.1, bounds.At(0))
+	assert.Equal(t, 18.8, bounds.At(1))
+	assert.Equal(t, 26.5, bounds.At(2))
+	assert.True(t, math.IsInf(bounds.At(3), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCounts := []int64{
+		5,  // [-infinity, 11.1)
+		11, // [11.1 +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_LinearBuckets{
+									LinearBuckets: &distribution.Distribution_BucketOptions_Linear{
+										// [-infinity, 11.1), [11.1, +infinity)
+										NumFiniteBuckets: 0,
+										Offset:           11.1,
+										Width:            7.7,
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 0, attributes.Len())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(16), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 2, bounds.Len())
+	assert.Equal(t, 11.1, bounds.At(0))
+	assert.True(t, math.IsInf(bounds.At(1), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCounts := []int64{
+		5,  // [-infinity, 10)
+		10, // [10, 12)
+		15, // [12, 14.4)
+		11, // [14.4 +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{
+			Labels: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_ExponentialBuckets{
+									ExponentialBuckets: &distribution.Distribution_BucketOptions_Exponential{
+										// [-infinity, 10), [10, 12), [12, 14.4), [14.4 +infinity)
+										NumFiniteBuckets: 2,
+										GrowthFactor:     1.2,
+										Scale:            10,
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 2, attributes.Len())
+	attr, ok := attributes.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, "value1", attr.Str())
+	attr, ok = attributes.Get("key2")
+	assert.True(t, ok)
+	assert.Equal(t, "value2", attr.Str())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(41), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 4, bounds.Len())
+	assert.Equal(t, float64(10), bounds.At(0))
+	assert.Equal(t, float64(12), bounds.At(1))
+	assert.InDelta(t, 14.4, bounds.At(2), 0.00000001, "explicit bound is '%f', expected 14.4", bounds.At(2))
+	assert.True(t, math.IsInf(bounds.At(3), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+}
+
+func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
+	logger := zap.NewNop()
+	mb := NewMetricsBuilder(logger)
+
+	sourceBucketCounts := []int64{
+		5,  // [-infinity, 10)
+		11, // [10 +infinity)
+	}
+	sourceCountTotal := int64(0)
+	for _, bucketCount := range sourceBucketCounts {
+		sourceCountTotal += bucketCount
+	}
+	ts := &monitoringpb.TimeSeries{
+		Metric: &metric.Metric{},
+		Points: []*monitoringpb.Point{
+			{
+				Interval: &monitoringpb.TimeInterval{
+					StartTime: &timestamppb.Timestamp{Seconds: 13},
+					EndTime:   &timestamppb.Timestamp{Seconds: 73},
+				},
+				Value: &monitoringpb.TypedValue{
+					Value: &monitoringpb.TypedValue_DistributionValue{
+						DistributionValue: &distribution.Distribution{
+							Count: sourceCountTotal,
+							BucketOptions: &distribution.Distribution_BucketOptions{
+								Options: &distribution.Distribution_BucketOptions_ExponentialBuckets{
+									ExponentialBuckets: &distribution.Distribution_BucketOptions_Exponential{
+										// [-infinity, 10), [10 +infinity)
+										NumFiniteBuckets: 0,
+										GrowthFactor:     1.2,
+										Scale:            10,
+									},
+								},
+							},
+							BucketCounts: sourceBucketCounts,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	m := pmetric.NewMetric()
+	mb.ConvertDistributionToMetrics(ts, m)
+
+	histogram := m.Histogram()
+	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
+	require.Equal(t, 1, histogram.DataPoints().Len())
+	targetDataPoint := histogram.DataPoints().At(0)
+
+	attributes := targetDataPoint.Attributes()
+	require.Equal(t, 0, attributes.Len())
+
+	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
+	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
+	assert.Equal(t, uint64(16), targetDataPoint.Count())
+
+	bucketCounts := targetDataPoint.BucketCounts()
+	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
+	for i, countValue := range sourceBucketCounts {
+		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
+	}
+
+	bounds := targetDataPoint.ExplicitBounds()
+	require.Equal(t, 2, bounds.Len())
+	assert.Equal(t, float64(10), bounds.At(0))
+	assert.True(t, math.IsInf(bounds.At(1), 1))
+
+	assert.False(t, targetDataPoint.HasSum())
+	assert.False(t, targetDataPoint.HasMin())
+	assert.False(t, targetDataPoint.HasMax())
+	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+}

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -72,6 +72,7 @@ func TestConvertGaugeToMetrics(t *testing.T) {
 			mb.ConvertGaugeToMetrics(tt.ts, m)
 
 			expectedFile := filepath.Join("testdata", tt.fileNameExpected)
+			// Uncomment to regenerate the yaml file with the expected metrics:
 			// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
@@ -205,6 +206,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_WithExemplars.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -246,6 +248,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_ZeroBoundsZeroCounts.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -295,6 +298,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -356,6 +360,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDa
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -412,6 +417,7 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -464,6 +470,7 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -520,6 +527,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
@@ -572,6 +580,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	mb.ConvertDistributionToMetrics(ts, m)
 
 	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// Uncomment to regenerate the yaml file with the expected metrics:
 	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -4,7 +4,6 @@
 package internal
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"testing"
@@ -259,16 +258,7 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	targetExemplar2 := targetExemplars.At(1)
 	assert.Equal(t, pmetric.ExemplarValueTypeDouble, targetExemplar2.ValueType())
 	assert.Equal(t, float64(23.3), targetExemplar2.DoubleValue())
-	targetExemplar2FilteredAttributes := targetExemplar2.FilteredAttributes()
-	targetArbitraryAttachmentAttr, ok := targetExemplar2FilteredAttributes.Get("type.googleapis.com/google.protobuf.Value_0")
-	assert.True(t, ok)
-	jsonBytes := targetArbitraryAttachmentAttr.Bytes()
-	assert.NotNil(t, jsonBytes)
-	var targetArbitraryAttachmentAsMap map[string]any
-	err = json.Unmarshal(jsonBytes.AsRaw(), &targetArbitraryAttachmentAsMap)
-	require.NoError(t, err)
-	assert.Equal(t, "value", targetArbitraryAttachmentAsMap["value"].(map[string]any)["string"])
-	assert.Equal(t, float64(13), targetArbitraryAttachmentAsMap["value"].(map[string]any)["number"])
+	assert.Equal(t, 0, targetExemplar2.FilteredAttributes().Len())
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
@@ -17,61 +18,66 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
 
-func TestConvertGaugeToMetrics_ValidGaugePoints(t *testing.T) {
-	logger := zap.NewNop()
-	mb := NewMetricsBuilder(logger)
-
-	ts := &monitoringpb.TimeSeries{
-		Points: []*monitoringpb.Point{
-			{
-				Interval: &monitoringpb.TimeInterval{
-					StartTime: &timestamppb.Timestamp{Seconds: 10},
-					EndTime:   &timestamppb.Timestamp{Seconds: 20},
-				},
-				Value: &monitoringpb.TypedValue{
-					Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 42.0},
-				},
-			},
-		},
-	}
-
-	m := pmetric.NewMetric()
-	mb.ConvertGaugeToMetrics(ts, m)
-
-	assert.Equal(t, 1, m.Gauge().DataPoints().Len())
-	dp := m.Gauge().DataPoints().At(0)
-	assert.Equal(t, int64(10), dp.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(20), dp.Timestamp().AsTime().Unix())
-	assert.Equal(t, 42.0, dp.DoubleValue())
-}
-
-func TestConvertGaugeToMetrics_InvalidEndTime(t *testing.T) {
-	logger := zap.NewNop()
-	mb := NewMetricsBuilder(logger)
-
-	ts := &monitoringpb.TimeSeries{
-		Points: []*monitoringpb.Point{
-			{
-				Interval: &monitoringpb.TimeInterval{
-					StartTime: &timestamppb.Timestamp{Seconds: 10},
-					EndTime:   nil,
-				},
-				Value: &monitoringpb.TypedValue{
-					Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 100},
+func TestConvertGaugeToMetrics(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		ts               *monitoringpb.TimeSeries
+		fileNameExpected string
+	}{
+		{
+			name: "valid gauge points",
+			ts: &monitoringpb.TimeSeries{
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							StartTime: &timestamppb.Timestamp{Seconds: 10},
+							EndTime:   &timestamppb.Timestamp{Seconds: 20},
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 42.0},
+						},
+					},
 				},
 			},
+			fileNameExpected: "TestConvertGaugeToMetrics_ValidGaugePoints.yaml",
 		},
+		{
+			name: "invalid end time",
+			ts: &monitoringpb.TimeSeries{
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							StartTime: &timestamppb.Timestamp{Seconds: 10},
+							EndTime:   nil,
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 100},
+						},
+					},
+				},
+			},
+			fileNameExpected: "TestConvertGaugeToMetrics_InvalidEndTime.yaml",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zap.NewNop()
+			mb := NewMetricsBuilder(logger)
+
+			m := pmetric.NewMetric()
+			mb.ConvertGaugeToMetrics(tt.ts, m)
+
+			expectedFile := filepath.Join("testdata", tt.fileNameExpected)
+			// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+			expectedMetrics, err := golden.ReadMetrics(expectedFile)
+			require.NoError(t, err)
+			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
+		})
 	}
-
-	m := pmetric.NewMetric()
-	mb.ConvertGaugeToMetrics(ts, m)
-
-	assert.Equal(t, 1, m.Gauge().DataPoints().Len())
-	dp := m.Gauge().DataPoints().At(0)
-	assert.Equal(t, int64(10), dp.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(100), dp.IntValue())
 }
 
 func TestConvertDistributionToMetrics_NoDataPoints(t *testing.T) {
@@ -198,65 +204,11 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 2, attributes.Len())
-	attr, ok := attributes.Get("key1")
-	assert.True(t, ok)
-	assert.Equal(t, "value1", attr.Str())
-	attr, ok = attributes.Get("key2")
-	assert.True(t, ok)
-	assert.Equal(t, "value2", attr.Str())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(41), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 3, bounds.Len())
-	assert.Equal(t, 11.1, bounds.At(0))
-	assert.Equal(t, 22.2, bounds.At(1))
-	assert.Equal(t, 33.3, bounds.At(2))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-
-	targetExemplars := targetDataPoint.Exemplars()
-	require.Equal(t, 2, targetExemplars.Len())
-	targetExemplar1 := targetExemplars.At(0)
-	assert.Equal(t, pmetric.ExemplarValueTypeDouble, targetExemplar1.ValueType())
-	assert.Equal(t, float64(15.5), targetExemplar1.DoubleValue())
-	assert.False(t, targetExemplar1.TraceID().IsEmpty())
-	assert.Equal(t, sourceTraceID, targetExemplar1.TraceID().String())
-	assert.False(t, targetExemplar1.SpanID().IsEmpty())
-	assert.Equal(t, sourceSpanID, targetExemplar1.SpanID().String())
-	targetExemplar1FilteredAttributes := targetExemplar1.FilteredAttributes()
-	assert.Equal(t, 1, targetExemplar1FilteredAttributes.Len())
-	targetDroppedLabelsAttr, ok := targetExemplar1FilteredAttributes.Get("type.googleapis.com/google.monitoring.v3.DroppedLabels")
-	assert.True(t, ok)
-	targetDroppedLabelsMap := targetDroppedLabelsAttr.Map()
-	assert.Equal(t, 2, targetDroppedLabelsMap.Len())
-	dl1, ok := targetDroppedLabelsMap.Get("dropped_key_1")
-	require.True(t, ok)
-	assert.Equal(t, "dropped value 1", dl1.Str())
-	dl2, ok := targetDroppedLabelsMap.Get("dropped_key_2")
-	require.True(t, ok)
-	assert.Equal(t, "dropped value 2", dl2.Str())
-	targetExemplar2 := targetExemplars.At(1)
-	assert.Equal(t, pmetric.ExemplarValueTypeDouble, targetExemplar2.ValueType())
-	assert.Equal(t, float64(23.3), targetExemplar2.DoubleValue())
-	assert.Equal(t, 0, targetExemplar2.FilteredAttributes().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_WithExemplars.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_ZeroBoundsZeroCounts(t *testing.T) {
@@ -293,27 +245,11 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 0, attributes.Len())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(0), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, 0, bucketCounts.Len())
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 0, bounds.Len())
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_ZeroBoundsZeroCounts.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
@@ -358,32 +294,11 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 0, attributes.Len())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(16), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 1, bounds.Len())
-	assert.Equal(t, 22.2, bounds.At(0))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint(t *testing.T) {
@@ -440,46 +355,11 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDa
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 3, histogram.DataPoints().Len())
-
-	for i := 0; i < histogram.DataPoints().Len(); i++ {
-		targetDataPoint := histogram.DataPoints().At(i)
-		attributes := targetDataPoint.Attributes()
-		require.Equal(t, 2, attributes.Len())
-		attr, ok := attributes.Get("key1")
-		assert.True(t, ok)
-		assert.Equal(t, "value1", attr.Str())
-		attr, ok = attributes.Get("key2")
-		assert.True(t, ok)
-		assert.Equal(t, "value2", attr.Str())
-
-		assert.Equal(t, 13+60*int64(i), targetDataPoint.StartTimestamp().AsTime().Unix())
-		assert.Equal(t, 13+60*int64(i+1), targetDataPoint.Timestamp().AsTime().Unix())
-		assert.Equal(t, 31+3*i, int(targetDataPoint.Count()))
-
-		bucketCounts := targetDataPoint.BucketCounts()
-		require.Equal(t, len(sourceBucketCountsAllDataPoints[i]), bucketCounts.Len())
-		for i, sourceCountValue := range sourceBucketCountsAllDataPoints[i] {
-			if sourceCountValue < 0 {
-				assert.Equal(t, uint64(0), bucketCounts.At(i))
-			} else {
-				assert.Equal(t, uint64(sourceCountValue), bucketCounts.At(i))
-			}
-		}
-
-		bounds := targetDataPoint.ExplicitBounds()
-		require.Equal(t, 3, bounds.Len())
-		assert.Equal(t, boundsAllDataPoints[i][0], bounds.At(0))
-		assert.Equal(t, boundsAllDataPoints[i][1], bounds.At(1))
-		assert.Equal(t, boundsAllDataPoints[i][2], bounds.At(2))
-
-		assert.False(t, targetDataPoint.HasSum())
-		assert.False(t, targetDataPoint.HasMin())
-		assert.False(t, targetDataPoint.HasMax())
-		assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
-	}
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint(t *testing.T) {
@@ -531,40 +411,11 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 2, attributes.Len())
-	attr, ok := attributes.Get("key1")
-	assert.True(t, ok)
-	assert.Equal(t, "value1", attr.Str())
-	attr, ok = attributes.Get("key2")
-	assert.True(t, ok)
-	assert.Equal(t, "value2", attr.Str())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(41), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 3, bounds.Len())
-	assert.Equal(t, 11.1, bounds.At(0))
-	assert.Equal(t, 18.8, bounds.At(1))
-	assert.Equal(t, 26.5, bounds.At(2))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
@@ -612,32 +463,11 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 0, attributes.Len())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(16), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 1, bounds.Len())
-	assert.Equal(t, 11.1, bounds.At(0))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint(t *testing.T) {
@@ -689,40 +519,11 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
-
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 2, attributes.Len())
-	attr, ok := attributes.Get("key1")
-	assert.True(t, ok)
-	assert.Equal(t, "value1", attr.Str())
-	attr, ok = attributes.Get("key2")
-	assert.True(t, ok)
-	assert.Equal(t, "value2", attr.Str())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(41), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 3, bounds.Len())
-	assert.Equal(t, float64(10), bounds.At(0))
-	assert.Equal(t, float64(12), bounds.At(1))
-	assert.InDelta(t, 14.4, bounds.At(2), 0.00000001, "explicit bound is '%f', expected 14.4", bounds.At(2))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
 }
 
 func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow(t *testing.T) {
@@ -770,30 +571,16 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	m := pmetric.NewMetric()
 	mb.ConvertDistributionToMetrics(ts, m)
 
-	histogram := m.Histogram()
-	assert.Equal(t, pmetric.AggregationTemporalityDelta, histogram.AggregationTemporality())
-	require.Equal(t, 1, histogram.DataPoints().Len())
-	targetDataPoint := histogram.DataPoints().At(0)
+	expectedFile := filepath.Join("testdata", "TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml")
+	// require.NoError(t, golden.WriteMetrics(t, expectedFile, wrapMetric(m)))
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, wrapMetric(m)))
+}
 
-	attributes := targetDataPoint.Attributes()
-	require.Equal(t, 0, attributes.Len())
-
-	assert.Equal(t, int64(13), targetDataPoint.StartTimestamp().AsTime().Unix())
-	assert.Equal(t, int64(73), targetDataPoint.Timestamp().AsTime().Unix())
-	assert.Equal(t, uint64(16), targetDataPoint.Count())
-
-	bucketCounts := targetDataPoint.BucketCounts()
-	require.Equal(t, len(sourceBucketCounts), bucketCounts.Len())
-	for i, countValue := range sourceBucketCounts {
-		assert.Equal(t, uint64(countValue), bucketCounts.At(i))
-	}
-
-	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 1, bounds.Len())
-	assert.Equal(t, float64(10), bounds.At(0))
-
-	assert.False(t, targetDataPoint.HasSum())
-	assert.False(t, targetDataPoint.HasMin())
-	assert.False(t, targetDataPoint.HasMax())
-	assert.Equal(t, 0, targetDataPoint.Exemplars().Len())
+func wrapMetric(m pmetric.Metric) pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	m.CopyTo(sm.Metrics().AppendEmpty())
+	return metrics
 }

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -5,7 +5,6 @@ package internal
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
@@ -224,11 +223,10 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 4, bounds.Len())
+	require.Equal(t, 3, bounds.Len())
 	assert.Equal(t, 11.1, bounds.At(0))
 	assert.Equal(t, 22.2, bounds.At(1))
 	assert.Equal(t, 33.3, bounds.At(2))
-	assert.True(t, math.IsInf(bounds.At(3), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())
@@ -322,9 +320,8 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleData
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 2, bounds.Len())
+	require.Equal(t, 1, bounds.Len())
 	assert.Equal(t, 22.2, bounds.At(0))
-	assert.True(t, math.IsInf(bounds.At(1), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())
@@ -412,11 +409,10 @@ func TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDa
 		}
 
 		bounds := targetDataPoint.ExplicitBounds()
-		require.Equal(t, 4, bounds.Len())
+		require.Equal(t, 3, bounds.Len())
 		assert.Equal(t, boundsAllDataPoints[i][0], bounds.At(0))
 		assert.Equal(t, boundsAllDataPoints[i][1], bounds.At(1))
 		assert.Equal(t, boundsAllDataPoints[i][2], bounds.At(2))
-		assert.True(t, math.IsInf(bounds.At(3), 1))
 
 		assert.False(t, targetDataPoint.HasSum())
 		assert.False(t, targetDataPoint.HasMin())
@@ -499,11 +495,10 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 4, bounds.Len())
+	require.Equal(t, 3, bounds.Len())
 	assert.Equal(t, 11.1, bounds.At(0))
 	assert.Equal(t, 18.8, bounds.At(1))
 	assert.Equal(t, 26.5, bounds.At(2))
-	assert.True(t, math.IsInf(bounds.At(3), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())
@@ -575,9 +570,8 @@ func TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPo
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 2, bounds.Len())
+	require.Equal(t, 1, bounds.Len())
 	assert.Equal(t, 11.1, bounds.At(0))
-	assert.True(t, math.IsInf(bounds.At(1), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())
@@ -659,11 +653,10 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 4, bounds.Len())
+	require.Equal(t, 3, bounds.Len())
 	assert.Equal(t, float64(10), bounds.At(0))
 	assert.Equal(t, float64(12), bounds.At(1))
 	assert.InDelta(t, 14.4, bounds.At(2), 0.00000001, "explicit bound is '%f', expected 14.4", bounds.At(2))
-	assert.True(t, math.IsInf(bounds.At(3), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())
@@ -735,9 +728,8 @@ func TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleD
 	}
 
 	bounds := targetDataPoint.ExplicitBounds()
-	require.Equal(t, 2, bounds.Len())
+	require.Equal(t, 1, bounds.Len())
 	assert.Equal(t, float64(10), bounds.At(0))
-	assert.True(t, math.IsInf(bounds.At(1), 1))
 
 	assert.False(t, targetDataPoint.HasSum())
 	assert.False(t, targetDataPoint.HasMin())

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_MultipleDataPoint.yaml
@@ -1,0 +1,65 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "5"
+                    - "0"
+                    - "15"
+                    - "11"
+                  count: "31"
+                  explicitBounds:
+                    - 11.1
+                    - 22.2
+                    - 33.3
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "6"
+                    - "0"
+                    - "16"
+                    - "12"
+                  count: "34"
+                  explicitBounds:
+                    - 111.1
+                    - 122.2
+                    - 133.3
+                  startTimeUnixNano: "73000000000"
+                  timeUnixNano: "133000000000"
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "7"
+                    - "0"
+                    - "17"
+                    - "13"
+                  count: "37"
+                  explicitBounds:
+                    - 211.1
+                    - 222.2
+                    - 233.3
+                  startTimeUnixNano: "133000000000"
+                  timeUnixNano: "193000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
@@ -1,0 +1,16 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - bucketCounts:
+                    - "5"
+                    - "11"
+                  count: "16"
+                  explicitBounds:
+                    - 22.2
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_WithExemplars.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_WithExemplars.yaml
@@ -1,0 +1,47 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "5"
+                    - "10"
+                    - "15"
+                    - "11"
+                  count: "41"
+                  exemplars:
+                    - asDouble: 15.5
+                      filteredAttributes:
+                        - key: type.googleapis.com/google.monitoring.v3.DroppedLabels
+                          value:
+                            kvlistValue:
+                              values:
+                                - key: dropped_key_1
+                                  value:
+                                    stringValue: dropped value 1
+                                - key: dropped_key_2
+                                  value:
+                                    stringValue: dropped value 2
+                      spanId: abcdef1234567890
+                      timeUnixNano: "22000000000"
+                      traceId: 1234567890abcdef1234567890abcdef
+                    - asDouble: 23.3
+                      spanId: ""
+                      timeUnixNano: "33000000000"
+                      traceId: ""
+                  explicitBounds:
+                    - 11.1
+                    - 22.2
+                    - 33.3
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_ZeroBoundsZeroCounts.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExplicitBuckets_SingleDataPoint_ZeroBoundsZeroCounts.yaml
@@ -1,0 +1,10 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint.yaml
@@ -1,0 +1,27 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "5"
+                    - "10"
+                    - "15"
+                    - "11"
+                  count: "41"
+                  explicitBounds:
+                    - 10
+                    - 12
+                    - 14.399999999999999
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_ExponentialBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
@@ -1,0 +1,16 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - bucketCounts:
+                    - "5"
+                    - "11"
+                  count: "16"
+                  explicitBounds:
+                    - 10
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint.yaml
@@ -1,0 +1,27 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - attributes:
+                    - key: key1
+                      value:
+                        stringValue: value1
+                    - key: key2
+                      value:
+                        stringValue: value2
+                  bucketCounts:
+                    - "5"
+                    - "10"
+                    - "15"
+                    - "11"
+                  count: "41"
+                  explicitBounds:
+                    - 11.1
+                    - 18.8
+                    - 26.5
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertDistributionToMetrics_ValidConversion_LinearBuckets_SingleDataPoint_OnlyUnderAndOverflow.yaml
@@ -1,0 +1,16 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - histogram:
+              aggregationTemporality: 1
+              dataPoints:
+                - bucketCounts:
+                    - "5"
+                    - "11"
+                  count: "16"
+                  explicitBounds:
+                    - 11.1
+                  startTimeUnixNano: "13000000000"
+                  timeUnixNano: "73000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_InvalidEndTime.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_InvalidEndTime.yaml
@@ -1,0 +1,9 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "10000000000"
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidGaugePoints.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidGaugePoints.yaml
@@ -1,0 +1,10 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asDouble: 42
+                  startTimeUnixNano: "10000000000"
+                  timeUnixNano: "20000000000"
+        scope: {}


### PR DESCRIPTION
#### Description

This adds support for converting Google Cloud monitoring delta distribution metrics to OpenTelemetry histograms.

#### Link to tracking issue

This is related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39600, although it might not be a complete solution, since this only contributes delta distributions, but not cumulative distributions.

#### Testing

This has been tested  extensively with the metric `run.googleapis.com/request_latencies`.

Here is a comparison of the p95 of that metric directly in Google Cloud and of the OTel metric as produced by the new code in a third party tool (Dash0). 

<img width="1742" alt="20250612_request_latencies_comparison" src="https://github.com/user-attachments/assets/dd88d338-3abd-4dfb-a969-72af7c345a5c" />

There charts have minor differences which I suspect are introduced by different interpolation strategies in the two tools (we only have one datapoint per minute), but besides that, the charts clearly show the same data -- peaks and valleys are at the same timestamps and the y-axis values also match.

There are also comprehensive unit tests for the new functionality in `receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go`.

#### Remarks

Unfortunately I only saw #40216 after I had more or less finished my implementation here. I realize that this is not ideal, since there are now two different PRs that attempt to add the same feature. I am not sure if the author of #40216 is still working on their PR actively. I think the last status there seems to be that tests are missing. I'm happy to port over changes from #40216 in case it has things that are missing here or help porting over changes from here to #40216, if that helps. That said, this PR has a full set of unit tests and it also has support for converting the span context exemplar (although that certainly needs to be double checked, see inline comments).