### PR TITLE
[processor/geoip] Align with semconv resource attributes

### DIFF
--- a/.chloggen/geoip_semconv_attributes.yaml
+++ b/.chloggen/geoip_semconv_attributes.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: geoipprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use semantic convention Geo attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34745]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Replace `geo.continent_code`, `geo.country_iso_code`, `geo.region_iso_code`
+  with semantic conventions `geo.continent.code`, `geo.country.iso_code`, `geo.region.iso_code`
+  attributes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/geoipprocessor/README.md
+++ b/processor/geoipprocessor/README.md
@@ -23,16 +23,16 @@ The following [resource attributes](./internal/convention/attributes.go) will be
 
 ```
   * geo.city_name
-  * geo.postal_code
+  * [geo.postal_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L71)
   * geo.country_name
-  * geo.country_iso_code
+  * [geo.country.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L53)
   * geo.continent_name
-  * geo.continent_code
+  * [geo.continent.code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L19)
   * geo.region_name
-  * geo.region_iso_code
+  * [geo.region.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L78)
   * geo.timezone
-  * geo.location.lat
-  * geo.location.lon
+  * [geo.location.lat](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L65)
+  * [geo.location.lon](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L59)
 ```
 
 ## Configuration

--- a/processor/geoipprocessor/README.md
+++ b/processor/geoipprocessor/README.md
@@ -21,19 +21,17 @@ The geoIP processor `geoipprocessor` enhances the attributes of a span, log, or 
 
 The following [resource attributes](./internal/convention/attributes.go) will be added if the corresponding information is found:
 
