### PR TITLE
[chore][cmd/opampsupervisor] Don't use SIGHUP in Windows tests

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -55,6 +55,36 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
 )
 
+// getTestModes returns the test modes for the supervisor tests.
+// On Windows, HUPReload mode is excluded as SIGHUP signals are not available.
+func getTestModes() []struct {
+	name               string
+	UseHUPConfigReload bool
+} {
+	modes := []struct {
+		name               string
+		UseHUPConfigReload bool
+	}{
+		{
+			name:               "ProcessRestart",
+			UseHUPConfigReload: false,
+		},
+	}
+
+	// Only add HUPReload mode on non-Windows platforms
+	if runtime.GOOS != "windows" {
+		modes = append(modes, struct {
+			name               string
+			UseHUPConfigReload bool
+		}{
+			name:               "HUPReload",
+			UseHUPConfigReload: true,
+		})
+	}
+
+	return modes
+}
+
 var _ clientTypes.Logger = testLogger{}
 
 type testLogger struct {
@@ -220,19 +250,7 @@ func getSupervisorConfig(t *testing.T, configType string, extraConfigData map[st
 }
 
 func TestSupervisorStartsCollectorWithRemoteConfig(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPReload",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -309,19 +327,7 @@ func TestSupervisorStartsCollectorWithRemoteConfig(t *testing.T) {
 }
 
 func TestSupervisorStartsCollectorWithLocalConfigOnly(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -382,19 +388,7 @@ func TestSupervisorStartsCollectorWithLocalConfigOnly(t *testing.T) {
 }
 
 func TestSupervisorStartsCollectorWithNoOpAMPServerWithNoLastRemoteConfig(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -458,19 +452,7 @@ func TestSupervisorStartsCollectorWithNoOpAMPServerWithNoLastRemoteConfig(t *tes
 }
 
 func TestSupervisorStartsCollectorWithNoOpAMPServerUsingLastRemoteConfig(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -717,19 +699,7 @@ func TestSupervisorStartsWithNoOpAMPServer(t *testing.T) {
 }
 
 func TestSupervisorRestartsCollectorAfterBadConfig(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -1323,19 +1293,7 @@ func waitForSupervisorConnection(connection chan bool, connected bool) {
 }
 
 func TestSupervisorRestartCommand(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -1511,19 +1469,7 @@ func TestSupervisorOpAMPWithHTTPEndpoint(t *testing.T) {
 }
 
 func TestSupervisorRestartsWithLastReceivedConfig(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {
@@ -2014,19 +1960,7 @@ func TestSupervisorLogging(t *testing.T) {
 }
 
 func TestSupervisorRemoteConfigApplyStatus(t *testing.T) {
-	modes := []struct {
-		name               string
-		UseHUPConfigReload bool
-	}{
-		{
-			name:               "ProcessRestart",
-			UseHUPConfigReload: false,
-		},
-		{
-			name:               "HUPRestart",
-			UseHUPConfigReload: true,
-		},
-	}
+	modes := getTestModes()
 
 	for _, mode := range modes {
 		t.Run(mode.name, func(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Don't use SIGHUP on Windows tests. The problem was introduced with a [previous PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40522).
