### PR TITLE
[encoding/jsonlogencodingextension] Add array_mode config to jsonlogencodingextension

### DIFF
--- a/.chloggen/feat_processing-mode-for-json-enc-ext.yaml
+++ b/.chloggen/feat_processing-mode-for-json-enc-ext.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jsonlogencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add array_mode configuration option and add support to process arbitrary JSON inputs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40877, 40545]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "`array_mode` is default set to true to preserve backward compatibility. When set to `true`, extension accepts single or concatenated Json (ex:- NDJSON)"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/jsonlogencodingextension/README.md
+++ b/extension/encoding/jsonlogencodingextension/README.md
@@ -13,11 +13,10 @@
 
 ## Configuration
 
-| Name                     | Description                                        | Default                                      |
-| ------------------------ | -------------------------------------------------- | -------------------------------------------- |
-| mode                     | What mode of the JSON encoding extension you want  | body                                         |
-
-
+| Name            | Description                                                                                   | Default |
+|-----------------|-----------------------------------------------------------------------------------------------|---------|
+| mode            | What mode of the JSON encoding extension you want                                             | body    |
+| processing_mode | Format of JSON payloads processed by the extension. Select from `array`, `single` or `ndjson` | array   |
 
 ### Mode
 
@@ -51,3 +50,20 @@ The `body_with_inline_attributes` mode within the JSON encoding extension grabs 
   }
 ]
 ```
+
+### processing_mode
+
+Configuration allows to define the format of JSON payload this extension is expected to process.
+
+- `array` : This is the default mode to preserve backward compatibility. JSON input is expected as an array
+  
+   > [{"key": "value"}, {"key": "value"}]
+
+- `single` : This mode expect input to contain a single JSON payload
+
+  > {"key": "value"}
+  
+- `ndjson` : This mode allows to handle new delimited JSON payloads
+
+  > {"key": "value"}\
+  > {"key": "value"}

--- a/extension/encoding/jsonlogencodingextension/README.md
+++ b/extension/encoding/jsonlogencodingextension/README.md
@@ -13,10 +13,10 @@
 
 ## Configuration
 
-| Name            | Description                                                                       | Default |
-|-----------------|-----------------------------------------------------------------------------------|---------|
-| mode            | What mode of the JSON encoding extension you want                                 | body    |
-| processing_mode | Format of JSON payloads processed by the extension. Select from `array` or `json` | array   |
+| Name       | Description                                                                           | Default |
+|------------|---------------------------------------------------------------------------------------|---------|
+| mode       | What mode of the JSON encoding extension you want                                     | body    |
+| array_mode | Set whether JSON payloads is extracted from an array(legacy mode). Accepts a boolean. | true    |
 
 ### Mode
 
@@ -51,15 +51,15 @@ The `body_with_inline_attributes` mode within the JSON encoding extension grabs 
 ]
 ```
 
-### processing_mode
+### array_mode
 
-Configuration allows to define the format of JSON payload this extension is expected to process.
+Configuration accepts a boolean.
 
-- `array` : This is the default mode to preserve backward compatibility. JSON input is expected as an array
+- `array_mode: true` : This is the default mode to preserve backward compatibility. JSON input is expected as an array
   
    > [{"key": "value"}, {"key": "value"}]
 
-- `json` : This mode supports a verity of JSON payload. This includes single document or even a concatenated JSON payload
+- `array_mode: false` : Disable legacy mode and allow to accept a verity of JSON payloads. This includes single document or even a concatenated JSON payload
 
   Single payload
   > {"key": "value"}

--- a/extension/encoding/jsonlogencodingextension/README.md
+++ b/extension/encoding/jsonlogencodingextension/README.md
@@ -13,10 +13,10 @@
 
 ## Configuration
 
-| Name            | Description                                                                                   | Default |
-|-----------------|-----------------------------------------------------------------------------------------------|---------|
-| mode            | What mode of the JSON encoding extension you want                                             | body    |
-| processing_mode | Format of JSON payloads processed by the extension. Select from `array`, `single` or `ndjson` | array   |
+| Name            | Description                                                                       | Default |
+|-----------------|-----------------------------------------------------------------------------------|---------|
+| mode            | What mode of the JSON encoding extension you want                                 | body    |
+| processing_mode | Format of JSON payloads processed by the extension. Select from `array` or `json` | array   |
 
 ### Mode
 
@@ -59,11 +59,12 @@ Configuration allows to define the format of JSON payload this extension is expe
   
    > [{"key": "value"}, {"key": "value"}]
 
