### PR TITLE
[prometheusremotewritereceiver] drop summary and classic histograms

### DIFF
--- a/.chloggen/drop-summary-and-classic-hist.yaml
+++ b/.chloggen/drop-summary-and-classic-hist.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'prometheusremotewritereceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Drop summary and classic histogram series as we will not handle them.'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40975]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -340,26 +340,27 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		metric, exists := metricCache[metricKey]
 		// If the metric does not exist, we create an empty metric and add it to the cache.
 		if !exists {
-			metric = scope.Metrics().AppendEmpty()
-			metric.SetName(metricName)
-			metric.SetUnit(unit)
-			metric.SetDescription(description)
-
 			switch ts.Metadata.Type {
 			case writev2.Metadata_METRIC_TYPE_GAUGE:
+				metric = setMetric(scope, metricName, unit, description)
 				metric.SetEmptyGauge()
 			case writev2.Metadata_METRIC_TYPE_COUNTER:
+				metric = setMetric(scope, metricName, unit, description)
 				sum := metric.SetEmptySum()
 				sum.SetIsMonotonic(true)
 				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
 				// Histograms that comes with samples are considered as classic histograms and are not supported.
-				if len(ts.Samples) == 0 {
-					hist := metric.SetEmptyExponentialHistogram()
-					hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				if len(ts.Samples) != 0 {
+					// Drop classic histogram series as we will not handle them.
+					continue
 				}
+				metric = setMetric(scope, metricName, unit, description)
+				hist := metric.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			case writev2.Metadata_METRIC_TYPE_SUMMARY:
-				metric.SetEmptySummary()
+				// Drop summary series as we will not handle them.
+				continue
 			}
 
 			metricCache[metricKey] = metric
@@ -378,18 +379,29 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		case writev2.Metadata_METRIC_TYPE_COUNTER:
 			addNumberDatapoints(metric.Sum().DataPoints(), ls, ts, &stats)
 		case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
-			// Histograms that comes with samples are considered as classic histograms and are not supported.
-			if len(ts.Samples) == 0 {
-				addExponentialHistogramDatapoints(metric.ExponentialHistogram().DataPoints(), ls, ts, &stats)
+			if len(ts.Samples) != 0 {
+				// Drop classic histogram series as we will not handle them.
+				continue
 			}
+			addExponentialHistogramDatapoints(metric.ExponentialHistogram().DataPoints(), ls, ts, &stats)
 		case writev2.Metadata_METRIC_TYPE_SUMMARY:
-			addSummaryDatapoints(metric.Summary().DataPoints(), ls, ts)
+			// Drop summary series as we will not handle them.
+			continue
 		default:
 			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
 		}
 	}
 
 	return otelMetrics, stats, badRequestErrors
+}
+
+// setMetric append a new empty metric and assign the name, unit and description to it.
+func setMetric(scope pmetric.ScopeMetrics, metricName, unit, description string) pmetric.Metric {
+	metric := scope.Metrics().AppendEmpty()
+	metric.SetName(metricName)
+	metric.SetUnit(unit)
+	metric.SetDescription(description)
+	return metric
 }
 
 // parseJobAndInstance turns the job and instance labels service resource attributes.
@@ -423,10 +435,6 @@ func addNumberDatapoints(datapoints pmetric.NumberDataPointSlice, ls labels.Labe
 		extractAttributes(ls).CopyTo(attributes)
 	}
 	stats.Samples += len(ts.Samples)
-}
-
-func addSummaryDatapoints(_ pmetric.SummaryDataPointSlice, _ labels.Labels, _ writev2.TimeSeries) {
-	// TODO: Implement this function
 }
 
 func addExponentialHistogramDatapoints(datapoints pmetric.ExponentialHistogramDataPointSlice, ls labels.Labels, ts writev2.TimeSeries, stats *promremote.WriteResponseStats) {

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -970,10 +970,52 @@ func TestTranslateV2(t *testing.T) {
 				sm.Scope().SetName("scope1")
 				sm.Scope().SetVersion("v1")
 
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-				m.SetUnit("")
-				m.SetDescription("")
+				return metrics
+			}(),
+		},
+		{
+			name: "summary - should be dropped",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_SUMMARY,
+						},
+						Samples: []writev2.Sample{
+							{
+								Value:     1,
+								Timestamp: 1,
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 0,
+				Exemplars:  0,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
 
 				return metrics
 			}(),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

* Drop classic histograms
* Drop Summaries
* Setting metric attributes just for metric types that we will handle, this to avoid accessing nil vars

More about how we found this "bug" ⬇️

[Reference](https://cloud-native.slack.com/archives/CJFCJHG4Q/p1751045531132159)

<!--Please delete paragraphs that you did not use before submitting.-->
