### PR TITLE
[receiver/receivercreator] Fix incorrect condition in filterConsumerSignals for traces filtering

### DIFF
--- a/.chloggen/fix-filter-consumer-signals.yaml
+++ b/.chloggen/fix-filter-consumer-signals.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receivercreator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+  "Fix incorrect condition in filterConsumerSignals function that prevented proper traces
+  consumer filtering"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41033]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The bug caused traces consumers to be incorrectly filtered when metrics were disabled,
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-filter-consumer-signals.yaml
+++ b/.chloggen/fix-filter-consumer-signals.yaml
@@ -7,9 +7,7 @@ change_type: bug_fix
 component: receivercreator
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
-  "Fix incorrect condition in filterConsumerSignals function that prevented proper traces
-  consumer filtering"
+note: Fix incorrect traces consumer filtering in filterConsumerSignals function
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [41033]
@@ -18,7 +16,7 @@ issues: [41033]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The bug caused traces consumers to be incorrectly filtered when metrics were disabled,
+  The bug caused traces consumers to be incorrectly filtered when metrics were disabled.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -232,7 +232,7 @@ func filterConsumerSignals(consumer *enhancingConsumer, signals receiverSignals)
 	if !signals.logs {
 		consumer.logs = nil
 	}
-	if !signals.metrics {
+	if !signals.traces {
 		consumer.traces = nil
 	}
 }

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -518,6 +518,36 @@ func TestOnRemoveForLogs(t *testing.T) {
 	require.NoError(t, r.lastError)
 }
 
+func TestOnRemoveForTraces(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	rcvrCfg := receiverConfig{
+		id:         component.MustNewIDWithName("with_endpoint", "some.name"),
+		config:     userConfigMap{"endpoint": "some.endpoint"},
+		endpointID: portEndpoint.ID,
+	}
+	cfg.receiverTemplates = map[string]receiverTemplate{
+		rcvrCfg.id.String(): {
+			receiverConfig:     rcvrCfg,
+			rule:               portRule,
+			Rule:               `type == "port"`,
+			ResourceAttributes: map[string]any{},
+			signals:            receiverSignals{metrics: true, logs: true, traces: true},
+		},
+	}
+	handler, r := newObserverHandler(t, cfg, nil, nil, consumertest.NewNop())
+	handler.OnAdd([]observer.Endpoint{portEndpoint})
+
+	rcvr := r.startedComponent
+	require.NotNil(t, rcvr)
+	require.NoError(t, r.lastError)
+
+	handler.OnRemove([]observer.Endpoint{portEndpoint})
+
+	assert.Equal(t, 0, handler.receiversByEndpointID.Size())
+	require.Same(t, rcvr, r.shutdownComponent)
+	require.NoError(t, r.lastError)
+}
+
 func TestOnChange(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fix logic bug in `filterConsumerSignals` function where `!signals.metrics` condition was incorrectly used twice instead of checking `!signals.traces` for traces consumer filtering.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41033 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

  - Added missing `TestOnRemoveForTraces` test for complete test coverage
  - All existing tests in `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator` pass

<!--Describe the documentation added.-->
#### Documentation

No documentation changes required.

<!--Please delete paragraphs that you did not use before submitting.-->
