### PR TITLE
docs: Add TODO comment for future configuration options

### DIFF
--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -66,3 +66,4 @@ func (config *Config) Validate() error {
 	}
 	return nil
 }
+// TODO(Sambhav800): Consider adding more configuration options.


### PR DESCRIPTION
This PR adds a TODO comment in receiver/azureeventhubreceiver/config.go.
This is a placeholder for potential future configuration options documentation or clarification.