### PR TITLE
[receiver/mysqlreceiver]: Unexport non-config structs from mysqlreceiver

### DIFF
--- a/.chloggen/unexport-mysql-structs.yaml
+++ b/.chloggen/unexport-mysql-structs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport TableStats,TableIoWaitsStats,StatementEventStats,ReplicaStatusStats,IoWaitsStats,IndexIoWaitsStats,MySQLTestConfig structs from mysqlreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40671]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -21,7 +21,7 @@ import (
 
 const mysqlPort = "3306"
 
-type MySQLTestConfig struct {
+type mySQLTestConfig struct {
 	name         string
 	containerCmd []string
 	tlsEnabled   bool
@@ -31,7 +31,7 @@ type MySQLTestConfig struct {
 }
 
 func TestIntegration(t *testing.T) {
-	testCases := []MySQLTestConfig{
+	testCases := []mySQLTestConfig{
 		{
 			name:         "MySql-8.0.33-WithoutTLS",
 			containerCmd: nil,

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -202,8 +202,8 @@ func (c *mockClient) getInnodbStats() (map[string]string, error) {
 	return readFile(c.innodbStatsFile)
 }
 
-func (c *mockClient) getTableStats() ([]TableStats, error) {
-	var stats []TableStats
+func (c *mockClient) getTableStats() ([]tableStats, error) {
+	var stats []tableStats
 	file, err := os.Open(filepath.Join("testdata", "scraper", c.tableStatsFile+".txt"))
 	if err != nil {
 		return nil, err
@@ -212,7 +212,7 @@ func (c *mockClient) getTableStats() ([]TableStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var s TableStats
+		var s tableStats
 		text := strings.Split(scanner.Text(), "\t")
 		s.schema = text[0]
 		s.name = text[1]
@@ -226,8 +226,8 @@ func (c *mockClient) getTableStats() ([]TableStats, error) {
 	return stats, nil
 }
 
-func (c *mockClient) getTableIoWaitsStats() ([]TableIoWaitsStats, error) {
-	var stats []TableIoWaitsStats
+func (c *mockClient) getTableIoWaitsStats() ([]tableIoWaitsStats, error) {
+	var stats []tableIoWaitsStats
 	file, err := os.Open(filepath.Join("testdata", "scraper", c.tableIoWaitsFile+".txt"))
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ func (c *mockClient) getTableIoWaitsStats() ([]TableIoWaitsStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var s TableIoWaitsStats
+		var s tableIoWaitsStats
 		text := strings.Split(scanner.Text(), "\t")
 
 		s.schema = text[0]
@@ -255,8 +255,8 @@ func (c *mockClient) getTableIoWaitsStats() ([]TableIoWaitsStats, error) {
 	return stats, nil
 }
 
-func (c *mockClient) getIndexIoWaitsStats() ([]IndexIoWaitsStats, error) {
-	var stats []IndexIoWaitsStats
+func (c *mockClient) getIndexIoWaitsStats() ([]indexIoWaitsStats, error) {
+	var stats []indexIoWaitsStats
 	file, err := os.Open(filepath.Join("testdata", "scraper", c.indexIoWaitsFile+".txt"))
 	if err != nil {
 		return nil, err
@@ -265,7 +265,7 @@ func (c *mockClient) getIndexIoWaitsStats() ([]IndexIoWaitsStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var s IndexIoWaitsStats
+		var s indexIoWaitsStats
 		text := strings.Split(scanner.Text(), "\t")
 
 		s.schema = text[0]
@@ -285,8 +285,8 @@ func (c *mockClient) getIndexIoWaitsStats() ([]IndexIoWaitsStats, error) {
 	return stats, nil
 }
 
-func (c *mockClient) getStatementEventsStats() ([]StatementEventStats, error) {
-	var stats []StatementEventStats
+func (c *mockClient) getStatementEventsStats() ([]statementEventStats, error) {
+	var stats []statementEventStats
 	file, err := os.Open(filepath.Join("testdata", "scraper", c.statementEventsFile+".txt"))
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func (c *mockClient) getStatementEventsStats() ([]StatementEventStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var s StatementEventStats
+		var s statementEventStats
 		text := strings.Split(scanner.Text(), "\t")
 
 		s.schema = text[0]
@@ -359,8 +359,8 @@ func (c *mockClient) getTableLockWaitEventStats() ([]tableLockWaitEventStats, er
 	return stats, nil
 }
 
-func (c *mockClient) getReplicaStatusStats() ([]ReplicaStatusStats, error) {
-	var stats []ReplicaStatusStats
+func (c *mockClient) getReplicaStatusStats() ([]replicaStatusStats, error) {
+	var stats []replicaStatusStats
 	file, err := os.Open(filepath.Join("testdata", "scraper", c.replicaStatusFile+".txt"))
 	if err != nil {
 		return nil, err
@@ -369,7 +369,7 @@ func (c *mockClient) getReplicaStatusStats() ([]ReplicaStatusStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		var s ReplicaStatusStats
+		var s replicaStatusStats
 		text := strings.Split(scanner.Text(), "\t")
 
 		s.replicaIOState = text[0]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Unexport TableStats,TableIoWaitsStats,StatementEventStats,ReplicaStatusStats,IoWaitsStats,IndexIoWaitsStats,MySQLTestConfig structs

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40671 


