### PR TITLE
[chore][receiver/mysql] Excluding https://dev.mysql.com from lychee

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -5,6 +5,7 @@ accept = ["200..=299", "429"]
 exclude  = [
     "^http(s)?://localhost",
     "^http(s)?://example.com"
+    "^https://dev.mysql.com"
 ]
 
 # better to be safe and avoid failures


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Excluding https://dev.mysql.com from lychee because link started causing persistent 403 in CI, for example [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/15810240977/job/44560581603?pr=40626).