### PR TITLE
[pkg/datadog] Set default logs compression back to gzip

### DIFF
--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 // indirect
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -55,8 +55,8 @@ github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 h1:vZTD
 github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0/go.mod h1:WfNHlGyZu4DocYRTO+QyV9RcleXEmLe8DNbg574UYno=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 h1:M+q1zx3hUJPtF5+HA2VLRa6cR8o2DS+yZ4C7qerlz74=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0/go.mod h1:cZGSQu7XpCZPBc8ZsgevfbmNLnLuzfQgGGwWrQijhas=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a h1:YgatlcLZLpm8Eyiqw/eDxvtw17+k5fQsAPiNdiUlXsc=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:6G2mQNus/0r5WlZKp5nVSUpgik03U0vXoSc4oQOTa2Q=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 h1:5w1/OoHhJMdDnz1D9WnzXMUPkbjReCBRIQnSpHDLZ4o=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0/go.mod h1:rGDLlaiajhgqm3XszjzlNVWSvNnYvrHq6Hj7y5vh7xA=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a h1:9A6VceJLSJOm0gmQX30NZhU3fDkxSoWnZcIUb98Hr74=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:KHQXmfnOV1iDqkcqd0utzPWGwBe2WGWxXnr40fNgYOw=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a h1:3xG2IDbke25n4ppUbwOQMfwFK1J2rKbzy36ubsXpS4A=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.156
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.67.0
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.67.0-devel.0.20250507144401-a64863d1e01a

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -66,8 +66,8 @@ github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 h1:vZTD
 github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0/go.mod h1:WfNHlGyZu4DocYRTO+QyV9RcleXEmLe8DNbg574UYno=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 h1:M+q1zx3hUJPtF5+HA2VLRa6cR8o2DS+yZ4C7qerlz74=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0/go.mod h1:cZGSQu7XpCZPBc8ZsgevfbmNLnLuzfQgGGwWrQijhas=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a h1:YgatlcLZLpm8Eyiqw/eDxvtw17+k5fQsAPiNdiUlXsc=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:6G2mQNus/0r5WlZKp5nVSUpgik03U0vXoSc4oQOTa2Q=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 h1:5w1/OoHhJMdDnz1D9WnzXMUPkbjReCBRIQnSpHDLZ4o=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0/go.mod h1:rGDLlaiajhgqm3XszjzlNVWSvNnYvrHq6Hj7y5vh7xA=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a h1:9A6VceJLSJOm0gmQX30NZhU3fDkxSoWnZcIUb98Hr74=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:KHQXmfnOV1iDqkcqd0utzPWGwBe2WGWxXnr40fNgYOw=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a h1:3xG2IDbke25n4ppUbwOQMfwFK1J2rKbzy36ubsXpS4A=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 // indirect
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.67.0-devel.0.20250507144401-a64863d1e01a // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -59,8 +59,8 @@ github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 h1:vZTD
 github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0/go.mod h1:WfNHlGyZu4DocYRTO+QyV9RcleXEmLe8DNbg574UYno=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 h1:M+q1zx3hUJPtF5+HA2VLRa6cR8o2DS+yZ4C7qerlz74=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0/go.mod h1:cZGSQu7XpCZPBc8ZsgevfbmNLnLuzfQgGGwWrQijhas=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a h1:YgatlcLZLpm8Eyiqw/eDxvtw17+k5fQsAPiNdiUlXsc=
-github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:6G2mQNus/0r5WlZKp5nVSUpgik03U0vXoSc4oQOTa2Q=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 h1:5w1/OoHhJMdDnz1D9WnzXMUPkbjReCBRIQnSpHDLZ4o=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0/go.mod h1:rGDLlaiajhgqm3XszjzlNVWSvNnYvrHq6Hj7y5vh7xA=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a h1:9A6VceJLSJOm0gmQX30NZhU3fDkxSoWnZcIUb98Hr74=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.67.0-devel.0.20250507144401-a64863d1e01a/go.mod h1:KHQXmfnOV1iDqkcqd0utzPWGwBe2WGWxXnr40fNgYOw=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.67.0-devel.0.20250507144401-a64863d1e01a h1:3xG2IDbke25n4ppUbwOQMfwFK1J2rKbzy36ubsXpS4A=

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.67.0 // indirect

