### PR TITLE
[exporter/dorisexporter] fix ddl for doris 3.0.6 and 2.1.10

### DIFF
--- a/.chloggen/doris306.yaml
+++ b/.chloggen/doris306.yaml
@@ -7,15 +7,15 @@ change_type: bug_fix
 component: dorisexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: fix trace graph for doris 3.0.6
+note: fix ddl for doris 3.0.6 and 2.1.10
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [40578]
+issues: [40578, 40827]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: 1. Use `size_based` compaction policy for the trace graph table instead of `time_series`. | 2. Use `zstd` as the default compression algorithm for all tables.
+subtext: 1. Use `size_based` compaction policy for the trace graph table instead of `time_series`. | 2. Use `"inverted_index_storage_format"="V2"`. | 3. Use `zstd` as the default compression algorithm for all tables.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/doris306.yaml
+++ b/.chloggen/doris306.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dorisexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix trace graph for doris 3.0.6
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40578]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 1. Use `size_based` compaction policy for the trace graph table instead of `time_series`. | 2. Use `zstd` as the default compression algorithm for all tables.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/dorisexporter/config.go
+++ b/exporter/dorisexporter/config.go
@@ -128,18 +128,30 @@ const (
 	properties = `
 PROPERTIES (
 "replication_num" = "%d",
-"compaction_policy" = "time_series",
+"compaction_policy" = "%s",
 "dynamic_partition.enable" = "true",
 "dynamic_partition.create_history_partition" = "true",
 "dynamic_partition.time_unit" = "DAY",
 "dynamic_partition.start" = "%d",
 "dynamic_partition.history_partition_num" = "%d",
 "dynamic_partition.end" = "1",
-"dynamic_partition.prefix" = "p"
+"dynamic_partition.prefix" = "p",
+"compression" = "zstd"
 )
 `
 )
 
+const (
+	compactionPolicySizeBased  = "size_based"
+	compactionPolicyTimeSeries = "time_series"
+)
+
+// // propertiesStr returns the properties string for non-unique key tables.
 func (cfg *Config) propertiesStr() string {
-	return fmt.Sprintf(properties, cfg.ReplicationNum, cfg.startHistoryDays(), cfg.CreateHistoryDays)
+	return fmt.Sprintf(properties, cfg.ReplicationNum, compactionPolicyTimeSeries, cfg.startHistoryDays(), cfg.CreateHistoryDays)
+}
+
+// // propertiesStrForUniqueKey returns the properties string for unique key tables.
+func (cfg *Config) propertiesStrForUniqueKey() string {
+	return fmt.Sprintf(properties, cfg.ReplicationNum, compactionPolicySizeBased, cfg.startHistoryDays(), cfg.CreateHistoryDays)
 }

--- a/exporter/dorisexporter/config.go
+++ b/exporter/dorisexporter/config.go
@@ -136,7 +136,8 @@ PROPERTIES (
 "dynamic_partition.history_partition_num" = "%d",
 "dynamic_partition.end" = "1",
 "dynamic_partition.prefix" = "p",
-"compression" = "zstd"
+"compression" = "zstd",
+"inverted_index_storage_format" = "V2"
 )
 `
 )

--- a/exporter/dorisexporter/exporter_traces.go
+++ b/exporter/dorisexporter/exporter_traces.go
@@ -109,7 +109,7 @@ func (e *tracesExporter) start(ctx context.Context, host component.Host) error {
 			e.logger.Warn("failed to create materialized view", zap.Error(err))
 		}
 
-		ddl = fmt.Sprintf(tracesGraphDDL, e.cfg.Traces, e.cfg.propertiesStr())
+		ddl = fmt.Sprintf(tracesGraphDDL, e.cfg.Traces, e.cfg.propertiesStrForUniqueKey())
 		_, err = conn.ExecContext(ctx, ddl)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
1. Use `size_based` compaction policy for the trace graph table instead of `time_series`. 
2. Use `zstd` as the default compression algorithm for all tables.
3. Use `"inverted_index_storage_format"="V2"`. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40578 #40827

<!--Please delete paragraphs that you did not use before submitting.-->
