### PR TITLE
[receiver/podmanreceiver] unexport ContainerScraper

### DIFF
--- a/.chloggen/unexport_containerScraper.yaml
+++ b/.chloggen/unexport_containerScraper.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: podmanreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport ContainerScraper
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40672]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -24,30 +24,30 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-type MockClient struct {
+type mockClient struct {
 	PingF   func(context.Context) error
 	StatsF  func(context.Context, url.Values) ([]containerStats, error)
 	ListF   func(context.Context, url.Values) ([]container, error)
 	EventsF func(context.Context, url.Values) (<-chan event, <-chan error)
 }
 
-func (c *MockClient) ping(ctx context.Context) error {
+func (c *mockClient) ping(ctx context.Context) error {
 	return c.PingF(ctx)
 }
 
-func (c *MockClient) stats(ctx context.Context, options url.Values) ([]containerStats, error) {
+func (c *mockClient) stats(ctx context.Context, options url.Values) ([]containerStats, error) {
 	return c.StatsF(ctx, options)
 }
 
-func (c *MockClient) list(ctx context.Context, options url.Values) ([]container, error) {
+func (c *mockClient) list(ctx context.Context, options url.Values) ([]container, error) {
 	return c.ListF(ctx, options)
 }
 
-func (c *MockClient) events(ctx context.Context, options url.Values) (<-chan event, <-chan error) {
+func (c *mockClient) events(ctx context.Context, options url.Values) (<-chan event, <-chan error) {
 	return c.EventsF(ctx, options)
 }
 
-var baseClient = MockClient{
+var baseClient = mockClient{
 	PingF: func(context.Context) error {
 		return nil
 	},

--- a/receiver/podmanreceiver/receiver.go
+++ b/receiver/podmanreceiver/receiver.go
@@ -28,7 +28,7 @@ type metricsReceiver struct {
 	config        *Config
 	set           receiver.Settings
 	clientFactory clientFactory
-	scraper       *ContainerScraper
+	scraper       *containerScraper
 	mb            *metadata.MetricsBuilder
 	cancel        context.CancelFunc
 }

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -46,7 +46,7 @@ func TestScraperLoop(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.CollectionInterval = 100 * time.Millisecond
 
-	client := make(mockClient)
+	client := make(mockPodmanClient)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -74,13 +74,13 @@ func TestScraperLoop(t *testing.T) {
 	assertStatsEqualToMetrics(t, genContainerStats(), md)
 }
 
-type mockClient chan containerStatsReport
+type mockPodmanClient chan containerStatsReport
 
-func (c mockClient) factory(_ *zap.Logger, _ *Config) (PodmanClient, error) {
+func (c mockPodmanClient) factory(_ *zap.Logger, _ *Config) (PodmanClient, error) {
 	return c, nil
 }
 
-func (c mockClient) stats(context.Context, url.Values) ([]containerStats, error) {
+func (c mockPodmanClient) stats(context.Context, url.Values) ([]containerStats, error) {
 	report := <-c
 	if report.Error.Message != "" {
 		return nil, errors.New(report.Error.Message)
@@ -88,14 +88,14 @@ func (c mockClient) stats(context.Context, url.Values) ([]containerStats, error)
 	return report.Stats, nil
 }
 
-func (c mockClient) ping(context.Context) error {
+func (c mockPodmanClient) ping(context.Context) error {
 	return nil
 }
 
-func (c mockClient) list(context.Context, url.Values) ([]container, error) {
+func (c mockPodmanClient) list(context.Context, url.Values) ([]container, error) {
 	return []container{{ID: "c1", Image: "localimage"}}, nil
 }
 
-func (c mockClient) events(context.Context, url.Values) (<-chan event, <-chan error) {
+func (c mockPodmanClient) events(context.Context, url.Values) (<-chan event, <-chan error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
these structs are not part of config and cannot be exported: MockClient,ContainerScraper

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40672

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