--- a/extension/datadogextension/go.sum
+++ b/extension/datadogextension/go.sum
@@ -34,6 +34,8 @@ github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 h1:vZTD
 github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0/go.mod h1:WfNHlGyZu4DocYRTO+QyV9RcleXEmLe8DNbg574UYno=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 h1:M+q1zx3hUJPtF5+HA2VLRa6cR8o2DS+yZ4C7qerlz74=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0/go.mod h1:cZGSQu7XpCZPBc8ZsgevfbmNLnLuzfQgGGwWrQijhas=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 h1:5w1/OoHhJMdDnz1D9WnzXMUPkbjReCBRIQnSpHDLZ4o=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0/go.mod h1:rGDLlaiajhgqm3XszjzlNVWSvNnYvrHq6Hj7y5vh7xA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.67.0 h1:jnZ7fTQd/HXxxuMMbMZuKQ5XltPdg1fO8mufW91mr2c=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.67.0/go.mod h1:IE0OqLuTyWKy/xHscRzgrYvUIgy+TKwoC9tt6TgUnnY=
 github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.67.0 h1:L96yBlbWETGr3WyNRB6MlblSg0m7jgWHTi292W0utQo=

--- a/pkg/datadog/agentcomponents/agentcomponents.go
+++ b/pkg/datadog/agentcomponents/agentcomponents.go
@@ -10,6 +10,7 @@ import (
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	corelog "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
+	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkgconfigutils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -151,6 +152,7 @@ func WithLogsDefaults() ConfigOption {
 		pkgconfig.Set("logs_config.auditor_ttl", pkgconfigsetup.DefaultAuditorTTL, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.batch_max_content_size", pkgconfigsetup.DefaultBatchMaxContentSize, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.batch_max_size", pkgconfigsetup.DefaultBatchMaxSize, pkgconfigmodel.SourceDefault)
+		pkgconfig.Set("logs_config.compression_kind", logsconfig.GzipCompressionKind, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.force_use_http", true, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.input_chan_size", pkgconfigsetup.DefaultInputChanSize, pkgconfigmodel.SourceDefault)
 		pkgconfig.Set("logs_config.max_message_size_bytes", pkgconfigsetup.DefaultMaxMessageSizeBytes, pkgconfigmodel.SourceDefault)

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.67.0
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.67.0
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.67.0
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.67.0
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.67.0

--- a/pkg/datadog/go.sum
+++ b/pkg/datadog/go.sum
@@ -34,6 +34,8 @@ github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0 h1:vZTD
 github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.67.0/go.mod h1:WfNHlGyZu4DocYRTO+QyV9RcleXEmLe8DNbg574UYno=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0 h1:M+q1zx3hUJPtF5+HA2VLRa6cR8o2DS+yZ4C7qerlz74=
 github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.67.0/go.mod h1:cZGSQu7XpCZPBc8ZsgevfbmNLnLuzfQgGGwWrQijhas=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0 h1:5w1/OoHhJMdDnz1D9WnzXMUPkbjReCBRIQnSpHDLZ4o=
+github.com/DataDog/datadog-agent/comp/logs/agent/config v0.67.0/go.mod h1:rGDLlaiajhgqm3XszjzlNVWSvNnYvrHq6Hj7y5vh7xA=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.67.0 h1:jnZ7fTQd/HXxxuMMbMZuKQ5XltPdg1fO8mufW91mr2c=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.67.0/go.mod h1:IE0OqLuTyWKy/xHscRzgrYvUIgy+TKwoC9tt6TgUnnY=
 github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.67.0 h1:L96yBlbWETGr3WyNRB6MlblSg0m7jgWHTi292W0utQo=


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The default logs agent compression kind was [recently changed](https://github.com/DataDog/datadog-agent/commit/db09bbc371b18d3eab5d57b470b8f374a1195da4#diff-a7b6619528f155e64cefe12cc4ba753eb7688c87fdf9d96e1052a12eeb519df5L85) to zstd in agent v7.67.0. With the version upgrade in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40888, we want to change this back to gzip in contrib.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
