### PR TITLE
[exporter/awsxray] Fix URL Path and Query

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -59,7 +59,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			urlParts[key] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case string(conventionsv112.HTTPTargetKey), string(conventions.URLQueryKey):
+		case string(conventionsv112.HTTPTargetKey):
 			urlParts[string(conventionsv112.HTTPTargetKey)] = value.Str()
 			hasHTTP = true
 		case string(conventionsv112.HTTPServerNameKey):
@@ -108,6 +108,9 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 				info.Request.ClientIP = awsxray.String(value.Str())
 			}
 		case string(conventions.URLPathKey):
+			urlParts[key] = value.Str()
+			hasHTTP = true
+		case string(conventions.URLQueryKey):
 			urlParts[key] = value.Str()
 			hasHTTP = true
 		case string(conventions.ServerAddressKey):
@@ -205,7 +208,12 @@ func constructClientURL(urlParts map[string]string) string {
 	if ok {
 		url += target
 	} else {
-		url += "/"
+		path, ok := urlParts[string(conventions.URLPathKey)]
+		if ok {
+			url += path
+		} else {
+			url += "/"
+		}
 	}
 	return url
 }

--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -107,10 +107,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			if net.ParseIP(value.Str()) != nil {
 				info.Request.ClientIP = awsxray.String(value.Str())
 			}
-		case string(conventions.URLPathKey):
-			urlParts[key] = value.Str()
-			hasHTTP = true
-		case string(conventions.URLQueryKey):
+		case string(conventions.URLPathKey), string(conventions.URLQueryKey):
 			urlParts[key] = value.Str()
 			hasHTTP = true
 		case string(conventions.ServerAddressKey):


### PR DESCRIPTION
#### Description

When url.query is present among attributes, the output HTTP Url is invalid because url.path is omitted

#### Link to tracking issue
Fixes #38242

#### Testing

Added a test with url.query attribute  and check output url contains url.path