-- `single` : This mode expect input to contain a single JSON payload
+- `json` : This mode supports a verity of JSON payload. This includes single document or even a concatenated JSON payload
 
+  Single payload
   > {"key": "value"}
-  
-- `ndjson` : This mode allows to handle new delimited JSON payloads
 
+  New line delimited JSON payload
   > {"key": "value"}\
   > {"key": "value"}
+  

--- a/extension/encoding/jsonlogencodingextension/config.go
+++ b/extension/encoding/jsonlogencodingextension/config.go
@@ -7,19 +7,15 @@ import "fmt"
 
 type JSONEncodingMode string
 
-type ProcessingMode string
-
 const (
 	JSONEncodingModeBodyWithInlineAttributes JSONEncodingMode = "body_with_inline_attributes"
 	JSONEncodingModeBody                     JSONEncodingMode = "body"
-	ArrayMode                                ProcessingMode   = "array"
-	JSONMode                                 ProcessingMode   = "json"
 )
 
 type Config struct {
 	// Export raw log string instead of log wrapper
-	Mode           JSONEncodingMode `mapstructure:"mode,omitempty"`
-	ProcessingMode ProcessingMode   `mapstructure:"processing_mode,omitempty"`
+	Mode      JSONEncodingMode `mapstructure:"mode,omitempty"`
+	ArrayMode bool             `mapstructure:"array_mode,omitempty"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}
@@ -29,15 +25,8 @@ func (c *Config) Validate() error {
 	// validate marshaling mode
 	switch c.Mode {
 	case JSONEncodingModeBodyWithInlineAttributes, JSONEncodingModeBody:
-	default:
-		return fmt.Errorf("invalid mode %q", c.Mode)
+		return nil
 	}
 
-	// validate unmarshaling mode
-	switch c.ProcessingMode {
-	case ArrayMode, JSONMode:
-		return nil
-	default:
-		return fmt.Errorf("invalid decoding mode %q", c.ProcessingMode)
-	}
+	return fmt.Errorf("invalid mode %q", c.Mode)
 }

--- a/extension/encoding/jsonlogencodingextension/config.go
+++ b/extension/encoding/jsonlogencodingextension/config.go
@@ -13,8 +13,7 @@ const (
 	JSONEncodingModeBodyWithInlineAttributes JSONEncodingMode = "body_with_inline_attributes"
 	JSONEncodingModeBody                     JSONEncodingMode = "body"
 	ArrayMode                                ProcessingMode   = "array"
-	SingleMode                               ProcessingMode   = "single"
-	NDJsonMode                               ProcessingMode   = "ndjson"
+	JSONMode                                 ProcessingMode   = "json"
 )
 
 type Config struct {
@@ -36,7 +35,7 @@ func (c *Config) Validate() error {
 
 	// validate unmarshaling mode
 	switch c.ProcessingMode {
-	case ArrayMode, SingleMode, NDJsonMode:
+	case ArrayMode, JSONMode:
 		return nil
 	default:
 		return fmt.Errorf("invalid decoding mode %q", c.ProcessingMode)

--- a/extension/encoding/jsonlogencodingextension/config.go
+++ b/extension/encoding/jsonlogencodingextension/config.go
@@ -7,24 +7,38 @@ import "fmt"
 
 type JSONEncodingMode string
 
+type ProcessingMode string
+
 const (
 	JSONEncodingModeBodyWithInlineAttributes JSONEncodingMode = "body_with_inline_attributes"
 	JSONEncodingModeBody                     JSONEncodingMode = "body"
+	ArrayMode                                ProcessingMode   = "array"
+	SingleMode                               ProcessingMode   = "single"
+	NDJsonMode                               ProcessingMode   = "ndjson"
 )
 
 type Config struct {
 	// Export raw log string instead of log wrapper
-	Mode JSONEncodingMode `mapstructure:"mode,omitempty"`
+	Mode           JSONEncodingMode `mapstructure:"mode,omitempty"`
+	ProcessingMode ProcessingMode   `mapstructure:"processing_mode,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
 
 func (c *Config) Validate() error {
+	// validate marshaling mode
 	switch c.Mode {
-	case JSONEncodingModeBodyWithInlineAttributes:
-	case JSONEncodingModeBody:
+	case JSONEncodingModeBodyWithInlineAttributes, JSONEncodingModeBody:
 	default:
 		return fmt.Errorf("invalid mode %q", c.Mode)
 	}
-	return nil
+
+	// validate unmarshaling mode
+	switch c.ProcessingMode {
+	case ArrayMode, SingleMode, NDJsonMode:
+		return nil
+	default:
+		return fmt.Errorf("invalid decoding mode %q", c.ProcessingMode)
+	}
 }

--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -73,7 +73,7 @@ func (e *jsonLogExtension) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	}
 
 	// check for processing mode so we can return the best format
