### PR TITLE
[chore] Docs: annotation value must be string

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -505,7 +505,7 @@ receiver_creator/logs:
     # (to avoid collecting Collector's own logs make sure that Collector Pods are properly annotated
     # with `io.opentelemetry.discovery.logs/enabled: "false"`)
     # default_annotations:
-    #   io.opentelemetry.discovery.logs/enabled: true
+    #   io.opentelemetry.discovery.logs/enabled: "true"
 ```
 
 See below for the supported annotations that user can define to automatically enable receivers to start


### PR DESCRIPTION
No biggy, but this is bound to trip some people up.
