### PR TITLE
[exporter/coralogix] Fix rate limit internal counter

### DIFF
--- a/.chloggen/40811.yaml
+++ b/.chloggen/40811.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix rate limit error count reset
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40811]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The rate limit error count was not reset just after a successful request.
+
+  Also, we are printing now when the rate limit is triggered.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/e2e_test.go
+++ b/exporter/coralogixexporter/e2e_test.go
@@ -1,0 +1,248 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package coralogixexporter
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func Test_E2E_RateLimit_HappyPath(t *testing.T) {
+	privateKey := os.Getenv("CORALOGIX_PRIVATE_KEY")
+	if privateKey == "" {
+		t.Skip("Skipping E2E test: CORALOGIX_PRIVATE_KEY not set")
+	}
+
+	cfg := &Config{
+		Domain:     "eu2.coralogix.com",
+		PrivateKey: configopaque.String(privateKey),
+		RateLimiter: RateLimiterConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Duration:  30 * time.Second,
+		},
+		AppName:   "e2e-test-app",
+		SubSystem: "e2e-test-subsystem",
+	}
+
+	t.Log("Creating exporter")
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	t.Log("Starting exporter")
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		t.Log("Shutting down exporter")
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	start := time.Now()
+
+	t.Log("Sending data for 5 mins")
+	count := 0
+	traces := generateTestTraces()
+	for time.Since(start) < 5*time.Minute {
+		err = exp.pushTraces(context.Background(), traces)
+		require.NoError(t, err)
+		if count%10 == 0 {
+			t.Logf("Sending traces %d", count)
+		}
+		count++
+	}
+}
+
+func Test_E2E_InvalidKeyRateLimit(t *testing.T) {
+	privateKey := os.Getenv("CORALOGIX_PRIVATE_KEY_LOW_QUOTA")
+	if privateKey == "" {
+		t.Skip("Skipping E2E test: CORALOGIX_PRIVATE_KEY_LOW_QUOTA not set")
+	}
+
+	cfg := &Config{
+		Domain:     "eu2.coralogix.com",
+		PrivateKey: configopaque.String("invalid-key"),
+		RateLimiter: RateLimiterConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Duration:  30 * time.Second,
+		},
+		AppName:   "e2e-test-app",
+		SubSystem: "e2e-test-subsystem",
+	}
+
+	t.Log("Creating exporter")
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	t.Log("Starting exporter")
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		t.Log("Shutting down exporter")
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	t.Log("Phase 1: Sending data until rate limiter is activated")
+	rateLimited := false
+	errorCount := 0
+	rateLimitedCount := 0
+
+	for !rateLimited {
+		traces := generateTestTraces()
+		err = exp.pushTraces(context.Background(), traces)
+		if err != nil {
+			errorCount++
+			if exp.rateError.isRateLimited() {
+				rateLimitedCount++
+				rateLimited = true
+				t.Logf("Rate limiter activated! Error count: %d, Rate limited count: %d", errorCount, rateLimitedCount)
+			} else {
+				t.Logf("Received error (not rate limited yet). Error count: %d", errorCount)
+			}
+		}
+	}
+
+	require.True(t, rateLimited, "Rate limiter should have been activated")
+
+	t.Log("Phase 2: trying to send data during rate limit period (but will be rate limited)")
+	rateLimitStart := time.Now()
+	rateLimitEnabled := false
+
+	count := 0
+	for time.Since(rateLimitStart) < cfg.RateLimiter.Duration {
+		traces := generateTestTraces()
+		err = exp.pushTraces(context.Background(), traces)
+		if err != nil && exp.rateError.isRateLimited() {
+			if count%5000 == 0 { // Do not spam the logs
+				t.Logf("Tried to send data but limited for %s", cfg.RateLimiter.Duration-time.Since(*exp.rateError.timestamp.Load()))
+			}
+			rateLimitEnabled = true
+		} else if exp.rateError.isRateLimited() {
+			t.Fatalf("Should have returned error")
+		}
+		count++
+	}
+
+	require.True(t, rateLimitEnabled, "Should have received rate limit errors")
+
+	t.Log("Phase 3: Verifying we can try to send data again")
+	assert.Eventually(t, func() bool {
+		return exp.canSend()
+	}, 2*time.Minute, 100*time.Millisecond, "Should be able to send data after rate limiter duration")
+}
+
+func Test_E2E_LowQuotaRateLimit(t *testing.T) {
+	privateKey := os.Getenv("CORALOGIX_PRIVATE_KEY_LOW_QUOTA")
+	if privateKey == "" {
+		t.Skip("Skipping E2E test: CORALOGIX_PRIVATE_KEY_LOW_QUOTA not set")
+	}
+
+	cfg := &Config{
+		Domain:     "eu2.coralogix.com",
+		PrivateKey: configopaque.String(privateKey),
+		RateLimiter: RateLimiterConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Duration:  30 * time.Second,
+		},
+		AppName:   "e2e-test-app",
+		SubSystem: "e2e-test-subsystem",
+	}
+
+	t.Log("Creating exporter")
+	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	t.Log("Starting exporter")
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		t.Log("Shutting down exporter")
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	t.Log("Phase 1: Sending data until rate limiter is activated")
+	rateLimited := false
+	errorCount := 0
+	rateLimitedCount := 0
+
+	for !rateLimited {
+		traces := generateTestTraces()
+		err = exp.pushTraces(context.Background(), traces)
+		if err != nil {
+			errorCount++
+			if exp.rateError.isRateLimited() {
+				rateLimitedCount++
+				rateLimited = true
+				t.Logf("Rate limiter activated! Error count: %d, Rate limited count: %d", errorCount, rateLimitedCount)
+			} else {
+				t.Logf("Received error (not rate limited yet). Error count: %d", errorCount)
+			}
+		}
+	}
+
+	require.True(t, rateLimited, "Rate limiter should have been activated")
+
+	t.Log("Phase 2: trying to send data during rate limit period (but will be rate limited)")
+	rateLimitEnabled := false
+
+	count := 0
+	for time.Since(*exp.rateError.timestamp.Load()) < cfg.RateLimiter.Duration {
+		traces := generateTestTraces()
+		err = exp.pushTraces(context.Background(), traces)
+		if err != nil && exp.rateError.isRateLimited() {
+			if count%5000 == 0 { // Do not spam the logs
+				t.Logf("Tried to send data but limited for %s", cfg.RateLimiter.Duration-time.Since(*exp.rateError.timestamp.Load()))
+			}
+			rateLimitEnabled = true
+		} else if exp.rateError.isRateLimited() {
+			t.Fatalf("Should have returned error")
+		}
+		count++
+	}
+
+	require.True(t, rateLimitEnabled, "Should have received rate limit errors")
+
+	t.Log("Phase 3: Verifying we can try to send data again")
+	assert.Eventually(t, func() bool {
+		return exp.canSend()
+	}, 2*time.Minute, 100*time.Millisecond, "Should be able to send data after rate limiter duration")
+}
+
+func generateTestTraces() ptrace.Traces {
+	traces := ptrace.NewTraces()
+	resourceSpans := traces.ResourceSpans()
+
+	for i := 0; i < 5000; i++ {
+		rs := resourceSpans.AppendEmpty()
+		resource := rs.Resource()
+		resource.Attributes().PutStr("service.name", "e2e-test-service")
+		resource.Attributes().PutStr("environment", "test")
+		scopeSpans := rs.ScopeSpans().AppendEmpty()
+		span := scopeSpans.Spans().AppendEmpty()
+		span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+		span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+		span.SetName("test-span")
+		span.SetKind(ptrace.SpanKindServer)
+		span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
+	}
+
+	return traces
+}

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -70,6 +70,7 @@ func (e *logsExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
 		)
 	}
 
