### PR TITLE
feat: add wal latency metrics

### DIFF
--- a/.chloggen/nickange_prometheusremotewriteexporter_feat-add-wal-latency-metrics.yaml
+++ b/.chloggen/nickange_prometheusremotewriteexporter_feat-add-wal-latency-metrics.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Adds WAL latency metrics to the Prometheus Remote Write Exporter. The new metrics are:
+  - `otelcol_exporter_prometheusremotewrite_wal_write_latency`: The latency of WAL writes.
+  - `otelcol_exporter_prometheusremotewrite_wal_read_latency`: The latency of WAL reads.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39556]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/documentation.md
+++ b/exporter/prometheusremotewriteexporter/documentation.md
@@ -38,6 +38,14 @@ Number of Prometheus time series that were translated from OTel metrics
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
+### otelcol_exporter_prometheusremotewrite_wal_read_latency
+
+Response latency in ms for the WAL reads.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| ms | Histogram | Int |
+
 ### otelcol_exporter_prometheusremotewrite_wal_reads
 
 Number of WAL reads
@@ -53,6 +61,14 @@ Number of WAL reads that failed
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
+
+### otelcol_exporter_prometheusremotewrite_wal_write_latency
+
+Response latency in ms for the WAL writes.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| ms | Histogram | Int |
 
 ### otelcol_exporter_prometheusremotewrite_wal_writes
 

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
@@ -30,8 +30,10 @@ type TelemetryBuilder struct {
 	ExporterPrometheusremotewriteFailedTranslations   metric.Int64Counter
 	ExporterPrometheusremotewriteSentBatches          metric.Int64Counter
 	ExporterPrometheusremotewriteTranslatedTimeSeries metric.Int64Counter
+	ExporterPrometheusremotewriteWalReadLatency       metric.Int64Histogram
 	ExporterPrometheusremotewriteWalReads             metric.Int64Counter
 	ExporterPrometheusremotewriteWalReadsFailures     metric.Int64Counter
+	ExporterPrometheusremotewriteWalWriteLatency      metric.Int64Histogram
 	ExporterPrometheusremotewriteWalWrites            metric.Int64Counter
 	ExporterPrometheusremotewriteWalWritesFailures    metric.Int64Counter
 }
@@ -89,6 +91,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
+	builder.ExporterPrometheusremotewriteWalReadLatency, err = builder.meter.Int64Histogram(
+		"otelcol_exporter_prometheusremotewrite_wal_read_latency",
+		metric.WithDescription("Response latency in ms for the WAL reads."),
+		metric.WithUnit("ms"),
+		metric.WithExplicitBucketBoundaries([]float64{5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000}...),
+	)
+	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalReads, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_reads",
 		metric.WithDescription("Number of WAL reads"),