-	if e.config.ProcessingMode == JSONMode {
+	if !e.config.ArrayMode {
 		var buf bytes.Buffer
 		for i, log := range logs {
 			m, err := json.Marshal(log)
@@ -102,14 +102,14 @@ func (e *jsonLogExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	var jsonLogs []map[string]any
 	var err error
 
-	if e.config.ProcessingMode == JSONMode {
-		jsonLogs, err = todDecodedJSONDocuments(bytes.NewReader(buf))
-		if err != nil {
+	if e.config.ArrayMode {
+		// Default mode to handle arrays having backward compatibility
+		if err = json.Unmarshal(buf, &jsonLogs); err != nil {
 			return p, err
 		}
 	} else {
-		// Default mode to handle arrays having backward compatibility
-		if err = json.Unmarshal(buf, &jsonLogs); err != nil {
+		jsonLogs, err = todDecodedJSONDocuments(bytes.NewReader(buf))
+		if err != nil {
 			return p, err
 		}
 	}

--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -4,10 +4,11 @@
 package jsonlogencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension"
 
 import (
-	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/component"
@@ -27,20 +28,40 @@ type jsonLogExtension struct {
 }
 
 func (e *jsonLogExtension) MarshalLogs(ld plog.Logs) ([]byte, error) {
-	if e.config.Mode == JSONEncodingModeBodyWithInlineAttributes {
-		return e.logProcessor(ld)
-	}
-	logs := make([]map[string]any, 0, ld.LogRecordCount())
+	var logs []map[string]any
 
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
 		rl := rls.At(i)
+		resourceAttrs := rl.Resource().Attributes().AsRaw()
 		sls := rl.ScopeLogs()
 		for j := 0; j < sls.Len(); j++ {
 			sl := sls.At(j)
 			logSlice := sl.LogRecords()
 			for k := 0; k < logSlice.Len(); k++ {
 				log := logSlice.At(k)
+				if e.config.Mode == JSONEncodingModeBodyWithInlineAttributes {
+					// special handling for inline attributes Mode
+					entry := make(map[string]any)
+
+					body := log.Body().AsRaw()
+					if body != nil {
+						entry["body"] = body
+					}
+
+					if len(resourceAttrs) != 0 {
+						entry["resourceAttributes"] = resourceAttrs
+					}
+
+					logAttribs := log.Attributes().AsRaw()
+					if len(logAttribs) != 0 {
+						entry["logAttributes"] = logAttribs
+					}
+
+					logs = append(logs, entry)
+					continue
+				}
+
 				switch log.Body().Type() {
 				case pcommon.ValueTypeMap:
 					logs = append(logs, log.Body().Map().AsRaw())
@@ -52,14 +73,8 @@ func (e *jsonLogExtension) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	}
 
 	// check for processing mode so we can return the best format
-	switch e.config.ProcessingMode {
-	case SingleMode:
-		if len(logs) == 1 {
-			return json.Marshal(logs[0])
-		}
-	case NDJsonMode:
+	if e.config.ProcessingMode == JSONMode {
 		var buf bytes.Buffer
-
 		for i, log := range logs {
 			m, err := json.Marshal(log)
 			if err != nil {
@@ -68,6 +83,7 @@ func (e *jsonLogExtension) MarshalLogs(ld plog.Logs) ([]byte, error) {
 
 			buf.Write(m)
 			if i < len(logs)-1 {
+				// if multiple logs, then consider exporting as ndjson
 				buf.WriteByte('\n')
 			}
 		}
@@ -84,31 +100,16 @@ func (e *jsonLogExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 
 	// get json logs from the buffer
 	var jsonLogs []map[string]any
-	switch e.config.ProcessingMode {
-	case ArrayMode:
-		if err := json.Unmarshal(buf, &jsonLogs); err != nil {
+	var err error
+
+	if e.config.ProcessingMode == JSONMode {
+		jsonLogs, err = todDecodedJSONDocuments(bytes.NewReader(buf))
+		if err != nil {
 			return p, err
 		}
-	case SingleMode:
-		var doc map[string]any
-		if err := json.Unmarshal(buf, &doc); err != nil {
-			return p, err
-		}
-		jsonLogs = append(jsonLogs, doc)
-	case NDJsonMode:
-		sc := bufio.NewScanner(bytes.NewReader(buf))
-		for sc.Scan() {
-			var line map[string]any
-			err := json.Unmarshal(sc.Bytes(), &line)
-			if err != nil {
-				return p, err
-			}
-
-			jsonLogs = append(jsonLogs, line)
-		}
-
-		if err := sc.Err(); err != nil {
-			// consider this as an error
+	} else {
+		// Default mode to handle arrays having backward compatibility
+		if err = json.Unmarshal(buf, &jsonLogs); err != nil {
 			return p, err
 		}
 	}
@@ -131,35 +132,23 @@ func (e *jsonLogExtension) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (e *jsonLogExtension) logProcessor(ld plog.Logs) ([]byte, error) {
-	logs := make([]logBody, 0, ld.LogRecordCount())
+// todDecodedJSONDocuments is a generic helper to derive json records decoded from a reader.
+func todDecodedJSONDocuments(reader io.Reader) ([]map[string]any, error) {
+	decoder := json.NewDecoder(reader)
+	jsonDocuments := make([]map[string]any, 0)
 
-	rls := ld.ResourceLogs()
-	for i := 0; i < rls.Len(); i++ {
-		rl := rls.At(i)
-		resourceAttrs := rl.Resource().Attributes().AsRaw()
-
-		sls := rl.ScopeLogs()
-		for j := 0; j < sls.Len(); j++ {
-			sl := sls.At(j)
-			logSlice := sl.LogRecords()
-			for k := 0; k < logSlice.Len(); k++ {
-				log := logSlice.At(k)
-				logEvent := logBody{
-					Body:               log.Body().AsRaw(),
-					ResourceAttributes: resourceAttrs,
-					LogAttributes:      log.Attributes().AsRaw(),
-				}
-				logs = append(logs, logEvent)
+	for {
+		var doc map[string]any
+		err := decoder.Decode(&doc)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			return nil, err
 		}
+
+		jsonDocuments = append(jsonDocuments, doc)
 	}
 
-	return json.Marshal(logs)
-}
-
-type logBody struct {
-	Body               any            `json:"body,omitempty"`
-	LogAttributes      map[string]any `json:"logAttributes,omitempty"`
-	ResourceAttributes map[string]any `json:"resourceAttributes,omitempty"`
+	return jsonDocuments, nil
 }

--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -157,7 +157,8 @@ func (r *streamReader) next() bool {
 		return false
 	}
 
-	err := r.decoder.Decode(&r.current)
+	var entry map[string]any
+	err := r.decoder.Decode(&entry)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			// EOF signals the end
@@ -172,6 +173,7 @@ func (r *streamReader) next() bool {
 		return true
 	}
 
+	r.current = entry
 	return true
 }
 

--- a/extension/encoding/jsonlogencodingextension/factory.go
+++ b/extension/encoding/jsonlogencodingextension/factory.go
@@ -23,12 +23,13 @@ func NewFactory() extension.Factory {
 
 func createExtension(_ context.Context, _ extension.Settings, config component.Config) (extension.Extension, error) {
 	return &jsonLogExtension{
-		config: config,
+		config: config.(*Config),
 	}, nil
 }
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Mode: JSONEncodingModeBody,
+		Mode:           JSONEncodingModeBody,
+		ProcessingMode: ArrayMode,
 	}
 }

--- a/extension/encoding/jsonlogencodingextension/factory.go
+++ b/extension/encoding/jsonlogencodingextension/factory.go
@@ -29,7 +29,7 @@ func createExtension(_ context.Context, _ extension.Settings, config component.C
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Mode:           JSONEncodingModeBody,
-		ProcessingMode: ArrayMode,
+		Mode:      JSONEncodingModeBody,
+		ArrayMode: true,
 	}
 }

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -5,6 +5,8 @@ go 1.23.0
 require (
 	github.com/goccy/go-json v0.10.5
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.129.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.129.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.35.1-0.20250708151327-74cb2f311035
 	go.opentelemetry.io/collector/component/componenttest v0.129.1-0.20250708151327-74cb2f311035
@@ -16,6 +18,7 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -32,6 +35,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.129.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.35.1-0.20250708151327-74cb2f311035 // indirect
@@ -57,3 +61,9 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding => ../
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../../pkg/pdatautil
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../../pkg/pdatatest
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../../pkg/golden

--- a/extension/encoding/jsonlogencodingextension/go.sum
+++ b/extension/encoding/jsonlogencodingextension/go.sum
@@ -1,3 +1,5 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -47,6 +49,12 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0 h1:GJzARUS5NcCeYr7pwlrYMEK+fl92cmCDED2to7nPuCQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0/go.mod h1:YrULw8EK8Vj0LX2ZhtfqMaIlLATIGOlbII9RDR8lPeI=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0 h1:+rUULr4xqOJjZK3SokFmRYzsiPq5onoWoSv3He4aaus=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0/go.mod h1:Fh2SXPeFkr4J97w9CV/apFAib8TC9Hi0P08xtiT7Lng=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.128.0 h1:8OWwRSdIhm3DY3PEYJ0PtSEz1a1OjL0fghLXSr14JMk=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.128.0/go.mod h1:32OeaysZe4vkSmD1LJ18Q1DfooryYqpSzFNmz+5A5RU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/extension/encoding/jsonlogencodingextension/go.sum
+++ b/extension/encoding/jsonlogencodingextension/go.sum
@@ -49,12 +49,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0 h1:GJzARUS5NcCeYr7pwlrYMEK+fl92cmCDED2to7nPuCQ=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.128.0/go.mod h1:YrULw8EK8Vj0LX2ZhtfqMaIlLATIGOlbII9RDR8lPeI=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0 h1:+rUULr4xqOJjZK3SokFmRYzsiPq5onoWoSv3He4aaus=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.128.0/go.mod h1:Fh2SXPeFkr4J97w9CV/apFAib8TC9Hi0P08xtiT7Lng=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.128.0 h1:8OWwRSdIhm3DY3PEYJ0PtSEz1a1OjL0fghLXSr14JMk=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.128.0/go.mod h1:32OeaysZe4vkSmD1LJ18Q1DfooryYqpSzFNmz+5A5RU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/extension/encoding/jsonlogencodingextension/json_test.go
+++ b/extension/encoding/jsonlogencodingextension/json_test.go
@@ -4,6 +4,8 @@
 package jsonlogencodingextension
 
 import (
+	"bufio"
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,20 +14,78 @@ import (
 
 func TestMarshalUnmarshal(t *testing.T) {
 	t.Parallel()
-	e := &jsonLogExtension{
-		config: &Config{
-			Mode: JSONEncodingModeBody,
+
+	tests := []struct {
+		name         string
+		decodingMode ProcessingMode
+		input        string
+		wantLogs     int
+	}{
+		{
+			name:         "Single log in array",
+			decodingMode: ArrayMode,
+			input:        `[{"example":"example valid json to test that the unmarshaler is correctly returning a plog value"}]`,
+			wantLogs:     1,
+		},
+		{
+			name:         "Single log as Json",
+			decodingMode: SingleMode,
+			input: `{
+					  "key-string": "value",
+					  "key-int": 123456789,
+					  "key-boolean": true
+					}`,
+			wantLogs: 1,
+		},
+		{
+			name:         "Logs in ndjson format",
+			decodingMode: NDJsonMode,
+			input:        "{\"key-string\": \"value\",\"key-int\": 123456789,\"key-boolean\": true}\n{\"key-string\": \"value\",\"key-int\": 987654321,\"key-boolean\": false}",
+			wantLogs:     2,
 		},
 	}
-	json := `[{"example":"example valid json to test that the unmarshaler is correctly returning a plog value"}]`
-	ld, err := e.UnmarshalLogs([]byte(json))
-	assert.NoError(t, err)
-	assert.Equal(t, 1, ld.LogRecordCount())
 
-	buf, err := e.MarshalLogs(ld)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, buf)
-	assert.JSONEq(t, json, string(buf))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &jsonLogExtension{
+				config: &Config{
+					Mode:           JSONEncodingModeBody,
+					ProcessingMode: tt.decodingMode,
+				},
+			}
+
+			ld, err := e.UnmarshalLogs([]byte(tt.input))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantLogs, ld.LogRecordCount())
+
+			buf, err := e.MarshalLogs(ld)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, buf)
+
+			if tt.decodingMode != NDJsonMode {
+				assert.JSONEq(t, tt.input, string(buf))
+				return
+			}
+
+			// special comparison for ndjson
+			inputScanner := bufio.NewScanner(bytes.NewReader([]byte(tt.input)))
+			var inputLines []string
+			for inputScanner.Scan() {
+				inputLines = append(inputLines, inputScanner.Text())
+			}
+
+			outputScanner := bufio.NewScanner(bytes.NewReader(buf))
+			var outputLines []string
+			for outputScanner.Scan() {
+				outputLines = append(outputLines, outputScanner.Text())
+			}
+
+			assert.Len(t, len(inputLines), len(outputLines))
+			for i, line := range inputLines {
+				assert.JSONEq(t, line, outputLines[i])
+			}
+		})
+	}
 }
 
 func TestInvalidMarshal(t *testing.T) {

--- a/extension/encoding/jsonlogencodingextension/json_test.go
+++ b/extension/encoding/jsonlogencodingextension/json_test.go
@@ -89,10 +89,23 @@ func TestMarshalUnmarshal(t *testing.T) {
 			}
 
 			// special comparison for non array JSON. Compared in decoded format.
-			inputDocuments, err := todDecodedJSONDocuments(bytes.NewReader([]byte(tt.input)))
-			require.NoError(t, err)
+			inputReader := newStreamReader(bytes.NewReader([]byte(tt.input)))
+			var inputDocuments []map[string]any
+			var value map[string]any
+			for inputReader.next() {
+				value, err = inputReader.value()
+				assert.NoError(t, err)
+				inputDocuments = append(inputDocuments, value)
+			}
 
-			outputDocuments, err := todDecodedJSONDocuments(bytes.NewReader(buf))
+			outputReader := newStreamReader(bytes.NewReader(buf))
+			var outputDocuments []map[string]any
+			for outputReader.next() {
+				value, err = outputReader.value()
+				assert.NoError(t, err)
+				outputDocuments = append(outputDocuments, value)
+			}
+
 			require.NoError(t, err)
 			for i, line := range inputDocuments {
 				assert.Equal(t, line, outputDocuments[i])

--- a/extension/encoding/jsonlogencodingextension/testdata/array_mode_multi_log.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/array_mode_multi_log.yml
@@ -1,0 +1,21 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: example
+                    value:
+                      stringValue: example valid json to test that the unmarshaler is correctly returning a plog value
+            spanId: ""
+            traceId: ""
+          - body:
+              kvlistValue:
+                values:
+                  - key: key
+                    value:
+                      stringValue: value
+            spanId: ""
+            traceId: ""
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/array_mode_single_log.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/array_mode_single_log.yml
@@ -1,0 +1,13 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: example
+                    value:
+                      stringValue: example valid json to test that the unmarshaler is correctly returning a plog value
+            spanId: ""
+            traceId: ""
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/json_mode_ndjson_log.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/json_mode_ndjson_log.yml
@@ -1,0 +1,33 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: key-string
+                    value:
+                      stringValue: value
+                  - key: key-int
+                    value:
+                      doubleValue: 1.23456789e+08
+                  - key: key-boolean
+                    value:
+                      boolValue: true
+            spanId: ""
+            traceId: ""
+          - body:
+              kvlistValue:
+                values:
+                  - key: key-string
+                    value:
+                      stringValue: value
+                  - key: key-int
+                    value:
+                      doubleValue: 9.87654321e+08
+                  - key: key-boolean
+                    value:
+                      boolValue: false
+            spanId: ""
+            traceId: ""
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/json_mode_single_log.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/json_mode_single_log.yml
@@ -1,0 +1,19 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: key-boolean
+                    value:
+                      boolValue: true
+                  - key: key-string
+                    value:
+                      stringValue: value
+                  - key: key-int
+                    value:
+                      doubleValue: 1.23456789e+08
+            spanId: ""
+            traceId: ""
+        scope: {}


### PR DESCRIPTION
#### Description

This PR adds `array_mode` configuration option to the extension. This allows this extension to be used by multiple JSON payload types,

- `array_mode: true` : This is the default mode which expects payload to be an json array (kept as default for backward compatiblity)
- `array_mode: false`: This mode accepts the payload to contain single JSON document or multiple delimited documents (ex:- ndjson)
 
Change includes implementation for both marshaling and unmarshaling. 

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40877 

#### Testing

I have validated the data flow for encoding with following scenarios,

- With empty `array_mode` : Works similarly to current implementation where payload is expected as array
- With `array_mode: true` : Default mode and expects array
- With `array_mode: false` : Accepts single json document as well as new line delimited JSON document

#### Documentation

I have updated the extension's documentation to reflect the changes. 
