### PR TITLE
[exporter/sentryexporter] unexport structs and methods which should be private

### DIFF
--- a/.chloggen/abhi-sentry-exporter-exports.yaml
+++ b/.chloggen/abhi-sentry-exporter-exports.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sentryexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: unexport structs and methods which should be private
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40651]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -68,15 +68,15 @@ var canonicalCodesGrpcMap = map[string]sentry.SpanStatus{
 	"16": sentry.SpanStatusUnauthenticated,
 }
 
-// SentryExporter defines the Sentry Exporter.
-type SentryExporter struct {
+// sentryExporter defines the Sentry Exporter.
+type sentryExporter struct {
 	transport   transport
 	environment string
 }
 
 // pushTraceData takes an incoming OpenTelemetry trace, converts them into Sentry spans and transactions
 // and sends them using Sentry's transport.
-func (s *SentryExporter) pushTraceData(_ context.Context, td ptrace.Traces) error {
+func (s *sentryExporter) pushTraceData(_ context.Context, td ptrace.Traces) error {
 	var exceptionEvents []*sentry.Event
 	resourceSpans := td.ResourceSpans()
 	if resourceSpans.Len() == 0 {
@@ -492,7 +492,7 @@ func createSentryExporter(config *Config, set exporter.Settings) (exporter.Trace
 
 	transport.Configure(clientOptions)
 
-	s := &SentryExporter{
+	s := &sentryExporter{
 		transport:   transport,
 		environment: config.Environment,
 	}

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -166,7 +166,7 @@ func generateOrphanSpansFromSpans(spans ...*sentry.Span) []*sentry.Span {
 	return orphanSpans
 }
 
-type SpanEventToSentryEventCases struct {
+type spanEventToSentryEventCases struct {
 	testName            string
 	errorMessage        string
 	errorType           string
@@ -221,7 +221,7 @@ func TestSpanEventToSentryEvent(t *testing.T) {
 
 	errorType := "mySampleType"
 	errorMessage := "Kernel Panic"
-	testCases := []SpanEventToSentryEventCases{
+	testCases := []spanEventToSentryEventCases{
 		{
 			testName:         "Exception Event with both exception type and message",
 			errorMessage:     errorMessage,
@@ -353,7 +353,7 @@ func TestSpanToSentrySpan(t *testing.T) {
 	})
 }
 
-type SpanDescriptorsCase struct {
+type spanDescriptorsCase struct {
 	testName string
 	// input
 	name     string
@@ -365,7 +365,7 @@ type SpanDescriptorsCase struct {
 }
 
 func TestGenerateSpanDescriptors(t *testing.T) {
-	testCases := []SpanDescriptorsCase{
+	testCases := []spanDescriptorsCase{
 		{
 			testName: "http-client",
 			name:     "/api/users/{user_id}",
@@ -470,7 +470,7 @@ func TestGenerateTagsFromAttributes(t *testing.T) {
 	assert.Equal(t, "321", intVal)
 }
 
-type SpanStatusCase struct {
+type spanStatusCase struct {
 	testName string
 	// input
 	spanStatus ptrace.Status
@@ -481,7 +481,7 @@ type SpanStatusCase struct {
 }
 
 func TestStatusFromSpanStatus(t *testing.T) {
-	testCases := []SpanStatusCase{
+	testCases := []spanStatusCase{
 		{
 			testName:   "with empty status",
 			spanStatus: ptrace.NewStatus(),
@@ -569,7 +569,7 @@ func TestStatusFromSpanStatus(t *testing.T) {
 	}
 }
 
-type ClassifyOrphanSpanTestCase struct {
+type classifyOrphanSpanTestCase struct {
 	testName string
 	// input
 	idMap          map[sentry.SpanID]sentry.SpanID
@@ -580,7 +580,7 @@ type ClassifyOrphanSpanTestCase struct {
 }
 
 func TestClassifyOrphanSpans(t *testing.T) {
-	testCases := []ClassifyOrphanSpanTestCase{
+	testCases := []classifyOrphanSpanTestCase{
 		{
 			testName:       "with no root spans",
 			idMap:          make(map[sentry.SpanID]sentry.SpanID),
@@ -666,7 +666,7 @@ func (t *mockTransport) Flush(_ context.Context) bool {
 	return true
 }
 
-type PushTraceDataTestCase struct {
+type pushTraceDataTestCase struct {
 	testName string
 	// input
 	td ptrace.Traces
@@ -675,7 +675,7 @@ type PushTraceDataTestCase struct {
 }
 
 func TestPushTraceData(t *testing.T) {
-	testCases := []PushTraceDataTestCase{
+	testCases := []pushTraceDataTestCase{
 		{
 			testName: "with no resources",
 			td:       ptrace.NewTraces(),
@@ -719,7 +719,7 @@ func TestPushTraceData(t *testing.T) {
 			transport := &mockTransport{
 				called: false,
 			}
-			s := &SentryExporter{
+			s := &sentryExporter{
 				transport: transport,
 			}
 
@@ -730,7 +730,7 @@ func TestPushTraceData(t *testing.T) {
 	}
 }
 
-type TransactionFromSpanMarshalEventTestCase struct {
+type transactionFromSpanMarshalEventTestCase struct {
 	testName string
 	// input
 	span *sentry.Span
@@ -741,7 +741,7 @@ type TransactionFromSpanMarshalEventTestCase struct {
 // This is a regression test for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13415
 // to make sure that `parent_span_id` is not included in the serialized context if it is not defined
 func TestTransactionContextFromSpanMarshalEvent(t *testing.T) {
-	testCases := []TransactionFromSpanMarshalEventTestCase{
+	testCases := []transactionFromSpanMarshalEventTestCase{
 		{
 			testName: "with parent span id",
 			span: &sentry.Span{


### PR DESCRIPTION
resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40651