### PR TITLE
[sumologicprocessor] unexport NestingProcessor

### DIFF
--- a/.chloggen/unexport-sumologic-nesting-processor.yaml
+++ b/.chloggen/unexport-sumologic-nesting-processor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sumologicprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Types that do not contribute to intended API surface will be unexported'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40660]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 'https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40641'
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/processor/sumologicprocessor/fuzz_test.go
+++ b/processor/sumologicprocessor/fuzz_test.go
@@ -26,7 +26,7 @@ func FuzzProcessTraces(f *testing.F) {
 			proc := &cloudNamespaceProcessor{}
 			_ = proc.processTraces(traces)
 		case 2:
-			proc := &NestingProcessor{}
+			proc := &nestingProcessor{}
 			_ = proc.processTraces(traces)
 		case 3:
 			proc := &translateAttributesProcessor{}
@@ -50,7 +50,7 @@ func FuzzProcessLogs(f *testing.F) {
 			proc := &cloudNamespaceProcessor{}
 			_ = proc.processLogs(logs)
 		case 2:
-			proc := &NestingProcessor{}
+			proc := &nestingProcessor{}
 			_ = proc.processLogs(logs)
 		case 3:
 			proc := &translateAttributesProcessor{}
@@ -74,7 +74,7 @@ func FuzzProcessMetrics(f *testing.F) {
 			proc := &cloudNamespaceProcessor{}
 			_ = proc.processMetrics(metrics)
 		case 2:
-			proc := &NestingProcessor{}
+			proc := &nestingProcessor{}
 			_ = proc.processMetrics(metrics)
 		case 3:
 			proc := &translateAttributesProcessor{}

--- a/processor/sumologicprocessor/nesting_processor.go
+++ b/processor/sumologicprocessor/nesting_processor.go
@@ -20,7 +20,7 @@ type NestingProcessorConfig struct {
 	SquashSingleValues bool     `mapstructure:"squash_single_values"`
 }
 
-type NestingProcessor struct {
+type nestingProcessor struct {
 	separator          string
 	enabled            bool
 	allowlist          []string
@@ -28,8 +28,8 @@ type NestingProcessor struct {
 	squashSingleValues bool
 }
 
-func newNestingProcessor(config *NestingProcessorConfig) *NestingProcessor {
-	proc := &NestingProcessor{
+func newNestingProcessor(config *NestingProcessorConfig) *nestingProcessor {
+	proc := &nestingProcessor{
 		separator:          config.Separator,
 		enabled:            config.Enabled,
 		allowlist:          config.Include,
@@ -40,7 +40,7 @@ func newNestingProcessor(config *NestingProcessorConfig) *NestingProcessor {
 	return proc
 }
 
-func (proc *NestingProcessor) processLogs(logs plog.Logs) error {
+func (proc *nestingProcessor) processLogs(logs plog.Logs) error {
 	if !proc.enabled {
 		return nil
 	}
@@ -66,7 +66,7 @@ func (proc *NestingProcessor) processLogs(logs plog.Logs) error {
 	return nil
 }
 
-func (proc *NestingProcessor) processMetrics(metrics pmetric.Metrics) error {
+func (proc *nestingProcessor) processMetrics(metrics pmetric.Metrics) error {
 	if !proc.enabled {
 		return nil
 	}
@@ -92,7 +92,7 @@ func (proc *NestingProcessor) processMetrics(metrics pmetric.Metrics) error {
 	return nil
 }
 
-func (proc *NestingProcessor) processTraces(traces ptrace.Traces) error {
+func (proc *nestingProcessor) processTraces(traces ptrace.Traces) error {
 	if !proc.enabled {
 		return nil
 	}
@@ -118,7 +118,7 @@ func (proc *NestingProcessor) processTraces(traces ptrace.Traces) error {
 	return nil
 }
 
-func (proc *NestingProcessor) processAttributes(attributes pcommon.Map) error {
+func (proc *nestingProcessor) processAttributes(attributes pcommon.Map) error {
 	newMap := pcommon.NewMap()
 
 	for k, v := range attributes.All() {
@@ -194,7 +194,7 @@ func (proc *NestingProcessor) processAttributes(attributes pcommon.Map) error {
 // Checks if given key fulfills the following conditions:
 // - has a prefix that exists in the allowlist (if it's not empty)
 // - does not have a prefix that exists in the denylist
-func (proc *NestingProcessor) shouldTranslateKey(k string) bool {
+func (proc *nestingProcessor) shouldTranslateKey(k string) bool {
 	if len(proc.allowlist) > 0 {
 		isOk := false
 		for i := 0; i < len(proc.allowlist); i++ {
@@ -221,7 +221,7 @@ func (proc *NestingProcessor) shouldTranslateKey(k string) bool {
 
 // Squashes maps that have single values, eg. map {"a": {"b": {"c": "C", "d": "D"}}}}
 // gets squashes into {"a.b": {"c": "C", "d": "D"}}}
-func (proc *NestingProcessor) squash(attributes pcommon.Map) pcommon.Map {
+func (proc *nestingProcessor) squash(attributes pcommon.Map) pcommon.Map {
 	newMap := pcommon.NewValueMap()
 	attributes.CopyTo(newMap.Map())
 	key := proc.squashAttribute(newMap)
@@ -242,7 +242,7 @@ func (proc *NestingProcessor) squash(attributes pcommon.Map) pcommon.Map {
 // and the key gets replaced if needed, "" is returned.
 //
 // Else, nothing happens and "" is returned.
-func (proc *NestingProcessor) squashAttribute(value pcommon.Value) string {
+func (proc *nestingProcessor) squashAttribute(value pcommon.Value) string {
 	if value.Type() != pcommon.ValueTypeMap {
 		return ""
 	}
@@ -279,17 +279,17 @@ func (proc *NestingProcessor) squashAttribute(value pcommon.Value) string {
 	return ""
 }
 
-func (proc *NestingProcessor) squashKey(key string, keySuffix string) string {
+func (proc *nestingProcessor) squashKey(key string, keySuffix string) string {
 	if keySuffix == "" {
 		return key
 	}
 	return key + proc.separator + keySuffix
 }
 
-func (proc *NestingProcessor) isEnabled() bool {
+func (proc *nestingProcessor) isEnabled() bool {
 	return proc.enabled
 }
 
-func (*NestingProcessor) ConfigPropertyName() string {
+func (*nestingProcessor) ConfigPropertyName() string {
 	return "nest_attributes"
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
As part of #40641, we should unexport NestingProcessor as it is not intended to be API surface.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40660