+	e.rateError.errorCount.Store(0)
 	return nil
 }
 

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -187,9 +187,8 @@ func TestLogsExporter_PushLogs_WhenCannotSend(t *testing.T) {
 				require.NoError(t, err)
 			}()
 
-			rateLimitErr := errors.New("rate limit exceeded")
-			exp.EnableRateLimit(rateLimitErr)
-			exp.EnableRateLimit(rateLimitErr)
+			exp.EnableRateLimit()
+			exp.EnableRateLimit()
 
 			logs := plog.NewLogs()
 			resourceLogs := logs.ResourceLogs()
@@ -433,9 +432,8 @@ func TestLogsExporter_PushLogs_Performance(t *testing.T) {
 	t.Run("Over rate limit", func(t *testing.T) {
 		mockSrv.recvCount = 0
 
-		rateLimitErr := errors.New("rate limit exceeded")
 		for i := 0; i < 5; i++ {
-			exp.EnableRateLimit(rateLimitErr)
+			exp.EnableRateLimit()
 		}
 
 		logs := plog.NewLogs()
@@ -463,7 +461,25 @@ func TestLogsExporter_PushLogs_Performance(t *testing.T) {
 
 	t.Run("Rate limit reset", func(t *testing.T) {
 		mockSrv.recvCount = 0
-		time.Sleep(2 * time.Second)
+
+		require.Eventually(t, func() bool {
+			testLogs := plog.NewLogs()
+			testRl := testLogs.ResourceLogs().AppendEmpty()
+			testRl.Resource().Attributes().PutStr("service.name", "test-service")
+			testSl := testRl.ScopeLogs().AppendEmpty()
+			testLogRecord := testSl.LogRecords().AppendEmpty()
+			testLogRecord.Body().SetStr("test log message")
+			testLogRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			testLogRecord.SetSeverityText("INFO")
+
+			errPush := exp.pushLogs(context.Background(), testLogs)
+			return errPush == nil
+		}, 3*time.Second, 100*time.Millisecond, "Rate limit should reset within 3 seconds")
+
+		// It's 1 because the last push is successful
+		require.Equal(t, 1, mockSrv.recvCount)
+
+		mockSrv.recvCount = 0
 
 		logs := plog.NewLogs()
 		rl := logs.ResourceLogs().AppendEmpty()
@@ -485,5 +501,135 @@ func TestLogsExporter_PushLogs_Performance(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, logCount, mockSrv.recvCount, "Expected to receive exactly %d logs after rate limit reset", logCount)
 		assert.Less(t, duration, time.Millisecond*100, "Operation took longer than 100 milliseconds")
+	})
+}
+
+func TestLogsExporter_RateLimitErrorCountReset(t *testing.T) {
+	endpoint, stopFn, srv := startMockOtlpLogsServer(t)
+	defer stopFn()
+
+	cfg := &Config{
+		Logs: configgrpc.ClientConfig{
+			Endpoint: endpoint,
+			TLS: configtls.ClientConfig{
+				Insecure: true,
+			},
+		},
+		PrivateKey: "test-key",
+		RateLimiter: RateLimiterConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Duration:  time.Second,
+		},
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	for i := 0; i < 5; i++ {
+		exp.EnableRateLimit()
+	}
+	assert.Equal(t, int32(5), exp.rateError.errorCount.Load())
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	resource := resourceLogs.Resource()
+	resource.Attributes().PutStr("service.name", "test-service")
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	logRecord := scopeLogs.LogRecords().AppendEmpty()
+	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	logRecord.Body().SetStr("test log message")
+
+	err = exp.pushLogs(context.Background(), logs)
+	assert.Error(t, err)
+	assert.Equal(t, int32(5), exp.rateError.errorCount.Load())
+	assert.Equal(t, 0, srv.recvCount)
+
+	require.Eventually(t, func() bool {
+		err = exp.pushLogs(context.Background(), logs)
+		return err == nil &&
+			exp.rateError.errorCount.Load() == 0 &&
+			srv.recvCount > 0
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestLogsExporter_RateLimitCounterResetOnSuccess(t *testing.T) {
+	endpoint, stopFn, srv := startMockOtlpLogsServer(t)
+	defer stopFn()
+
+	cfg := &Config{
+		Logs: configgrpc.ClientConfig{
+			Endpoint: endpoint,
+			TLS: configtls.ClientConfig{
+				Insecure: true,
+			},
+		},
+		PrivateKey: "test-key",
+		RateLimiter: RateLimiterConfig{
+			Enabled:   true,
+			Threshold: 5,
+			Duration:  time.Second,
+		},
+	}
+
+	exp, err := newLogsExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
+	require.NoError(t, err)
+
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = exp.shutdown(context.Background())
+		require.NoError(t, err)
+	}()
+
+	createTestLogs := func() plog.Logs {
+		logs := plog.NewLogs()
+		resourceLogs := logs.ResourceLogs().AppendEmpty()
+		resource := resourceLogs.Resource()
+		resource.Attributes().PutStr("service.name", "test-service")
+		scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+		logRecord := scopeLogs.LogRecords().AppendEmpty()
+		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		logRecord.Body().SetStr("test log message")
+		return logs
+	}
+
+	t.Run("Initial successful push", func(t *testing.T) {
+		logs := createTestLogs()
+		err = exp.pushLogs(context.Background(), logs)
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), exp.rateError.errorCount.Load())
+		assert.Equal(t, 1, srv.recvCount)
+	})
+
+	t.Run("Trigger errors below threshold", func(t *testing.T) {
+		for i := 0; i < 4; i++ {
+			exp.EnableRateLimit()
+		}
+		assert.Equal(t, int32(4), exp.rateError.errorCount.Load())
+		assert.False(t, exp.rateError.isRateLimited(), "Should not be rate limited yet")
+	})
+
+	t.Run("Successful push after errors", func(t *testing.T) {
+		logs := createTestLogs()
+		err = exp.pushLogs(context.Background(), logs)
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), exp.rateError.errorCount.Load())
+		assert.Equal(t, 2, srv.recvCount)
+	})
+
+	t.Run("Verify error count stays at 0", func(t *testing.T) {
+		logs := createTestLogs()
+		err = exp.pushLogs(context.Background(), logs)
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), exp.rateError.errorCount.Load())
+		assert.Equal(t, 3, srv.recvCount)
 	})
 }

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -84,6 +84,7 @@ func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) e
 		)
 	}
 
