### PR TITLE
[processor/k8sattributes]: fix pod_association for container.id

### DIFF
--- a/.chloggen/k8s-multiple-containers.yaml
+++ b/.chloggen/k8s-multiple-containers.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/k8s-multiple-containers.yaml
+++ b/.chloggen/k8s-multiple-containers.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure getIdentifiersFromAssoc() can handle container.id
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40745]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -979,6 +979,7 @@ func getPodReplicaSetUID(pod *api_v1.Pod) string {
 // getIdentifiersFromAssoc returns list of PodIdentifiers for given pod
 func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 	var ids []PodIdentifier
+	gotPodUID := false
 	for _, assoc := range c.Associations {
 		ret := PodIdentifier{}
 		skip := false
@@ -1007,6 +1008,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 							PodIdentifierAttributeFromSource(source, cid),
 						})
 					}
+					skip = true
 				} else {
 					attr := ""
 					switch source.Name {
@@ -1016,6 +1018,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 						attr = pod.Name
 					case string(conventions.K8SPodUIDKey):
 						attr = pod.PodUID
+						gotPodUID = true
 					case string(conventions.HostNameKey):
 						attr = pod.Address
 					// k8s.pod.ip is set by passthrough mode
@@ -1042,7 +1045,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 	}
 
 	// Ensure backward compatibility
-	if pod.PodUID != "" {
+	if pod.PodUID != "" && !gotPodUID {
 		ids = append(ids, PodIdentifier{
 			PodIdentifierAttributeFromResourceAttribute(string(conventions.K8SPodUIDKey), pod.PodUID),
 		})

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -1020,13 +1020,15 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 				case K8sIPLabelName:
 					attr = pod.Address
 				case string(conventions.ContainerIDKey):
+					// At this point just an empty attr is added and we remember the position.
+					// Later this position in PodIdentifier will be filled with the actual
+					// value for container.ID.
 					retID4containerID = i
 				default:
 					if v, ok := pod.Attributes[source.Name]; ok {
 						attr = v
 					}
 				}
-				_ = retID4containerID
 				if attr == "" && retID4containerID == -1 {
 					skip = true
 					break
@@ -1037,6 +1039,8 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 
 		if !skip {
 			if retID4containerID != -1 {
+				// As there can be multiple container.IDs per pod,
+				// one PodIdentifier is added per container.ID.
 				cIDs := maps.Keys(pod.Containers.ByID)
 				for cID := range cIDs {
 					retCpy := ret

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -2386,12 +2386,14 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 	}{
 		"K8SPodUID": {
 			associations: []Association{
-				{Sources: []AssociationSource{
-					{
-						From: ResourceSource,
-						Name: string(conventions.K8SPodUIDKey),
+				{
+					Sources: []AssociationSource{
+						{
+							From: ResourceSource,
+							Name: string(conventions.K8SPodUIDKey),
+						},
 					},
-				}},
+				},
 			},
 			pod: &Pod{
 				PodUID: "myK8sPodUID",
@@ -2407,12 +2409,14 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 		},
 		"ContainerID": {
 			associations: []Association{
-				{Sources: []AssociationSource{
-					{
-						From: ResourceSource,
-						Name: string(conventions.ContainerIDKey),
+				{
+					Sources: []AssociationSource{
+						{
+							From: ResourceSource,
+							Name: string(conventions.ContainerIDKey),
+						},
 					},
-				}},
+				},
 			},
 			pod: &Pod{
 				PodUID: "myK8sPodUID",
@@ -2442,6 +2446,61 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 				},
 				{
 					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "k8s.pod.uid"}, Value: "myK8sPodUID"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
+			},
+		},
+		"multiple associations": {
+			associations: []Association{
+				{
+					Sources: []AssociationSource{
+						{
+							From: ResourceSource,
+							Name: string(conventions.ContainerIDKey),
+						},
+						{
+							From: ConnectionSource,
+						},
+					},
+				},
+			},
+			pod: &Pod{
+				PodUID:  "myK8sPodUID",
+				Address: "localhost",
+				Containers: PodContainers{
+					ByID: map[string]*Container{
+						"id1": {
+							Name: "id1",
+						},
+						"id2": {
+							Name: "id2",
+						},
+					},
+				},
+			},
+			expected: []PodIdentifier{
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "container.id"}, Value: "id1"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "connection", Name: ""}, Value: "localhost"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "container.id"}, Value: "id2"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "connection", Name: ""}, Value: "localhost"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "k8s.pod.uid"}, Value: "myK8sPodUID"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "k8s.pod.ip"}, Value: "localhost"},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -2525,7 +2525,7 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 			wc, _ := newTestClient(t)
 			wc.Associations = tc.associations
 			actual := wc.getIdentifiersFromAssoc(tc.pod)
-			assert.Equal(t, tc.expected, actual)
+			assert.ElementsMatch(t, tc.expected, actual)
 		})
 	}
 }

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -2387,8 +2387,10 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 		"K8SPodUID": {
 			associations: []Association{
 				{Sources: []AssociationSource{
-					{From: ResourceSource,
-						Name: string(conventions.K8SPodUIDKey)},
+					{
+						From: ResourceSource,
+						Name: string(conventions.K8SPodUIDKey),
+					},
 				}},
 			},
 			pod: &Pod{
@@ -2406,8 +2408,10 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 		"ContainerID": {
 			associations: []Association{
 				{Sources: []AssociationSource{
-					{From: ResourceSource,
-						Name: string(conventions.ContainerIDKey)},
+					{
+						From: ResourceSource,
+						Name: string(conventions.ContainerIDKey),
+					},
 				}},
 			},
 			pod: &Pod{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -466,7 +466,7 @@ func TestPodDelete(t *testing.T) {
 	tsBeforeDelete := time.Now()
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 3)
+	assert.Len(t, c.deleteQueue, 2)
 	deleteRequest := c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1"), deleteRequest.id)
 	assert.Equal(t, "podB", deleteRequest.podName)
@@ -482,7 +482,7 @@ func TestPodDelete(t *testing.T) {
 	tsBeforeDelete = time.Now()
 	c.handlePodDelete(cache.DeletedFinalStateUnknown{Obj: pod})
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 4)
+	assert.Len(t, c.deleteQueue, 3)
 	deleteRequest = c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2"), deleteRequest.id)
 	assert.Equal(t, "podC", deleteRequest.podName)
@@ -577,7 +577,7 @@ func TestDeleteQueue(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 3)
+	assert.Len(t, c.deleteQueue, 2)
 }
 
 func TestDeleteLoop(t *testing.T) {
@@ -592,7 +592,7 @@ func TestDeleteLoop(t *testing.T) {
 
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 2)
-	assert.Len(t, c.deleteQueue, 3)
+	assert.Len(t, c.deleteQueue, 2)
 
 	gracePeriod := time.Millisecond * 500
 	go c.deleteLoop(time.Millisecond, gracePeriod)
@@ -602,7 +602,7 @@ func TestDeleteLoop(t *testing.T) {
 		assert.Len(t, c.Pods, 2)
 		c.m.Unlock()
 		c.deleteMut.Lock()
-		assert.Len(t, c.deleteQueue, 3)
+		assert.Len(t, c.deleteQueue, 2)
 		c.deleteMut.Unlock()
 
 		time.Sleep(gracePeriod + (time.Millisecond * 50))

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -466,7 +466,7 @@ func TestPodDelete(t *testing.T) {
 	tsBeforeDelete := time.Now()
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 2)
+	assert.Len(t, c.deleteQueue, 3)
 	deleteRequest := c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1"), deleteRequest.id)
 	assert.Equal(t, "podB", deleteRequest.podName)
@@ -482,7 +482,7 @@ func TestPodDelete(t *testing.T) {
 	tsBeforeDelete = time.Now()
 	c.handlePodDelete(cache.DeletedFinalStateUnknown{Obj: pod})
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 3)
+	assert.Len(t, c.deleteQueue, 5)
 	deleteRequest = c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2"), deleteRequest.id)
 	assert.Equal(t, "podC", deleteRequest.podName)
@@ -577,7 +577,7 @@ func TestDeleteQueue(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 2)
+	assert.Len(t, c.deleteQueue, 3)
 }
 
 func TestDeleteLoop(t *testing.T) {
@@ -592,7 +592,7 @@ func TestDeleteLoop(t *testing.T) {
 
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 2)
-	assert.Len(t, c.deleteQueue, 2)
+	assert.Len(t, c.deleteQueue, 3)
 
 	gracePeriod := time.Millisecond * 500
 	go c.deleteLoop(time.Millisecond, gracePeriod)
@@ -602,7 +602,7 @@ func TestDeleteLoop(t *testing.T) {
 		assert.Len(t, c.Pods, 2)
 		c.m.Unlock()
 		c.deleteMut.Lock()
-		assert.Len(t, c.deleteQueue, 2)
+		assert.Len(t, c.deleteQueue, 3)
 		c.deleteMut.Unlock()
 
 		time.Sleep(gracePeriod + (time.Millisecond * 50))
@@ -2405,6 +2405,12 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 				},
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "k8s.pod.uid"}, Value: "myK8sPodUID"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
 			},
 		},
 		"ContainerID": {
@@ -2495,6 +2501,12 @@ func TestGetIdentifiersFromAssoc(t *testing.T) {
 				},
 				{
 					PodIdentifierAttribute{Source: AssociationSource{From: "resource_attribute", Name: "k8s.pod.uid"}, Value: "myK8sPodUID"},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
+				},
+				{
+					PodIdentifierAttribute{Source: AssociationSource{From: "connection", Name: ""}, Value: "localhost"},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},
 					PodIdentifierAttribute{Source: AssociationSource{From: "", Name: ""}, Value: ""},

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -482,7 +482,7 @@ func TestPodDelete(t *testing.T) {
 	tsBeforeDelete = time.Now()
 	c.handlePodDelete(cache.DeletedFinalStateUnknown{Obj: pod})
 	assert.Len(t, c.Pods, 5)
-	assert.Len(t, c.deleteQueue, 5)
+	assert.Len(t, c.deleteQueue, 4)
 	deleteRequest = c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2"), deleteRequest.id)
 	assert.Equal(t, "podC", deleteRequest.podName)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When setting pod_association to container.id it can not match at the moment, as it will look up pod.Attributes and fail to match. Update getIdentifiersFromAssoc() to generate PodIdentifier also from pod.Containers.ByID. This then also covers the case, where a single k8s.pod.UID covers multiple container.ids.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40745

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
