### PR TITLE
[exporter/loadbalancing] transition from Endpoints to EndpointSlices

### DIFF
--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -56,7 +56,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -42,8 +42,6 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
-github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/foxboron/go-tpm-keyfiles v0.0.0-20250323135004-b31fac66206e h1:2jjYsGgM13xId2Ku+UGDQTO5It50LhT6lljiVJvBj1Y=
@@ -452,8 +450,6 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.32.3 h1:Hw7KqxRusq+6QSplE3NYG4MBxZw1BZnq4aP4cJVINls=
 k8s.io/api v0.32.3/go.mod h1:2wEDTXADtm/HA7CCMD8D8bK4yuBUptzaRhYcYEEYA3k=
-k8s.io/apiextensions-apiserver v0.32.1 h1:hjkALhRUeCariC8DiVmb5jj0VjIc1N0DREP32+6UXZw=
-k8s.io/apiextensions-apiserver v0.32.1/go.mod h1:sxWIGuGiYov7Io1fAS2X06NjMIk5CbRHc2StSmbaQto=
 k8s.io/apimachinery v0.32.3 h1:JmDuDarhDmA/Li7j3aPrwhpNBA94Nvk5zLeOge9HH1U=
 k8s.io/apimachinery v0.32.3/go.mod h1:GpHVgxoKlTxClKcteaeuF1Ul/lDVb74KpZcxcmLDElE=
 k8s.io/client-go v0.32.3 h1:RKPVltzopkSgHS7aS98QdscAgtgah/+zmpAogooIqVU=

--- a/exporter/loadbalancingexporter/resolver_k8s_handler.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_handler.go
@@ -43,7 +43,6 @@ func (h handler) OnAdd(obj any, _ bool) {
 			h.logger.Warn(epMissingHostnamesMsg, zap.Any("obj", obj))
 			h.telemetry.LoadbalancerNumResolutions.Add(context.Background(), 1, metric.WithAttributeSet(k8sResolverFailureAttrSet))
 			return
-
 		}
 	case *corev1.Endpoints:
 		ok, endpoints = convertToEndpoints(h.returnNames, object)
@@ -52,7 +51,6 @@ func (h handler) OnAdd(obj any, _ bool) {
 			h.telemetry.LoadbalancerNumResolutions.Add(context.Background(), 1, metric.WithAttributeSet(k8sResolverFailureAttrSet))
 			return
 		}
-
 	default: // unsupported
 		h.logger.Warn("Got an unexpected Kubernetes data type during the inclusion of a new pods for the service", zap.Any("obj", obj))
 		h.telemetry.LoadbalancerNumResolutions.Add(context.Background(), 1, metric.WithAttributeSet(k8sResolverFailureAttrSet))