+	e.rateError.errorCount.Store(0)
 	return nil
 }
 

--- a/exporter/coralogixexporter/profiles_client.go
+++ b/exporter/coralogixexporter/profiles_client.go
@@ -69,6 +69,7 @@ func (e *profilesExporter) pushProfiles(ctx context.Context, md pprofile.Profile
 			zap.Int64("rejected_profiles", partialSuccess.RejectedProfiles()),
 		)
 	}
+	e.rateError.errorCount.Store(0)
 	return nil
 }
 

--- a/exporter/coralogixexporter/ratelimit.go
+++ b/exporter/coralogixexporter/ratelimit.go
@@ -3,22 +3,21 @@
 package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
 )
 
 type rateError struct {
-	rateLimited atomic.Bool
-	enabled     bool
-	state       atomic.Pointer[rateErrorState]
-	errorCount  atomic.Int32
-	threshold   int
-	duration    time.Duration
-}
-
-type rateErrorState struct {
-	timestamp time.Time
-	err       error
+	rateLimited   atomic.Bool
+	enabled       bool
+	timestamp     atomic.Pointer[time.Time]
+	internalError atomic.Pointer[error]
+	errorCount    atomic.Int32
+	threshold     int
+	duration      time.Duration
 }
 
 func (r *rateError) isRateLimited() bool {
@@ -30,27 +29,25 @@ func (r *rateError) isRateLimited() bool {
 		return true
 	}
 
-	r.errorCount.Store(0) // reset the error count
 	return false
 }
 
 // canDisableRateLimit checks if we can disable the limiter in the exporter.
 func (r *rateError) canDisableRateLimit() bool {
-	return time.Since(r.state.Load().timestamp) > r.duration
+	return time.Since(*r.timestamp.Load()) > r.duration
 }
 
