### PR TITLE
[processor/logdedupprocessor] Avoid zero-value map

### DIFF
--- a/.chloggen/jeffalder_fix-dedup.yaml
+++ b/.chloggen/jeffalder_fix-dedup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logdedupprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Taught logdedupprocessor not to panic if the dedup field source was not found or not a map
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40204]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
#### Description
Reduces the chance that an uninitialized `pcommon.Map` will escape a scope.

#### Link to tracking issue
Fixes #40204

#### Testing
Unit tests on logdedupprocessor

#### Documentation
Just one godoc line about behavior if no dedup_fields were found. Previous behavior was undefined.