@@ -71,6 +69,8 @@ func (h handler) OnAdd(obj any, _ bool) {
 
 func (h handler) OnUpdate(oldObj, newObj any) {
 	switch oldEps := oldObj.(type) {
+	case *discoveryv1.EndpointSlice:
+		// TODO
 	case *corev1.Endpoints:
 		newEps, ok := newObj.(*corev1.Endpoints)
 		if !ok {
@@ -125,6 +125,8 @@ func (h handler) OnDelete(obj any) {
 	case *cache.DeletedFinalStateUnknown:
 		h.OnDelete(object.Obj)
 		return
+	case *discoveryv1.EndpointSlice:
+		// TODO
 	case *corev1.Endpoints:
 		if object != nil {
 			ok, endpoints = convertToEndpoints(h.returnNames, object)

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -131,7 +131,7 @@ func TestK8sResolve(t *testing.T) {
 					Update(context.TODO(), updated, metav1.UpdateOptions{})
 				return err
 			},
-			verifyFn: func(ctx *suiteContext, args args) error {
+			verifyFn: func(ctx *suiteContext, _ args) error {
 				// Force resolver to re-resolve
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
 					return err

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/utils/ptr"
 )
 
 func TestK8sResolve(t *testing.T) {
@@ -27,43 +27,64 @@ func TestK8sResolve(t *testing.T) {
 		namespace       string
 		returnHostnames bool
 	}
+
 	type suiteContext struct {
-		endpoint  *corev1.Endpoints
-		clientset *fake.Clientset
-		resolver  *k8sResolver
+		endpointSlice *discoveryv1.EndpointSlice
+		clientset     *fake.Clientset
+		resolver      *k8sResolver
 	}
+
 	setupSuite := func(t *testing.T, args args) (*suiteContext, func(*testing.T)) {
 		service, defaultNs, ports, returnHostnames := args.service, args.namespace, args.ports, args.returnHostnames
-		endpoint := &corev1.Endpoints{
+
+		endpointSlice := &discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      service,
+				Name:      "lb-slice",
 				Namespace: defaultNs,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: args.service,
+				},
 			},
-			Subsets: []corev1.EndpointSubset{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
 				{
-					Addresses: []corev1.EndpointAddress{
-						{
-							Hostname: "pod-0",
-							IP:       "192.168.10.100",
-						},
-					},
+					Addresses: []string{"10.10.0.11"},
+					Hostname:  ptr.To("pod-0"),
+				},
+				{
+					Addresses: []string{"192.168.10.100"},
+					Hostname:  ptr.To("pod-1"),
+				},
+			},
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Name:     ptr.To("http"),
+					Port:     ptr.To(int32(8080)),
+					Protocol: ptr.To(corev1.ProtocolTCP),
+				},
+				{
+					Name:     ptr.To("other"),
+					Port:     ptr.To(int32(9090)),
+					Protocol: ptr.To(corev1.ProtocolTCP),
 				},
 			},
 		}
+
 		var expectInit []string
-		for _, subset := range endpoint.Subsets {
-			for _, address := range subset.Addresses {
-				for _, port := range args.ports {
-					if returnHostnames {
-						expectInit = append(expectInit, fmt.Sprintf("%s.%s.%s:%d", address.Hostname, service, defaultNs, port))
-					} else {
-						expectInit = append(expectInit, fmt.Sprintf("%s:%d", address.IP, port))
-					}
+		for _, ep := range endpointSlice.Endpoints {
+			for _, port := range endpointSlice.Ports {
+				if returnHostnames && ep.Hostname != nil {
+					expectInit = append(expectInit,
+						fmt.Sprintf("%s.%s.%s:%d", *ep.Hostname, service, defaultNs, *port.Port))
+				} else {
+					expectInit = append(expectInit,
+						fmt.Sprintf("%s:%d", ep.Addresses[0], *port.Port))
 				}
 			}
 		}
 
-		cl := fake.NewClientset(endpoint)
+		cl := fake.NewClientset(endpointSlice)
+
 		_, tb := getTelemetryAssets(t)
 		res, err := newK8sResolver(cl, zap.NewNop(), service, ports, defaultListWatchTimeout, returnHostnames, tb)
 		require.NoError(t, err)
@@ -74,13 +95,14 @@ func TestK8sResolve(t *testing.T) {
 		assert.Equal(t, expectInit, res.Endpoints())
 
 		return &suiteContext{
-				endpoint:  endpoint,
-				clientset: cl,
-				resolver:  res,
+				endpointSlice: endpointSlice,
+				clientset:     cl,
+				resolver:      res,
 			}, func(*testing.T) {
 				require.NoError(t, res.shutdown(context.Background()))
 			}
 	}
+
 	tests := []struct {
 		name       string
 		args       args
@@ -97,20 +119,20 @@ func TestK8sResolve(t *testing.T) {
 				ports:     []int32{8080, 9090},
 			},
 			simulateFn: func(suiteCtx *suiteContext, args args) error {
-				endpoint, exist := suiteCtx.endpoint.DeepCopy(), suiteCtx.endpoint.DeepCopy()
-				endpoint.Subsets = append(endpoint.Subsets, corev1.EndpointSubset{
-					Addresses: []corev1.EndpointAddress{{IP: "10.10.0.11"}},
+				// DeepCopy the existing EndpointSlice
+				updated := suiteCtx.endpointSlice.DeepCopy()
+				// Append a new Endpoint
+				updated.Endpoints = append(updated.Endpoints, discoveryv1.Endpoint{
+					Addresses: []string{"10.10.0.11"},
+					Hostname:  ptr.To("pod-1"),
 				})
-				patch := client.MergeFrom(exist)
-				data, err := patch.Data(endpoint)
-				if err != nil {
-					return err
-				}
-				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
-					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
+				// Update in fake client
+				_, err := suiteCtx.clientset.DiscoveryV1().EndpointSlices(args.namespace).
+					Update(context.TODO(), updated, metav1.UpdateOptions{})
 				return err
 			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
+			verifyFn: func(ctx *suiteContext, args args) error {
+				// Force resolver to re-resolve
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
 					return err
 				}
@@ -122,133 +144,6 @@ func TestK8sResolve(t *testing.T) {
 					"192.168.10.100:9090",
 				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
 
-				return nil
-			},
-		},
-		{
-			name: "simulate re-list that does not change endpoints",
-			args: args{
-				logger:    zap.NewNop(),
-				service:   "lb",
-				namespace: "default",
-				ports:     []int32{8080, 9090},
-			},
-			simulateFn: func(suiteCtx *suiteContext, args args) error {
-				exist := suiteCtx.endpoint.DeepCopy()
-				patch := client.MergeFrom(exist)
-				data, err := patch.Data(exist)
-				if err != nil {
-					return err
-				}
-				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
-					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
-				return err
-			},
-			onChangeFn: func([]string) {
-				assert.Fail(t, "should not call onChange")
-			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"192.168.10.100:8080",
-					"192.168.10.100:9090",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
-			},
-		},
-		{
-			name: "add new hostname to existing backends",
-			args: args{
-				logger:          zap.NewNop(),
-				service:         "lb",
-				namespace:       "default",
-				ports:           []int32{8080, 9090},
-				returnHostnames: true,
-			},
-			simulateFn: func(suiteCtx *suiteContext, args args) error {
-				endpoint, exist := suiteCtx.endpoint.DeepCopy(), suiteCtx.endpoint.DeepCopy()
-				endpoint.Subsets = append(endpoint.Subsets, corev1.EndpointSubset{
-					Addresses: []corev1.EndpointAddress{{IP: "10.10.0.11", Hostname: "pod-1"}},
-				})
-				patch := client.MergeFrom(exist)
-				data, err := patch.Data(endpoint)
-				if err != nil {
-					return err
-				}
-				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
-					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
-				return err
-			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"pod-0.lb.default:8080",
-					"pod-0.lb.default:9090",
-					"pod-1.lb.default:8080",
-					"pod-1.lb.default:9090",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
-			},
-		},
-		{
-			name: "change existing backend ip address",
-			args: args{
-				logger:    zap.NewNop(),
-				service:   "lb",
-				namespace: "default",
-				ports:     []int32{4317},
-			},
-			simulateFn: func(suiteCtx *suiteContext, args args) error {
-				endpoint, exist := suiteCtx.endpoint.DeepCopy(), suiteCtx.endpoint.DeepCopy()
-				endpoint.Subsets = []corev1.EndpointSubset{
-					{Addresses: []corev1.EndpointAddress{{IP: "10.10.0.11"}}},
-				}
-				patch := client.MergeFrom(exist)
-				data, err := patch.Data(endpoint)
-				if err != nil {
-					return err
-				}
-				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
-					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
-				return err
-			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"10.10.0.11:4317",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
-			},
-		},
-		{
-			name: "simulate deletion of backends",
-			args: args{
-				logger:    zap.NewNop(),
-				service:   "lb",
-				namespace: "default",
-				ports:     []int32{8080, 9090},
-			},
-			simulateFn: func(suiteCtx *suiteContext, args args) error {
-				return suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
-					Delete(context.TODO(), args.service, metav1.DeleteOptions{})
-			},
-			verifyFn: func(suiteCtx *suiteContext, _ args) error {
-				if _, err := suiteCtx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-				assert.Empty(t, suiteCtx.resolver.Endpoints(), "resolver failed, endpoints should empty")
 				return nil
 			},
 		},
@@ -271,73 +166,6 @@ func TestK8sResolve(t *testing.T) {
 				assert.NoError(t, err)
 				return true
 			}, time.Second, 20*time.Millisecond)
-		})
-	}
-}
-
-func Test_newK8sResolver(t *testing.T) {
-	type args struct {
-		logger  *zap.Logger
-		service string
-		ports   []int32
-	}
-	tests := []struct {
-		name          string
-		args          args
-		wantNil       bool
-		wantErr       error
-		wantService   string
-		wantNamespace string
-	}{
-		{
-			name: "invalid name of k8s service",
-			args: args{
-				logger:  zap.NewNop(),
-				service: "",
-				ports:   []int32{8080},
-			},
-			wantNil: true,
-			wantErr: errNoSvc,
-		},
-		{
-			name: "use `default` namespace if namespace is not specified",
-			args: args{
-				logger:  zap.NewNop(),
-				service: "lb",
-				ports:   []int32{8080},
-			},
-			wantNil:       false,
-			wantErr:       nil,
-			wantService:   "lb",
-			wantNamespace: "default",
-		},
-		{
-			name: "use specified namespace",
-			args: args{
-				logger:  zap.NewNop(),
-				service: "lb.kube-public",
-				ports:   []int32{8080},
-			},
-			wantNil:       false,
-			wantErr:       nil,
-			wantService:   "lb",
-			wantNamespace: "kube-public",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, tb := getTelemetryAssets(t)
-			got, err := newK8sResolver(fake.NewClientset(), tt.args.logger, tt.args.service, tt.args.ports, defaultListWatchTimeout, false, tb)
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.wantNil, got == nil)
-				if !tt.wantNil {
-					require.Equal(t, tt.wantService, got.svcName)
-					require.Equal(t, tt.wantNamespace, got.svcNs)
-				}
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR transitions the k8s resolver from `corev1.Endpoints` to `discoveryv1.EndpointSlices`. See https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/ for more info.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40871 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- [ ] unit tests (I removed a handful of test cases I intend to put back!)
- [ ] local testing in kind

<!--Describe the documentation added.-->
#### Documentation

TODO

<!--Please delete paragraphs that you did not use before submitting.-->
