### PR TITLE
[chore] Fix MySQL lychee exclude

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -4,7 +4,7 @@ accept = ["200..=299", "429"]
 
 exclude  = [
     "^http(s)?://localhost",
-    "^http(s)?://example.com"
+    "^http(s)?://example.com",
     "^https://dev.mysql.com"
 ]
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add a comma before the MySQL exclude in Lychee config. The issue came from an [earlier PR that excluded the MySQL doc link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40919), but CI still passed—updating the config should now trigger a Lychee config check.
