### PR TITLE
[chore] Unexport MockDiscovery struct of k8sobjects receiver

### DIFF
--- a/receiver/k8sobjectsreceiver/mock_discovery_client_test.go
+++ b/receiver/k8sobjectsreceiver/mock_discovery_client_test.go
@@ -9,11 +9,11 @@ import (
 	fakeDiscovery "k8s.io/client-go/discovery/fake"
 )
 
-type MockDiscovery struct {
+type mockDiscovery struct {
 	fakeDiscovery.FakeDiscovery
 }
 
-func (c *MockDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+func (c *mockDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return []*metav1.APIResourceList{
 		{
 			GroupVersion: "v1",
@@ -59,5 +59,5 @@ func (c *MockDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, e
 }
 
 func getMockDiscoveryClient() (discovery.ServerResourcesInterface, error) {
-	return &MockDiscovery{}, nil
+	return &mockDiscovery{}, nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR unexports `MockDiscovery` struct of the `k8sobjects` receiver

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40668

/cc @atoulme 

