### PR TITLE
chore: Move gzip out of AWS unmarshalers

### DIFF
--- a/extension/encoding/awslogsencodingextension/extension.go
+++ b/extension/encoding/awslogsencodingextension/extension.go
@@ -30,7 +30,7 @@ type encodingExtension struct {
 	format      string
 	gzipPool    sync.Pool
 
-	// if format is VPC, then content come in parquet or
+	// if format is VPC, then content can be in parquet or
 	// gzip encoding
 	vpcFormat string
 }

--- a/extension/encoding/awslogsencodingextension/extension.go
+++ b/extension/encoding/awslogsencodingextension/extension.go
@@ -4,14 +4,19 @@
 package awslogsencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension"
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"sync"
 
+	"github.com/klauspost/compress/gzip"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
+	awsunmarshaler "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler"
 	s3accesslog "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log"
 	subscriptionfilter "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter"
 	vpcflowlog "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log"
@@ -21,8 +26,13 @@ import (
 var _ encoding.LogsUnmarshalerExtension = (*encodingExtension)(nil)
 
 type encodingExtension struct {
-	unmarshaler plog.Unmarshaler
+	unmarshaler awsunmarshaler.AWSUnmarshaler
 	format      string
+	gzipPool    sync.Pool
+
+	// if format is VPC, then content come in parquet or
+	// gzip encoding
+	vpcFormat string
 }
 
 func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension, error) {
@@ -31,29 +41,31 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 		return &encodingExtension{
 			unmarshaler: subscriptionfilter.NewSubscriptionFilterUnmarshaler(settings.BuildInfo),
 			format:      formatCloudWatchLogsSubscriptionFilter,
+			gzipPool:    sync.Pool{},
 		}, nil
 	case formatVPCFlowLog:
-		unmarshaler, err := vpcflowlog.NewVPCFlowLogUnmarshaler(
+		unmarshaler := vpcflowlog.NewVPCFlowLogUnmarshaler(
 			cfg.VPCFlowLogConfig.FileFormat,
 			settings.BuildInfo,
 			settings.Logger,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create encoding extension for %q format: %w", formatVPCFlowLog, err)
-		}
 		return &encodingExtension{
 			unmarshaler: unmarshaler,
+			vpcFormat:   cfg.VPCFlowLogConfig.FileFormat,
 			format:      formatVPCFlowLog,
+			gzipPool:    sync.Pool{},
 		}, nil
 	case formatS3AccessLog:
 		return &encodingExtension{
 			unmarshaler: s3accesslog.NewS3AccessLogUnmarshaler(settings.BuildInfo),
 			format:      formatS3AccessLog,
+			gzipPool:    sync.Pool{},
 		}, nil
 	case formatWAFLog:
 		return &encodingExtension{
 			unmarshaler: waf.NewWAFLogUnmarshaler(settings.BuildInfo),
 			format:      formatWAFLog,
+			gzipPool:    sync.Pool{},
 		}, nil
 	default:
 		// Format will have been validated by Config.Validate,
@@ -71,8 +83,60 @@ func (*encodingExtension) Shutdown(_ context.Context) error {
 	return nil
 }
 
+func (e *encodingExtension) getGzipReader(buf []byte) (io.Reader, error) {
+	var errGzipReader error
+	gzipReader, ok := e.gzipPool.Get().(*gzip.Reader)
+	if !ok {
+		gzipReader, errGzipReader = gzip.NewReader(bytes.NewReader(buf))
+	} else {
+		errGzipReader = gzipReader.Reset(bytes.NewReader(buf))
+	}
+	if errGzipReader != nil {
+		if gzipReader != nil {
+			e.gzipPool.Put(gzipReader)
+		}
+		return nil, fmt.Errorf("failed to decompress content: %w", errGzipReader)
+	}
+	defer func() {
+		_ = gzipReader.Close()
+		e.gzipPool.Put(gzipReader)
+	}()
+	return gzipReader, nil
+}
+
+func (e *encodingExtension) getReaderFromFormat(buf []byte) (io.Reader, error) {
+	switch e.format {
+	case formatWAFLog, formatCloudWatchLogsSubscriptionFilter:
+		return e.getGzipReader(buf)
+	case formatS3AccessLog:
+		return bytes.NewReader(buf), nil
+	case formatVPCFlowLog:
+		switch e.vpcFormat {
+		case fileFormatParquet:
+			return nil, fmt.Errorf("%q still needs to be implemented", e.vpcFormat)
+		case fileFormatPlainText:
+			return e.getGzipReader(buf)
+		default:
+			// should not be possible
+			return nil, fmt.Errorf(
+				"unsupported file fileFormat %q for VPC flow log, expected one of %q",
+				e.vpcFormat,
+				supportedVPCFlowLogFileFormat,
+			)
+		}
+	default:
+		// should not be possible
+		return nil, fmt.Errorf("unimplemented: format %q has no reader", e.format)
+	}
+}
+
 func (e *encodingExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
-	logs, err := e.unmarshaler.UnmarshalLogs(buf)
+	reader, err := e.getReaderFromFormat(buf)
+	if err != nil {
+		return plog.Logs{}, fmt.Errorf("failed to get reader for %q logs: %w", e.format, err)
+	}
+
+	logs, err := e.unmarshaler.UnmarshalAWSLogs(reader)
 	if err != nil {
 		return plog.Logs{}, fmt.Errorf("failed to unmarshal logs as %q format: %w", e.format, err)
 	}

--- a/extension/encoding/awslogsencodingextension/extension.go
+++ b/extension/encoding/awslogsencodingextension/extension.go
@@ -43,7 +43,7 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 			format:      formatCloudWatchLogsSubscriptionFilter,
 		}, nil
 	case formatVPCFlowLog:
-		unmarshaler := vpcflowlog.NewVPCFlowLogUnmarshaler(
+		unmarshaler, err := vpcflowlog.NewVPCFlowLogUnmarshaler(
 			cfg.VPCFlowLogConfig.FileFormat,
 			settings.BuildInfo,
 			settings.Logger,
@@ -52,19 +52,16 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 			unmarshaler: unmarshaler,
 			vpcFormat:   cfg.VPCFlowLogConfig.FileFormat,
 			format:      formatVPCFlowLog,
-			gzipPool:    sync.Pool{},
-		}, nil
+		}, err
 	case formatS3AccessLog:
 		return &encodingExtension{
 			unmarshaler: s3accesslog.NewS3AccessLogUnmarshaler(settings.BuildInfo),
 			format:      formatS3AccessLog,
-			gzipPool:    sync.Pool{},
 		}, nil
 	case formatWAFLog:
 		return &encodingExtension{
 			unmarshaler: waf.NewWAFLogUnmarshaler(settings.BuildInfo),
 			format:      formatWAFLog,
-			gzipPool:    sync.Pool{},
 		}, nil
 	default:
 		// Format will have been validated by Config.Validate,

--- a/extension/encoding/awslogsencodingextension/extension.go
+++ b/extension/encoding/awslogsencodingextension/extension.go
@@ -41,7 +41,6 @@ func newExtension(cfg *Config, settings extension.Settings) (*encodingExtension,
 		return &encodingExtension{
 			unmarshaler: subscriptionfilter.NewSubscriptionFilterUnmarshaler(settings.BuildInfo),
 			format:      formatCloudWatchLogsSubscriptionFilter,
-			gzipPool:    sync.Pool{},
 		}, nil
 	case formatVPCFlowLog:
 		unmarshaler := vpcflowlog.NewVPCFlowLogUnmarshaler(

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler.go
@@ -5,7 +5,6 @@ package s3accesslog // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +19,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler"
 )
 
 const (
@@ -34,9 +34,7 @@ type s3AccessLogUnmarshaler struct {
 	buildInfo component.BuildInfo
 }
 
-var _ plog.Unmarshaler = (*s3AccessLogUnmarshaler)(nil)
-
-func NewS3AccessLogUnmarshaler(buildInfo component.BuildInfo) plog.Unmarshaler {
+func NewS3AccessLogUnmarshaler(buildInfo component.BuildInfo) unmarshaler.AWSUnmarshaler {
 	return &s3AccessLogUnmarshaler{
 		buildInfo: buildInfo,
 	}
@@ -47,8 +45,8 @@ type resourceAttributes struct {
 	bucketName  string
 }
 
-func (s *s3AccessLogUnmarshaler) UnmarshalLogs(buf []byte) (plog.Logs, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(buf))
+func (s *s3AccessLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error) {
+	scanner := bufio.NewScanner(reader)
 
 	logs, resourceLogs, scopeLogs := s.createLogs()
 	resourceAttr := &resourceAttributes{}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler_test.go
@@ -4,6 +4,7 @@
 package s3accesslog
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -210,7 +211,7 @@ func TestUnmarshalLogs(t *testing.T) {
 			data, err := os.ReadFile(filepath.Join(dir, test.logFilename))
 			require.NoError(t, err)
 
-			logs, err := u.UnmarshalLogs(data)
+			logs, err := u.UnmarshalAWSLogs(bytes.NewReader(data))
 			if test.expectedErr != "" {
 				require.ErrorContains(t, err, test.expectedErr)
 				return

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler_test.go
@@ -5,6 +5,7 @@ package subscriptionfilter
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -82,24 +83,25 @@ func TestValidateLog(t *testing.T) {
 	}
 }
 
-// compressData in gzip format
-func compressData(t *testing.T, buf []byte) []byte {
+// compressToGZIPReader compresses buf into a gzip-formatted io.Reader.
+func compressToGZIPReader(t *testing.T, buf []byte) io.Reader {
 	var compressedData bytes.Buffer
 	gzipWriter := gzip.NewWriter(&compressedData)
 	_, err := gzipWriter.Write(buf)
 	require.NoError(t, err)
 	err = gzipWriter.Close()
 	require.NoError(t, err)
-	return compressedData.Bytes()
+	gzipReader, err := gzip.NewReader(bytes.NewReader(compressedData.Bytes()))
+	require.NoError(t, err)
+	return gzipReader
 }
 
-// getLogFromFile reads the cloudwatchLog inside
-// the file and returns it in the format the data
-// is expected to be: gzip compressed.
-func getLogFromFile(t *testing.T, dir string, file string) []byte {
+// readAndCompressLogFile reads the data inside it, compresses it
+// and returns a GZIP reader for it.
+func readAndCompressLogFile(t *testing.T, dir string, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
-	return compressData(t, data)
+	return compressToGZIPReader(t, data)
 }
 
 func TestUnmarshallCloudwatchLog_SubscriptionFilter(t *testing.T) {
@@ -107,32 +109,32 @@ func TestUnmarshallCloudwatchLog_SubscriptionFilter(t *testing.T) {
 
 	filesDirectory := "testdata"
 	tests := map[string]struct {
-		record               []byte
+		reader               io.Reader
 		logsExpectedFilename string
 		expectedErr          string
 	}{
 		"valid_cloudwatch_log": {
-			record:               getLogFromFile(t, filesDirectory, "valid_cloudwatch_log.json"),
+			reader:               readAndCompressLogFile(t, filesDirectory, "valid_cloudwatch_log.json"),
 			logsExpectedFilename: "valid_cloudwatch_log_expected.yaml",
 		},
 		"invalid_cloudwatch_log": {
-			record:      getLogFromFile(t, filesDirectory, "invalid_cloudwatch_log.json"),
+			reader:      readAndCompressLogFile(t, filesDirectory, "invalid_cloudwatch_log.json"),
 			expectedErr: "invalid cloudwatch log",
 		},
 		"invalid_gzip_record": {
-			record:      []byte("invalid"),
-			expectedErr: "failed to decompress record: unexpected EOF",
+			reader:      bytes.NewReader([]byte("invalid")),
+			expectedErr: "failed to decode decompressed reader",
 		},
 		"invalid_json_struct": {
-			record:      compressData(t, []byte("invalid")),
-			expectedErr: "failed to decode decompressed record",
+			reader:      compressToGZIPReader(t, []byte("invalid")),
+			expectedErr: "failed to decode decompressed reader",
 		},
 	}
 
 	unmarshalerCW := NewSubscriptionFilterUnmarshaler(component.BuildInfo{})
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			logs, err := unmarshalerCW.UnmarshalLogs(test.record)
+			logs, err := unmarshalerCW.UnmarshalAWSLogs(test.reader)
 			if test.expectedErr != "" {
 				require.ErrorContains(t, err, test.expectedErr)
 				return

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package unmarshaler
+
+import (
+	"io"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+type AWSUnmarshaler interface {
+	UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error)
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package unmarshaler
+package unmarshaler // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler"
 
 import (
 	"io"

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
@@ -5,16 +5,13 @@ package vpcflowlog // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/klauspost/compress/gzip"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -22,14 +19,13 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler"
 )
 
 const (
 	fileFormatPlainText = "plain-text"
 	fileFormatParquet   = "parquet"
 )
-
-var supportedVPCFlowLogFileFormat = []string{fileFormatPlainText, fileFormatParquet}
 
 type vpcFlowLogUnmarshaler struct {
 	// VPC flow logs can be sent in plain text
@@ -38,56 +34,22 @@ type vpcFlowLogUnmarshaler struct {
 	// See https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-path.html.
 	fileFormat string
 
-	// Pool the gzip readers, which are expensive to create.
-	gzipPool sync.Pool
-
 	buildInfo component.BuildInfo
 	logger    *zap.Logger
 }
 
-func NewVPCFlowLogUnmarshaler(format string, buildInfo component.BuildInfo, logger *zap.Logger) (plog.Unmarshaler, error) {
-	switch format {
-	case fileFormatParquet:
-		// TODO
-		return nil, errors.New("still needs to be implemented")
-	case fileFormatPlainText: // valid
-	default:
-		return nil, fmt.Errorf(
-			"unsupported file fileFormat %q for VPC flow log, expected one of %q",
-			format,
-			supportedVPCFlowLogFileFormat,
-		)
-	}
+func NewVPCFlowLogUnmarshaler(format string, buildInfo component.BuildInfo, logger *zap.Logger) unmarshaler.AWSUnmarshaler {
 	return &vpcFlowLogUnmarshaler{
 		fileFormat: format,
-		gzipPool:   sync.Pool{},
 		buildInfo:  buildInfo,
 		logger:     logger,
-	}, nil
+	}
 }
 
-func (v *vpcFlowLogUnmarshaler) UnmarshalLogs(content []byte) (plog.Logs, error) {
-	var errGzipReader error
-	gzipReader, ok := v.gzipPool.Get().(*gzip.Reader)
-	if !ok {
-		gzipReader, errGzipReader = gzip.NewReader(bytes.NewReader(content))
-	} else {
-		errGzipReader = gzipReader.Reset(bytes.NewReader(content))
-	}
-	if errGzipReader != nil {
-		if gzipReader != nil {
-			v.gzipPool.Put(gzipReader)
-		}
-		return plog.Logs{}, fmt.Errorf("failed to decompress content: %w", errGzipReader)
-	}
-	defer func() {
-		_ = gzipReader.Close()
-		v.gzipPool.Put(gzipReader)
-	}()
-
+func (v *vpcFlowLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error) {
 	switch v.fileFormat {
 	case fileFormatPlainText:
-		return v.unmarshalPlainTextLogs(gzipReader)
+		return v.unmarshalPlainTextLogs(reader)
 	case fileFormatParquet:
 		// TODO
 		return plog.Logs{}, errors.New("still needs to be implemented")

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
@@ -27,6 +27,8 @@ const (
 	fileFormatParquet   = "parquet"
 )
 
+var supportedVPCFlowLogFileFormat = []string{fileFormatPlainText, fileFormatParquet}
+
 type vpcFlowLogUnmarshaler struct {
 	// VPC flow logs can be sent in plain text
 	// or parquet files to S3.
@@ -38,12 +40,28 @@ type vpcFlowLogUnmarshaler struct {
 	logger    *zap.Logger
 }
 
-func NewVPCFlowLogUnmarshaler(format string, buildInfo component.BuildInfo, logger *zap.Logger) unmarshaler.AWSUnmarshaler {
+func NewVPCFlowLogUnmarshaler(
+	format string,
+	buildInfo component.BuildInfo,
+	logger *zap.Logger,
+) (unmarshaler.AWSUnmarshaler, error) {
+	switch format {
+	case fileFormatParquet:
+		// TODO
+		return nil, errors.New("still needs to be implemented")
+	case fileFormatPlainText: // valid
+	default:
+		return nil, fmt.Errorf(
+			"unsupported file fileFormat %q for VPC flow log, expected one of %q",
+			format,
+			supportedVPCFlowLogFileFormat,
+		)
+	}
 	return &vpcFlowLogUnmarshaler{
 		fileFormat: format,
 		buildInfo:  buildInfo,
 		logger:     logger,
-	}
+	}, nil
 }
 
 func (v *vpcFlowLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error) {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
@@ -5,6 +5,7 @@ package vpcflowlog
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,24 +21,25 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 )
 
-// compressData in gzip format
-func compressData(tb testing.TB, buf []byte) []byte {
+// compressToGZIPReader compresses buf into a gzip-formatted io.Reader.
+func compressToGZIPReader(t *testing.T, buf []byte) io.Reader {
 	var compressedData bytes.Buffer
 	gzipWriter := gzip.NewWriter(&compressedData)
 	_, err := gzipWriter.Write(buf)
-	require.NoError(tb, err)
+	require.NoError(t, err)
 	err = gzipWriter.Close()
-	require.NoError(tb, err)
-	return compressedData.Bytes()
+	require.NoError(t, err)
+	gzipReader, err := gzip.NewReader(bytes.NewReader(compressedData.Bytes()))
+	require.NoError(t, err)
+	return gzipReader
 }
 
-// getLogFromFileInPlainText reads the file content
-// returns it in the format the data is expected to
-// be: in plain text and gzip compressed.
-func getLogFromFileInPlainText(t *testing.T, dir string, file string) []byte {
+// readAndCompressLogFile reads the data inside it, compresses it
+// and returns a GZIP reader for it.
+func readAndCompressLogFile(t *testing.T, dir string, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
-	return compressData(t, data)
+	return compressToGZIPReader(t, data)
 }
 
 func TestUnmarshalLogs_PlainText(t *testing.T) {
@@ -45,34 +47,29 @@ func TestUnmarshalLogs_PlainText(t *testing.T) {
 
 	dir := "testdata"
 	tests := map[string]struct {
-		content              []byte
+		reader               io.Reader
 		logsExpectedFilename string
 		expectedErr          string
 	}{
 		"valid_vpc_flow_log": {
-			content:              getLogFromFileInPlainText(t, dir, "valid_vpc_flow_log.log"),
+			reader:               readAndCompressLogFile(t, dir, "valid_vpc_flow_log.log"),
 			logsExpectedFilename: "valid_vpc_flow_log_expected.yaml",
 		},
 		"vpc_flow_log_with_more_fields_than_allowed": {
-			content:     getLogFromFileInPlainText(t, dir, "vpc_flow_log_too_few_fields.log"),
+			reader:      readAndCompressLogFile(t, dir, "vpc_flow_log_too_few_fields.log"),
 			expectedErr: "log line has less fields than the ones expected",
 		},
 		"vpc_flow_log_with_less_fields_than_required": {
-			content:     getLogFromFileInPlainText(t, dir, "vpc_flow_log_too_many_fields.log"),
+			reader:      readAndCompressLogFile(t, dir, "vpc_flow_log_too_many_fields.log"),
 			expectedErr: "log line has more fields than the ones expected",
-		},
-		"invalid_gzip_record": {
-			content:     []byte("invalid"),
-			expectedErr: "failed to decompress content",
 		},
 	}
 
-	u, errCreate := NewVPCFlowLogUnmarshaler(fileFormatPlainText, component.BuildInfo{}, zap.NewNop())
-	require.NoError(t, errCreate)
+	u := NewVPCFlowLogUnmarshaler(fileFormatPlainText, component.BuildInfo{}, zap.NewNop())
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			logs, err := u.UnmarshalLogs(test.content)
+			logs, err := u.UnmarshalAWSLogs(test.reader)
 
 			if test.expectedErr != "" {
 				require.ErrorContains(t, err, test.expectedErr)
@@ -159,14 +156,4 @@ func TestHandleAddresses(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUnmarshalLogs_Parquet(t *testing.T) {
-	_, errCreate := NewVPCFlowLogUnmarshaler(fileFormatParquet, component.BuildInfo{}, zap.NewNop())
-	require.ErrorContains(t, errCreate, "still needs to be implemented")
-}
-
-func TestUnmarshalLogs_Unsupported(t *testing.T) {
-	_, errCreate := NewVPCFlowLogUnmarshaler("unsupported", component.BuildInfo{}, zap.NewNop())
-	require.ErrorContains(t, errCreate, `unsupported file fileFormat "unsupported" for VPC flow log`)
 }

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
@@ -65,7 +65,8 @@ func TestUnmarshalLogs_PlainText(t *testing.T) {
 		},
 	}
 
-	u := NewVPCFlowLogUnmarshaler(fileFormatPlainText, component.BuildInfo{}, zap.NewNop())
+	u, err := NewVPCFlowLogUnmarshaler(fileFormatPlainText, component.BuildInfo{}, zap.NewNop())
+	require.NoError(t, err)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/benchmark_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/benchmark_test.go
@@ -54,7 +54,7 @@ func BenchmarkUnmarshalLogs(b *testing.B) {
 		b.Run(name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, err := u.unmarshalWAFLogs(bytes.NewReader(data))
+				_, err := u.UnmarshalAWSLogs(bytes.NewReader(data))
 				require.NoError(b, err)
 			}
 		})

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
@@ -5,31 +5,26 @@ package waf // import "github.com/open-telemetry/opentelemetry-collector-contrib
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 
 	gojson "github.com/goccy/go-json"
-	"github.com/klauspost/compress/gzip"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/otel/semconv/v1.28.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler"
 )
 
 type wafLogUnmarshaler struct {
 	buildInfo component.BuildInfo
-	gzipPool  sync.Pool
 }
 
-var _ plog.Unmarshaler = (*wafLogUnmarshaler)(nil)
-
-func NewWAFLogUnmarshaler(buildInfo component.BuildInfo) plog.Unmarshaler {
+func NewWAFLogUnmarshaler(buildInfo component.BuildInfo) unmarshaler.AWSUnmarshaler {
 	return &wafLogUnmarshaler{
 		buildInfo: buildInfo,
 	}
@@ -65,29 +60,7 @@ type wafLog struct {
 	Ja4Fingerprint   string `json:"ja4Fingerprint"`
 }
 
-func (w *wafLogUnmarshaler) UnmarshalLogs(content []byte) (plog.Logs, error) {
-	var errGzipReader error
-	gzipReader, ok := w.gzipPool.Get().(*gzip.Reader)
-	if !ok {
-		gzipReader, errGzipReader = gzip.NewReader(bytes.NewReader(content))
-	} else {
-		errGzipReader = gzipReader.Reset(bytes.NewReader(content))
-	}
-	if errGzipReader != nil {
-		if gzipReader != nil {
-			w.gzipPool.Put(gzipReader)
-		}
-		return plog.Logs{}, fmt.Errorf("failed to decompress content: %w", errGzipReader)
-	}
-	defer func() {
-		_ = gzipReader.Close()
-		w.gzipPool.Put(gzipReader)
-	}()
-
-	return w.unmarshalWAFLogs(gzipReader)
-}
-
-func (w *wafLogUnmarshaler) unmarshalWAFLogs(reader io.Reader) (plog.Logs, error) {
+func (w *wafLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error) {
 	logs := plog.NewLogs()
 
 	resourceLogs := logs.ResourceLogs().AppendEmpty()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The gzip reader now is created at the extension level, and not on the unmarshalers. This way we can have less repetitive code, as currently we are doing it 3 times instead of 1.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests added and updated.

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Please delete paragraphs that you did not use before submitting.-->