@@ -99,6 +108,13 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_exporter_prometheusremotewrite_wal_reads_failures",
 		metric.WithDescription("Number of WAL reads that failed"),
 		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterPrometheusremotewriteWalWriteLatency, err = builder.meter.Int64Histogram(
+		"otelcol_exporter_prometheusremotewrite_wal_write_latency",
+		metric.WithDescription("Response latency in ms for the WAL writes."),
+		metric.WithUnit("ms"),
+		metric.WithExplicitBucketBoundaries([]float64{5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalWrites, err = builder.meter.Int64Counter(

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
@@ -85,6 +85,21 @@ func AssertEqualExporterPrometheusremotewriteTranslatedTimeSeries(t *testing.T, 
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualExporterPrometheusremotewriteWalReadLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_prometheusremotewrite_wal_read_latency",
+		Description: "Response latency in ms for the WAL reads.",
+		Unit:        "ms",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_prometheusremotewrite_wal_read_latency")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualExporterPrometheusremotewriteWalReads(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_reads",
@@ -113,6 +128,21 @@ func AssertEqualExporterPrometheusremotewriteWalReadsFailures(t *testing.T, tt *
 		},
 	}
 	got, err := tt.GetMetric("otelcol_exporter_prometheusremotewrite_wal_reads_failures")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualExporterPrometheusremotewriteWalWriteLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_prometheusremotewrite_wal_write_latency",
+		Description: "Response latency in ms for the WAL writes.",
+		Unit:        "ms",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_prometheusremotewrite_wal_write_latency")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -24,8 +24,10 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ExporterPrometheusremotewriteFailedTranslations.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteSentBatches.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteTranslatedTimeSeries.Add(context.Background(), 1)
+	tb.ExporterPrometheusremotewriteWalReadLatency.Record(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalReads.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalReadsFailures.Add(context.Background(), 1)
+	tb.ExporterPrometheusremotewriteWalWriteLatency.Record(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalWrites.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalWritesFailures.Add(context.Background(), 1)
 	AssertEqualExporterPrometheusremotewriteConsumers(t, testTel,
@@ -40,11 +42,17 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualExporterPrometheusremotewriteTranslatedTimeSeries(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterPrometheusremotewriteWalReadLatency(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPrometheusremotewriteWalReads(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPrometheusremotewriteWalReadsFailures(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterPrometheusremotewriteWalWriteLatency(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPrometheusremotewriteWalWrites(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -74,3 +74,17 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    exporter_prometheusremotewrite_wal_write_latency:
+      enabled: true
+      description: Response latency in ms for the WAL writes.
+      unit: ms
+      histogram:
+        value_type: int
+        bucket_boundaries: [5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
+    exporter_prometheusremotewrite_wal_read_latency:
+      enabled: true
+      description: Response latency in ms for the WAL reads.
+      unit: ms
+      histogram:
+        value_type: int
+        bucket_boundaries: [5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -25,8 +25,10 @@ import (
 )
 
 type prwWalTelemetry interface {
+	recordWALWriteLatency(ctx context.Context, durationMs int64)
 	recordWALWrites(ctx context.Context)
 	recordWALWritesFailures(ctx context.Context)
+	recordWALReadLatency(ctx context.Context, durationMs int64)
 	recordWALReads(ctx context.Context)
 	recordWALReadsFailures(ctx context.Context)
 }
@@ -36,12 +38,20 @@ type prwWalTelemetryOTel struct {
 	otelAttrs        []attribute.KeyValue
 }
 
+func (p *prwWalTelemetryOTel) recordWALWriteLatency(ctx context.Context, durationMs int64) {
+	p.telemetryBuilder.ExporterPrometheusremotewriteWalWriteLatency.Record(ctx, durationMs, metric.WithAttributes(p.otelAttrs...))
+}
+
 func (p *prwWalTelemetryOTel) recordWALWrites(ctx context.Context) {
 	p.telemetryBuilder.ExporterPrometheusremotewriteWalWrites.Add(ctx, 1, metric.WithAttributes(p.otelAttrs...))
 }
 
 func (p *prwWalTelemetryOTel) recordWALWritesFailures(ctx context.Context) {
 	p.telemetryBuilder.ExporterPrometheusremotewriteWalWritesFailures.Add(ctx, 1, metric.WithAttributes(p.otelAttrs...))
+}
+
+func (p *prwWalTelemetryOTel) recordWALReadLatency(ctx context.Context, durationMs int64) {
+	p.telemetryBuilder.ExporterPrometheusremotewriteWalReadLatency.Record(ctx, durationMs, metric.WithAttributes(p.otelAttrs...))
 }
 
 func (p *prwWalTelemetryOTel) recordWALReads(ctx context.Context) {
@@ -400,7 +410,10 @@ func (prweWAL *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wr
 			return nil, errors.New("attempt to read from closed WAL")
 		}
 		prweWAL.telemetry.recordWALReads(ctx)
+		start := time.Now()
 		protoBlob, err = prweWAL.wal.Read(index)
+		duration := time.Since(start)
+		prweWAL.telemetry.recordWALReadLatency(ctx, duration.Milliseconds())
 		if err == nil { // The read succeeded.
 			req := new(prompb.WriteRequest)
 			if err = proto.Unmarshal(protoBlob, req); err != nil {

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -295,8 +295,6 @@ func TestWALWrite_Telemetry(t *testing.T) {
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_write_latency")
 	require.NoError(t, err)
-	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_read_latency")
-	require.NoError(t, err)
 }
 
 func TestWALRead_Telemetry(t *testing.T) {
@@ -371,5 +369,8 @@ func TestWALRead_Telemetry(t *testing.T) {
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_reads_failures")
 
 	// verify that the metric exists, so it's incremented
+	require.NoError(t, err)
+
+	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_read_latency")
 	require.NoError(t, err)
 }

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -292,6 +292,11 @@ func TestWALWrite_Telemetry(t *testing.T) {
 	metadatatest.AssertEqualExporterPrometheusremotewriteWalWritesFailures(t, tel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+
+	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_write_latency")
+	require.NoError(t, err)
+	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_read_latency")
+	require.NoError(t, err)
 }
 
 func TestWALRead_Telemetry(t *testing.T) {
@@ -364,6 +369,7 @@ func TestWALRead_Telemetry(t *testing.T) {
 	// Unable to start the WAL cause there is a corrupted entry
 	require.Error(t, err)
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_reads_failures")
+
 	// verify that the metric exists, so it's incremented
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds two new histogram metrics to track the latency of Write-Ahead Log (WAL) operations in the Prometheus Remote Write Exporter:
- `otelcol_exporter_prometheusremotewrite_wal_write_latency`: Tracks latency for WAL write operations
- `otelcol_exporter_prometheusremotewrite_wal_read_latency`: Tracks latency for WAL read operations

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Part of #39556

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added UT

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
