### PR TITLE
fix: unexport CodecovConfig struct

### DIFF
--- a/cmd/codecovgen/main.go
+++ b/cmd/codecovgen/main.go
@@ -110,7 +110,7 @@ type ComponentManagement struct {
 	IndividualComponents []Component `json:"individual_components"`
 }
 
-type CodecovConfig struct {
+type codecovConfig struct {
 	ComponentManagement ComponentManagement `json:"component_management"`
 }
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,8 @@
+Microsoft Windows [Version 10.0.26100.4061]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>
+C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>
+C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>
+C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>
+C:\Users\sambh\open-source\opentelemetry-operator\opentelemetry-collector-contrib>


### PR DESCRIPTION
This PR unexports the CodecovConfig struct from cmd/codecovgen/main.go as per the suggestion in issue #40641.