-func (r *rateError) enableRateLimit(err error) {
+func (r *rateError) enableRateLimit() {
 	r.errorCount.Add(1)
 	if r.errorCount.Load() < int32(r.threshold) {
 		return
 	}
 
 	now := time.Now()
-	r.state.Store(&rateErrorState{
-		timestamp: now,
-		err:       err,
-	})
+	r.timestamp.Store(&now)
 	r.rateLimited.Store(true)
+	err := consumererror.NewPermanent(errors.New("rate limit exceeded at " + now.Format(time.RFC3339)))
+	r.internalError.Store(&err)
 }
 
 func (r *rateError) disableRateLimit() {
@@ -59,5 +56,5 @@ func (r *rateError) disableRateLimit() {
 }
 
 func (r *rateError) GetError() error {
-	return r.state.Load().err
+	return *r.internalError.Load()
 }

--- a/exporter/coralogixexporter/ratelimit_test.go
+++ b/exporter/coralogixexporter/ratelimit_test.go
@@ -8,24 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRateError_ErrorCountReset(t *testing.T) {
-	re := &rateError{
-		threshold: 5,
-		enabled:   true,
-	}
-	assert.Equal(t, int32(0), re.errorCount.Load())
-
-	for i := 0; i < 5; i++ {
-		re.enableRateLimit(nil)
-	}
-	assert.Equal(t, int32(5), re.errorCount.Load())
-
-	re.rateLimited.Store(false)
-	re.isRateLimited()
-
-	assert.Equal(t, int32(0), re.errorCount.Load())
-}
-
 func TestRateError_ErrorCountNotResetWhenRateLimited(t *testing.T) {
 	re := &rateError{
 		threshold: 1,
@@ -33,7 +15,7 @@ func TestRateError_ErrorCountNotResetWhenRateLimited(t *testing.T) {
 	}
 
 	for i := 0; i < re.threshold; i++ {
-		re.enableRateLimit(nil)
+		re.enableRateLimit()
 	}
 
 	initialCount := re.errorCount.Load()

--- a/exporter/coralogixexporter/signals_test.go
+++ b/exporter/coralogixexporter/signals_test.go
@@ -37,17 +37,15 @@ func TestSignalExporter_CanSend_AfterRateLimitTimeout(t *testing.T) {
 	exp, err := newSignalExporter(cfg, exportertest.NewNopSettings(exportertest.NopType), "", nil)
 	require.NoError(t, err)
 
-	rateLimitErr := errors.New("rate limit exceeded")
-	exp.EnableRateLimit(rateLimitErr)
-	exp.EnableRateLimit(rateLimitErr)
+	// Add two rate limit errors
+	exp.EnableRateLimit()
+	exp.EnableRateLimit()
 
 	assert.False(t, exp.canSend())
 
 	// Mock the time to be after the rate limit timeout (1 minute)
-	exp.rateError.state.Store(&rateErrorState{
-		timestamp: time.Now().Add(-2 * time.Minute), // Set timestamp to 2 minutes ago
-		err:       rateLimitErr,
-	})
+	now := time.Now().Add(-2 * time.Minute)
+	exp.rateError.timestamp.Store(&now)
 
 	assert.True(t, exp.canSend())
 	assert.False(t, exp.rateError.isRateLimited())
@@ -67,9 +65,8 @@ func TestSignalExporter_CanSend_FeatureDisabled(t *testing.T) {
 	exp, err := newSignalExporter(cfg, exportertest.NewNopSettings(exportertest.NopType), "", nil)
 	require.NoError(t, err)
 
-	rateLimitErr := errors.New("rate limit exceeded")
-	exp.EnableRateLimit(rateLimitErr)
-	exp.EnableRateLimit(rateLimitErr)
+	exp.EnableRateLimit()
+	exp.EnableRateLimit()
 
 	assert.True(t, exp.canSend())
 }
@@ -88,15 +85,13 @@ func TestSignalExporter_CanSend_BeforeRateLimitTimeout(t *testing.T) {
 	exp, err := newSignalExporter(cfg, exportertest.NewNopSettings(exportertest.NopType), "", nil)
 	require.NoError(t, err)
 
-	rateLimitErr := errors.New("rate limit exceeded")
-	exp.EnableRateLimit(rateLimitErr)
-	exp.EnableRateLimit(rateLimitErr)
+	// Add two rate limit errors
+	exp.EnableRateLimit()
+	exp.EnableRateLimit()
 
 	// Mock the time to be before the rate limit timeout (30 seconds ago)
-	exp.rateError.state.Store(&rateErrorState{
-		timestamp: time.Now().Add(-30 * time.Second),
-		err:       rateLimitErr,
-	})
+	now := time.Now().Add(-30 * time.Second)
+	exp.rateError.timestamp.Store(&now)
 
 	// Should not be able to send because we're still within the timeout period
 	assert.False(t, exp.canSend())

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -70,6 +70,7 @@ func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error
 		)
 	}
 
+	e.rateError.errorCount.Store(0)
 	return nil
 }
 


### PR DESCRIPTION
#### Description
- Fix internal counter for the rate limiter feature
- Added some E2E tests that can be run with a proper API key
- Added new tests to handle this situation

#### Link to tracking issue
Fixes #40811

<!--Describe what testing was performed and which tests were added.-->
#### Testing
##### Manual test

This is the [output log](https://github.com/user-attachments/files/20802604/output.txt). You will be able to see how:
1. The exporter tries to send data
2. The rate limit mechanism is enabled
3. Every try to send data will print an error explaining when the rate limiting started
4. After the duration, the exporter tries to send data again
5. The rate limit feature is enabled again

Configuration used:
```
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: "localhost:4317"
exporters:
  coralogix:
    domain: "eu2.coralogix.com"
    private_key: "${env:CORALOGIX_PRIVATE_KEY_LOW_QUOTA}"
    application_name: "MyBusinessEnvironment"
    subsystem_name: "MyBusinessSystem"

    rate_limiter:
      enabled: true
      threshold: 5
      duration: 10s

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [coralogix]
```

##### E2E test
Log output [e2e_output.log](https://github.com/user-attachments/files/20802689/e2e_output.log)


