### PR TITLE
[exporter/azuremonitor] Enrich azuremonitor tags

### DIFF
--- a/.chloggen/enrich_azuremonitor_tags.yaml
+++ b/.chloggen/enrich_azuremonitor_tags.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add additional mapping of standard OTel properties to builtin Application Insights properties
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40598]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/enrich_azuremonitor_tags.yaml
+++ b/.chloggen/enrich_azuremonitor_tags.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: azuremonitorexporter
+component: exporter/azuremonitor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add additional mapping of standard OTel properties to builtin Application Insights properties

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -43,6 +43,33 @@ func applyCloudTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes p
 	envelope.Tags[contracts.InternalSdkVersion] = getCollectorVersion()
 }
 
+// Sets ai.application.* tags on the envelope
+func applyApplicationTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map) {
+	if serviceVersion, serviceVersionExists := resourceAttributes.Get(string(conventions.ServiceVersionKey)); serviceVersionExists {
+		envelope.Tags[contracts.ApplicationVersion] = serviceVersion.Str()
+	}
+}
+
+func applyDeviceTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map) {
+	if osName, osNameExists := resourceAttributes.Get(string(conventions.OSNameKey)); osNameExists {
+		deviceOs := osName.Str()
+
+		if osVersion, osVersionExists := resourceAttributes.Get(string(conventions.OSVersionKey)); osVersionExists {
+			deviceOs = deviceOs + " " + osVersion.Str()
+		}
+
+		envelope.Tags[contracts.DeviceOSVersion] = deviceOs
+	}
+
+	if manufacturer, manufacturerExists := resourceAttributes.Get(string(conventions.DeviceManufacturerKey)); manufacturerExists {
+		envelope.Tags[contracts.DeviceModel] = manufacturer.Str()
+	}
+
+	if deviceType, deviceTypeExists := resourceAttributes.Get(string(conventions.DeviceModelIdentifierKey)); deviceTypeExists {
+		envelope.Tags[contracts.DeviceType] = deviceType.Str()
+	}
+}
+
 // Applies internal sdk version tag on the envelope
 func applyInternalSdkVersionTagToEnvelope(envelope *contracts.Envelope) {
 	envelope.Tags[contracts.InternalSdkVersion] = getCollectorVersion()

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -50,6 +50,7 @@ func applyApplicationTagsToEnvelope(envelope *contracts.Envelope, resourceAttrib
 	}
 }
 
