### PR TITLE
[receiver/simpleprometheus] Pass labels configuration to Prometheus properly

### DIFF
--- a/.chloggen/fix_simpleprom_labels.yaml
+++ b/.chloggen/fix_simpleprom_labels.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/simpleprometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug that caused the labels configuration option to be ignored
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40722]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/simpleprometheusreceiver/receiver.go
+++ b/receiver/simpleprometheusreceiver/receiver.go
@@ -129,9 +129,8 @@ func getPrometheusConfig(cfg *Config) (*prometheusreceiver.Config, error) {
 		ServiceDiscoveryConfigs: discovery.Configs{
 			discovery.StaticConfig{
 				{
-					Targets: []model.LabelSet{
-						labels,
-					},
+					Targets: []model.LabelSet{{model.AddressLabel: model.LabelValue(cfg.Endpoint)}},
+					Labels:  labels,
 				},
 			},
 		},

--- a/receiver/simpleprometheusreceiver/receiver.go
+++ b/receiver/simpleprometheusreceiver/receiver.go
@@ -112,7 +112,6 @@ func getPrometheusConfig(cfg *Config) (*prometheusreceiver.Config, error) {
 	for k, v := range cfg.Labels {
 		labels[model.LabelName(k)] = model.LabelValue(v)
 	}
-	labels[model.AddressLabel] = model.LabelValue(cfg.Endpoint)
 
 	jobName := cfg.JobName
 	if jobName == "" {

--- a/receiver/simpleprometheusreceiver/receiver_test.go
+++ b/receiver/simpleprometheusreceiver/receiver_test.go
@@ -117,6 +117,7 @@ func TestGetPrometheusConfig(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue("localhost:1234")},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -152,6 +153,7 @@ func TestGetPrometheusConfig(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue("localhost:1234")},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -184,6 +186,7 @@ func TestGetPrometheusConfig(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue("localhost:1234")},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -224,9 +227,11 @@ func TestGetPrometheusConfig(t *testing.T) {
 									{
 										Targets: []model.LabelSet{
 											{
-												model.AddressLabel:     model.LabelValue("localhost:1234"),
-												model.LabelName("key"): model.LabelValue("value"),
+												model.AddressLabel: model.LabelValue("localhost:1234"),
 											},
+										},
+										Labels: model.LabelSet{
+											model.LabelName("key"): model.LabelValue("value"),
 										},
 									},
 								},
@@ -304,6 +309,7 @@ func TestGetPrometheusConfigWrapper(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue(defaultEndpoint)},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -347,6 +353,7 @@ func TestGetPrometheusConfigWrapper(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue(defaultEndpoint)},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -384,6 +391,7 @@ func TestGetPrometheusConfigWrapper(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue(defaultEndpoint)},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},
@@ -421,6 +429,7 @@ func TestGetPrometheusConfigWrapper(t *testing.T) {
 										Targets: []model.LabelSet{
 											{model.AddressLabel: model.LabelValue(defaultEndpoint)},
 										},
+										Labels: map[model.LabelName]model.LabelValue{},
 									},
 								},
 							},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Provides fix as described in the issue. The original issue was the the receiver was not properly configuring the Prometheus receiver, which this is a wrapper for. This change is to simply pass the labels under the `Labels` Prometheus receiver option, rather than under `Target`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40722

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Manually tested on CLI. There aren't good tests for this component, shown by this bug not being caught earlier. If anyone has any ideas for good ways to add tests here, I'd be happy to add them.

<!--Please delete paragraphs that you did not use before submitting.-->
