### PR TITLE
Make non public some exporter azuredata structs

### DIFF
--- a/.chloggen/unexport_azuredata_exporter_structs.yaml
+++ b/.chloggen/unexport_azuredata_exporter_structs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuredataexplorerexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport Status, Link, AdxTrace, AdxLog, Event, AdxMetric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/azuredataexplorerexporter/e2e_test.go
+++ b/exporter/azuredataexplorerexporter/e2e_test.go
@@ -78,7 +78,7 @@ func TestCreateTracesE2E(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 	// Validate the results
-	recs := []AdxTrace{}
+	recs := []adxTrace{}
 	tableResult := <-dataset.Tables()
 	if tableResult.Err() != nil {
 		panic(tableResult.Err())
@@ -92,7 +92,7 @@ func TestCreateTracesE2E(t *testing.T) {
 		}
 		row := rowResult.Row()
 
-		rec := AdxTrace{}
+		rec := adxTrace{}
 		if err = row.ToStruct(&rec); err != nil {
 			err = rowResult.Err()
 		}
@@ -146,7 +146,7 @@ func TestCreateLogsE2E(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 	// Validate the results
-	recs := []AdxLog{}
+	recs := []adxLog{}
 	tableResult := <-dataset.Tables()
 	if tableResult.Err() != nil {
 		panic(tableResult.Err())
@@ -160,7 +160,7 @@ func TestCreateLogsE2E(t *testing.T) {
 		}
 		row := rowResult.Row()
 
-		rec := AdxLog{}
+		rec := adxLog{}
 		if err = row.ToStruct(&rec); err != nil {
 			err = rowResult.Err()
 		}
@@ -214,7 +214,7 @@ func TestCreateMetricsE2E(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 	// Validate the results
-	recs := []AdxMetric{}
+	recs := []adxMetric{}
 	tableResult := <-dataset.Tables()
 	if err != nil {
 		assert.Fail(t, err.Error())
@@ -231,7 +231,7 @@ func TestCreateMetricsE2E(t *testing.T) {
 		}
 		row := rowResult.Row()
 
-		rec := AdxMetric{}
+		rec := adxMetric{}
 		if err = row.ToStruct(&rec); err != nil {
 			err = rowResult.Err()
 		}

--- a/exporter/azuredataexplorerexporter/logsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/logsdata_to_adx.go
@@ -13,7 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 )
 
-type AdxLog struct {
+type adxLog struct {
 	Timestamp          string         // The timestamp of the occurrence. Formatted into string as RFC3339Nano
 	ObservedTimestamp  string         // The timestamp of logs observed in opentelemetry collector.  Formatted into string as RFC3339Nano
 	TraceID            string         // TraceId associated to the log
@@ -26,11 +26,11 @@ type AdxLog struct {
 }
 
 // Convert the plog to the type ADXLog, this matches the scheme in the Log table in the database
-func mapToAdxLog(resource pcommon.Resource, scope pcommon.InstrumentationScope, logData plog.LogRecord, _ *zap.Logger) *AdxLog {
+func mapToAdxLog(resource pcommon.Resource, scope pcommon.InstrumentationScope, logData plog.LogRecord, _ *zap.Logger) *adxLog {
 	logAttrib := logData.Attributes().AsRaw()
 	clonedLogAttrib := cloneMap(logAttrib)
 	copyMap(clonedLogAttrib, getScopeMap(scope))
-	adxLog := &AdxLog{
+	adxLog := &adxLog{
 		Timestamp:          logData.Timestamp().AsTime().Format(time.RFC3339Nano),
 		ObservedTimestamp:  logData.ObservedTimestamp().AsTime().Format(time.RFC3339Nano),
 		TraceID:            traceutil.TraceIDToHexOrEmptyString(logData.TraceID()),

--- a/exporter/azuredataexplorerexporter/logsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/logsdata_to_adx_test.go
@@ -31,7 +31,7 @@ func Test_mapToAdxLog(t *testing.T) {
 		logRecordFn     func() plog.LogRecord // function that generates the logs
 		logResourceFn   func() pcommon.Resource
 		logScopeFn      func() pcommon.InstrumentationScope
-		expectedAdxLogs []*AdxLog
+		expectedAdxLogs []*adxLog
 	}{
 		{
 			name: "valid",
@@ -49,7 +49,7 @@ func Test_mapToAdxLog(t *testing.T) {
 			},
 			logResourceFn: newDummyResource,
 			logScopeFn:    newScopeWithData,
-			expectedAdxLogs: []*AdxLog{
+			expectedAdxLogs: []*adxLog{
 				{
 					Timestamp:          tstr,
 					ObservedTimestamp:  tstr,
@@ -78,7 +78,7 @@ func Test_mapToAdxLog(t *testing.T) {
 			},
 			logResourceFn: newDummyResource,
 			logScopeFn:    newScopeWithData,
-			expectedAdxLogs: []*AdxLog{
+			expectedAdxLogs: []*adxLog{
 				{
 					Timestamp:          tstr,
 					ObservedTimestamp:  tstr,
@@ -106,7 +106,7 @@ func Test_mapToAdxLog(t *testing.T) {
 			},
 			logResourceFn: newDummyResource,
 			logScopeFn:    newScopeWithData,
-			expectedAdxLogs: []*AdxLog{
+			expectedAdxLogs: []*adxLog{
 				{
 					Timestamp:          tstr,
 					ObservedTimestamp:  tstr,
@@ -140,7 +140,7 @@ func Test_mapToAdxLog(t *testing.T) {
 			},
 			logResourceFn: newDummyResource,
 			logScopeFn:    newScopeWithData,
-			expectedAdxLogs: []*AdxLog{
+			expectedAdxLogs: []*adxLog{
 				{
 					Timestamp:          tstr,
 					ObservedTimestamp:  tstr,
@@ -163,7 +163,7 @@ func Test_mapToAdxLog(t *testing.T) {
 			},
 			logResourceFn: pcommon.NewResource,
 			logScopeFn:    pcommon.NewInstrumentationScope,
-			expectedAdxLogs: []*AdxLog{
+			expectedAdxLogs: []*adxLog{
 				{
 					Timestamp:          defaultTime,
 					ObservedTimestamp:  defaultTime,

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
@@ -32,7 +32,7 @@ const (
 )
 
 // This is derived from the specification https://opentelemetry.io/docs/reference/specification/metrics/datamodel/
-type AdxMetric struct {
+type adxMetric struct {
 	Timestamp string // The timestamp of the occurrence. A metric is measured at a point of time. Formatted into string as RFC3339Nano
 	// Including name, the Metric object is defined by the following properties:
 	MetricName        string         // Name of the metric field
@@ -50,7 +50,7 @@ type AdxMetric struct {
 	Convert the pMetric to the type ADXMetric , this matches the scheme in the OTELMetric table in the database
 */
 
-func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[string]any, logger *zap.Logger) []*AdxMetric {
+func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[string]any, logger *zap.Logger) []*adxMetric {
 	logger.Debug("Entering processing of toAdxMetric function")
 	// default to collectors host name. Ignore the error here. This should not cause the failure of the process
 	host, err := os.Hostname()
@@ -61,7 +61,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 	if h := resourceAttrs[hostkey]; h != nil {
 		host = h.(string)
 	}
-	createMetric := func(times time.Time, attr pcommon.Map, value func() float64, name string, desc string, mt pmetric.MetricType) *AdxMetric {
+	createMetric := func(times time.Time, attr pcommon.Map, value func() float64, name string, desc string, mt pmetric.MetricType) *adxMetric {
 		clonedScopedAttributes := copyMap(cloneMap(scopeattrs), attr.AsRaw())
 		if isEmpty(name) {
 			name = md.Name()
@@ -69,7 +69,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 		if isEmpty(desc) {
 			desc = md.Description()
 		}
-		return &AdxMetric{
+		return &adxMetric{
 			Timestamp:          times.Format(time.RFC3339Nano),
 			MetricName:         name,
 			MetricType:         mt.String(),
@@ -85,7 +85,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 	switch md.Type() {
 	case pmetric.MetricTypeGauge:
 		dataPoints := md.Gauge().DataPoints()
-		adxMetrics := make([]*AdxMetric, dataPoints.Len())
+		adxMetrics := make([]*adxMetric, dataPoints.Len())
 		for gi := 0; gi < dataPoints.Len(); gi++ {
 			dataPoint := dataPoints.At(gi)
 			adxMetrics[gi] = createMetric(dataPoint.Timestamp().AsTime(), dataPoint.Attributes(), func() float64 {
@@ -102,7 +102,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 		return adxMetrics
 	case pmetric.MetricTypeHistogram:
 		dataPoints := md.Histogram().DataPoints()
-		var adxMetrics []*AdxMetric
+		var adxMetrics []*adxMetric
 		for gi := 0; gi < dataPoints.Len(); gi++ {
 			dataPoint := dataPoints.At(gi)
 			bounds := dataPoint.ExplicitBounds()
@@ -168,7 +168,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 		return adxMetrics
 	case pmetric.MetricTypeSum:
 		dataPoints := md.Sum().DataPoints()
-		adxMetrics := make([]*AdxMetric, dataPoints.Len())
+		adxMetrics := make([]*adxMetric, dataPoints.Len())
 		for gi := 0; gi < dataPoints.Len(); gi++ {
 			dataPoint := dataPoints.At(gi)
 			adxMetrics[gi] = createMetric(dataPoint.Timestamp().AsTime(), dataPoint.Attributes(), func() float64 {
@@ -185,7 +185,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 		return adxMetrics
 	case pmetric.MetricTypeSummary:
 		dataPoints := md.Summary().DataPoints()
-		var adxMetrics []*AdxMetric
+		var adxMetrics []*adxMetric
 		for gi := 0; gi < dataPoints.Len(); gi++ {
 			dataPoint := dataPoints.At(gi)
 			// first, add one event for sum, and one for count
@@ -238,8 +238,8 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 }
 
 // Given all the metrics , transform that to the representative structure
-func rawMetricsToAdxMetrics(_ context.Context, metrics pmetric.Metrics, logger *zap.Logger) []*AdxMetric {
-	var transformedAdxMetrics []*AdxMetric
+func rawMetricsToAdxMetrics(_ context.Context, metrics pmetric.Metrics, logger *zap.Logger) []*adxMetric {
+	var transformedAdxMetrics []*adxMetric
 	resourceMetric := metrics.ResourceMetrics()
 	for i := 0; i < resourceMetric.Len(); i++ {
 		res := resourceMetric.At(i).Resource()

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
@@ -51,14 +51,14 @@ func Test_rawMetricsToAdxMetrics(t *testing.T) {
 		name               string                                                                    // name of the test
 		metricsDataFn      func(metricType pmetric.MetricType, ts pcommon.Timestamp) pmetric.Metrics // function that generates the metric
 		metricDataType     pmetric.MetricType
-		expectedAdxMetrics []*AdxMetric // expected results
+		expectedAdxMetrics []*adxMetric // expected results
 	}{
 		{
 			//
 			name:           "metrics_counter_over_time",
 			metricsDataFn:  newMetrics,
 			metricDataType: pmetric.MetricTypeSum,
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "page_faults",
@@ -75,7 +75,7 @@ func Test_rawMetricsToAdxMetrics(t *testing.T) {
 			name:           "metrics_simple_histogram_with_value",
 			metricsDataFn:  newMetrics,
 			metricDataType: pmetric.MetricTypeHistogram,
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "http.server.duration_sum",
@@ -187,7 +187,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 		name               string                  // name of the test
 		resourceFn         func() pcommon.Resource // function that generates the resources
 		metricDataFn       func() pmetric.Metric   // function that generates the metric
-		expectedAdxMetrics []*AdxMetric            // expected results
+		expectedAdxMetrics []*adxMetric            // expected results
 		configFn           func() *Config          // the config to apply
 	}{
 		{
@@ -207,7 +207,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 				return createDefaultConfig().(*Config)
 			},
 
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "page_faults",
@@ -237,7 +237,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 				return createDefaultConfig().(*Config)
 			},
 
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "page_faults",
@@ -286,7 +286,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 				return createDefaultConfig().(*Config)
 			},
 
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "http.server.duration_sum",
@@ -391,7 +391,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 			configFn: func() *Config {
 				return createDefaultConfig().(*Config)
 			},
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "cpu.frequency",
@@ -422,7 +422,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 			configFn: func() *Config {
 				return createDefaultConfig().(*Config)
 			},
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "cpu.frequency",
@@ -458,7 +458,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 				qt2.SetValue(45)
 				return summary
 			},
-			expectedAdxMetrics: []*AdxMetric{
+			expectedAdxMetrics: []*adxMetric{
 				{
 					Timestamp:          tstr,
 					MetricName:         "http.server.duration_sum",

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
@@ -12,7 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 )
 
-type AdxTrace struct {
+type adxTrace struct {
 	TraceID            string         // TraceID associated to the Trace
 	SpanID             string         // SpanID associated to the Trace
 	ParentID           string         // ParentID associated to the Trace
@@ -24,34 +24,34 @@ type AdxTrace struct {
 	EndTime            string         // The end time of the occurrence. Formatted into string as RFC3339Nano
 	ResourceAttributes map[string]any // JSON Resource attributes that can then be parsed.
 	TraceAttributes    map[string]any // JSON attributes that can then be parsed.
-	Events             []*Event       // Array containing the events in a span
-	Links              []*Link        // Array containing the link in a span
+	Events             []*event       // Array containing the events in a span
+	Links              []*link        // Array containing the link in a span
 }
 
-type Event struct {
+type event struct {
 	EventName       string
 	Timestamp       string
 	EventAttributes map[string]any
 }
 
-type Link struct {
+type link struct {
 	TraceID            string
 	SpanID             string
 	TraceState         string
 	SpanLinkAttributes map[string]any
 }
 
-type Status struct {
+type status struct {
 	Code    string
 	Message string
 }
 
-func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope, spanData ptrace.Span) *AdxTrace {
+func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope, spanData ptrace.Span) *adxTrace {
 	traceAttrib := spanData.Attributes().AsRaw()
 	clonedTraceAttrib := cloneMap(traceAttrib)
 	copyMap(clonedTraceAttrib, getScopeMap(scope))
 
-	return &AdxTrace{
+	return &adxTrace{
 		TraceID:            traceutil.TraceIDToHexOrEmptyString(spanData.TraceID()),
 		SpanID:             traceutil.SpanIDToHexOrEmptyString(spanData.SpanID()),
 		ParentID:           traceutil.SpanIDToHexOrEmptyString(spanData.ParentSpanID()),
@@ -68,11 +68,11 @@ func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope
 	}
 }
 
-func getEventsData(sd ptrace.Span) []*Event {
-	events := make([]*Event, sd.Events().Len())
+func getEventsData(sd ptrace.Span) []*event {
+	events := make([]*event, sd.Events().Len())
 
 	for i := 0; i < sd.Events().Len(); i++ {
-		event := &Event{
+		event := &event{
 			Timestamp:       sd.Events().At(i).Timestamp().AsTime().Format(time.RFC3339Nano),
 			EventName:       sd.Events().At(i).Name(),
 			EventAttributes: sd.Events().At(i).Attributes().AsRaw(),
@@ -82,10 +82,10 @@ func getEventsData(sd ptrace.Span) []*Event {
 	return events
 }
 
-func getLinksData(sd ptrace.Span) []*Link {
-	links := make([]*Link, sd.Links().Len())
+func getLinksData(sd ptrace.Span) []*link {
+	links := make([]*link, sd.Links().Len())
 	for i := 0; i < sd.Links().Len(); i++ {
-		link := &Link{
+		link := &link{
 			TraceID:            traceutil.TraceIDToHexOrEmptyString(sd.Links().At(i).TraceID()),
 			SpanID:             traceutil.SpanIDToHexOrEmptyString(sd.Links().At(i).SpanID()),
 			TraceState:         sd.Links().At(i).TraceState().AsRaw(),

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
@@ -41,11 +41,6 @@ type link struct {
 	SpanLinkAttributes map[string]any
 }
 
-type status struct {
-	Code    string
-	Message string
-}
-
 func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope, spanData ptrace.Span) *adxTrace {
 	traceAttrib := spanData.Attributes().AsRaw()
 	clonedTraceAttrib := cloneMap(traceAttrib)

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
@@ -28,7 +28,7 @@ func Test_mapToAdxTrace(t *testing.T) {
 		spanDatafn       func() ptrace.Span // function that generates the required spans for the test
 		resourceFn       func() pcommon.Resource
 		insScopeFn       func() pcommon.InstrumentationScope
-		expectedAdxTrace *AdxTrace
+		expectedAdxTrace *adxTrace
 	}{
 		{
 			name: "valid",
@@ -47,7 +47,7 @@ func Test_mapToAdxTrace(t *testing.T) {
 			},
 			resourceFn: newDummyResource,
 			insScopeFn: newScopeWithData,
-			expectedAdxTrace: &AdxTrace{
+			expectedAdxTrace: &adxTrace{
 				TraceID:            "00000000000000000000000000000064",
 				SpanID:             "0000000000000032",
 				ParentID:           "",
@@ -70,7 +70,7 @@ func Test_mapToAdxTrace(t *testing.T) {
 			},
 			resourceFn: pcommon.NewResource,
 			insScopeFn: newScopeWithData,
-			expectedAdxTrace: &AdxTrace{
+			expectedAdxTrace: &adxTrace{
 				SpanStatus:         "STATUS_CODE_UNSET",
 				SpanKind:           "SPAN_KIND_UNSPECIFIED",
 				StartTime:          defaultTime,
@@ -107,7 +107,7 @@ func Test_mapToAdxTrace(t *testing.T) {
 			},
 			resourceFn: newDummyResource,
 			insScopeFn: newScopeWithData,
-			expectedAdxTrace: &AdxTrace{
+			expectedAdxTrace: &adxTrace{
 				TraceID:            "00000000000000000000000000000064",
 				SpanID:             "0000000000000032",
 				ParentID:           "",
@@ -118,14 +118,14 @@ func Test_mapToAdxTrace(t *testing.T) {
 				EndTime:            tstr,
 				ResourceAttributes: tmap,
 				TraceAttributes:    newMapFromAttr(`{"traceAttribKey":"traceAttribVal", "scope.name":"testscope", "scope.version":"1.0"}`),
-				Events: []*Event{
+				Events: []*event{
 					{
 						EventName:       "eventName",
 						EventAttributes: newMapFromAttr(`{"eventkey": "eventvalue"}`),
 						Timestamp:       tstr,
 					},
 				},
-				Links: []*Link{{
+				Links: []*link{{
 					TraceID:            "00000000000000000000000000000064",
 					SpanID:             "0000000000000032",
 					TraceState:         "",
@@ -159,7 +159,7 @@ func Test_mapToAdxTrace(t *testing.T) {
 			},
 			resourceFn: newDummyResource,
 			insScopeFn: newScopeWithData,
-			expectedAdxTrace: &AdxTrace{
+			expectedAdxTrace: &adxTrace{
 				TraceID:            "00000000000000000000000000000064",
 				SpanID:             "0000000000000032",
 				ParentID:           "",
@@ -171,14 +171,14 @@ func Test_mapToAdxTrace(t *testing.T) {
 				EndTime:            tstr,
 				ResourceAttributes: tmap,
 				TraceAttributes:    newMapFromAttr(`{"traceAttribKey":"traceAttribVal", "scope.name":"testscope", "scope.version":"1.0"}`),
-				Events: []*Event{
+				Events: []*event{
 					{
 						EventName:       "eventName",
 						EventAttributes: newMapFromAttr(`{"eventkey": "eventvalue"}`),
 						Timestamp:       tstr,
 					},
 				},
-				Links: []*Link{{
+				Links: []*link{{
 					TraceID:            "00000000000000000000000000000064",
 					SpanID:             "0000000000000032",
 					TraceState:         "",
@@ -197,10 +197,10 @@ func Test_mapToAdxTrace(t *testing.T) {
 	}
 }
 
-func getEmptyEvents() []*Event {
-	return []*Event{}
+func getEmptyEvents() []*event {
+	return []*event{}
 }
 
-func getEmptyLinks() []*Link {
-	return []*Link{}
+func getEmptyLinks() []*link {
+	return []*link{}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Move to internal visibility some Azuredata exporter structs and removes an unused Status struct

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40647

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