+// Sets ai.device.* tags on the envelope
 func applyDeviceTagsToEnvelope(envelope *contracts.Envelope, resourceAttributes pcommon.Map) {
 	if osName, osNameExists := resourceAttributes.Get(string(conventions.OSNameKey)); osNameExists {
 		deviceOs := osName.Str()

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -65,6 +65,8 @@ func (packer *logPacker) handleMessageData(envelope *contracts.Envelope, data *c
 	applyResourcesToDataProperties(messageData.Properties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(messageData.Properties, instrumentationScope)
 	applyCloudTagsToEnvelope(envelope, resourceAttributes)
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 
 	setAttributesAsProperties(logRecord.Attributes(), messageData.Properties)
@@ -119,6 +121,8 @@ func (packer *logPacker) handleExceptionData(envelope *contracts.Envelope, data 
 	applyResourcesToDataProperties(exceptionData.Properties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(exceptionData.Properties, instrumentationScope)
 	applyCloudTagsToEnvelope(envelope, resourceAttributes)
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 
 	setAttributesAsProperties(logAttributeMap, exceptionData.Properties)

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -181,6 +181,38 @@ func TestLogRecordToEnvelopeCloudTags(t *testing.T) {
 	require.Equal(t, expectedCloudRoleInstance, envelope.Tags[aiCloudRoleInstanceConvention])
 }
 
+func TestLogRecordToEnvelopeApplicationTags(t *testing.T) {
+	const aiAppVersionConvention = "ai.application.ver"
+
+	resource, scope, logRecord := getTestLogRecord(1)
+	logPacker := getLogPacker()
+
+	envelope := logPacker.LogRecordToEnvelope(logRecord, resource, scope)
+
+	resourceAttributes := resource.Attributes().AsRaw()
+	expectedAppVer := resourceAttributes[string(conventions.ServiceVersionKey)].(string)
+	require.Equal(t, expectedAppVer, envelope.Tags[aiAppVersionConvention])
+}
+
+func TestLogRecordToEnvelopeDeviceTags(t *testing.T) {
+	const aiDeviceModelConvention = "ai.device.model"
+	const aiDeviceTypeConvention = "ai.device.type"
+	const aiDeviceOSConvention = "ai.device.osVersion"
+
+	resource, scope, logRecord := getTestLogRecord(1)
+	logPacker := getLogPacker()
+
+	envelope := logPacker.LogRecordToEnvelope(logRecord, resource, scope)
+
+	resourceAttributes := resource.Attributes().AsRaw()
+	expectedDeviceModel := resourceAttributes[string(conventions.DeviceManufacturerKey)].(string)
+	require.Equal(t, expectedDeviceModel, envelope.Tags[aiDeviceModelConvention])
+	expectedDeviceType := resourceAttributes[string(conventions.DeviceModelIdentifierKey)].(string)
+	require.Equal(t, expectedDeviceType, envelope.Tags[aiDeviceTypeConvention])
+	expectedOSVersion := resourceAttributes[string(conventions.OSNameKey)].(string) + " " + resourceAttributes[string(conventions.OSVersionKey)].(string)
+	require.Equal(t, expectedOSVersion, envelope.Tags[aiDeviceOSConvention])
+}
+
 func getLogsExporter(config *Config, transportChannel appinsights.TelemetryChannel) *azureMonitorExporter {
 	return &azureMonitorExporter{
 		config,
@@ -203,6 +235,11 @@ func getTestLogs() plog.Logs {
 	resource.Attributes().PutStr(string(conventions.ServiceNameKey), defaultServiceName)
 	resource.Attributes().PutStr(string(conventions.ServiceNamespaceKey), defaultServiceNamespace)
 	resource.Attributes().PutStr(string(conventions.ServiceInstanceIDKey), defaultServiceInstance)
+	resource.Attributes().PutStr(string(conventions.ServiceVersionKey), defaultServiceVersion)
+	resource.Attributes().PutStr(string(conventions.OSNameKey), defaultOSName)
+	resource.Attributes().PutStr(string(conventions.OSVersionKey), defaultOSVersion)
+	resource.Attributes().PutStr(string(conventions.DeviceManufacturerKey), defaultDeviceManufacturer)
+	resource.Attributes().PutStr(string(conventions.DeviceModelIdentifierKey), defaultDeviceModelIdentifier)
 
 	// add the scope
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()

--- a/exporter/azuremonitorexporter/metric_to_envelopes.go
+++ b/exporter/azuremonitorexporter/metric_to_envelopes.go
@@ -54,6 +54,8 @@ func (packer *metricPacker) MetricToEnvelopes(metric pmetric.Metric, resource pc
 			applyResourcesToDataProperties(metricData.Properties, resourceAttributes)
 			applyInstrumentationScopeValueToDataProperties(metricData.Properties, instrumentationScope)
 			applyCloudTagsToEnvelope(envelope, resourceAttributes)
+			applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+			applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 			applyInternalSdkVersionTagToEnvelope(envelope)
 
 			setAttributesAsProperties(timedDataPoint.attributes, metricData.Properties)

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -171,9 +171,9 @@ func spanToEnvelopes(
 		applyResourcesToDataProperties(dataProperties, resourceAttributes)
 		applyInstrumentationScopeValueToDataProperties(dataProperties, instrumentationScope)
 		applyCloudTagsToEnvelope(spanEventEnvelope, resourceAttributes)
-		applyApplicationTagsToEnvelope(envelope, resourceAttributes)
-		applyDeviceTagsToEnvelope(envelope, resourceAttributes)
-		applyInternalSdkVersionTagToEnvelope(envelope)
+		applyApplicationTagsToEnvelope(spanEventEnvelope, resourceAttributes)
+		applyDeviceTagsToEnvelope(spanEventEnvelope, resourceAttributes)
+		applyInternalSdkVersionTagToEnvelope(spanEventEnvelope)
 
 		// Sanitize the base data, the envelope and envelope tags
 		sanitize(dataSanitizeFunc, logger)

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -122,6 +122,8 @@ func spanToEnvelopes(
 	applyResourcesToDataProperties(dataProperties, resourceAttributes)
 	applyInstrumentationScopeValueToDataProperties(dataProperties, instrumentationScope)
 	applyCloudTagsToEnvelope(envelope, resourceAttributes)
+	applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+	applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 	applyInternalSdkVersionTagToEnvelope(envelope)
 	applyLinksToDataProperties(dataProperties, span.Links(), logger)
 
@@ -169,6 +171,8 @@ func spanToEnvelopes(
 		applyResourcesToDataProperties(dataProperties, resourceAttributes)
 		applyInstrumentationScopeValueToDataProperties(dataProperties, instrumentationScope)
 		applyCloudTagsToEnvelope(spanEventEnvelope, resourceAttributes)
+		applyApplicationTagsToEnvelope(envelope, resourceAttributes)
+		applyDeviceTagsToEnvelope(envelope, resourceAttributes)
 		applyInternalSdkVersionTagToEnvelope(envelope)
 
 		// Sanitize the base data, the envelope and envelope tags

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -29,6 +29,11 @@ const (
 	defaultServiceName                      = "foo"
 	defaultServiceNamespace                 = "ns1"
 	defaultServiceInstance                  = "112345"
+	defaultServiceVersion                   = "1.0"
+	defaultOSName                           = "Linux"
+	defaultOSVersion                        = "1.0"
+	defaultDeviceManufacturer               = "Initech"
+	defaultDeviceModelIdentifier            = "Machine"
 	defaultScopeName                        = "myinstrumentationlib"
 	defaultScopeVersion                     = "1.0"
 	defaultHTTPMethod                       = http.MethodGet
@@ -523,6 +528,11 @@ func TestSpanWithEventsToEnvelopes(t *testing.T) {
 		assert.Equal(t, defaultSpanIDAsHex, envelope.Tags[contracts.OperationParentId])
 		assert.Equal(t, defaultServiceNamespace+"."+defaultServiceName, envelope.Tags[contracts.CloudRole])
 		assert.Equal(t, defaultServiceInstance, envelope.Tags[contracts.CloudRoleInstance])
+		assert.Equal(t, defaultServiceVersion, envelope.Tags[contracts.ApplicationVersion])
+		assert.Equal(t, defaultDeviceManufacturer, envelope.Tags[contracts.DeviceModel])
+		assert.Equal(t, defaultDeviceModelIdentifier, envelope.Tags[contracts.DeviceType])
+		assert.Equal(t, defaultOSName+" "+defaultOSVersion, envelope.Tags[contracts.DeviceOSVersion])
+		assert.Contains(t, envelope.Tags[contracts.InternalSdkVersion], "otelc-")
 		assert.NotNil(t, envelope.Data)
 	}
 
@@ -623,6 +633,10 @@ func commonEnvelopeValidations(
 	assert.Equal(t, defaultParentSpanIDAsHex, envelope.Tags[contracts.OperationParentId])
 	assert.Equal(t, defaultServiceNamespace+"."+defaultServiceName, envelope.Tags[contracts.CloudRole])
 	assert.Equal(t, defaultServiceInstance, envelope.Tags[contracts.CloudRoleInstance])
+	assert.Equal(t, defaultServiceVersion, envelope.Tags[contracts.ApplicationVersion])
+	assert.Equal(t, defaultDeviceManufacturer, envelope.Tags[contracts.DeviceModel])
+	assert.Equal(t, defaultDeviceModelIdentifier, envelope.Tags[contracts.DeviceType])
+	assert.Equal(t, defaultOSName+" "+defaultOSVersion, envelope.Tags[contracts.DeviceOSVersion])
 	assert.Contains(t, envelope.Tags[contracts.InternalSdkVersion], "otelc-")
 	assert.NotNil(t, envelope.Data)
 
@@ -893,6 +907,11 @@ func getResource() pcommon.Resource {
 	r.Attributes().PutStr(string(conventions.ServiceNameKey), defaultServiceName)
 	r.Attributes().PutStr(string(conventions.ServiceNamespaceKey), defaultServiceNamespace)
 	r.Attributes().PutStr(string(conventions.ServiceInstanceIDKey), defaultServiceInstance)
+	r.Attributes().PutStr(string(conventions.ServiceVersionKey), defaultServiceVersion)
+	r.Attributes().PutStr(string(conventions.DeviceManufacturerKey), defaultDeviceManufacturer)
+	r.Attributes().PutStr(string(conventions.DeviceModelIdentifierKey), defaultDeviceModelIdentifier)
+	r.Attributes().PutStr(string(conventions.OSNameKey), defaultOSName)
+	r.Attributes().PutStr(string(conventions.OSVersionKey), defaultOSVersion)
 	return r
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds additional mapping in Azure Monitor Exporter to the following Application Insights properties:

| Application Insights property | OpenTelemetry attribute                               
| ----------------------------- | -----------------------------------------------------
| application_Version                   | service.version     
| client_OS                | os.name concatenated with os.version      
| client_Model               |  device.manufacturer    
| client_Type              | device.model.identifier

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40598 
