### PR TITLE
[podmanreceiver] deprecate ssh-dss host algorithm for ssh connections

### DIFF
--- a/.chloggen/deprecate_podman_ssh_dsa.yaml
+++ b/.chloggen/deprecate_podman_ssh_dsa.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: deprecation
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: podmanreceiver

--- a/.chloggen/deprecate_podman_ssh_dsa.yaml
+++ b/.chloggen/deprecate_podman_ssh_dsa.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: podmanreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate "ssh-dss" host key algorithm for SSH connections
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40796]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/podmanreceiver/podman_connection.go
+++ b/receiver/podmanreceiver/podman_connection.go
@@ -153,7 +153,6 @@ func sshConnection(logger *zap.Logger, _url *url.URL, secure bool, key, passphra
 			HostKeyCallback: callback,
 			HostKeyAlgorithms: []string{
 				ssh.KeyAlgoRSA,
-				ssh.KeyAlgoDSA,
 				ssh.KeyAlgoECDSA256,
 				ssh.KeyAlgoECDSA384,
 				ssh.KeyAlgoECDSA521,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The SSH DSA host key algorithm is being deprecated in crypto Go v0.39.0: https://pkg.go.dev/golang.org/x/crypto@v0.39.0/ssh#InsecureKeyAlgoDSA because its vulnerabilities. In other tools like `sshd`, it won't accept this key type because of the same reason.

This PR proposes removing support for non-secure key algorithms. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40594

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
