### PR TITLE
add start_time_metric strategy to the metricstarttime processor

### DIFF
--- a/.chloggen/metricstarttime-starttimemetric.yaml
+++ b/.chloggen/metricstarttime-starttimemetric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the start_time_metric, which sets the start time based on another metric in the batch of metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38383]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/processor/metricstarttimeprocessor/README.md
+++ b/processor/metricstarttimeprocessor/README.md
@@ -69,3 +69,34 @@ Cons:
 
 * The absolute value of counters is modified. This is generally not an issue, since counters are usually used to compute rates.
 * The initial point is dropped, which loses information.
+
+### Strategy: Start Time Metric
+
+The `start_time_metric` strategy handles missing start times by looking for the
+`process_start_time` metric, which is commonly supported by Prometheus exporters.
+If found, it uses the value of the `process_start_time` metric as the start time
+for all other cumulative points in the batch of metrics.
+
+Use the `start_time_metric_regex` configuration option to change the name of the
+metric used for the start time.
+
+If the start time metric is not found, it falls back to the time at which the
+collector started.
+
+This strategy should only be used in limited circumstances:
+
+* When your application has a metric with the start time in Unix nanoseconds,
+  such as `process_start_time`.
+* The metricstarttime processor is used _before_ any batching, so that the
+  batch of metrics all originate from a single application.
+* This strategy can be used when the collector is run as a sidecar to the
+  application, where the collector's start time is a good approximation of the
+  application's start time.
+
+Cons:
+
+* If the collector's start time is used as a fallback and the collector
+  restarts, it can produce rates that are incorrect and higher than expected.
+* The process' start time isn't the time at which individual instruments or
+  timeseries are initialized. It may result in lower rates if the first
+  observation is significantly later than the process' start time.

