### PR TITLE
kafkareceiver: Opt-in to use franz-go client

### DIFF
--- a/.chloggen/f_kafkareceiver-opt-in-franz-go-client.yaml
+++ b/.chloggen/f_kafkareceiver-opt-in-franz-go-client.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add an Alpha feature gate `receiver.kafkareceiver.UseFranzGo` to use franz-go in the Kafka receiver for better performance."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40628]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds an experimental opt-in support to use the franz-go client in the Kafka receiver.
+  The franz-go client is a high-performance Kafka client that can improve the performance of the Kafka receiver.
+  The default client remains sarama, which is used by the Kafka exporter and other components.
+  Enable the franz-go client by setting the `receiver.kafkareceiver.UseFranzGo` feature gate.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -87,7 +87,7 @@ func (e *kafkaExporter[T]) Start(ctx context.Context, host component.Host) (err 
 	}
 
 	if franzGoClientFeatureGate.IsEnabled() {
-		producer, ferr := kafka.NewFranzSyncProducer(e.cfg.ClientConfig,
+		producer, ferr := kafka.NewFranzSyncProducer(ctx, e.cfg.ClientConfig,
 			e.cfg.Producer, e.cfg.TimeoutSettings.Timeout, e.logger,
 		)
 		if ferr != nil {

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
@@ -45,15 +46,16 @@ func NewFranzSyncProducer(clientCfg configkafka.ClientConfig,
 	default:
 		codec = codec.WithLevel(int(cfg.CompressionParams.Level))
 	}
-	opts := []kgo.Opt{
-		kgo.SeedBrokers(clientCfg.Brokers...),
-		kgo.WithLogger(kzap.New(logger.Named("kafka"))),
+	opts, err := commonOpts(clientCfg, []kgo.Opt{
 		kgo.ProduceRequestTimeout(timeout),
 		kgo.ProducerBatchCompression(codec),
 		// Use the UniformBytesPartitioner that is the default in franz-go with
 		// the legacy compatibility sarama hashing to avoid hashing to different
 		// partitions in case partitioning is enabled.
 		kgo.RecordPartitioner(newSaramaCompatPartitioner()),
+	})
+	if err != nil {
+		return nil, err
 	}
 	// Configure required acks
 	switch cfg.RequiredAcks {
@@ -68,9 +70,116 @@ func NewFranzSyncProducer(clientCfg configkafka.ClientConfig,
 		opts = append(opts, kgo.DisableIdempotentWrite())
 		opts = append(opts, kgo.RequiredAcks(kgo.LeaderAck()))
 	}
+
+	// Configure max message size
+	if cfg.MaxMessageBytes > 0 {
+		opts = append(opts, kgo.ProducerBatchMaxBytes(
+			int32(cfg.MaxMessageBytes),
+		))
+	}
+	// Configure batch size
+	if cfg.FlushMaxMessages > 0 {
+		opts = append(opts, kgo.MaxBufferedRecords(cfg.FlushMaxMessages))
+	}
+
+	return kgo.NewClient(opts...)
+}
+
+// NewFranzConsumerGroup creates a new Kafka consumer client using the franz-go library.
+func NewFranzConsumerGroup(clientCfg configkafka.ClientConfig,
+	consumerCfg configkafka.ConsumerConfig,
+	topics []string,
+	logger *zap.Logger,
+	opts ...kgo.Opt,
+) (*kgo.Client, error) {
+	opts, err := commonOpts(clientCfg, append([]kgo.Opt{
+		kgo.WithLogger(kzap.New(logger.Named("franz"))),
+		kgo.ConsumeTopics(topics...),
+		kgo.ConsumerGroup(consumerCfg.GroupID),
+	}, opts...))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range topics {
+		// Similar to librdkafka, if the topic starts with `^`, it is a regex topic:
+		// https://github.com/confluentinc/librdkafka/blob/b871fdabab84b2ea1be3866a2ded4def7e31b006/src/rdkafka.h#L3899-L3938
+		if strings.HasPrefix(t, "^") {
+			opts = append(opts, kgo.ConsumeRegex())
+			break
+		}
+	}
+
+	// Configure session timeout
+	if consumerCfg.SessionTimeout > 0 {
+		opts = append(opts, kgo.SessionTimeout(consumerCfg.SessionTimeout))
+	}
+
+	// Configure heartbeat interval
+	if consumerCfg.HeartbeatInterval > 0 {
+		opts = append(opts, kgo.HeartbeatInterval(consumerCfg.HeartbeatInterval))
+	}
+
+	// Configure fetch sizes
+	if consumerCfg.MinFetchSize > 0 {
+		opts = append(opts, kgo.FetchMinBytes(consumerCfg.MinFetchSize))
+	}
+	if consumerCfg.DefaultFetchSize > 0 {
+		opts = append(opts, kgo.FetchMaxBytes(consumerCfg.DefaultFetchSize))
+	}
+
+	// Configure max fetch wait
+	if consumerCfg.MaxFetchWait > 0 {
+		opts = append(opts, kgo.FetchMaxWait(consumerCfg.MaxFetchWait))
+	}
+
+	// Configure auto-commit
+	if consumerCfg.AutoCommit.Enable {
+		// Set message marking to be used by the autocommitting logic.
+		opts = append(opts, kgo.AutoCommitMarks())
+		opts = append(opts, kgo.AutoCommitInterval(consumerCfg.AutoCommit.Interval))
+	} else { // Otherwise, we'll handle committing manually.
+		opts = append(opts,
+			// Disable auto-commit and block rebalance on poll
+			// This is the safest way to handle commits manually.
+			kgo.DisableAutoCommit(), kgo.BlockRebalanceOnPoll(),
+		)
+	}
+
+	// Configure the offset to reset to if an exception is found (or no current
+	// partition offset is found.
+	switch consumerCfg.InitialOffset {
+	case configkafka.EarliestOffset:
+		opts = append(opts, kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()))
+	case configkafka.LatestOffset:
+		opts = append(opts, kgo.ConsumeResetOffset(kgo.NewOffset().AtEnd()))
+	}
+
+	// Configure group instance ID if provided
+	if consumerCfg.GroupInstanceID != "" {
+		opts = append(opts, kgo.InstanceID(consumerCfg.GroupInstanceID))
+	}
+
+	// Configure rebalance strategy
+	switch consumerCfg.GroupRebalanceStrategy {
+	case "range": // Sarama default.
+		opts = append(opts, kgo.Balancers(kgo.RangeBalancer()))
+	case "roundrobin":
+		opts = append(opts, kgo.Balancers(kgo.RoundRobinBalancer()))
+	case "sticky":
+		opts = append(opts, kgo.Balancers(kgo.StickyBalancer()))
+	// NOTE(marclop): This is a new type of balancer, document accordingly.
+	case "cooperative-sticky":
+		opts = append(opts, kgo.Balancers(kgo.CooperativeStickyBalancer()))
+	}
+	return kgo.NewClient(opts...)
+}
+
+func commonOpts(clientCfg configkafka.ClientConfig, opts []kgo.Opt) ([]kgo.Opt, error) {
+	opts = append(opts, kgo.SeedBrokers(clientCfg.Brokers...))
 	// Configure TLS if needed
 	if clientCfg.TLS != nil {
-		tlsCfg, err := clientCfg.TLS.LoadTLSConfig(context.Background())
+		tlsCfg, err := clientCfg.TLS.LoadTLSConfig(nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load TLS config: %w", err)
 		}
@@ -78,7 +187,7 @@ func NewFranzSyncProducer(clientCfg configkafka.ClientConfig,
 			opts = append(opts, kgo.DialTLSConfig(tlsCfg))
 		}
 	}
-	// Configure Auth
+	// Configure authentication
 	if clientCfg.Authentication.PlainText != nil {
 		auth := plain.Auth{
 			User: clientCfg.Authentication.PlainText.Username,
@@ -104,18 +213,7 @@ func NewFranzSyncProducer(clientCfg configkafka.ClientConfig,
 	if clientCfg.ClientID != "" {
 		opts = append(opts, kgo.ClientID(clientCfg.ClientID))
 	}
-	// Configure max message size
-	if cfg.MaxMessageBytes > 0 {
-		opts = append(opts, kgo.ProducerBatchMaxBytes(
-			int32(cfg.MaxMessageBytes),
-		))
-	}
-	// Configure batch size
-	if cfg.FlushMaxMessages > 0 {
-		opts = append(opts, kgo.MaxBufferedRecords(cfg.FlushMaxMessages))
-	}
-
-	return kgo.NewClient(opts...)
+	return opts, nil
 }
 
 func configureKgoSASL(cfg *configkafka.SASLConfig) (kgo.Opt, error) {

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -140,7 +140,9 @@ func NewFranzConsumerGroup(ctx context.Context, clientCfg configkafka.ClientConf
 	}
 	// Configure auto-commit to use marks, this simplifies the committing
 	// logic and makes it more consistent with the Sarama client.
-	opts = append(opts, kgo.AutoCommitMarks(), kgo.AutoCommitInterval(interval))
+	opts = append(opts, kgo.AutoCommitMarks(),
+		kgo.AutoCommitInterval(interval),
+	)
 
 	// Configure the offset to reset to if an exception is found (or no current
 	// partition offset is found.

--- a/internal/kafka/metadata.yaml
+++ b/internal/kafka/metadata.yaml
@@ -2,3 +2,9 @@ status:
   disable_codecov_badge: true
   codeowners:
     active: [pavolloffay, MovieStoreGuy, axw]
+
+tests:
+  goleak:
+    ignore:
+      top:
+        - github.com/twmb/franz-go/pkg/kfake.(*group).manage

--- a/internal/kafka/package_test.go
+++ b/internal/kafka/package_test.go
@@ -10,5 +10,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/twmb/franz-go/pkg/kfake.(*group).manage"))
 }

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -24,6 +24,13 @@ If used in conjunction with the `kafkaexporter` configured with `include_metadat
 > You can opt-in to use [`franz-go`](https://github.com/twmb/franz-go) client by enabling the feature gate
 > `receiver.kafkareceiver.UseFranzGo` when you run the OpenTelemetry Collector. See the following page
 > for more details: [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate#controlling-gates)
+>
+> The `franz-go` client supports directly consuming from multiple topics by specifying a regex expression.
+> To enable this feature, prefix your topic with the `^` character. This is identical to how the `librdkafka`
+> client works.
+>
+> If you use the `^` prefix, in the deprecated `topic` setting, if **any** of the topics have the `^` prefix,
+> regex consuming will be enabled.
 
 There are no required settings.
 

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -20,6 +20,11 @@ If used in conjunction with the `kafkaexporter` configured with `include_metadat
 
 ## Getting Started
 
+> [!NOTE]
+> You can opt-in to use [`franz-go`](https://github.com/twmb/franz-go) client by enabling the feature gate
+> `receiver.kafkareceiver.UseFranzGo` when you run the OpenTelemetry Collector. See the following page
+> for more details: [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate#controlling-gates)
+
 There are no required settings.
 
 The following settings can be optionally configured:

--- a/receiver/kafkareceiver/consumer_bench_test.go
+++ b/receiver/kafkareceiver/consumer_bench_test.go
@@ -1,0 +1,207 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
+)
+
+var (
+	batchSizes     = []int{1, 10}
+	partitions     = []int32{1, 2}
+	clients        = []string{"Sarama", "Franz"}
+	benchmarkCases = []struct {
+		name string
+		MessageMarking
+		configkafka.AutoCommitConfig
+	}{
+		{
+			name:             "AutoCommit OnError=false (default)",
+			MessageMarking:   createDefaultConfig().(*Config).MessageMarking,
+			AutoCommitConfig: createDefaultConfig().(*Config).AutoCommit,
+		},
+		{
+			name:             "AutoCommit OnError=true",
+			MessageMarking:   MessageMarking{After: true, OnError: true},
+			AutoCommitConfig: createDefaultConfig().(*Config).AutoCommit,
+		},
+		{
+			name:             "After=true OnError=false",
+			MessageMarking:   MessageMarking{After: true},
+			AutoCommitConfig: configkafka.AutoCommitConfig{Enable: false, Interval: time.Second},
+		},
+		{
+			name:             "After=true OnError=true",
+			MessageMarking:   MessageMarking{After: true, OnError: true},
+			AutoCommitConfig: configkafka.AutoCommitConfig{Enable: false, Interval: time.Second},
+		},
+		{
+			name:             "After=false OnError=false",
+			MessageMarking:   MessageMarking{After: false},
+			AutoCommitConfig: configkafka.AutoCommitConfig{Enable: false, Interval: time.Second},
+		},
+		{
+			name:             "After=false OnError=true",
+			MessageMarking:   MessageMarking{After: false, OnError: true},
+			AutoCommitConfig: configkafka.AutoCommitConfig{Enable: false, Interval: time.Second},
+		},
+	}
+)
+
+func newBenchConfigClient(b *testing.B, topic string, partitions int32,
+	autoCommit configkafka.AutoCommitConfig,
+	messageMarking MessageMarking,
+) (*Config, *kgo.Client) {
+	const encoding = "otlp_proto"
+	client, cfg := mustNewFakeCluster(b, kfake.SeedTopics(partitions, topic))
+	cfg.Logs.Topic = topic
+	cfg.Logs.Encoding = encoding
+	cfg.Traces.Topic = topic
+	cfg.Traces.Encoding = encoding
+	cfg.Metrics.Topic = topic
+	cfg.Metrics.Encoding = encoding
+	cfg.GroupID = b.Name()
+	cfg.InitialOffset = "earliest"
+	cfg.AutoCommit = autoCommit
+	cfg.MessageMarking = messageMarking
+	return cfg, client
+}
+
+func runBenchmark(b *testing.B, topic string, data []byte,
+	rcv component.Component, client *kgo.Client,
+) {
+	require.NoError(b,
+		rcv.Start(context.Background(), componenttest.NewNopHost()),
+	)
+	defer func() { require.NoError(b, rcv.Shutdown(context.Background())) }()
+
+	<-time.After(50 * time.Millisecond)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			client.Produce(context.Background(), &kgo.Record{
+				Topic: topic, Value: data,
+			}, func(_ *kgo.Record, err error) {
+				require.NoError(b, err)
+			})
+		}
+	})
+	client.Flush(context.Background())
+}
+
+func BenchmarkTracesReceiver(b *testing.B) {
+	const topic = "otlp_traces_bench"
+	var marshaler ptrace.ProtoMarshaler
+	logger := zaptest.NewLogger(b, zaptest.Level(zap.ErrorLevel))
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.Logger = logger
+	var sink consumertest.TracesSink
+
+	for _, tc := range benchmarkCases {
+		for _, size := range batchSizes {
+			data, err := marshaler.MarshalTraces(testdata.GenerateTraces(size))
+			require.NoError(b, err)
+			for _, p := range partitions {
+				for _, client := range clients {
+					name := fmt.Sprintf("%s/%s/batch_%d/partitions_%d", client, tc.name, size, p)
+					b.Run(name, func(b *testing.B) {
+						defer sink.Reset()
+						setFranzGo(b, client == "Franz")
+						cfg, client := newBenchConfigClient(b, topic, p,
+							tc.AutoCommitConfig, tc.MessageMarking,
+						)
+						rcv, err := newTracesReceiver(cfg, set, &sink)
+						require.NoError(b, err)
+
+						runBenchmark(b, topic, data, rcv, client)
+						b.ReportMetric(float64(sink.SpanCount())/b.Elapsed().Seconds(), "spans/s")
+					})
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkLogsReceiver(b *testing.B) {
+	const topic = "otlp_logs_bench"
+	var marshaler plog.ProtoMarshaler
+	logger := zaptest.NewLogger(b, zaptest.Level(zap.ErrorLevel))
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.Logger = logger
+	var sink consumertest.LogsSink
+	for _, tc := range benchmarkCases {
+		for _, size := range batchSizes {
+			data, err := marshaler.MarshalLogs(testdata.GenerateLogs(size))
+			require.NoError(b, err)
+			for _, p := range partitions {
+				for _, client := range clients {
+					name := fmt.Sprintf("%s/%s/batch_%d/partitions_%d", client, tc.name, size, p)
+					b.Run(name, func(b *testing.B) {
+						defer sink.Reset()
+						setFranzGo(b, client == "Franz")
+						cfg, client := newBenchConfigClient(b, topic, p,
+							tc.AutoCommitConfig, tc.MessageMarking,
+						)
+						rcv, err := newLogsReceiver(cfg, set, &sink)
+						require.NoError(b, err)
+
+						runBenchmark(b, topic, data, rcv, client)
+						b.ReportMetric(float64(sink.LogRecordCount())/b.Elapsed().Seconds(), "logs/s")
+					})
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkMetricsReceiver(b *testing.B) {
+	const topic = "otlp_metrics_bench"
+	var marshaler pmetric.ProtoMarshaler
+	logger := zaptest.NewLogger(b, zaptest.Level(zap.ErrorLevel))
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.Logger = logger
+	var sink consumertest.MetricsSink
+	for _, tc := range benchmarkCases {
+		for _, size := range batchSizes {
+			data, err := marshaler.MarshalMetrics(testdata.GenerateMetrics(size))
+			require.NoError(b, err)
+			for _, p := range partitions {
+				suffix := fmt.Sprintf("/%s/batch_%d/partitions_%d", tc.name, size, p)
+				b.Run("Sarama"+suffix, func(b *testing.B) {
+					defer sink.Reset()
+					setFranzGo(b, false)
+					cfg, client := newBenchConfigClient(b, topic, p,
+						tc.AutoCommitConfig, tc.MessageMarking,
+					)
+					rcv, err := newMetricsReceiver(cfg, set, &sink)
+					require.NoError(b, err)
+
+					runBenchmark(b, topic, data, rcv, client)
+					b.ReportMetric(float64(sink.DataPointCount())/b.Elapsed().Seconds(), "metrics/s")
+				})
+			}
+		}
+	}
+}

--- a/receiver/kafkareceiver/consumer_bench_test.go
+++ b/receiver/kafkareceiver/consumer_bench_test.go
@@ -73,14 +73,10 @@ func newBenchConfigClient(b *testing.B, topic string, partitions int32,
 	autoCommit configkafka.AutoCommitConfig,
 	messageMarking MessageMarking,
 ) (*Config, *kgo.Client) {
-	const encoding = "otlp_proto"
 	client, cfg := mustNewFakeCluster(b, kfake.SeedTopics(partitions, topic))
 	cfg.Logs.Topic = topic
-	cfg.Logs.Encoding = encoding
 	cfg.Traces.Topic = topic
-	cfg.Traces.Encoding = encoding
 	cfg.Metrics.Topic = topic
-	cfg.Metrics.Encoding = encoding
 	cfg.GroupID = b.Name()
 	cfg.InitialOffset = "earliest"
 	cfg.AutoCommit = autoCommit

--- a/receiver/kafkareceiver/consumer_bench_test.go
+++ b/receiver/kafkareceiver/consumer_bench_test.go
@@ -92,8 +92,6 @@ func runBenchmark(b *testing.B, topic string, data []byte,
 	)
 	defer func() { require.NoError(b, rcv.Shutdown(context.Background())) }()
 
-	<-time.After(50 * time.Millisecond)
-
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"sync"
 	"time"
@@ -65,16 +66,9 @@ type franzConsumer struct {
 	obsrecv     *receiverhelper.ObsReport
 	assignments map[topicPartition]*pc
 
-	logger *zap.Logger
-
-	// processingCtx is passed to all operations except PollRecords.
+	// processingCtx is passed to all operations.
 	processingCtx    context.Context
 	cancelProcessing context.CancelCauseFunc
-
-	// consumeCtx is passed to the PollRecords() function and is cancelled
-	// by Shutdown().
-	consumeCtx    context.Context
-	stopConsuming context.CancelCauseFunc
 }
 
 // newFranzKafkaConsumer creates a new franz-go based Kafka consumer
@@ -94,7 +88,6 @@ func newFranzKafkaConsumer(config *Config, set receiver.Settings, topics []strin
 		topics:           topics,
 		newConsumeFn:     newConsumeFn,
 		settings:         set,
-		logger:           set.Logger,
 		telemetryBuilder: telemetryBuilder,
 		started:          make(chan struct{}),
 		consumerClosed:   make(chan struct{}),
@@ -128,14 +121,18 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	c.obsrecv = obsrecv
 
 	// Create franz-go consumer client
-	client, err := kafka.NewFranzConsumerGroup(
+	client, err := kafka.NewFranzConsumerGroup(ctx,
 		c.config.ClientConfig,
 		c.config.ConsumerConfig,
 		c.topics,
 		c.settings.Logger,
 		kgo.OnPartitionsAssigned(c.assigned),
-		kgo.OnPartitionsRevoked(c.lost),
-		kgo.OnPartitionsLost(c.lost),
+		kgo.OnPartitionsRevoked(func(ctx context.Context, _ *kgo.Client, m map[string][]int32) {
+			c.lost(ctx, c.client, m, false)
+		}),
+		kgo.OnPartitionsLost(func(ctx context.Context, _ *kgo.Client, m map[string][]int32) {
+			c.lost(ctx, c.client, m, true)
+		}),
 	)
 	if err != nil {
 		return err
@@ -148,8 +145,7 @@ func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
 	}
 	c.consumeMessage = cm
 
-	c.consumeCtx, c.stopConsuming = context.WithCancelCause(ctx)
-	go c.consumeLoop(c.consumeCtx)
+	go c.consumeLoop(c.processingCtx)
 	return nil
 }
 
@@ -179,35 +175,33 @@ func (c *franzConsumer) consumeLoop(ctx context.Context) {
 
 // consume consumes a batch of messages from the Kafka topic. This is meant to
 // be called in a loop until consume returns false.
-func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
-	fetch := c.client.PollRecords(consumeCtx, size)
+func (c *franzConsumer) consume(ctx context.Context, size int) bool {
+	fetch := c.client.PollRecords(ctx, size)
 	defer c.client.AllowRebalance()
 
-	if err := fetch.Err0(); fetch.IsClientClosed() ||
-		errors.Is(err, context.Canceled) ||
-		errors.Is(err, context.DeadlineExceeded) {
+	if err := fetch.Err0(); fetch.IsClientClosed() {
 		c.settings.Logger.Info("consumer stopped", zap.Error(err))
 		return false // Shut down the consumer loop.
 	}
-	// There's a variety of errors that arer eturned by fetch.Errors(). We
+	// There's a variety of errors that are returned by fetch.Errors(). We
 	// handle the errors that require a client restart above. The rest can
 	// simply be logged and keep fetching.
-	if errs := fetch.Errors(); len(errs) > 0 {
-		for _, err := range errs {
-			c.settings.Logger.Error("consumer fetch error",
-				zap.Error(err.Err),
-				zap.String(attrTopic, err.Topic),
-				zap.String(attrPartition, strconv.Itoa(int(err.Partition))),
-			)
+	var hasError bool
+	fetch.EachError(func(topic string, partition int32, err error) {
+		c.settings.Logger.Error("consumer fetch error", zap.Error(err),
+			zap.String(attrTopic, topic),
+			zap.String(attrPartition, strconv.Itoa(int(partition))),
+		)
+		if !hasError {
+			hasError = true
 		}
-		return true
-	}
-	if fetch.Empty() {
-		return true // Return right away after an empty fetch.
+	})
+	if hasError || fetch.Empty() {
+		return true // Return right away after errors or empty fetch.
 	}
 
 	select { // Check if Shutdown's been called.
-	case <-consumeCtx.Done():
+	case <-ctx.Done():
 		return false
 	case <-c.closing:
 		// The client is now closed (Shutdown has been called), so we need to
@@ -218,13 +212,14 @@ func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
 	}
 
 	// Acquire the read lock on each consume to ensure the client is not closed
-	// and the assignments map is not modified while consuming.
+	// and the assignments map is not modified while consuming. Copy the map
+	// to avoid locking for the duration of the consume loop.
 	c.mu.RLock()
-	defer c.mu.RUnlock()
+	assignments := make(map[topicPartition]*pc, len(c.assignments))
+	maps.Copy(assignments, c.assignments)
+	c.mu.RUnlock()
 
 	var wg sync.WaitGroup
-	var mu sync.Mutex
-	var records []*kgo.Record
 	// Process messages on a per partition basis, wait for them to finish and
 	// commit the processed records (if autocommit is disabled).
 	fetch.EachPartition(func(p kgo.FetchTopicPartition) {
@@ -233,12 +228,11 @@ func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
 			return // Skip partitions without any records.
 		}
 		tp := topicPartition{topic: p.Topic, partition: p.Partition}
-		assign, ok := c.assignments[tp]
-		// NOTE(marclop): This shouldn't happen, given BlockRebalanceOnPoll
-		// is used in the client and rebalances aren't supposed to happen until
-		// client.AllowRebalance() is used. Better to log a warning than panic.
+		assign, ok := assignments[tp]
+		// NOTE(marclop): This could happen if the partition is lost between
+		// the time the assignments map is copied and the partition is accessed.
 		if !ok {
-			c.logger.Warn(
+			c.settings.Logger.Warn(
 				"attempted to process records for a partition not assigned to this consumer",
 				zap.String(attrTopic, tp.topic),
 				zap.String(attrPartition, strconv.Itoa(int(tp.partition))),
@@ -256,11 +250,11 @@ func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
 			fatalOffset := int64(-1)
 			var lastProcessed *kgo.Record
 			for _, msg := range msgs {
-				if !c.config.MessageMarking.After { // Noop if autocommit == false.
+				if !c.config.MessageMarking.After {
 					c.client.MarkCommitRecords(msg)
 				}
 				m := wrapFranzMsg(msg)
-				if err := c.handleMessage(c.processingCtx, m, pc); err != nil {
+				if err := c.handleMessage(pc.ctx, m, pc); err != nil {
 					pc.logger.Error("unable to process message",
 						zap.Error(err),
 						zap.Int64("offset", msg.Offset),
@@ -299,7 +293,7 @@ func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
 				)
 			}
 			if lastProcessed == nil {
-				return // Return if no records were actually processed.
+				return // No metrics nor marks to update.
 			}
 			// Otherwise, publish consumer lag.
 			c.telemetryBuilder.KafkaReceiverOffsetLag.Record(
@@ -308,44 +302,19 @@ func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
 				metric.WithAttributeSet(pc.attrs),
 			)
 			if c.config.MessageMarking.After {
-				c.client.MarkCommitRecords(lastProcessed) // Noop if autocommit == false.
-			}
-			if !c.config.AutoCommit.Enable {
-				// Even if !MessageMarking.After, we need to propagate the last record
-				// to commit it later. This is the same in Sarama.
-				mu.Lock()
-				defer mu.Unlock()
-				records = append(records, lastProcessed)
+				c.client.MarkCommitRecords(lastProcessed)
 			}
 		}(assign, p.Records)
 	})
-	wg.Wait() // Wait for all records to be processed.
-	// If autocommit isn't enabled, commit the records.
-	if !c.config.AutoCommit.Enable && len(records) > 0 {
-		if err := c.client.CommitRecords(c.processingCtx, records...); err != nil {
-			c.logger.Error("failed to commit records", zap.Error(err))
-		}
+	wg.Wait() // Wait for all records to be processed, and commit marks.
+	if err := c.client.CommitMarkedOffsets(ctx); err != nil {
+		c.settings.Logger.Error("failed to commit offsets", zap.Error(err))
 	}
 	return true
 }
 
 func (c *franzConsumer) Shutdown(ctx context.Context) error {
-	select {
-	case <-c.closing:
-		return nil
-	default:
-		c.mu.Lock()
-		c.stopConsuming(errors.New("shutdown called, closing processing"))
-		close(c.closing)
-		c.mu.Unlock()
-		// Close the client without holding the write mutex, otherwise, the
-		// Shutdown will deadlock when `franzConsumer` inevitably calls the
-		// lost/assigned callback.
-		c.client.Close()
-	}
-	select {
-	case <-c.started:
-	default: // Return immediately if the receiver hasn't started.
+	if !c.triggerShutdown() {
 		return nil
 	}
 
@@ -360,19 +329,42 @@ func (c *franzConsumer) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// assigned must be set as a kgo.OnPartitionsAssigned callback. Ensuring all
+// If it returns false, the caller should return immediately.
+func (c *franzConsumer) triggerShutdown() bool {
+	c.mu.Lock()
+	select {
+	case <-c.closing:
+		c.mu.Unlock()
+		return true
+	default:
+		close(c.closing)
+		c.mu.Unlock()
+		// Close the client without holding the write mutex, otherwise, the
+		// Shutdown will deadlock when `franzConsumer` inevitably calls the
+		// lost/assigned callback.
+		c.client.Close()
+	}
+	select {
+	case <-c.started:
+	default: // Return immediately if the receiver hasn't started.
+		return false
+	}
+	return true
+}
+
+// assigned must be set as kgo.OnPartitionsAssigned callback. Ensuring all
 // assigned partitions to this consumer process received records.
 func (c *franzConsumer) assigned(ctx context.Context, _ *kgo.Client, assigned map[string][]int32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for topic, partitions := range assigned {
 		for _, partition := range partitions {
-			c.telemetryBuilder.KafkaReceiverPartitionStart.Add(ctx,
+			c.telemetryBuilder.KafkaReceiverPartitionStart.Add(context.Background(),
 				1, metric.WithAttributes(attribute.String(attrInstanceName, c.id.Name())),
 			)
-			c.assignments[topicPartition{topic: topic, partition: partition}] = &pc{
+			partitionConsumer := pc{
 				backOff: newExponentialBackOff(c.config.ErrorBackOff),
-				logger: c.logger.With(
+				logger: c.settings.Logger.With(
 					zap.String(attrTopic, topic),
 					zap.String(attrPartition, strconv.Itoa(int(partition))),
 				),
@@ -382,32 +374,50 @@ func (c *franzConsumer) assigned(ctx context.Context, _ *kgo.Client, assigned ma
 					attribute.String(attrPartition, strconv.Itoa(int(partition))),
 				),
 			}
+			partitionConsumer.ctx, partitionConsumer.cancel = context.WithCancelCause(ctx)
+			c.assignments[topicPartition{topic: topic, partition: partition}] = &partitionConsumer
 		}
 	}
 }
 
-// lost must be set as a kgo.OnPartitionsLost and kgo.OnPartitionsReassigned
+// lost must be set both on kgo.OnPartitionsLost and kgo.OnPartitionsReassigned
 // callbacks. Ensures that partitions that are lost (see kgo.OnPartitionsLost
 // for more details) or reassigned (see kgo.OnPartitionsReassigned for more
 // details) have their partition consumer stopped.
 // This callback must finish within the re-balance timeout.
-func (c *franzConsumer) lost(_ context.Context, _ *kgo.Client, lost map[string][]int32) {
+func (c *franzConsumer) lost(ctx context.Context, _ *kgo.Client,
+	lost map[string][]int32, fatal bool,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for topic, partitions := range lost {
 		for _, partition := range partitions {
 			tp := topicPartition{topic: topic, partition: partition}
+			pc := c.assignments[tp]
+			delete(c.assignments, tp)
+			pc.cancel(errors.New(
+				"stopping processing: partition reassigned or lost",
+			))
 			c.telemetryBuilder.KafkaReceiverPartitionClose.Add(context.Background(),
 				1, metric.WithAttributes(attribute.String(attrInstanceName, c.id.Name())),
 			)
-			delete(c.assignments, tp)
 		}
+	}
+	if fatal {
+		return
+	}
+	// NOTE(marclop) commit the marked offsets when the partition is rebalanced
+	// away from this consumer.
+	if err := c.client.CommitMarkedOffsets(ctx); err != nil {
+		c.settings.Logger.Error("failed to commit marked offsets", zap.Error(err))
 	}
 }
 
 // handleMessage is called on a per-partition basis.
 func (c *franzConsumer) handleMessage(ctx context.Context, msg kafkaMessage, pc *pc) error {
-	defer pc.resetBackoff()
+	if pc.backOff != nil {
+		defer pc.backOff.Reset()
+	}
 
 	for {
 		err := c.consumeMessage(ctx, msg, pc.attrs)
@@ -418,11 +428,13 @@ func (c *franzConsumer) handleMessage(ctx context.Context, msg kafkaMessage, pc 
 		// within a configurable timeout, are re-delivered to the consumer in
 		// the Share group, however, at the time of writing this feature isn't
 		// yet GA nor widely deployed.
-		// Share groups are more in line with observability and OTel collector
-		// use cases than traditional consumer groups.
+		// Share groups are generally more in line with observability and OTel
+		// collector use cases than traditional consumer groups.
 		// https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka.
+		// One possible exception is if the OTel collector is used for analytics
+		// pipelines, where it may make sense to make share groups opt-in.
 		if pc.backOff != nil && !consumererror.IsPermanent(err) {
-			backOffDelay := pc.getNextBackoff()
+			backOffDelay := pc.backOff.NextBackOff()
 			if backOffDelay != backoff.Stop {
 				pc.logger.Info("Backing off due to error from the next consumer.",
 					zap.Error(err),
@@ -435,7 +447,7 @@ func (c *franzConsumer) handleMessage(ctx context.Context, msg kafkaMessage, pc 
 					continue
 				}
 			}
-			pc.logger.Info("Stop error backoff because the configured max_elapsed_time is reached",
+			pc.logger.Warn("Stop error backoff because the configured max_elapsed_time is reached",
 				zap.Duration("max_elapsed_time", pc.backOff.MaxElapsedTime),
 			)
 		}
@@ -456,21 +468,8 @@ type pc struct {
 	logger *zap.Logger
 	attrs  attribute.Set
 
-	backOff      *backoff.ExponentialBackOff
-	backOffMutex sync.Mutex
-}
-
-func (c *pc) getNextBackoff() time.Duration {
-	c.backOffMutex.Lock()
-	defer c.backOffMutex.Unlock()
-	return c.backOff.NextBackOff()
-}
-
-func (c *pc) resetBackoff() {
-	if c.backOff == nil {
-		return
-	}
-	c.backOffMutex.Lock()
-	defer c.backOffMutex.Unlock()
-	c.backOff.Reset()
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+	// Not safe for concurrent use, this field is never accessed concurrently.
+	backOff *backoff.ExponentialBackOff
 }

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -1,0 +1,476 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
+)
+
+// franzGoConsumerFeatureGateName is the name of the feature gate for franz-go consumer
+const franzGoConsumerFeatureGateName = "receiver.kafkareceiver.UseFranzGo"
+
+// franzGoConsumerFeatureGate is a feature gate that controls whether the Kafka receiver
+// uses the franz-go client or the Sarama client for consuming messages. When enabled,
+// the Kafka receiver will use the franz-go client, which is more performant and has
+// better support for modern Kafka features.
+var franzGoConsumerFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	franzGoConsumerFeatureGateName, featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, the Kafka receiver will use the franz-go client to consume messages."),
+	featuregate.WithRegisterFromVersion("v0.129.0"),
+)
+
+type topicPartition struct {
+	topic     string
+	partition int32
+}
+
+// franzConsumer implements a Kafka consumer using the franz-go client library.
+// It provides the same interface as the original kafkaConsumer but uses franz-go
+// for better performance and modern Kafka feature support.
+type franzConsumer struct {
+	id               component.ID
+	config           *Config
+	topics           []string
+	settings         receiver.Settings
+	telemetryBuilder *metadata.TelemetryBuilder
+	newConsumeFn     newConsumeMessageFunc
+	consumeMessage   consumeMessageFunc
+
+	mu             sync.RWMutex
+	started        chan struct{}
+	consumerClosed chan struct{}
+	closing        chan struct{}
+
+	client      *kgo.Client
+	obsrecv     *receiverhelper.ObsReport
+	assignments map[topicPartition]*pc
+
+	logger *zap.Logger
+
+	// processingCtx is passed to all operations except PollRecords.
+	processingCtx    context.Context
+	cancelProcessing context.CancelCauseFunc
+
+	// consumeCtx is passed to the PollRecords() function and is cancelled
+	// by Shutdown().
+	consumeCtx    context.Context
+	stopConsuming context.CancelCauseFunc
+}
+
+// newFranzKafkaConsumer creates a new franz-go based Kafka consumer
+func newFranzKafkaConsumer(config *Config, set receiver.Settings, topics []string,
+	newConsumeFn newConsumeMessageFunc,
+) (*franzConsumer, error) {
+	telemetryBuilder, err := metadata.NewTelemetryBuilder(set.TelemetrySettings)
+	if err != nil {
+		return nil, err
+	}
+	// `cancelProcessing` is only called if the context that's passed to the
+	// Shutdown() method is cancelled.
+	processingCtx, cancelProcessing := context.WithCancelCause(context.Background())
+	return &franzConsumer{
+		id:               set.ID,
+		config:           config,
+		topics:           topics,
+		newConsumeFn:     newConsumeFn,
+		settings:         set,
+		logger:           set.Logger,
+		telemetryBuilder: telemetryBuilder,
+		started:          make(chan struct{}),
+		consumerClosed:   make(chan struct{}),
+		closing:          make(chan struct{}),
+		assignments:      make(map[topicPartition]*pc),
+		processingCtx:    processingCtx,
+		cancelProcessing: cancelProcessing,
+	}, nil
+}
+
+func (c *franzConsumer) Start(ctx context.Context, host component.Host) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	select {
+	case <-c.closing:
+		return errors.New("franz kafka consumer already shut down")
+	case <-c.started:
+		return errors.New("franz kafka consumer already started")
+	default:
+		close(c.started)
+	}
+
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             c.settings.ID,
+		Transport:              transport,
+		ReceiverCreateSettings: c.settings,
+	})
+	if err != nil {
+		return err
+	}
+	c.obsrecv = obsrecv
+
+	// Create franz-go consumer client
+	client, err := kafka.NewFranzConsumerGroup(
+		c.config.ClientConfig,
+		c.config.ConsumerConfig,
+		c.topics,
+		c.settings.Logger,
+		kgo.OnPartitionsAssigned(c.assigned),
+		kgo.OnPartitionsRevoked(c.lost),
+		kgo.OnPartitionsLost(c.lost),
+	)
+	if err != nil {
+		return err
+	}
+	c.client = client
+
+	cm, err := c.newConsumeFn(host, c.obsrecv, c.telemetryBuilder)
+	if err != nil {
+		return err
+	}
+	c.consumeMessage = cm
+
+	c.consumeCtx, c.stopConsuming = context.WithCancelCause(ctx)
+	go c.consumeLoop(c.consumeCtx)
+	return nil
+}
+
+func (c *franzConsumer) consumeLoop(ctx context.Context) {
+	defer close(c.consumerClosed)
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.settings.Logger.Info("Consumer loop stopped due to shutdown")
+			return
+		case <-c.closing:
+			c.settings.Logger.Info("Consumer loop stopped due to shutdown")
+			return
+		default:
+		}
+		// Consume messages until the ctx is cancelled (the client is closed).
+		// NOTE(marclop) we should make the fetch size configurable. It returns
+		// all the internally buffered records. This isn't something that's
+		// configurable in Sarama, and theoretically the max records to iterate
+		// on is a factor of default / max (byte) fetch size.
+		if !c.consume(ctx, -1) {
+			return
+		}
+	}
+}
+
+// consume consumes a batch of messages from the Kafka topic. This is meant to
+// be called in a loop until consume returns false.
+func (c *franzConsumer) consume(consumeCtx context.Context, size int) bool {
+	fetch := c.client.PollRecords(consumeCtx, size)
+	defer c.client.AllowRebalance()
+
+	if err := fetch.Err0(); fetch.IsClientClosed() ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		c.settings.Logger.Info("consumer stopped", zap.Error(err))
+		return false // Shut down the consumer loop.
+	}
+	// There's a variety of errors that arer eturned by fetch.Errors(). We
+	// handle the errors that require a client restart above. The rest can
+	// simply be logged and keep fetching.
+	if errs := fetch.Errors(); len(errs) > 0 {
+		for _, err := range errs {
+			c.settings.Logger.Error("consumer fetch error",
+				zap.Error(err.Err),
+				zap.String(attrTopic, err.Topic),
+				zap.String(attrPartition, strconv.Itoa(int(err.Partition))),
+			)
+		}
+		return true
+	}
+	if fetch.Empty() {
+		return true // Return right away after an empty fetch.
+	}
+
+	select { // Check if Shutdown's been called.
+	case <-consumeCtx.Done():
+		return false
+	case <-c.closing:
+		// The client is now closed (Shutdown has been called), so we need to
+		// return and stop consuming. At this point it's safe to return, since
+		// no offsets have been marked for commits (autocommit) or committed.
+		return false
+	default:
+	}
+
+	// Acquire the read lock on each consume to ensure the client is not closed
+	// and the assignments map is not modified while consuming.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var records []*kgo.Record
+	// Process messages on a per partition basis, wait for them to finish and
+	// commit the processed records (if autocommit is disabled).
+	fetch.EachPartition(func(p kgo.FetchTopicPartition) {
+		count := len(p.Records)
+		if count == 0 {
+			return // Skip partitions without any records.
+		}
+		tp := topicPartition{topic: p.Topic, partition: p.Partition}
+		assign, ok := c.assignments[tp]
+		// NOTE(marclop): This shouldn't happen, given BlockRebalanceOnPoll
+		// is used in the client and rebalances aren't supposed to happen until
+		// client.AllowRebalance() is used. Better to log a warning than panic.
+		if !ok {
+			c.logger.Warn(
+				"attempted to process records for a partition not assigned to this consumer",
+				zap.String(attrTopic, tp.topic),
+				zap.String(attrPartition, strconv.Itoa(int(tp.partition))),
+			)
+			return
+		}
+		wg.Add(1)
+		assign.logger.Debug("processing fetched records",
+			zap.Int("count", count),
+			zap.Int64("start_offset", p.Records[0].Offset),
+			zap.Int64("end_offset", p.Records[count-1].Offset),
+		)
+		go func(pc *pc, msgs []*kgo.Record) {
+			defer wg.Done()
+			fatalOffset := int64(-1)
+			var lastProcessed *kgo.Record
+			for _, msg := range msgs {
+				if !c.config.MessageMarking.After { // Noop if autocommit == false.
+					c.client.MarkCommitRecords(msg)
+				}
+				m := wrapFranzMsg(msg)
+				if err := c.handleMessage(c.processingCtx, m, pc); err != nil {
+					pc.logger.Error("unable to process message",
+						zap.Error(err),
+						zap.Int64("offset", msg.Offset),
+					)
+					// To keep both Sarama and Franz implementations consistent,
+					// we pause consumption for partitions that have fatal errors,
+					// which isn't ideal since there needs to be some sort of manual
+					// intervention to unlock the partition. But this is already
+					// mentioned in the docs and also happens with Sarama.
+					if !c.config.MessageMarking.OnError {
+						fatalOffset = msg.Offset
+						break // Stop processing messages.
+					}
+					continue
+				}
+				lastProcessed = msg // Store so we can commit later.
+			}
+			// Pause topic/partition processing locally, any rebalances that move
+			// away the process the partition regularly, which will re-process
+			// the message.
+			if fatalOffset > -1 {
+				c.client.PauseFetchPartitions(map[string][]int32{
+					p.Topic: {p.Partition},
+				})
+				// We don't return false since we want to avoid shutting down
+				// the consumer loop and consumption due to message poisoning.
+				// If we did, we would cause an eventual systematic failure if
+				// there are more topic / partitions in this consumer group when
+				// the partition is rebalanced to another consumer in the group.
+				//
+				// Ideally, we would attempt to re-process permanent errors
+				// for up to N times and then pause processing, or even better,
+				// produce the message to a dead letter topic.
+				pc.logger.Error("unable to process message: pausing consumption of this topic / partition on this consumer instance due to MessageMarking.OnError=false",
+					zap.Int64("offset", fatalOffset),
+				)
+			}
+			if lastProcessed == nil {
+				return // Return if no records were actually processed.
+			}
+			// Otherwise, publish consumer lag.
+			c.telemetryBuilder.KafkaReceiverOffsetLag.Record(
+				context.Background(),
+				(p.HighWatermark-1)-(lastProcessed.Offset),
+				metric.WithAttributeSet(pc.attrs),
+			)
+			if c.config.MessageMarking.After {
+				c.client.MarkCommitRecords(lastProcessed) // Noop if autocommit == false.
+			}
+			if !c.config.AutoCommit.Enable {
+				// Even if !MessageMarking.After, we need to propagate the last record
+				// to commit it later. This is the same in Sarama.
+				mu.Lock()
+				defer mu.Unlock()
+				records = append(records, lastProcessed)
+			}
+		}(assign, p.Records)
+	})
+	wg.Wait() // Wait for all records to be processed.
+	// If autocommit isn't enabled, commit the records.
+	if !c.config.AutoCommit.Enable && len(records) > 0 {
+		if err := c.client.CommitRecords(c.processingCtx, records...); err != nil {
+			c.logger.Error("failed to commit records", zap.Error(err))
+		}
+	}
+	return true
+}
+
+func (c *franzConsumer) Shutdown(ctx context.Context) error {
+	select {
+	case <-c.closing:
+		return nil
+	default:
+		c.mu.Lock()
+		c.stopConsuming(errors.New("shutdown called, closing processing"))
+		close(c.closing)
+		c.mu.Unlock()
+		// Close the client without holding the write mutex, otherwise, the
+		// Shutdown will deadlock when `franzConsumer` inevitably calls the
+		// lost/assigned callback.
+		c.client.Close()
+	}
+	select {
+	case <-c.started:
+	default: // Return immediately if the receiver hasn't started.
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		c.cancelProcessing(fmt.Errorf(
+			"kafka consumer: shutdown context done: %w", ctx.Err(),
+		))
+		return ctx.Err()
+	case <-c.consumerClosed:
+	}
+	return nil
+}
+
+// assigned must be set as a kgo.OnPartitionsAssigned callback. Ensuring all
+// assigned partitions to this consumer process received records.
+func (c *franzConsumer) assigned(ctx context.Context, _ *kgo.Client, assigned map[string][]int32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for topic, partitions := range assigned {
+		for _, partition := range partitions {
+			c.telemetryBuilder.KafkaReceiverPartitionStart.Add(ctx,
+				1, metric.WithAttributes(attribute.String(attrInstanceName, c.id.Name())),
+			)
+			c.assignments[topicPartition{topic: topic, partition: partition}] = &pc{
+				backOff: newExponentialBackOff(c.config.ErrorBackOff),
+				logger: c.logger.With(
+					zap.String(attrTopic, topic),
+					zap.String(attrPartition, strconv.Itoa(int(partition))),
+				),
+				attrs: attribute.NewSet(
+					attribute.String(attrInstanceName, c.id.String()),
+					attribute.String(attrTopic, topic),
+					attribute.String(attrPartition, strconv.Itoa(int(partition))),
+				),
+			}
+		}
+	}
+}
+
+// lost must be set as a kgo.OnPartitionsLost and kgo.OnPartitionsReassigned
+// callbacks. Ensures that partitions that are lost (see kgo.OnPartitionsLost
+// for more details) or reassigned (see kgo.OnPartitionsReassigned for more
+// details) have their partition consumer stopped.
+// This callback must finish within the re-balance timeout.
+func (c *franzConsumer) lost(_ context.Context, _ *kgo.Client, lost map[string][]int32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for topic, partitions := range lost {
+		for _, partition := range partitions {
+			tp := topicPartition{topic: topic, partition: partition}
+			c.telemetryBuilder.KafkaReceiverPartitionClose.Add(context.Background(),
+				1, metric.WithAttributes(attribute.String(attrInstanceName, c.id.Name())),
+			)
+			delete(c.assignments, tp)
+		}
+	}
+}
+
+// handleMessage is called on a per-partition basis.
+func (c *franzConsumer) handleMessage(ctx context.Context, msg kafkaMessage, pc *pc) error {
+	defer pc.resetBackoff()
+
+	for {
+		err := c.consumeMessage(ctx, msg, pc.attrs)
+		if err == nil {
+			return nil // Successfully processed.
+		}
+		// In the future, with Consumer Share Groups, messages not processed
+		// within a configurable timeout, are re-delivered to the consumer in
+		// the Share group, however, at the time of writing this feature isn't
+		// yet GA nor widely deployed.
+		// Share groups are more in line with observability and OTel collector
+		// use cases than traditional consumer groups.
+		// https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka.
+		if pc.backOff != nil && !consumererror.IsPermanent(err) {
+			backOffDelay := pc.getNextBackoff()
+			if backOffDelay != backoff.Stop {
+				pc.logger.Info("Backing off due to error from the next consumer.",
+					zap.Error(err),
+					zap.Duration("delay", backOffDelay),
+				)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(backOffDelay):
+					continue
+				}
+			}
+			pc.logger.Info("Stop error backoff because the configured max_elapsed_time is reached",
+				zap.Duration("max_elapsed_time", pc.backOff.MaxElapsedTime),
+			)
+		}
+		if c.config.MessageMarking.After && !c.config.MessageMarking.OnError {
+			// Only return an error if messages are marked after successful processing.
+			return err
+		}
+		pc.logger.Error("failed to consume message, skipping due to message_marking config",
+			zap.Error(err),
+			zap.Int64("offset", msg.offset()),
+		)
+		return nil
+	}
+}
+
+// pc represents the partition consumer shared information.
+type pc struct {
+	logger *zap.Logger
+	attrs  attribute.Set
+
+	backOff      *backoff.ExponentialBackOff
+	backOffMutex sync.Mutex
+}
+
+func (c *pc) getNextBackoff() time.Duration {
+	c.backOffMutex.Lock()
+	defer c.backOffMutex.Unlock()
+	return c.backOff.NextBackOff()
+}
+
+func (c *pc) resetBackoff() {
+	if c.backOff == nil {
+		return
+	}
+	c.backOffMutex.Lock()
+	defer c.backOffMutex.Unlock()
+	c.backOff.Reset()
+}

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -4,10 +4,26 @@
 package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver/internal/metadata"
 )
 
 func setFranzGo(tb testing.TB, value bool) {
@@ -16,4 +32,75 @@ func setFranzGo(tb testing.TB, value bool) {
 	tb.Cleanup(func() {
 		require.NoError(tb, featuregate.GlobalRegistry().Set(franzGoConsumerFeatureGate.ID(), currentFranzState))
 	})
+}
+
+func TestConsumerShutdownConsuming(t *testing.T) {
+	// Test that the consumer shuts down while consuming a message and
+	// commits the offset after it's left the group.
+	setFranzGo(t, true)
+
+	topic := "otlp_spans"
+	kafkaClient, cfg := mustNewFakeCluster(t, kfake.SeedTopics(1, topic))
+	cfg.ConsumerConfig = configkafka.ConsumerConfig{
+		GroupID:    t.Name(),
+		AutoCommit: configkafka.AutoCommitConfig{Enable: true, Interval: 10 * time.Second},
+	}
+
+	var called atomic.Int64
+	var wg sync.WaitGroup
+	settings, _, _ := mustNewSettings(t)
+	newConsumeFunc := func() (newConsumeMessageFunc, chan<- struct{}) {
+		consuming := make(chan struct{})
+		return func(component.Host, *receiverhelper.ObsReport, *metadata.TelemetryBuilder) (consumeMessageFunc, error) {
+			return func(ctx context.Context, _ kafkaMessage, _ attribute.Set) error {
+				wg.Add(1)
+				defer wg.Done()
+
+				<-consuming
+				called.Add(1)
+				// Wait for the consumer to shutdown.
+				<-ctx.Done()
+				return nil
+			}, nil
+		}, consuming
+	}
+
+	// Send some traces to the otlp_spans topic.
+	traces := testdata.GenerateTraces(5)
+	data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+	require.NoError(t, err)
+	rs := []*kgo.Record{
+		{Topic: topic, Value: data},
+		{Topic: topic, Value: data},
+	}
+
+	test := func(expected int64) {
+		ctx := context.Background()
+		consumeFn, consuming := newConsumeFunc()
+		consumer, err := newFranzKafkaConsumer(cfg, settings, []string{topic}, consumeFn)
+		require.NoError(t, err)
+		require.NoError(t, consumer.Start(ctx, componenttest.NewNopHost()))
+		require.NoError(t, kafkaClient.ProduceSync(ctx, rs...).FirstErr())
+
+		select {
+		case consuming <- struct{}{}:
+			close(consuming) // Close the channel so the rest exit.
+		case <-time.After(time.Second):
+			// panic("expected to consume a message")
+		}
+		require.NoError(t, consumer.Shutdown(ctx))
+		wg.Wait() // Wait for the consume functions to exit.
+		// Ensure that the consume function was called twice.
+		require.Equal(t, expected, called.Load())
+	}
+
+	test(2)
+	test(4)
+
+	offsets, err := kadm.NewClient(kafkaClient).FetchOffsets(context.Background(), t.Name())
+	require.NoError(t, err)
+	// Lookup the last committed offset for partition 0
+	offset, ok := offsets.Lookup(topic, 0)
+	require.True(t, ok)
+	require.Equal(t, int64(4), offset.Offset.At)
 }

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -5,17 +5,20 @@ package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/testdata"
@@ -35,72 +38,210 @@ func setFranzGo(tb testing.TB, value bool) {
 }
 
 func TestConsumerShutdownConsuming(t *testing.T) {
-	// Test that the consumer shuts down while consuming a message and
-	// commits the offset after it's left the group.
-	setFranzGo(t, true)
-
-	topic := "otlp_spans"
-	kafkaClient, cfg := mustNewFakeCluster(t, kfake.SeedTopics(1, topic))
-	cfg.ConsumerConfig = configkafka.ConsumerConfig{
-		GroupID:    t.Name(),
-		AutoCommit: configkafka.AutoCommitConfig{Enable: true, Interval: 10 * time.Second},
+	type tCfg struct {
+		mark        MessageMarking
+		backOff     configretry.BackOffConfig
+		returnError bool
+	}
+	type assertions struct {
+		firstBatchProcessedCount  int64
+		secondBatchProcessedCount int64
+		committedOffset           int64
+	}
+	type testCase struct {
+		name       string
+		testConfig tCfg
+		want       assertions
+	}
+	testCases := []testCase{
+		{
+			name:       "BackOff default marking",
+			testConfig: tCfg{MessageMarking{}, configretry.NewDefaultBackOffConfig(), false},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		{
+			name:       "NoBackoff default marking",
+			testConfig: tCfg{MessageMarking{}, configretry.BackOffConfig{Enabled: false}, false},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		{
+			name:       "BackOff default marking with error",
+			testConfig: tCfg{MessageMarking{}, configretry.NewDefaultBackOffConfig(), true},
+			want: assertions{
+				firstBatchProcessedCount:  1,
+				secondBatchProcessedCount: 2,
+				committedOffset:           2,
+			},
+		},
+		{
+			name:       "NoBackoff default marking with error",
+			testConfig: tCfg{MessageMarking{}, configretry.BackOffConfig{Enabled: false}, true},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		{
+			name:       "BackOff after marking",
+			testConfig: tCfg{MessageMarking{After: true}, configretry.NewDefaultBackOffConfig(), false},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		{
+			name:       "NoBackoff after marking",
+			testConfig: tCfg{MessageMarking{After: true}, configretry.BackOffConfig{Enabled: false}, false},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		// With error
+		{
+			name:       "BackOff after marking with error",
+			testConfig: tCfg{MessageMarking{After: true}, configretry.NewDefaultBackOffConfig(), true},
+			want: assertions{
+				firstBatchProcessedCount:  1,
+				secondBatchProcessedCount: 2,
+				committedOffset:           0,
+			},
+		},
+		{
+			name:       "NoBackoff after marking with error",
+			testConfig: tCfg{MessageMarking{After: true}, configretry.BackOffConfig{Enabled: false}, true},
+			want: assertions{
+				firstBatchProcessedCount:  1,
+				secondBatchProcessedCount: 2,
+				committedOffset:           0,
+			},
+		},
+		// WithError OnError=true
+		{
+			name:       "BackOff after marking with error and OnError=true",
+			testConfig: tCfg{MessageMarking{After: true, OnError: true}, configretry.NewDefaultBackOffConfig(), true},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
+		{
+			name:       "NoBackoff after marking with error and OnError=true",
+			testConfig: tCfg{MessageMarking{After: true, OnError: true}, configretry.BackOffConfig{Enabled: false}, true},
+			want: assertions{
+				firstBatchProcessedCount:  2,
+				secondBatchProcessedCount: 4,
+				committedOffset:           4,
+			},
+		},
 	}
 
-	var called atomic.Int64
-	var wg sync.WaitGroup
-	settings, _, _ := mustNewSettings(t)
-	newConsumeFunc := func() (newConsumeMessageFunc, chan<- struct{}) {
-		consuming := make(chan struct{})
-		return func(component.Host, *receiverhelper.ObsReport, *metadata.TelemetryBuilder) (consumeMessageFunc, error) {
-			return func(ctx context.Context, _ kafkaMessage, _ attribute.Set) error {
-				wg.Add(1)
-				defer wg.Done()
+	testShutdown := func(tb testing.TB, testConfig tCfg, want assertions) {
+		// Test that the consumer shuts down while consuming a message and
+		// commits the offset after it's left the group.
+		setFranzGo(tb, true)
 
-				<-consuming
-				called.Add(1)
-				// Wait for the consumer to shutdown.
-				<-ctx.Done()
-				return nil
-			}, nil
-		}, consuming
-	}
-
-	// Send some traces to the otlp_spans topic.
-	traces := testdata.GenerateTraces(5)
-	data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-	require.NoError(t, err)
-	rs := []*kgo.Record{
-		{Topic: topic, Value: data},
-		{Topic: topic, Value: data},
-	}
-
-	test := func(expected int64) {
-		ctx := context.Background()
-		consumeFn, consuming := newConsumeFunc()
-		consumer, err := newFranzKafkaConsumer(cfg, settings, []string{topic}, consumeFn)
-		require.NoError(t, err)
-		require.NoError(t, consumer.Start(ctx, componenttest.NewNopHost()))
-		require.NoError(t, kafkaClient.ProduceSync(ctx, rs...).FirstErr())
-
-		select {
-		case consuming <- struct{}{}:
-			close(consuming) // Close the channel so the rest exit.
-		case <-time.After(time.Second):
-			// panic("expected to consume a message")
+		topic := "otlp_spans"
+		kafkaClient, cfg := mustNewFakeCluster(tb, kfake.SeedTopics(1, topic))
+		cfg.ConsumerConfig = configkafka.ConsumerConfig{
+			GroupID:    tb.Name(),
+			AutoCommit: configkafka.AutoCommitConfig{Enable: true, Interval: 10 * time.Second},
 		}
-		require.NoError(t, consumer.Shutdown(ctx))
-		wg.Wait() // Wait for the consume functions to exit.
-		// Ensure that the consume function was called twice.
-		require.Equal(t, expected, called.Load())
+		cfg.ErrorBackOff = testConfig.backOff
+		cfg.MessageMarking = testConfig.mark
+
+		var called atomic.Int64
+		var wg sync.WaitGroup
+		settings, _, _ := mustNewSettings(tb)
+		newConsumeFunc := func() (newConsumeMessageFunc, chan<- struct{}) {
+			consuming := make(chan struct{})
+			return func(component.Host, *receiverhelper.ObsReport, *metadata.TelemetryBuilder) (consumeMessageFunc, error) {
+				return func(ctx context.Context, _ kafkaMessage, _ attribute.Set) error {
+					wg.Add(1)
+					defer wg.Done()
+
+					<-consuming
+					called.Add(1)
+					// Wait for the consumer to shutdown.
+					<-ctx.Done()
+					if testConfig.returnError {
+						return errors.New("error")
+					}
+					return nil
+				}, nil
+			}, consuming
+		}
+
+		// Send some traces to the otlp_spans topic.
+		traces := testdata.GenerateTraces(5)
+		data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+		require.NoError(t, err)
+		rs := []*kgo.Record{
+			{Topic: topic, Value: data},
+			{Topic: topic, Value: data},
+		}
+
+		test := func(tb testing.TB, expected int64) {
+			ctx := context.Background()
+			consumeFn, consuming := newConsumeFunc()
+			consumer, e := newFranzKafkaConsumer(cfg, settings, []string{topic}, consumeFn)
+			require.NoError(tb, e)
+			require.NoError(tb, consumer.Start(ctx, componenttest.NewNopHost()))
+			require.NoError(tb, kafkaClient.ProduceSync(ctx, rs...).FirstErr())
+
+			select {
+			case consuming <- struct{}{}:
+				close(consuming) // Close the channel so the rest exit.
+			case <-time.After(time.Second):
+				tb.Fatal("expected to consume a message")
+			}
+			require.NoError(tb, consumer.Shutdown(ctx))
+			wg.Wait() // Wait for the consume functions to exit.
+			// Ensure that the consume function was called twice.
+			assert.Equal(tb, expected, called.Load(), "consume function processed calls mismatch")
+		}
+
+		test(tb, want.firstBatchProcessedCount)
+		test(tb, want.secondBatchProcessedCount)
+
+		offsets, err := kadm.NewClient(kafkaClient).FetchOffsets(context.Background(), tb.Name())
+		require.NoError(tb, err)
+		// Lookup the last committed offset for partition 0
+		offset, _ := offsets.Lookup(topic, 0)
+		assert.Equal(tb, want.committedOffset, offset.At)
 	}
 
-	test(2)
-	test(4)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testShutdown(t, tc.testConfig, tc.want)
+		})
+	}
 
-	offsets, err := kadm.NewClient(kafkaClient).FetchOffsets(context.Background(), t.Name())
-	require.NoError(t, err)
-	// Lookup the last committed offset for partition 0
-	offset, ok := offsets.Lookup(topic, 0)
-	require.True(t, ok)
-	require.Equal(t, int64(4), offset.Offset.At)
+	// for _, backoff := range []bool{true, false} {
+	// 	for _, returnError := range []bool{true, false} {
+	// 		t.Run(fmt.Sprintf("MessageMarking.OnError=%v returnError=%v", backoff, returnError), func(t *testing.T) {
+	// 			t.Run("BackOff", func(t *testing.T) {
+	// 				backoffCfg := configretry.NewDefaultBackOffConfig()
+	// 				testShutdown(t, tCfg{MessageMarking{OnError: backoff}, backoffCfg, returnError}, assertions{1, 1, 1})
+	// 			})
+	// 			t.Run("NoBackoff", func(t *testing.T) {
+	// 				backoffCfg := configretry.NewDefaultBackOffConfig()
+	// 				backoffCfg.Enabled = false
+	// 				testShutdown(t, tCfg{MessageMarking{OnError: backoff}, backoffCfg, returnError}, assertions{1, 1, 1})
+	// 			})
+	// 		})
+	// 	}
+	// }
 }

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -241,6 +241,5 @@ func TestConsumerShutdownNotStarted(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		require.EqualError(t, c.Shutdown(context.Background()),
 			"kafka consumer: consumer isn't running")
-
 	}
 }

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -229,3 +229,18 @@ func TestConsumerShutdownConsuming(t *testing.T) {
 		})
 	}
 }
+
+func TestConsumerShutdownNotStarted(t *testing.T) {
+	setFranzGo(t, true)
+
+	_, cfg := mustNewFakeCluster(t, kfake.SeedTopics(1, "test"))
+	settings, _, _ := mustNewSettings(t)
+	c, err := newFranzKafkaConsumer(cfg, settings, []string{"test"}, nil)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		require.EqualError(t, c.Shutdown(context.Background()),
+			"kafka consumer: consumer isn't running")
+
+	}
+}

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+func setFranzGo(tb testing.TB, value bool) {
+	currentFranzState := franzGoConsumerFeatureGate.IsEnabled()
+	require.NoError(tb, featuregate.GlobalRegistry().Set(franzGoConsumerFeatureGate.ID(), value))
+	tb.Cleanup(func() {
+		require.NoError(tb, featuregate.GlobalRegistry().Set(franzGoConsumerFeatureGate.ID(), currentFranzState))
+	})
+}

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -228,20 +228,4 @@ func TestConsumerShutdownConsuming(t *testing.T) {
 			testShutdown(t, tc.testConfig, tc.want)
 		})
 	}
-
-	// for _, backoff := range []bool{true, false} {
-	// 	for _, returnError := range []bool{true, false} {
-	// 		t.Run(fmt.Sprintf("MessageMarking.OnError=%v returnError=%v", backoff, returnError), func(t *testing.T) {
-	// 			t.Run("BackOff", func(t *testing.T) {
-	// 				backoffCfg := configretry.NewDefaultBackOffConfig()
-	// 				testShutdown(t, tCfg{MessageMarking{OnError: backoff}, backoffCfg, returnError}, assertions{1, 1, 1})
-	// 			})
-	// 			t.Run("NoBackoff", func(t *testing.T) {
-	// 				backoffCfg := configretry.NewDefaultBackOffConfig()
-	// 				backoffCfg.Enabled = false
-	// 				testShutdown(t, tCfg{MessageMarking{OnError: backoff}, backoffCfg, returnError}, assertions{1, 1, 1})
-	// 			})
-	// 		})
-	// 	}
-	// }
 }

--- a/receiver/kafkareceiver/consumer_message.go
+++ b/receiver/kafkareceiver/consumer_message.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // kafkaMessage provides a generic interface for Kafka messages that abstracts
@@ -82,6 +83,63 @@ func (h saramaHeaders) all() iter.Seq[header] {
 	return func(yield func(header) bool) {
 		for _, hdr := range h.headers {
 			if !yield(header{key: string(hdr.Key), value: hdr.Value}) {
+				return
+			}
+		}
+	}
+}
+
+// Franz
+
+type franzMessage struct {
+	record *kgo.Record
+}
+
+func wrapFranzMsg(record *kgo.Record) franzMessage {
+	return franzMessage{record: record}
+}
+
+func (w franzMessage) value() []byte {
+	return w.record.Value
+}
+
+func (w franzMessage) headers() messageHeaders {
+	return franzHeaders{headers: w.record.Headers}
+}
+
+func (w franzMessage) topic() string {
+	return w.record.Topic
+}
+
+func (w franzMessage) partition() int32 {
+	return w.record.Partition
+}
+
+func (w franzMessage) offset() int64 {
+	return w.record.Offset
+}
+
+func (w franzMessage) timestamp() time.Time {
+	return w.record.Timestamp
+}
+
+type franzHeaders struct {
+	headers []kgo.RecordHeader
+}
+
+func (h franzHeaders) get(key string) (string, bool) {
+	for _, header := range h.headers {
+		if header.Key == key {
+			return string(header.Value), true
+		}
+	}
+	return "", false
+}
+
+func (h franzHeaders) all() iter.Seq[header] {
+	return func(yield func(header) bool) {
+		for _, hdr := range h.headers {
+			if !yield(header{key: hdr.Key, value: hdr.Value}) {
 				return
 			}
 		}

--- a/receiver/kafkareceiver/consumer_sarama.go
+++ b/receiver/kafkareceiver/consumer_sarama.go
@@ -242,7 +242,7 @@ func (c *consumerGroupHandler) handleMessage(
 					return err
 				}
 			}
-			c.logger.Info("Stop error backoff because the configured max_elapsed_time is reached",
+			c.logger.Warn("Stop error backoff because the configured max_elapsed_time is reached",
 				zap.Duration("max_elapsed_time", c.backOff.MaxElapsedTime))
 		}
 		if c.messageMarking.After && !c.messageMarking.OnError {

--- a/receiver/kafkareceiver/generated_package_test.go
+++ b/receiver/kafkareceiver/generated_package_test.go
@@ -9,5 +9,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/twmb/franz-go/pkg/kfake.(*group).manage"))
 }

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumererror v0.128.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/consumer/consumertest v0.128.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/exporter v0.128.1-0.20250610090210-188191247685
+	go.opentelemetry.io/collector/featuregate v1.34.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/pdata v1.34.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/pdata/testdata v0.128.1-0.20250610090210-188191247685
 	go.opentelemetry.io/collector/receiver v1.34.1-0.20250610090210-188191247685
@@ -111,7 +112,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.128.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/extension v1.34.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.128.1-0.20250610090210-188191247685 // indirect
-	go.opentelemetry.io/collector/featuregate v1.34.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.128.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.128.1-0.20250610090210-188191247685 // indirect
 	go.opentelemetry.io/collector/pipeline v0.128.1-0.20250610090210-188191247685 // indirect

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -6,6 +6,7 @@ package kafkareceiver
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -51,29 +52,39 @@ func init() {
 	metrics.UseNilMetrics = true
 }
 
+func runTestForClients(t *testing.T, fn func(t *testing.T)) {
+	clients := []string{"Sarama", "Franz"}
+	for _, client := range clients {
+		if client == "Franz" {
+			setFranzGo(t, true)
+		}
+		t.Run(client, fn)
+	}
+}
+
 func TestReceiver(t *testing.T) {
-	t.Parallel()
-	kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+	runTestForClients(t, func(t *testing.T) {
+		kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-	// Send some traces to the otlp_spans topic.
-	traces := testdata.GenerateTraces(5)
-	data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-	require.NoError(t, err)
-	results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
-		Topic: "otlp_spans",
-		Value: data,
+		// Send some traces to the otlp_spans topic.
+		traces := testdata.GenerateTraces(5)
+		data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+		require.NoError(t, err)
+		results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
+			Topic: "otlp_spans",
+			Value: data,
+		})
+		require.NoError(t, results.FirstErr())
+
+		// Wait for message to be consumed.
+		received := make(chan consumerArgs[ptrace.Traces], 1)
+		mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
+		args := <-received
+		assert.NoError(t, ptracetest.CompareTraces(traces, args.data))
 	})
-	require.NoError(t, results.FirstErr())
-
-	// Wait for message to be consumed.
-	received := make(chan consumerArgs[ptrace.Traces], 1)
-	mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
-	args := <-received
-	assert.NoError(t, ptracetest.CompareTraces(traces, args.data))
 }
 
 func TestReceiver_Headers_Metadata(t *testing.T) {
-	t.Parallel()
 	for name, testcase := range map[string]struct {
 		headers  []kgo.RecordHeader
 		expected map[string][]string
@@ -108,84 +119,84 @@ func TestReceiver_Headers_Metadata(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+			runTestForClients(t, func(t *testing.T) {
+				kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-			// Send some traces to the otlp_spans topic, including headers.
-			traces := testdata.GenerateTraces(1)
-			data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-			require.NoError(t, err)
-			results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
-				Topic:   "otlp_spans",
-				Value:   data,
-				Headers: testcase.headers,
+				// Send some traces to the otlp_spans topic, including headers.
+				traces := testdata.GenerateTraces(1)
+				data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+				require.NoError(t, err)
+				results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
+					Topic:   "otlp_spans",
+					Value:   data,
+					Headers: testcase.headers,
+				})
+				require.NoError(t, results.FirstErr())
+
+				// Wait for message to be consumed.
+				received := make(chan consumerArgs[ptrace.Traces], 1)
+				mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
+				args := <-received
+				info := client.FromContext(args.ctx)
+				for key, values := range testcase.expected {
+					assert.Equal(t, values, info.Metadata.Get(key))
+				}
 			})
-			require.NoError(t, results.FirstErr())
-
-			// Wait for message to be consumed.
-			received := make(chan consumerArgs[ptrace.Traces], 1)
-			mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
-			args := <-received
-			info := client.FromContext(args.ctx)
-			for key, values := range testcase.expected {
-				assert.Equal(t, values, info.Metadata.Get(key))
-			}
 		})
 	}
 }
 
 func TestReceiver_Headers_HeaderExtraction(t *testing.T) {
-	t.Parallel()
 	for _, enabled := range []bool{false, true} {
 		name := "enabled"
 		if !enabled {
 			name = "disabled"
 		}
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+			runTestForClients(t, func(t *testing.T) {
+				kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-			// Send some traces to the otlp_spans topic, including headers.
-			traces := testdata.GenerateTraces(1)
-			data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-			require.NoError(t, err)
-			results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
-				Topic: "otlp_spans",
-				Value: data,
-				Headers: []kgo.RecordHeader{{
-					Key:   "extracted",
-					Value: []byte("value1"),
-				}, {
-					Key:   "extracted",
-					Value: []byte("value2"),
-				}, {
-					Key:   "not_extracted",
-					Value: []byte("value3"),
-				}},
+				// Send some traces to the otlp_spans topic, including headers.
+				traces := testdata.GenerateTraces(1)
+				data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+				require.NoError(t, err)
+				results := kafkaClient.ProduceSync(context.Background(), &kgo.Record{
+					Topic: "otlp_spans",
+					Value: data,
+					Headers: []kgo.RecordHeader{{
+						Key:   "extracted",
+						Value: []byte("value1"),
+					}, {
+						Key:   "extracted",
+						Value: []byte("value2"),
+					}, {
+						Key:   "not_extracted",
+						Value: []byte("value3"),
+					}},
+				})
+				require.NoError(t, results.FirstErr())
+
+				// Wait for message to be consumed.
+				received := make(chan consumerArgs[ptrace.Traces], 1)
+				receiverConfig.HeaderExtraction.ExtractHeaders = enabled
+				receiverConfig.HeaderExtraction.Headers = []string{"extracted"}
+				mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
+				args := <-received
+
+				resource := args.data.ResourceSpans().At(0).Resource()
+				value, ok := resource.Attributes().Get("kafka.header.extracted")
+				if enabled {
+					require.True(t, ok)
+					assert.Equal(t, "value1", value.Str()) // only first value is extracted
+				} else {
+					require.False(t, ok)
+				}
 			})
-			require.NoError(t, results.FirstErr())
-
-			// Wait for message to be consumed.
-			received := make(chan consumerArgs[ptrace.Traces], 1)
-			receiverConfig.HeaderExtraction.ExtractHeaders = enabled
-			receiverConfig.HeaderExtraction.Headers = []string{"extracted"}
-			mustNewTracesReceiver(t, receiverConfig, newChannelTracesConsumer(received))
-			args := <-received
-
-			resource := args.data.ResourceSpans().At(0).Resource()
-			value, ok := resource.Attributes().Get("kafka.header.extracted")
-			if enabled {
-				require.True(t, ok)
-				assert.Equal(t, "value1", value.Str()) // only first value is extracted
-			} else {
-				require.False(t, ok)
-			}
 		})
 	}
 }
 
 func TestReceiver_ConsumeError(t *testing.T) {
-	t.Parallel()
 	for name, testcase := range map[string]struct {
 		err         error
 		shouldRetry bool
@@ -199,147 +210,148 @@ func TestReceiver_ConsumeError(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+			runTestForClients(t, func(t *testing.T) {
+				kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-			// Send some traces to the otlp_spans topic.
-			traces := testdata.GenerateTraces(1)
-			data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-			require.NoError(t, err)
-			results := kafkaClient.ProduceSync(context.Background(),
-				&kgo.Record{Topic: "otlp_spans", Value: data},
-			)
-			require.NoError(t, results.FirstErr())
+				// Send some traces to the otlp_spans topic.
+				traces := testdata.GenerateTraces(1)
+				data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+				require.NoError(t, err)
+				results := kafkaClient.ProduceSync(context.Background(),
+					&kgo.Record{Topic: "otlp_spans", Value: data},
+				)
+				require.NoError(t, results.FirstErr())
 
-			var calls atomic.Int64
-			consumer := newTracesConsumer(func(context.Context, ptrace.Traces) error {
-				calls.Add(1)
-				return testcase.err
+				var calls atomic.Int64
+				consumer := newTracesConsumer(func(context.Context, ptrace.Traces) error {
+					calls.Add(1)
+					return testcase.err
+				})
+
+				// Wait for messages to be consumed.
+				receiverConfig.ErrorBackOff.Enabled = true
+				receiverConfig.ErrorBackOff.InitialInterval = 10 * time.Millisecond
+				receiverConfig.ErrorBackOff.MaxInterval = 10 * time.Millisecond
+				receiverConfig.ErrorBackOff.MaxElapsedTime = 500 * time.Millisecond
+				mustNewTracesReceiver(t, receiverConfig, consumer)
+
+				if testcase.shouldRetry {
+					assert.Eventually(
+						t, func() bool { return calls.Load() > 1 },
+						10*time.Second, 100*time.Millisecond,
+					)
+				} else {
+					assert.Eventually(
+						t, func() bool { return calls.Load() == 1 },
+						10*time.Second, 100*time.Millisecond,
+					)
+					// Verify that no retries have been attempted.
+					time.Sleep(100 * time.Millisecond)
+					assert.Equal(t, int64(1), calls.Load())
+				}
 			})
-
-			// Wait for messages to be consumed.
-			receiverConfig.ErrorBackOff.Enabled = true
-			receiverConfig.ErrorBackOff.InitialInterval = 10 * time.Millisecond
-			receiverConfig.ErrorBackOff.MaxInterval = 10 * time.Millisecond
-			receiverConfig.ErrorBackOff.MaxElapsedTime = 500 * time.Millisecond
-			mustNewTracesReceiver(t, receiverConfig, consumer)
-
-			if testcase.shouldRetry {
-				assert.Eventually(
-					t, func() bool { return calls.Load() > 1 },
-					10*time.Second, 100*time.Millisecond,
-				)
-			} else {
-				assert.Eventually(
-					t, func() bool { return calls.Load() == 1 },
-					10*time.Second, 100*time.Millisecond,
-				)
-				// Verify that no retries have been attempted.
-				time.Sleep(100 * time.Millisecond)
-				assert.Equal(t, int64(1), calls.Load())
-			}
 		})
 	}
 }
 
 func TestReceiver_InternalTelemetry(t *testing.T) {
-	t.Parallel()
-	kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+	runTestForClients(t, func(t *testing.T) {
+		kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-	// Send some traces to the otlp_spans topic.
-	traces := testdata.GenerateTraces(1)
-	data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-	require.NoError(t, err)
-	results := kafkaClient.ProduceSync(context.Background(),
-		&kgo.Record{Topic: "otlp_spans", Value: data},
-		&kgo.Record{Topic: "otlp_spans", Value: data},
-		&kgo.Record{Topic: "otlp_spans", Value: data},
-		&kgo.Record{Topic: "otlp_spans", Value: data},
-		&kgo.Record{Topic: "otlp_spans", Value: []byte("junk")},
-	)
-	require.NoError(t, results.FirstErr())
+		// Send some traces to the otlp_spans topic.
+		traces := testdata.GenerateTraces(1)
+		data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+		require.NoError(t, err)
+		results := kafkaClient.ProduceSync(context.Background(),
+			&kgo.Record{Topic: "otlp_spans", Value: data},
+			&kgo.Record{Topic: "otlp_spans", Value: data},
+			&kgo.Record{Topic: "otlp_spans", Value: data},
+			&kgo.Record{Topic: "otlp_spans", Value: data},
+			&kgo.Record{Topic: "otlp_spans", Value: []byte("junk")},
+		)
+		require.NoError(t, results.FirstErr())
 
-	// Wait for messages to be consumed.
-	received := make(chan consumerArgs[ptrace.Traces], 1)
-	set, tel, observedLogs := mustNewSettings(t)
-	f := NewFactory()
-	r, err := f.CreateTraces(context.Background(), set, receiverConfig, newChannelTracesConsumer(received))
-	require.NoError(t, err)
-	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		assert.NoError(t, r.Shutdown(context.Background()))
+		// Wait for messages to be consumed.
+		received := make(chan consumerArgs[ptrace.Traces], 1)
+		set, tel, observedLogs := mustNewSettings(t)
+		f := NewFactory()
+		r, err := f.CreateTraces(context.Background(), set, receiverConfig, newChannelTracesConsumer(received))
+		require.NoError(t, err)
+		require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+		t.Cleanup(func() {
+			assert.NoError(t, r.Shutdown(context.Background()))
+		})
+		for range 4 {
+			<-received
+		}
+
+		// There should be one failed message due to the invalid third message payload.
+		// It may not be available immediately, as the receiver may not have processed it yet.
+		assert.Eventually(t, func() bool {
+			_, getMetricErr := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_spans")
+			return getMetricErr == nil
+		}, 10*time.Second, 100*time.Millisecond)
+		metadatatest.AssertEqualKafkaReceiverUnmarshalFailedSpans(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_spans"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+		// After receiving messages, the internal metrics should be updated.
+		metadatatest.AssertEqualKafkaReceiverPartitionStart(t, tel, []metricdata.DataPoint[int64]{{
+			Value:      1,
+			Attributes: attribute.NewSet(attribute.String("name", set.ID.Name())),
+		}}, metricdatatest.IgnoreTimestamp())
+
+		metadatatest.AssertEqualKafkaReceiverMessages(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 5,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_spans"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp())
+
+		// Shut down and check that the partition close metric is updated.
+		err = r.Shutdown(context.Background())
+		require.NoError(t, err)
+		metadatatest.AssertEqualKafkaReceiverPartitionClose(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.Name()),
+			),
+		}}, metricdatatest.IgnoreTimestamp())
+
+		observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+		logEntries := observedErrorLogs.All()
+		assert.Len(t, logEntries, 2)
+		assert.Equal(t, "failed to unmarshal message", logEntries[0].Message)
+		assert.Equal(t, "failed to consume message, skipping due to message_marking config", logEntries[1].Message)
+
+		metadatatest.AssertEqualKafkaReceiverCurrentOffset(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 4, // offset of the final message
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_spans"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp())
+
+		metadatatest.AssertEqualKafkaReceiverOffsetLag(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 0,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_spans"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp())
 	})
-	for range 4 {
-		<-received
-	}
-
-	// There should be one failed message due to the invalid third message payload.
-	// It may not be available immediately, as the receiver may not have processed it yet.
-	assert.Eventually(t, func() bool {
-		_, getMetricErr := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_spans")
-		return getMetricErr == nil
-	}, 10*time.Second, 100*time.Millisecond)
-	metadatatest.AssertEqualKafkaReceiverUnmarshalFailedSpans(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 1,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_spans"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
-
-	// After receiving messages, the internal metrics should be updated.
-	metadatatest.AssertEqualKafkaReceiverPartitionStart(t, tel, []metricdata.DataPoint[int64]{{
-		Value:      1,
-		Attributes: attribute.NewSet(attribute.String("name", set.ID.Name())),
-	}}, metricdatatest.IgnoreTimestamp())
-
-	metadatatest.AssertEqualKafkaReceiverMessages(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 5,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_spans"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp())
-
-	// Shut down and check that the partition close metric is updated.
-	err = r.Shutdown(context.Background())
-	require.NoError(t, err)
-	metadatatest.AssertEqualKafkaReceiverPartitionClose(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 1,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.Name()),
-		),
-	}}, metricdatatest.IgnoreTimestamp())
-
-	observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-	logEntries := observedErrorLogs.All()
-	assert.Len(t, logEntries, 2)
-	assert.Equal(t, "failed to unmarshal message", logEntries[0].Message)
-	assert.Equal(t, "failed to consume message, skipping due to message_marking config", logEntries[1].Message)
-
-	metadatatest.AssertEqualKafkaReceiverCurrentOffset(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 4, // offset of the final message
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_spans"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp())
-
-	metadatatest.AssertEqualKafkaReceiverOffsetLag(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 0,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_spans"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp())
 }
 
 func TestReceiver_MessageMarking(t *testing.T) {
-	t.Parallel()
 	for name, testcase := range map[string]struct {
 		markAfter  bool
 		markErrors bool
@@ -359,189 +371,209 @@ func TestReceiver_MessageMarking(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
+			runTestForClients(t, func(t *testing.T) {
+				kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_spans"))
 
-			// Send some invalid data to the otlp_spans topic so unmarshaling fails,
-			// and then send some valid data to show that the invalid data does not
-			// block the consumer.
-			traces := testdata.GenerateTraces(1)
-			data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
-			require.NoError(t, err)
-			results := kafkaClient.ProduceSync(context.Background(),
-				&kgo.Record{Topic: "otlp_spans", Value: []byte("junk")},
-				&kgo.Record{Topic: "otlp_spans", Value: data},
-			)
-			require.NoError(t, results.FirstErr())
-
-			var calls atomic.Int64
-			consumer := newTracesConsumer(func(_ context.Context, received ptrace.Traces) error {
-				calls.Add(1)
-				return ptracetest.CompareTraces(traces, received)
-			})
-
-			// Only mark messages after consuming, including for errors.
-			receiverConfig.MessageMarking.After = testcase.markAfter
-			receiverConfig.MessageMarking.OnError = testcase.markErrors
-			set, tel, observedLogs := mustNewSettings(t)
-			f := NewFactory()
-			r, err := f.CreateTraces(context.Background(), set, receiverConfig, consumer)
-			require.NoError(t, err)
-			require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
-			t.Cleanup(func() {
-				assert.NoError(t, r.Shutdown(context.Background()))
-			})
-
-			if testcase.errorShouldRestart {
-				// Verify that the consumer restarts at least once.
-				assert.Eventually(t, func() bool {
-					m, err := tel.GetMetric("otelcol_kafka_receiver_partition_start")
-					require.NoError(t, err)
-
-					dataPoints := m.Data.(metricdata.Sum[int64]).DataPoints
-					assert.Len(t, dataPoints, 1)
-					return dataPoints[0].Value > 5
-				}, time.Second, 100*time.Millisecond, "unmarshal error should restart consumer")
-
-				// The invalid message should block the consumer.
-				assert.Zero(t, calls.Load())
-
-				observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-				logEntries := observedErrorLogs.All()
-				require.NotEmpty(t, logEntries)
-				for _, entry := range logEntries {
-					assert.Equal(t, "failed to unmarshal message", entry.Message)
-				}
-			} else {
-				assert.Eventually(t, func() bool {
-					return calls.Load() == 1
-				}, time.Second, 100*time.Millisecond, "unmarshal error should not block consumption")
-
-				// Verify that the consumer did not restart.
-				metadatatest.AssertEqualKafkaReceiverPartitionStart(t, tel, []metricdata.DataPoint[int64]{{
-					Value:      1,
-					Attributes: attribute.NewSet(attribute.String("name", set.ID.Name())),
-				}}, metricdatatest.IgnoreTimestamp())
-
-				observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
-				logEntries := observedErrorLogs.All()
-				require.Len(t, logEntries, 2)
-				assert.Equal(t, "failed to unmarshal message", logEntries[0].Message)
-				assert.Equal(t,
-					"failed to consume message, skipping due to message_marking config",
-					logEntries[1].Message,
+				// Send some invalid data to the otlp_spans topic so unmarshaling fails,
+				// and then send some valid data to show that the invalid data does not
+				// block the consumer.
+				traces := testdata.GenerateTraces(1)
+				data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+				require.NoError(t, err)
+				results := kafkaClient.ProduceSync(context.Background(),
+					&kgo.Record{Topic: "otlp_spans", Value: []byte("junk")},
+					&kgo.Record{Topic: "otlp_spans", Value: data},
 				)
-			}
+				require.NoError(t, results.FirstErr())
+
+				var calls atomic.Int64
+				consumer := newTracesConsumer(func(_ context.Context, received ptrace.Traces) error {
+					calls.Add(1)
+					return ptracetest.CompareTraces(traces, received)
+				})
+
+				// Only mark messages after consuming, including for errors.
+				receiverConfig.MessageMarking.After = testcase.markAfter
+				receiverConfig.MessageMarking.OnError = testcase.markErrors
+				set, tel, observedLogs := mustNewSettings(t)
+				f := NewFactory()
+				r, err := f.CreateTraces(context.Background(), set, receiverConfig, consumer)
+				require.NoError(t, err)
+				require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+				t.Cleanup(func() {
+					assert.NoError(t, r.Shutdown(context.Background()))
+				})
+
+				if testcase.errorShouldRestart {
+					value := int64(5)
+					timesProcessed := value - 1
+					// Franz doesn't "restart" the consumer
+					if strings.Contains(t.Name(), "Franz") {
+						value = 1
+						timesProcessed = 1
+					}
+
+					// Verify that the consumer restarts at least once.
+					assert.Eventually(t, func() bool {
+						m, err := tel.GetMetric("otelcol_kafka_receiver_partition_start")
+						require.NoError(t, err)
+
+						dataPoints := m.Data.(metricdata.Sum[int64]).DataPoints
+						assert.Len(t, dataPoints, 1)
+						return dataPoints[0].Value >= value
+					}, time.Second, 100*time.Millisecond, "unmarshal error should restart consumer")
+
+					// reprocesses of the same message
+					metadatatest.AssertEqualKafkaReceiverMessages(t, tel, []metricdata.DataPoint[int64]{
+						{
+							Value: timesProcessed,
+							Attributes: attribute.NewSet(
+								attribute.String("name", set.ID.String()),
+								attribute.String("topic", "otlp_spans"),
+								attribute.String("partition", "0"),
+							),
+						},
+					}, metricdatatest.IgnoreTimestamp())
+
+					// The invalid message should block the consumer.
+					assert.Zero(t, calls.Load())
+
+					observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+					logEntries := observedErrorLogs.FilterMessage("failed to unmarshal message")
+					require.NotEmpty(t, logEntries)
+				} else {
+					assert.Eventually(t, func() bool {
+						return calls.Load() == 1
+					}, time.Second, 100*time.Millisecond, "unmarshal error should not block consumption")
+
+					// Verify that the consumer did not restart.
+					metadatatest.AssertEqualKafkaReceiverPartitionStart(t, tel, []metricdata.DataPoint[int64]{{
+						Value:      1,
+						Attributes: attribute.NewSet(attribute.String("name", set.ID.Name())),
+					}}, metricdatatest.IgnoreTimestamp())
+
+					observedErrorLogs := observedLogs.FilterLevelExact(zapcore.ErrorLevel)
+					logEntries := observedErrorLogs.All()
+					require.Len(t, logEntries, 2)
+					assert.Equal(t, "failed to unmarshal message", logEntries[0].Message)
+					assert.Equal(t,
+						"failed to consume message, skipping due to message_marking config",
+						logEntries[1].Message,
+					)
+				}
+			})
 		})
 	}
 }
 
 func TestNewLogsReceiver(t *testing.T) {
-	t.Parallel()
-	kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_logs"))
+	runTestForClients(t, func(t *testing.T) {
+		kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_logs"))
 
-	var sink consumertest.LogsSink
-	receiverConfig.HeaderExtraction.ExtractHeaders = true
-	receiverConfig.HeaderExtraction.Headers = []string{"key1"}
-	set, tel, _ := mustNewSettings(t)
-	r, err := newLogsReceiver(receiverConfig, set, &sink)
-	require.NoError(t, err)
+		var sink consumertest.LogsSink
+		receiverConfig.HeaderExtraction.ExtractHeaders = true
+		receiverConfig.HeaderExtraction.Headers = []string{"key1"}
+		set, tel, _ := mustNewSettings(t)
+		r, err := newLogsReceiver(receiverConfig, set, &sink)
+		require.NoError(t, err)
 
-	// Send some logs to the otlp_logs topic.
-	logs := testdata.GenerateLogs(1)
-	data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
-	require.NoError(t, err)
-	results := kafkaClient.ProduceSync(context.Background(),
-		&kgo.Record{
-			Topic: "otlp_logs",
-			Value: data,
-			Headers: []kgo.RecordHeader{
-				{Key: "key1", Value: []byte("value1")},
+		// Send some logs to the otlp_logs topic.
+		logs := testdata.GenerateLogs(1)
+		data, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+		require.NoError(t, err)
+		results := kafkaClient.ProduceSync(context.Background(),
+			&kgo.Record{
+				Topic: "otlp_logs",
+				Value: data,
+				Headers: []kgo.RecordHeader{
+					{Key: "key1", Value: []byte("value1")},
+				},
 			},
-		},
-		&kgo.Record{Topic: "otlp_logs", Value: []byte("junk")},
-	)
-	require.NoError(t, results.FirstErr())
+			&kgo.Record{Topic: "otlp_logs", Value: []byte("junk")},
+		)
+		require.NoError(t, results.FirstErr())
 
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, r.Shutdown(context.Background()))
+		err = r.Start(context.Background(), componenttest.NewNopHost())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			assert.NoError(t, r.Shutdown(context.Background()))
+		})
+
+		// There should be one failed message due to the invalid message payload.
+		// It may not be available immediately, as the receiver may not have processed it yet.
+		assert.Eventually(t, func() bool {
+			_, err := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_log_records")
+			return err == nil
+		}, 10*time.Second, 100*time.Millisecond)
+		metadatatest.AssertEqualKafkaReceiverUnmarshalFailedLogRecords(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_logs"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+		// There should be one successfully processed batch of logs.
+		assert.Len(t, sink.AllLogs(), 1)
+		_, ok := sink.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes().Get("kafka.header.key1")
+		require.True(t, ok)
 	})
-
-	// There should be one failed message due to the invalid message payload.
-	// It may not be available immediately, as the receiver may not have processed it yet.
-	assert.Eventually(t, func() bool {
-		_, err := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_log_records")
-		return err == nil
-	}, 10*time.Second, 100*time.Millisecond)
-	metadatatest.AssertEqualKafkaReceiverUnmarshalFailedLogRecords(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 1,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_logs"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
-
-	// There should be one successfully processed batch of logs.
-	assert.Len(t, sink.AllLogs(), 1)
-	_, ok := sink.AllLogs()[0].ResourceLogs().At(0).Resource().Attributes().Get("kafka.header.key1")
-	require.True(t, ok)
 }
 
 func TestNewMetricsReceiver(t *testing.T) {
-	t.Parallel()
-	kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_metrics"))
+	runTestForClients(t, func(t *testing.T) {
+		kafkaClient, receiverConfig := mustNewFakeCluster(t, kfake.SeedTopics(1, "otlp_metrics"))
 
-	var sink consumertest.MetricsSink
-	receiverConfig.HeaderExtraction.ExtractHeaders = true
-	receiverConfig.HeaderExtraction.Headers = []string{"key1"}
-	set, tel, _ := mustNewSettings(t)
-	r, err := newMetricsReceiver(receiverConfig, set, &sink)
-	require.NoError(t, err)
+		var sink consumertest.MetricsSink
+		receiverConfig.HeaderExtraction.ExtractHeaders = true
+		receiverConfig.HeaderExtraction.Headers = []string{"key1"}
+		set, tel, _ := mustNewSettings(t)
+		r, err := newMetricsReceiver(receiverConfig, set, &sink)
+		require.NoError(t, err)
 
-	// Send some metrics to the otlp_metrics topic.
-	metrics := testdata.GenerateMetrics(1)
-	data, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(metrics)
-	require.NoError(t, err)
-	results := kafkaClient.ProduceSync(context.Background(),
-		&kgo.Record{
-			Topic: "otlp_metrics",
-			Value: data,
-			Headers: []kgo.RecordHeader{
-				{Key: "key1", Value: []byte("value1")},
+		// Send some metrics to the otlp_metrics topic.
+		metrics := testdata.GenerateMetrics(1)
+		data, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(metrics)
+		require.NoError(t, err)
+		results := kafkaClient.ProduceSync(context.Background(),
+			&kgo.Record{
+				Topic: "otlp_metrics",
+				Value: data,
+				Headers: []kgo.RecordHeader{
+					{Key: "key1", Value: []byte("value1")},
+				},
 			},
-		},
-		&kgo.Record{Topic: "otlp_metrics", Value: []byte("junk")},
-	)
-	require.NoError(t, results.FirstErr())
+			&kgo.Record{Topic: "otlp_metrics", Value: []byte("junk")},
+		)
+		require.NoError(t, results.FirstErr())
 
-	err = r.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		assert.NoError(t, r.Shutdown(context.Background()))
+		err = r.Start(context.Background(), componenttest.NewNopHost())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			assert.NoError(t, r.Shutdown(context.Background()))
+		})
+
+		// There should be one failed message due to the invalid message payload.
+		// It may not be available immediately, as the receiver may not have processed it yet.
+		assert.Eventually(t, func() bool {
+			_, err := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_metric_points")
+			return err == nil
+		}, 10*time.Second, 100*time.Millisecond)
+		metadatatest.AssertEqualKafkaReceiverUnmarshalFailedMetricPoints(t, tel, []metricdata.DataPoint[int64]{{
+			Value: 1,
+			Attributes: attribute.NewSet(
+				attribute.String("name", set.ID.String()),
+				attribute.String("topic", "otlp_metrics"),
+				attribute.String("partition", "0"),
+			),
+		}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+		// There should be one successfully processed batch of metrics.
+		assert.Len(t, sink.AllMetrics(), 1)
+		_, ok := sink.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes().Get("kafka.header.key1")
+		require.True(t, ok)
 	})
-
-	// There should be one failed message due to the invalid message payload.
-	// It may not be available immediately, as the receiver may not have processed it yet.
-	assert.Eventually(t, func() bool {
-		_, err := tel.GetMetric("otelcol_kafka_receiver_unmarshal_failed_metric_points")
-		return err == nil
-	}, 10*time.Second, 100*time.Millisecond)
-	metadatatest.AssertEqualKafkaReceiverUnmarshalFailedMetricPoints(t, tel, []metricdata.DataPoint[int64]{{
-		Value: 1,
-		Attributes: attribute.NewSet(
-			attribute.String("name", set.ID.String()),
-			attribute.String("topic", "otlp_metrics"),
-			attribute.String("partition", "0"),
-		),
-	}}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
-
-	// There should be one successfully processed batch of metrics.
-	assert.Len(t, sink.AllMetrics(), 1)
-	_, ok := sink.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes().Get("kafka.header.key1")
-	require.True(t, ok)
 }
 
 func mustNewTracesReceiver(tb testing.TB, cfg *Config, nextConsumer consumer.Traces) {

--- a/receiver/kafkareceiver/metadata.yaml
+++ b/receiver/kafkareceiver/metadata.yaml
@@ -13,6 +13,10 @@ status:
 # TODO: Update the receiver to pass the tests
 tests:
   skip_lifecycle: true
+  goleak:
+    ignore:
+      top:
+        - github.com/twmb/franz-go/pkg/kfake.(*group).manage
 
 telemetry:
   metrics:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds the option to use the franz-go client in the `kafkareceiver`. The
main rationale for this change is to allow users to opt-in to use a
more performant Kafka client, as the default Sarama client has been
known to have performance issues in high-throughput scenarios.

The change _should_ be backward compatible, and significantly increases
the consumption performance of the `kafkareceiver` when in use.

In all cases, but particularly if AutoCommit isn't enabled. The benchmarks
I've run (and committed) show a significant performance improvement:

- Default (AutoCommit enabled): `+0-29%`
- AutoCommit enabled, OnError=rue: `+20-38%`
- After=true OnError=false: `+1000-4000%`
- After=true_OnError=true: `+1100-4100%`
- After=false_OnError=false: `+1100-3900%`
- After=false_OnError=true: `+1100-3900%`


```
                                                                           │  sarama.txt  │                franz.txt                 │
                                                                           │   spans/s    │    spans/s      vs base                  │
TracesReceiver/AutoCommit_OnError=false_(default)/batch_1/partitions_1-12    367.4k ±  3%     475.1k ±  1%    +29.32% (p=0.000 n=10)
TracesReceiver/AutoCommit_OnError=false_(default)/batch_1/partitions_2-12    557.2k ±  4%     620.8k ± 22%          ~ (p=0.143 n=10)
TracesReceiver/AutoCommit_OnError=false_(default)/batch_10/partitions_1-12   1.382M ±  3%     1.706M ±  4%    +23.42% (p=0.000 n=10)
TracesReceiver/AutoCommit_OnError=false_(default)/batch_10/partitions_2-12   2.104M ±  4%     1.926M ± 13%          ~ (p=0.353 n=10)
TracesReceiver/AutoCommit_OnError=true/batch_1/partitions_1-12               361.9k ±  2%     502.4k ±  2%    +38.80% (p=0.000 n=10)
TracesReceiver/AutoCommit_OnError=true/batch_1/partitions_2-12               561.7k ±  5%     675.8k ± 22%    +20.31% (p=0.019 n=10)
TracesReceiver/AutoCommit_OnError=true/batch_10/partitions_1-12              1.368M ±  3%     1.746M ±  3%    +27.61% (p=0.000 n=10)
TracesReceiver/AutoCommit_OnError=true/batch_10/partitions_2-12              2.157M ±  4%     2.210M ± 18%          ~ (p=0.684 n=10)
TracesReceiver/After=true_OnError=false/batch_1/partitions_1-12              9.918k ±  1%   410.510k ±  2%  +4038.83% (p=0.000 n=10)
TracesReceiver/After=true_OnError=false/batch_1/partitions_2-12              16.54k ±  4%    515.87k ± 16%  +3019.11% (p=0.000 n=10)
TracesReceiver/After=true_OnError=false/batch_10/partitions_1-12             100.1k ±  0%    1619.3k ±  3%  +1518.39% (p=0.000 n=10)
TracesReceiver/After=true_OnError=false/batch_10/partitions_2-12             171.5k ± 15%    1969.4k ± 19%  +1048.12% (p=0.000 n=10)
TracesReceiver/After=true_OnError=true/batch_1/partitions_1-12               9.807k ±  1%   414.966k ±  1%  +4131.32% (p=0.000 n=10)
TracesReceiver/After=true_OnError=true/batch_1/partitions_2-12               17.02k ±  7%    445.86k ± 31%  +2518.85% (p=0.000 n=10)
TracesReceiver/After=true_OnError=true/batch_10/partitions_1-12              99.46k ±  1%   1620.77k ±  3%  +1529.50% (p=0.000 n=10)
TracesReceiver/After=true_OnError=true/batch_10/partitions_2-12              147.3k ± 17%    1603.6k ± 23%   +988.30% (p=0.000 n=10)
TracesReceiver/After=false_OnError=false/batch_1/partitions_1-12             9.775k ±  1%   400.567k ±  2%  +3997.66% (p=0.000 n=10)
TracesReceiver/After=false_OnError=false/batch_1/partitions_2-12             15.73k ±  7%    464.95k ± 15%  +2854.86% (p=0.000 n=10)
TracesReceiver/After=false_OnError=false/batch_10/partitions_1-12            99.48k ±  0%   1586.74k ±  2%  +1494.98% (p=0.000 n=10)
TracesReceiver/After=false_OnError=false/batch_10/partitions_2-12            146.7k ±  1%    1868.7k ± 16%  +1174.18% (p=0.000 n=10)
TracesReceiver/After=false_OnError=true/batch_1/partitions_1-12              9.759k ±  1%   395.539k ±  1%  +3952.87% (p=0.000 n=10)
TracesReceiver/After=false_OnError=true/batch_1/partitions_2-12              15.68k ±  2%    413.63k ± 26%  +2538.10% (p=0.000 n=10)
TracesReceiver/After=false_OnError=true/batch_10/partitions_1-12             99.39k ±  1%   1589.17k ±  3%  +1498.95% (p=0.000 n=10)
TracesReceiver/After=false_OnError=true/batch_10/partitions_2-12             146.6k ± 15%    1894.1k ± 18%  +1192.17% (p=0.000 n=10)
geomean                                                                      111.0k           912.9k         +722.19%
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Closes #40628

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tested and benchmarked.

<!--Describe the documentation added.-->
#### Documentation

Updated readme
