### PR TITLE
receiver/prometheusremotewrite: Correctly handle metrics without type metadata

### DIFF
--- a/.chloggen/prwreceiver-unspecified-types.yaml
+++ b/.chloggen/prwreceiver-unspecified-types.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: receiver/prometheusremotewrite
+note: Handle metrics with unspecified types without panicking.
+issues: [41005]
+subtext:
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -361,6 +361,9 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			case writev2.Metadata_METRIC_TYPE_SUMMARY:
 				// Drop summary series as we will not handle them.
 				continue
+			default:
+				badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
+				continue
 			}
 
 			metricCache[metricKey] = metric

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -254,6 +254,26 @@ func TestTranslateV2(t *testing.T) {
 			expectError: "help ref 3 is out of bounds of symbolsTable",
 		},
 		{
+			name: "unsupported metric type UNSPECIFIED",
+			request: &writev2.Request{
+				Symbols: []string{"", "__name__", "test_metric", "job", "test_job", "instance", "test_instance"},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_UNSPECIFIED},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6},
+						Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+					},
+				},
+			},
+			expectError: `unsupported metric type "METRIC_TYPE_UNSPECIFIED" for metric "test_metric"`,
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  false,
+				Samples:    0,
+				Histograms: 0,
+				Exemplars:  0,
+			},
+		},
+		{
 			name:    "valid request",
 			request: writeV2RequestFixture,
 			expectedMetrics: func() pmetric.Metrics {


### PR DESCRIPTION
#### Description

While trying the component end-to-end, I've noticed we would hit nilpointer references almost immediately. While accessing this code path:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/57704cea35e430e3c5de76add038b99e06f79d73/receiver/prometheusremotewritereceiver/receiver.go#L371

`metric` was nil

The `metric` variable is generated in this code path:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/57704cea35e430e3c5de76add038b99e06f79d73/receiver/prometheusremotewritereceiver/receiver.go#L340-L367

Suppose it's present in the cache—perfect. It was already assigned from the start. If it was not present in the cache, we create it in the next if conditional, but only for the types we support! With this PR, we're now skipping all metrics without type metadata.