### PR TITLE
fix: unexport CodecovConfig struct

### DIFF
--- a/cmd/codecovgen/main.go
+++ b/cmd/codecovgen/main.go
@@ -110,7 +110,7 @@ type ComponentManagement struct {
 	IndividualComponents []Component `json:"individual_components"`
 }
 
-type CodecovConfig struct {
+type codecovConfig struct {
 	ComponentManagement ComponentManagement `json:"component_management"`
 }
 


### PR DESCRIPTION
### Description

This PR unexports the `CodecovConfig` struct from `cmd/codecovgen/main.go` by changing its name from `CodecovConfig` to `codecovConfig`.

This change aligns with Go's convention of using unexported (lowercase) struct names when they are not used outside the local package. This also matches the intention described in issue #40641.

### Link to tracking issue

Fixes #40641

### Testing

No functional logic has been changed, so existing tests (if any) should continue to pass.

### Documentation

Not applicable — this is a small internal visibility change with no impact on external documentation.