--- a/processor/metricstarttimeprocessor/config.go
+++ b/processor/metricstarttimeprocessor/config.go
@@ -6,18 +6,21 @@ package metricstarttimeprocessor // import "github.com/open-telemetry/openteleme
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/starttimemetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
 
 // Config holds configuration of the metric start time processor.
 type Config struct {
-	Strategy   string        `mapstructure:"strategy"`
-	GCInterval time.Duration `mapstructure:"gc_interval"`
+	Strategy             string        `mapstructure:"strategy"`
+	GCInterval           time.Duration `mapstructure:"gc_interval"`
+	StartTimeMetricRegex string        `mapstructure:"start_time_metric_regex"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -34,11 +37,17 @@ func (cfg *Config) Validate() error {
 	switch cfg.Strategy {
 	case truereset.Type:
 	case subtractinitial.Type:
+	case starttimemetric.Type:
 	default:
 		return fmt.Errorf("%q is not a valid strategy", cfg.Strategy)
 	}
 	if cfg.GCInterval <= 0 {
 		return errors.New("gc_interval must be positive")
+	}
+	if cfg.StartTimeMetricRegex != "" {
+		if _, err := regexp.Compile(cfg.StartTimeMetricRegex); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/processor/metricstarttimeprocessor/config.go
+++ b/processor/metricstarttimeprocessor/config.go
@@ -18,9 +18,10 @@ import (
 
 // Config holds configuration of the metric start time processor.
 type Config struct {
-	Strategy             string        `mapstructure:"strategy"`
-	GCInterval           time.Duration `mapstructure:"gc_interval"`
-	StartTimeMetricRegex string        `mapstructure:"start_time_metric_regex"`
+	Strategy   string        `mapstructure:"strategy"`
+	GCInterval time.Duration `mapstructure:"gc_interval"`
+	// StartTimeMetricRegex only applies then the start_time_metric strategy is used
+	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -47,6 +48,9 @@ func (cfg *Config) Validate() error {
 	if cfg.StartTimeMetricRegex != "" {
 		if _, err := regexp.Compile(cfg.StartTimeMetricRegex); err != nil {
 			return err
+		}
+		if cfg.Strategy != starttimemetric.Type {
+			return errors.New("start_time_metric_regex can only be used with the start_time_metric strategy")
 		}
 	}
 	return nil

--- a/processor/metricstarttimeprocessor/config_test.go
+++ b/processor/metricstarttimeprocessor/config_test.go
@@ -76,6 +76,10 @@ func TestLoadConfig(t *testing.T) {
 			id:           component.NewIDWithName(metadata.Type, "invalid_regex"),
 			errorMessage: "error parsing regexp: missing closing ): `((((`",
 		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "regex_with_subtract_initial_point"),
+			errorMessage: "start_time_metric_regex can only be used with the start_time_metric strategy",
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/metricstarttimeprocessor/config_test.go
+++ b/processor/metricstarttimeprocessor/config_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/starttimemetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
@@ -55,6 +56,25 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_strategy"),
 			errorMessage: "\"bad\" is not a valid strategy",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "true_reset_point"),
+			expected: &Config{
+				Strategy:   truereset.Type,
+				GCInterval: 10 * time.Minute,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "start_time_metric"),
+			expected: &Config{
+				Strategy:             starttimemetric.Type,
+				GCInterval:           10 * time.Minute,
+				StartTimeMetricRegex: "^.+_process_start_time_seconds$",
+			},
+		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "invalid_regex"),
+			errorMessage: "error parsing regexp: missing closing ): `((((`",
 		},
 	}
 

--- a/processor/metricstarttimeprocessor/factory.go
+++ b/processor/metricstarttimeprocessor/factory.go
@@ -5,6 +5,7 @@ package metricstarttimeprocessor // import "github.com/open-telemetry/openteleme
 
 import (
 	"context"
+	"regexp"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -12,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/starttimemetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/subtractinitial"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/truereset"
 )
@@ -41,6 +43,17 @@ func createMetricsProcessor(
 		adjustMetrics = adjuster.AdjustMetrics
 	case subtractinitial.Type:
 		adjuster := subtractinitial.NewAdjuster(set.TelemetrySettings, rCfg.GCInterval)
+		adjustMetrics = adjuster.AdjustMetrics
+	case starttimemetric.Type:
+		var startTimeMetricRegex *regexp.Regexp
+		var err error
+		if rCfg.StartTimeMetricRegex != "" {
+			startTimeMetricRegex, err = regexp.Compile(rCfg.StartTimeMetricRegex)
+			if err != nil {
+				return nil, err
+			}
+		}
+		adjuster := starttimemetric.NewAdjuster(set.TelemetrySettings, startTimeMetricRegex)
 		adjustMetrics = adjuster.AdjustMetrics
 	}
 

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
@@ -1,0 +1,158 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package starttimemetric // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/starttimemetric"
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+)
+
+const (
+	// Type is the value users can use to configure the start time metric adjuster.
+	Type                = "start_time_metric"
+	startTimeMetricName = "process_start_time_seconds"
+)
+
+var (
+	errNoStartTimeMetrics             = errors.New("start_time metric is missing")
+	errNoDataPointsStartTimeMetric    = errors.New("start time metric with no data points")
+	errUnsupportedTypeStartTimeMetric = errors.New("unsupported data type for start time metric")
+	// approximateCollectorStartTime is the approximate start time of the
+	// collector. Used as a fallback start time for metrics that don't have a
+	// start time set (when the
+	// receiver.prometheusreceiver.UseCollectorStartTimeFallback feature gate is
+	// enabled).  Set when the component is initialized.
+	approximateCollectorStartTime time.Time
+)
+
+func init() {
+	approximateCollectorStartTime = time.Now()
+}
+
+type Adjuster struct {
+	startTimeMetricRegex *regexp.Regexp
+	set                  component.TelemetrySettings
+}
+
+// NewAdjuster returns a new Adjuster which adjust metrics' start times based on the initial received points.
+func NewAdjuster(set component.TelemetrySettings, startTimeMetricRegex *regexp.Regexp) *Adjuster {
+	return &Adjuster{
+		set:                  set,
+		startTimeMetricRegex: startTimeMetricRegex,
+	}
+}
+
+// AdjustMetrics adjusts the start time of metrics based on a different metric in the batch.
+func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pmetric.Metrics, error) {
+	startTime, err := a.getStartTime(metrics)
+	if err != nil {
+		a.set.Logger.Debug("Couldn't get start time for metrics. Using fallback start time.", zap.Error(err), zap.Time("fallback_start_time", approximateCollectorStartTime))
+		startTime = float64(approximateCollectorStartTime.Unix())
+	}
+
+	startTimeTs := timestampFromFloat64(startTime)
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			ilm := rm.ScopeMetrics().At(j)
+			for k := 0; k < ilm.Metrics().Len(); k++ {
+				metric := ilm.Metrics().At(k)
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					continue
+
+				case pmetric.MetricTypeSum:
+					dataPoints := metric.Sum().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeSummary:
+					dataPoints := metric.Summary().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeHistogram:
+					dataPoints := metric.Histogram().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeExponentialHistogram:
+					dataPoints := metric.ExponentialHistogram().DataPoints()
+					for l := 0; l < dataPoints.Len(); l++ {
+						dp := dataPoints.At(l)
+						dp.SetStartTimestamp(startTimeTs)
+					}
+
+				case pmetric.MetricTypeEmpty:
+					fallthrough
+
+				default:
+					a.set.Logger.Warn("Unknown metric type", zap.String("type", metric.Type().String()))
+				}
+			}
+		}
+	}
+	// TODO: handle resets by factoring reset handling out of other strategies
+	return metrics, nil
+}
+
+func timestampFromFloat64(ts float64) pcommon.Timestamp {
+	secs := int64(ts)
+	nanos := int64((ts - float64(secs)) * 1e9)
+	return pcommon.Timestamp(secs*1e9 + nanos)
+}
+
+func (a *Adjuster) getStartTime(metrics pmetric.Metrics) (float64, error) {
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			ilm := rm.ScopeMetrics().At(j)
+			for k := 0; k < ilm.Metrics().Len(); k++ {
+				metric := ilm.Metrics().At(k)
+				if a.matchStartTimeMetric(metric.Name()) {
+					switch metric.Type() {
+					case pmetric.MetricTypeGauge:
+						if metric.Gauge().DataPoints().Len() == 0 {
+							return 0.0, errNoDataPointsStartTimeMetric
+						}
+						return metric.Gauge().DataPoints().At(0).DoubleValue(), nil
+
+					case pmetric.MetricTypeSum:
+						if metric.Sum().DataPoints().Len() == 0 {
+							return 0.0, errNoDataPointsStartTimeMetric
+						}
+						return metric.Sum().DataPoints().At(0).DoubleValue(), nil
+
+					case pmetric.MetricTypeEmpty, pmetric.MetricTypeHistogram, pmetric.MetricTypeExponentialHistogram, pmetric.MetricTypeSummary:
+						fallthrough
+					default:
+						return 0, errUnsupportedTypeStartTimeMetric
+					}
+				}
+			}
+		}
+	}
+	return 0.0, errNoStartTimeMetrics
+}
+
+func (a *Adjuster) matchStartTimeMetric(metricName string) bool {
+	if a.startTimeMetricRegex != nil {
+		return a.startTimeMetricRegex.MatchString(metricName)
+	}
+
+	return metricName == startTimeMetricName
+}

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
@@ -26,10 +26,8 @@ var (
 	errNoDataPointsStartTimeMetric    = errors.New("start time metric with no data points")
 	errUnsupportedTypeStartTimeMetric = errors.New("unsupported data type for start time metric")
 	// approximateCollectorStartTime is the approximate start time of the
-	// collector. Used as a fallback start time for metrics that don't have a
-	// start time set (when the
-	// receiver.prometheusreceiver.UseCollectorStartTimeFallback feature gate is
-	// enabled).  Set when the component is initialized.
+	// collector. Used as a fallback start time for metrics when the start time
+	// metric is not found. Set when the component is initialized.
 	approximateCollectorStartTime time.Time
 )
 

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
@@ -1,0 +1,259 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package starttimemetric
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/testhelper"
+)
+
+func TestStartTimeMetricMatch(t *testing.T) {
+	const startTime = pcommon.Timestamp(123 * 1e9)
+	const currentTime = pcommon.Timestamp(126 * 1e9)
+	const collectorStartTime = pcommon.Timestamp(129 * 1e9)
+	const matchBuilderStartTime = 124
+
+	tests := []struct {
+		name                 string
+		inputs               pmetric.Metrics
+		startTimeMetricRegex *regexp.Regexp
+		expectedStartTime    pcommon.Timestamp
+	}{
+		{
+			name: "regexp_match_sum_metric",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
+				testhelper.ExponentialHistogramMetric("test_exponential_histogram_metric", testhelper.ExponentialHistogramPointSimplified(nil, startTime, currentTime, 3, 1, -5, 3)),
+			),
+			startTimeMetricRegex: regexp.MustCompile("^.*_process_start_time_seconds$"),
+			expectedStartTime:    timestampFromFloat64(matchBuilderStartTime),
+		},
+		{
+			name: "match_default_sum_start_time_metric",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
+				testhelper.ExponentialHistogramMetric("test_exponential_histogram_metric", testhelper.ExponentialHistogramPointSimplified(nil, startTime, currentTime, 3, 1, -5, 3)),
+			),
+			expectedStartTime: timestampFromFloat64(matchBuilderStartTime + 1),
+		},
+		{
+			name: "regexp_match_gauge_metric",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.GaugeMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
+			),
+			startTimeMetricRegex: regexp.MustCompile("^.*_process_start_time_seconds$"),
+			expectedStartTime:    timestampFromFloat64(matchBuilderStartTime),
+		},
+		{
+			name: "match_default_gauge_start_time_metric",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.GaugeMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
+			),
+			expectedStartTime: timestampFromFloat64(matchBuilderStartTime + 1),
+		},
+		{
+			name: "empty gauge start time metrics",
+			inputs: testhelper.Metrics(
+				testhelper.GaugeMetric("process_start_time_seconds"),
+			),
+			expectedStartTime: collectorStartTime,
+		},
+		{
+			name: "empty sum start time metrics",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("process_start_time_seconds"),
+			),
+			expectedStartTime: collectorStartTime,
+		},
+		{
+			name: "unsupported type start time metric",
+			inputs: testhelper.Metrics(
+				testhelper.HistogramMetric("process_start_time_seconds"),
+			),
+			expectedStartTime: collectorStartTime,
+		},
+		{
+			name: "regexp_nomatch",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("subprocess_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+			),
+			startTimeMetricRegex: regexp.MustCompile("^.+_process_start_time_seconds$"),
+			expectedStartTime:    collectorStartTime,
+		},
+		{
+			name: "nomatch_default_start_time_metric",
+			inputs: testhelper.Metrics(
+				testhelper.GaugeMetric("subprocess_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+			),
+			expectedStartTime: collectorStartTime,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// To test that the adjuster is using the fallback correctly, override the fallback time to use
+			// directly.
+			approximateCollectorStartTime = collectorStartTime.AsTime()
+
+			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex)
+
+			// We need to make sure the job and instance labels are set before the adjuster is used.
+			pmetrics := tt.inputs
+			pmetrics.ResourceMetrics().At(0).Resource().Attributes().PutStr(string(semconv.ServiceInstanceIDKey), "0")
+			pmetrics.ResourceMetrics().At(0).Resource().Attributes().PutStr(string(semconv.ServiceNameKey), "job")
+			_, err := stma.AdjustMetrics(context.Background(), tt.inputs)
+			assert.NoError(t, err)
+			for i := 0; i < tt.inputs.ResourceMetrics().Len(); i++ {
+				rm := tt.inputs.ResourceMetrics().At(i)
+				for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+					ilm := rm.ScopeMetrics().At(j)
+					for k := 0; k < ilm.Metrics().Len(); k++ {
+						metric := ilm.Metrics().At(k)
+						switch metric.Type() {
+						case pmetric.MetricTypeSum:
+							dps := metric.Sum().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeSummary:
+							dps := metric.Summary().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeHistogram:
+							dps := metric.Histogram().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeExponentialHistogram:
+							dps := metric.ExponentialHistogram().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeEmpty, pmetric.MetricTypeGauge:
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStartTimeMetricFallback(t *testing.T) {
+	const startTime = pcommon.Timestamp(123 * 1e9)
+	const currentTime = pcommon.Timestamp(126 * 1e9)
+	mockStartTime := time.Now().Add(-10 * time.Hour)
+	mockStartTimeSeconds := float64(mockStartTime.Unix())
+	processStartTime := mockStartTime.Add(-10 * time.Hour)
+	processStartTimeSeconds := float64(processStartTime.Unix())
+
+	tests := []struct {
+		name                 string
+		inputs               pmetric.Metrics
+		startTimeMetricRegex *regexp.Regexp
+		expectedStartTime    pcommon.Timestamp
+	}{
+		{
+			name: "regexp_match_metric_no_fallback",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, processStartTimeSeconds)),
+				testhelper.SumMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, processStartTimeSeconds)),
+				testhelper.ExponentialHistogramMetric("test_exponential_histogram_metric", testhelper.ExponentialHistogramPointSimplified(nil, startTime, currentTime, 3, 1, -5, 3)),
+			),
+			startTimeMetricRegex: regexp.MustCompile("^.*_process_start_time_seconds$"),
+			expectedStartTime:    timestampFromFloat64(processStartTimeSeconds),
+		},
+		{
+			name: "regexp_no_regex_match_metric_fallback",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+			),
+			startTimeMetricRegex: regexp.MustCompile("^.*_process_start_time_seconds$"),
+			expectedStartTime:    timestampFromFloat64(mockStartTimeSeconds),
+		},
+		{
+			name: "match_no_match_metric_fallback",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, startTime, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, startTime, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, startTime, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+			),
+			expectedStartTime: timestampFromFloat64(mockStartTimeSeconds),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex)
+
+			// To test that the adjuster is using the fallback correctly, override the fallback time to use
+			// directly.
+			approximateCollectorStartTime = mockStartTime
+
+			// We need to make sure the job and instance labels are set before the adjuster is used.
+			pmetrics := tt.inputs
+			pmetrics.ResourceMetrics().At(0).Resource().Attributes().PutStr(string(semconv.ServiceInstanceIDKey), "0")
+			pmetrics.ResourceMetrics().At(0).Resource().Attributes().PutStr(string(semconv.ServiceNameKey), "job")
+			_, err := stma.AdjustMetrics(context.Background(), tt.inputs)
+			assert.NoError(t, err, tt.inputs)
+			for i := 0; i < tt.inputs.ResourceMetrics().Len(); i++ {
+				rm := tt.inputs.ResourceMetrics().At(i)
+				for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+					ilm := rm.ScopeMetrics().At(j)
+					for k := 0; k < ilm.Metrics().Len(); k++ {
+						metric := ilm.Metrics().At(k)
+						switch metric.Type() {
+						case pmetric.MetricTypeSum:
+							dps := metric.Sum().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeSummary:
+							dps := metric.Summary().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						case pmetric.MetricTypeHistogram:
+							dps := metric.Histogram().DataPoints()
+							for l := 0; l < dps.Len(); l++ {
+								assert.Equal(t, tt.expectedStartTime, dps.At(l).StartTimestamp())
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/processor/metricstarttimeprocessor/internal/testhelper/util.go
+++ b/processor/metricstarttimeprocessor/internal/testhelper/util.go
@@ -172,6 +172,39 @@ func ExponentialHistogramPointNoValue(attributes []*KV, startTimestamp, timestam
 	return hdp
 }
 
+// exponentialHistogramPointSimplified let's you define an exponential
+// histogram with just a few parameters.
+// Scale and ZeroCount are set to the provided values.
+// Positive and negative buckets are generated using the offset and bucketCount
+// parameters by adding buckets from offset in both positive and negative
+// directions. Bucket counts start from 1 and increase by 1 for each bucket.
+// Sum and Count will be proportional to the bucket count.
+func ExponentialHistogramPointSimplified(attributes []*KV, startTimestamp, timestamp pcommon.Timestamp, scale int32, zeroCount uint64, offset int32, bucketCount int) pmetric.ExponentialHistogramDataPoint {
+	hdp := ExponentialHistogramPointRaw(attributes, startTimestamp, timestamp)
+	hdp.SetScale(scale)
+	hdp.SetZeroCount(zeroCount)
+
+	positive := hdp.Positive()
+	positive.SetOffset(offset)
+	positive.BucketCounts().EnsureCapacity(bucketCount)
+	negative := hdp.Negative()
+	negative.SetOffset(offset)
+	negative.BucketCounts().EnsureCapacity(bucketCount)
+
+	var sum float64
+	var count uint64
+	for i := 0; i < bucketCount; i++ {
+		positive.BucketCounts().Append(uint64(i + 1))
+		negative.BucketCounts().Append(uint64(i + 1))
+		count += uint64(i+1) + uint64(i+1)
+		sum += float64(i+1)*10 + float64(i+1)*10.0
+	}
+	hdp.SetCount(count)
+	hdp.SetSum(sum)
+
+	return hdp
+}
+
 func DoublePointRaw(attributes []*KV, startTimestamp, timestamp pcommon.Timestamp) pmetric.NumberDataPoint {
 	ndp := pmetric.NewNumberDataPoint()
 	ndp.SetStartTimestamp(startTimestamp)

--- a/processor/metricstarttimeprocessor/testdata/config.yaml
+++ b/processor/metricstarttimeprocessor/testdata/config.yaml
@@ -9,5 +9,17 @@ metricstarttime/gc_interval:
 metricstarttime/negative_interval:
   gc_interval: -1h
 
+metricstarttime/true_reset_point:
+  strategy: true_reset_point
+
+metricstarttime/start_time_metric:
+  strategy: start_time_metric
+  start_time_metric_regex: "^.+_process_start_time_seconds$"
+
+
+metricstarttime/invalid_regex:
+  strategy: start_time_metric
+  start_time_metric_regex: "(((("
+
 metricstarttime/invalid_strategy:
   strategy: bad

--- a/processor/metricstarttimeprocessor/testdata/config.yaml
+++ b/processor/metricstarttimeprocessor/testdata/config.yaml
@@ -16,10 +16,13 @@ metricstarttime/start_time_metric:
   strategy: start_time_metric
   start_time_metric_regex: "^.+_process_start_time_seconds$"
 
-
 metricstarttime/invalid_regex:
   strategy: start_time_metric
   start_time_metric_regex: "(((("
 
 metricstarttime/invalid_strategy:
   strategy: bad
+
+metricstarttime/regex_with_subtract_initial_point:
+  strategy: subtract_initial_point
+  start_time_metric_regex: "^.+_process_start_time_seconds$"


### PR DESCRIPTION
#### Description

Add the `start_time_metric` strategy to the metricstarttime processor.  This is needed to reach feature parity with the prometheus receiver's adjuster.  It supports the same `start_time_metric_regex` configuration parameter, and falls back to the collector's start time.

It does not yet support reset detection.  That will be implemented in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38381, and I left a TODO in the code.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38383

#### Testing

Added unit tests.

#### Documentation

Updated the README.md

@ridwanmsharif 
