### PR TITLE
[receiver/netflowreceiver]: add `tcp_flags` field to netflow receiver

### DIFF
--- a/.chloggen/netflowreceiver_add_tcp_flags_attribute.yaml
+++ b/.chloggen/netflowreceiver_add_tcp_flags_attribute.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: netflowreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add TCP flags attribute to netflow receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40487]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/netflowreceiver/README.md
+++ b/receiver/netflowreceiver/README.md
@@ -108,6 +108,7 @@ The log record will have the following attributes (with examples):
 * **flow.end**: Int(1736309689871846400)
 * **flow.sampling_rate**: Int(0)
 * **flow.sampler_address**: Str(172.28.176.1)
+* **flow.tcp_flags**: Int(0)
 
 The log record timestamps will be:
 

--- a/receiver/netflowreceiver/parser.go
+++ b/receiver/netflowreceiver/parser.go
@@ -252,6 +252,7 @@ func addMessageAttributes(m producer.ProducerMessage, r *plog.LogRecord) error {
 	r.Attributes().PutInt("flow.end", int64(pm.TimeFlowEndNs))
 	r.Attributes().PutInt("flow.sampling_rate", int64(pm.SamplingRate))
 	r.Attributes().PutStr("flow.sampler_address", samplerAddr.String())
+	r.Attributes().PutInt("flow.tcp_flags", int64(pm.TcpFlags))
 
 	return nil
 }

--- a/receiver/netflowreceiver/parser_test.go
+++ b/receiver/netflowreceiver/parser_test.go
@@ -57,6 +57,7 @@ func TestConvertToOtel(t *testing.T) {
 			TimeFlowEndNs:   1000000200,
 			SequenceNum:     1,
 			SamplingRate:    1,
+			TcpFlags:        1,
 		},
 	}
 
@@ -86,6 +87,7 @@ func TestConvertToOtel(t *testing.T) {
 	expectedAttributes.PutInt("flow.end", 1000000200)
 	expectedAttributes.PutInt("flow.sampling_rate", 1)
 	expectedAttributes.PutStr("flow.sampler_address", "192.168.1.100")
+	expectedAttributes.PutInt("flow.tcp_flags", 1)
 
 	assert.Equal(t, expectedAttributes, record.Attributes())
 }
@@ -119,6 +121,7 @@ func TestEmptyConvertToOtel(t *testing.T) {
 	expectedAttributes.PutInt("flow.end", 0)
 	expectedAttributes.PutInt("flow.sampling_rate", 0)
 	expectedAttributes.PutStr("flow.sampler_address", "invalid IP")
+	expectedAttributes.PutInt("flow.tcp_flags", 0)
 
 	assert.Equal(t, expectedAttributes, record.Attributes())
 }


### PR DESCRIPTION
#### Description
- Adds existing field used in the `goflow2` proto: [`tcp_flags`](https://github.com/netsampler/goflow2/blob/0b47cd51a1666564fec4943926d9e8af321eee4f/pb/flow.proto#L66). 

#### Link to tracking issue
Fixes [#40487](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40487)

#### Testing
- parse_test.go

#### Documentation
- Update README.md for netflowreceiver
