### PR TITLE
metricstarttimeprocessor: keep keys with empty values when hashing

### DIFF
--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
@@ -49,7 +49,7 @@ func (tsm *TimeseriesMap) Get(metric pmetric.Metric, kv pcommon.Map) (*Timeserie
 	name := metric.Name()
 	key := TimeseriesKey{
 		Name:       name,
-		Attributes: getAttributesSignature(kv),
+		Attributes: pdatautil.MapHash(kv),
 	}
 	switch metric.Type() {
 	case pmetric.MetricTypeHistogram:
@@ -72,19 +72,6 @@ func (tsm *TimeseriesMap) Get(metric pmetric.Metric, kv pcommon.Map) (*Timeserie
 	}
 	tsi.Mark = true
 	return tsi, ok
-}
-
-// Create a unique string signature for attributes values sorted by attribute keys.
-func getAttributesSignature(m pcommon.Map) AttributeHash {
-	// TODO(#38621): Investigate whether we should treat empty labels differently.
-	clearedMap := pcommon.NewMap()
-	for k, attrValue := range m.All() {
-		value := attrValue.Str()
-		if value != "" {
-			clearedMap.PutStr(k, value)
-		}
-	}
-	return pdatautil.MapHash(clearedMap)
 }
 
 // Remove timeseries that have aged out.

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
@@ -108,36 +108,6 @@ func TestTimeseriesMap_GC(t *testing.T) {
 	assert.Empty(t, tsm2.TsiMap)
 }
 
-func TestGetAttributesSignature(t *testing.T) {
-	m1 := pcommon.NewMap()
-	m1.PutStr("k1", "v1")
-	m1.PutStr("k2", "v2")
-	m1.PutStr("k3", "")
-
-	m2 := pcommon.NewMap()
-	m2.PutStr("k2", "v2")
-	m2.PutStr("k1", "v1")
-	m2.PutStr("k4", "")
-
-	m3 := pcommon.NewMap()
-	m3.PutStr("k1", "v1")
-	m3.PutStr("k2", "v2")
-
-	m4 := pcommon.NewMap()
-	m4.PutStr("k1", "v1")
-	m4.PutStr("k2", "v2")
-	m4.PutStr("k3", "v3")
-
-	sig1 := getAttributesSignature(m1)
-	sig2 := getAttributesSignature(m2)
-	sig3 := getAttributesSignature(m3)
-	sig4 := getAttributesSignature(m4)
-
-	assert.Equal(t, sig1, sig2)
-	assert.Equal(t, sig1, sig3)
-	assert.NotEqual(t, sig1, sig4)
-}
-
 func TestNewTimeseriesMap(t *testing.T) {
 	tsm := newTimeseriesMap()
 	assert.NotNil(t, tsm)
@@ -654,24 +624,5 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 			s := tt.setupS()
 			assert.Equal(t, tt.expectedReset, IsResetSum(s, tsi.Number))
 		})
-	}
-}
-
-func BenchmarkGetAttributesSignature(b *testing.B) {
-	attrs := pcommon.NewMap()
-	attrs.PutStr("key1", "some-random-test-value-1")
-	attrs.PutStr("key2", "some-random-test-value-2")
-	attrs.PutStr("key6", "some-random-test-value-6")
-	attrs.PutStr("key3", "some-random-test-value-3")
-	attrs.PutStr("key4", "some-random-test-value-4")
-	attrs.PutStr("key5", "some-random-test-value-5")
-	attrs.PutStr("key7", "some-random-test-value-7")
-	attrs.PutStr("key8", "some-random-test-value-8")
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		getAttributesSignature(attrs)
 	}
 }

--- a/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
@@ -47,10 +47,6 @@ var (
 		{Key: "k1", Value: "v100"},
 		{Key: "k2", Value: "v200"},
 	}
-
-	emptyLabels              []*testhelper.KV
-	k1vEmpty                 = []*testhelper.KV{{Key: "k1", Value: ""}}
-	k1vEmptyk2vEmptyk3vEmpty = []*testhelper.KV{{Key: "k1", Value: ""}, {Key: "k2", Value: ""}, {Key: "k3", Value: ""}}
 )
 
 func TestGauge(t *testing.T) {
@@ -563,32 +559,6 @@ func TestMultiTimeseries(t *testing.T) {
 				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v10k2v20, t2, t5, 45.0)),
 				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v100k2v200, t4, t5, 12.0)),
 			),
-		},
-	}
-	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
-}
-
-func TestEmptyLabels(t *testing.T) {
-	script := []*testhelper.MetricsAdjusterTest{
-		{
-			Description: "EmptyLabels: round 1 - initial instance, implicitly empty labels, start time is established",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t1, t1, 44))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1)),
-		},
-		{
-			Description: "EmptyLabels: round 2 - instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t2, t2, 66))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t1, t2, 22))),
-		},
-		{
-			Description: "EmptyLabels: round 3 - one explicitly empty label, instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmpty, t3, t3, 77))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmpty, t1, t3, 33))),
-		},
-		{
-			Description: "EmptyLabels: round 4 - three explicitly empty labels, instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmptyk2vEmptyk3vEmpty, t3, t3, 88))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmptyk2vEmptyk3vEmpty, t1, t3, 44))),
 		},
 	}
 	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
@@ -47,10 +47,6 @@ var (
 		{Key: "k1", Value: "v100"},
 		{Key: "k2", Value: "v200"},
 	}
-
-	emptyLabels              []*testhelper.KV
-	k1vEmpty                 = []*testhelper.KV{{Key: "k1", Value: ""}}
-	k1vEmptyk2vEmptyk3vEmpty = []*testhelper.KV{{Key: "k1", Value: ""}, {Key: "k2", Value: ""}, {Key: "k3", Value: ""}}
 )
 
 func TestGauge(t *testing.T) {
@@ -572,32 +568,6 @@ func TestMultiTimeseries(t *testing.T) {
 				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v10k2v20, t2, t5, 65.0)),
 				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v100k2v200, t4, t5, 22.0)),
 			),
-		},
-	}
-	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
-}
-
-func TestEmptyLabels(t *testing.T) {
-	script := []*testhelper.MetricsAdjusterTest{
-		{
-			Description: "EmptyLabels: round 1 - initial instance, implicitly empty labels, start time is established",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t1, t1, 44))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t1, t1, 44))),
-		},
-		{
-			Description: "EmptyLabels: round 2 - instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t2, t2, 66))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(emptyLabels, t1, t2, 66))),
-		},
-		{
-			Description: "EmptyLabels: round 3 - one explicitly empty label, instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmpty, t3, t3, 77))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmpty, t1, t3, 77))),
-		},
-		{
-			Description: "EmptyLabels: round 4 - three explicitly empty labels, instance adjusted based on round 1",
-			Metrics:     testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmptyk2vEmptyk3vEmpty, t3, t3, 88))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric(sum1, testhelper.DoublePoint(k1vEmptyk2vEmptyk3vEmpty, t1, t3, 88))),
 		},
 	}
 	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)


### PR DESCRIPTION
#### Description

Use standard collector pdata hashing functions when hashing attributes instead of removing attributes with empty values.  Translation from Prometheus already removes empty values (because prometheus treats empty the same as non-existent).

#### Link to tracking issue

Fixes #38621

#### Testing

N/A

#### Documentation

N/A