-```
-  * geo.city_name
-  * [geo.postal_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L71)
-  * geo.country_name
-  * [geo.country.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L53)
-  * geo.continent_name
-  * [geo.continent.code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L19)
-  * geo.region_name
-  * [geo.region.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L78)
-  * geo.timezone
-  * [geo.location.lat](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L65)
-  * [geo.location.lon](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L59)
-```
+  - geo.city_name
+  - [geo.postal_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L71)
+  - geo.country_name
+  - [geo.country.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L53)
+  - geo.continent_name
+  - [geo.continent.code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L19)
+  - geo.region_name
+  - [geo.region.iso_code](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L78)
+  - geo.timezone
+  - [geo.location.lat](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L65)
+  - [geo.location.lon](https://github.com/open-telemetry/semantic-conventions/blob/v1.34.0/model/geo/registry.yaml#L59)
 
 ## Configuration
 

--- a/processor/geoipprocessor/internal/convention/attributes.go
+++ b/processor/geoipprocessor/internal/convention/attributes.go
@@ -3,38 +3,39 @@
 
 package conventions // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor/internal/convention"
 
-// TODO: replace for semconv once https://github.com/open-telemetry/semantic-conventions/issues/1033 is closed.
+import semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+
 const (
 	// AttributeGeoCityName represents the attribute name for the city name in geographical data.
 	AttributeGeoCityName = "geo.city_name"
 
 	// AttributeGeoPostalCode represents the attribute name for the city postal code.
-	AttributeGeoPostalCode = "geo.postal_code"
+	AttributeGeoPostalCode = string(semconv.GeoPostalCodeKey)
 
 	// AttributeGeoCountryName represents the attribute name for the country name in geographical data.
 	AttributeGeoCountryName = "geo.country_name"
 
 	// AttributeGeoCountryIsoCode represents the attribute name for the Two-letter ISO Country Code.
-	AttributeGeoCountryIsoCode = "geo.country_iso_code"
+	AttributeGeoCountryIsoCode = string(semconv.GeoCountryISOCodeKey)
 
 	// AttributeGeoContinentName represents the attribute name for the continent name in geographical data.
 	AttributeGeoContinentName = "geo.continent_name"
 
 	// AttributeGeoContinentIsoCode represents the attribute name for the Two-letter Continent Code.
-	AttributeGeoContinentCode = "geo.continent_code"
+	AttributeGeoContinentCode = string(semconv.GeoContinentCodeKey)
 
 	// AttributeGeoRegionName represents the attribute name for the region name in geographical data.
 	AttributeGeoRegionName = "geo.region_name"
 
 	// AttributeGeoRegionIsoCode represents the attribute name for the Two-letter ISO Region Code.
-	AttributeGeoRegionIsoCode = "geo.region_iso_code"
+	AttributeGeoRegionIsoCode = string(semconv.GeoRegionISOCodeKey)
 
 	// AttributeGeoTimezone represents the attribute name for the timezone.
 	AttributeGeoTimezone = "geo.timezone"
 
 	// AttributeGeoLocationLat represents the attribute name for the latitude.
-	AttributeGeoLocationLat = "geo.location.lat"
+	AttributeGeoLocationLat = string(semconv.GeoLocationLatKey)
 
 	// AttributeGeoLocationLon represents the attribute name for the longitude.
-	AttributeGeoLocationLon = "geo.location.lon"
+	AttributeGeoLocationLon = string(semconv.GeoLocationLonKey)
 )

--- a/processor/geoipprocessor/testdata/record_client_address/output-logs.yaml
+++ b/processor/geoipprocessor/testdata/record_client_address/output-logs.yaml
@@ -19,13 +19,13 @@ resourceLogs:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -40,7 +40,7 @@ resourceLogs:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_client_address/output-metrics.yaml
+++ b/processor/geoipprocessor/testdata/record_client_address/output-metrics.yaml
@@ -17,16 +17,19 @@ resourceMetrics:
                     - key: a
                       value:
                         stringValue: AAAA
+                    - key: client.address
+                      value:
+                        stringValue: 1.2.3.4
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -41,7 +44,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -50,24 +53,24 @@ resourceMetrics:
                     - key: geo.timezone
                       value:
                         stringValue: Europe/London
-                    - key: client.address
-                      value:
-                        stringValue: 1.2.3.4
             unit: "1"
           - histogram:
               aggregationTemporality: 1
               dataPoints:
                 - attributes:
+                    - key: client.address
+                      value:
+                        stringValue: 1.2.3.4
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -82,7 +85,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -91,9 +94,6 @@ resourceMetrics:
                     - key: geo.timezone
                       value:
                         stringValue: Europe/London
-                    - key: client.address
-                      value:
-                        stringValue: 1.2.3.4
                   bucketCounts:
                     - "9"
                     - "12"
@@ -112,16 +112,19 @@ resourceMetrics:
             summary:
               dataPoints:
                 - attributes:
+                    - key: client.address
+                      value:
+                        stringValue: 1.2.3.4
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -136,7 +139,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -145,9 +148,6 @@ resourceMetrics:
                     - key: geo.timezone
                       value:
                         stringValue: Europe/London
-                    - key: client.address
-                      value:
-                        stringValue: 1.2.3.4
                   quantileValues:
                     - quantile: 0.25
                       value: 50
@@ -165,16 +165,19 @@ resourceMetrics:
                     - key: aaa
                       value:
                         stringValue: bbb
+                    - key: client.address
+                      value:
+                        stringValue: 1.2.3.4
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -189,7 +192,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -198,9 +201,6 @@ resourceMetrics:
                     - key: geo.timezone
                       value:
                         stringValue: Europe/London
-                    - key: client.address
-                      value:
-                        stringValue: 1.2.3.4
                   timeUnixNano: "1000000"
             name: test.gauge
         schemaUrl: https://test-scope-schema.com/schema

--- a/processor/geoipprocessor/testdata/record_client_address/output-traces.yaml
+++ b/processor/geoipprocessor/testdata/record_client_address/output-traces.yaml
@@ -22,13 +22,13 @@ resourceSpans:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -43,7 +43,7 @@ resourceSpans:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_custom_address/output-logs.yaml
+++ b/processor/geoipprocessor/testdata/record_custom_address/output-logs.yaml
@@ -19,13 +19,13 @@ resourceLogs:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -40,7 +40,7 @@ resourceLogs:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_custom_address/output-metrics.yaml
+++ b/processor/geoipprocessor/testdata/record_custom_address/output-metrics.yaml
@@ -11,22 +11,22 @@ resourceMetrics:
               dataPoints:
                 - asDouble: 345
                   attributes:
-                    - key: custom.address
-                      value:
-                        stringValue: 1.2.3.4
                     - key: aaa
                       value:
                         stringValue: bbb
+                    - key: custom.address
+                      value:
+                        stringValue: 1.2.3.4
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -41,7 +41,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_custom_address/output-traces.yaml
+++ b/processor/geoipprocessor/testdata/record_custom_address/output-traces.yaml
@@ -23,13 +23,13 @@ resourceSpans:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -44,7 +44,7 @@ resourceSpans:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_source_address/output-logs.yaml
+++ b/processor/geoipprocessor/testdata/record_source_address/output-logs.yaml
@@ -19,13 +19,13 @@ resourceLogs:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -40,7 +40,7 @@ resourceLogs:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_source_address/output-metrics.yaml
+++ b/processor/geoipprocessor/testdata/record_source_address/output-metrics.yaml
@@ -20,13 +20,13 @@ resourceMetrics:
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -41,7 +41,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -61,13 +61,13 @@ resourceMetrics:
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -82,7 +82,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -115,13 +115,13 @@ resourceMetrics:
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -136,7 +136,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name
@@ -168,13 +168,13 @@ resourceMetrics:
                     - key: geo.city_name
                       value:
                         stringValue: Boxford
-                    - key: geo.continent_code
+                    - key: geo.continent.code
                       value:
                         stringValue: EU
                     - key: geo.continent_name
                       value:
                         stringValue: Europe
-                    - key: geo.country_iso_code
+                    - key: geo.country.iso_code
                       value:
                         stringValue: GB
                     - key: geo.country_name
@@ -189,7 +189,7 @@ resourceMetrics:
                     - key: geo.postal_code
                       value:
                         stringValue: OX1
-                    - key: geo.region_iso_code
+                    - key: geo.region.iso_code
                       value:
                         stringValue: WBK
                     - key: geo.region_name

--- a/processor/geoipprocessor/testdata/record_source_address/output-traces.yaml
+++ b/processor/geoipprocessor/testdata/record_source_address/output-traces.yaml
@@ -22,13 +22,13 @@ resourceSpans:
               - key: geo.city_name
                 value:
                   stringValue: Boxford
-              - key: geo.continent_code
+              - key: geo.continent.code
                 value:
                   stringValue: EU
               - key: geo.continent_name
                 value:
                   stringValue: Europe
-              - key: geo.country_iso_code
+              - key: geo.country.iso_code
                 value:
                   stringValue: GB
               - key: geo.country_name
@@ -43,7 +43,7 @@ resourceSpans:
               - key: geo.postal_code
                 value:
                   stringValue: OX1
-              - key: geo.region_iso_code
+              - key: geo.region.iso_code
                 value:
                   stringValue: WBK
               - key: geo.region_name

--- a/processor/geoipprocessor/testdata/resource_source_address/output-logs.yaml
+++ b/processor/geoipprocessor/testdata/resource_source_address/output-logs.yaml
@@ -10,13 +10,13 @@ resourceLogs:
         - key: geo.city_name
           value:
             stringValue: Boxford
-        - key: geo.continent_code
+        - key: geo.continent.code
           value:
             stringValue: EU
         - key: geo.continent_name
           value:
             stringValue: Europe
-        - key: geo.country_iso_code
+        - key: geo.country.iso_code
           value:
             stringValue: GB
         - key: geo.country_name
@@ -31,7 +31,7 @@ resourceLogs:
         - key: geo.postal_code
           value:
             stringValue: OX1
-        - key: geo.region_iso_code
+        - key: geo.region.iso_code
           value:
             stringValue: WBK
         - key: geo.region_name

--- a/processor/geoipprocessor/testdata/resource_source_address/output-metrics.yaml
+++ b/processor/geoipprocessor/testdata/resource_source_address/output-metrics.yaml
@@ -4,13 +4,13 @@ resourceMetrics:
         - key: geo.city_name
           value:
             stringValue: Boxford
-        - key: geo.continent_code
+        - key: geo.continent.code
           value:
             stringValue: EU
         - key: geo.continent_name
           value:
             stringValue: Europe
-        - key: geo.country_iso_code
+        - key: geo.country.iso_code
           value:
             stringValue: GB
         - key: geo.country_name
@@ -25,7 +25,7 @@ resourceMetrics:
         - key: geo.postal_code
           value:
             stringValue: OX1
-        - key: geo.region_iso_code
+        - key: geo.region.iso_code
           value:
             stringValue: WBK
         - key: geo.region_name

--- a/processor/geoipprocessor/testdata/resource_source_address/output-traces.yaml
+++ b/processor/geoipprocessor/testdata/resource_source_address/output-traces.yaml
@@ -10,13 +10,13 @@ resourceSpans:
         - key: geo.city_name
           value:
             stringValue: Boxford
-        - key: geo.continent_code
+        - key: geo.continent.code
           value:
             stringValue: EU
         - key: geo.continent_name
           value:
             stringValue: Europe
-        - key: geo.country_iso_code
+        - key: geo.country.iso_code
           value:
             stringValue: GB
         - key: geo.country_name
@@ -31,7 +31,7 @@ resourceSpans:
         - key: geo.postal_code
           value:
             stringValue: OX1
-        - key: geo.region_iso_code
+        - key: geo.region.iso_code
           value:
             stringValue: WBK
         - key: geo.region_name


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR changes the resource attributes keys added by the processor with the ones matching in Semantic Conventions. There are three breaking changes in terms of the resource attribute key names: `geo.continent.code`, `geo.country.iso_code` and `geo.region.iso_code`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34745

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
