### PR TITLE
[feat] receiver/prometheusremotewrite: Add support for NHCB

### DIFF
--- a/.chloggen/prwreceiver-cbnh.yaml
+++ b/.chloggen/prwreceiver-cbnh.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for Custom Buckets Native Histograms (CBNH).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41043]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prwreceiver-cbnh.yaml
+++ b/.chloggen/prwreceiver-cbnh.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/prometheusremotewrite
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for Custom Buckets Native Histograms (CBNH).
+note: Add support for Native Histogram Custom Buckets (NHCB).
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [41043]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -756,11 +756,6 @@ func convertNHCBBuckets(histogram writev2.Histogram) []uint64 {
 				bucketIdx++
 			}
 		}
-
-		// Convert from cumulative to delta buckets (like classic histograms)
-		for i := len(bucketCounts) - 1; i > 0; i-- {
-			bucketCounts[i] -= bucketCounts[i-1]
-		}
 	} else {
 		// Integer histograms: values are deltas between buckets
 		bucketIdx := 0
@@ -782,29 +777,6 @@ func convertNHCBBuckets(histogram writev2.Histogram) []uint64 {
 				bucketIdx++
 			}
 		}
-
-		// Convert from cumulative to delta buckets (like classic histograms)
-		for i := len(bucketCounts) - 1; i > 0; i-- {
-			bucketCounts[i] -= bucketCounts[i-1]
-		}
-	}
-
-	// Ensure the final (+inf) bucket count so that sum of bucket counts equals overall count
-	totalBucketCount := uint64(0)
-	for i := 0; i < len(bucketCounts)-1; i++ {
-		totalBucketCount += bucketCounts[i]
-	}
-
-	var overallCount uint64
-	if histogram.IsFloatHistogram() {
-		overallCount = uint64(histogram.GetCountFloat())
-	} else {
-		overallCount = histogram.GetCountInt()
-	}
-
-	// Set the final bucket count to make the total equal to overall count
-	if overallCount >= totalBucketCount {
-		bucketCounts[len(bucketCounts)-1] = overallCount - totalBucketCount
 	}
 
 	return bucketCounts

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -17,6 +17,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/value"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	promremote "github.com/prometheus/prometheus/storage/remote"
 	"go.opentelemetry.io/collector/component"
@@ -237,8 +238,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		otelMetrics      = pmetric.NewMetrics()
 		labelsBuilder    = labels.NewScratchBuilder(0)
 		// More about stats: https://github.com/prometheus/docs/blob/main/docs/specs/prw/remote_write_spec_2_0.md#required-written-response-headers
-		// TODO: add histograms and exemplars to the stats. Histograms can be added after this PR be merged. Ref #39864
-		// Exemplars should be implemented to add them to the stats.
+		// TODO: add exemplars to the stats.
 		stats = promremote.WriteResponseStats{
 			Confirmed: true,
 		}
@@ -281,18 +281,6 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			continue
 		}
 
-		// For metrics other than target_info, we need to follow the standard process of creating a metric.
-		var rm pmetric.ResourceMetrics
-		hashedLabels := xxhash.Sum64String(ls.Get("job") + string([]byte{'\xff'}) + ls.Get("instance"))
-		existingRM, ok := prw.rmCache.Get(hashedLabels)
-		if ok {
-			rm = existingRM
-		} else {
-			rm = otelMetrics.ResourceMetrics().AppendEmpty()
-			parseJobAndInstance(rm.Resource().Attributes(), ls.Get("job"), ls.Get("instance"))
-			prw.rmCache.Add(hashedLabels, rm)
-		}
-
 		scopeName, scopeVersion := prw.extractScopeInfo(ls)
 		metricName := ls.Get(labels.MetricName)
 		if ts.Metadata.UnitRef >= uint32(len(req.Symbols)) {
@@ -308,8 +296,25 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		unit := req.Symbols[ts.Metadata.UnitRef]
 		description := req.Symbols[ts.Metadata.HelpRef]
 
-		resourceID := identity.OfResource(rm.Resource())
+		// Handle histograms separately due to their complex mixed-schema processing
+		if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM {
+			prw.processHistogramTimeSeries(otelMetrics, ls, ts, scopeName, scopeVersion, metricName, unit, description, metricCache, &stats)
+			continue
+		}
 
+		// Handle regular metrics (gauge, counter, summary)
+		hashedLabels := xxhash.Sum64String(ls.Get("job") + string([]byte{'\xff'}) + ls.Get("instance"))
+		existingRM, ok := prw.rmCache.Get(hashedLabels)
+		var rm pmetric.ResourceMetrics
+		if ok {
+			rm = existingRM
+		} else {
+			rm = otelMetrics.ResourceMetrics().AppendEmpty()
+			parseJobAndInstance(rm.Resource().Attributes(), ls.Get("job"), ls.Get("instance"))
+			prw.rmCache.Add(hashedLabels, rm)
+		}
+
+		resourceID := identity.OfResource(rm.Resource())
 		metricIdentity := createMetricIdentity(
 			resourceID.String(), // Resource identity
 			scopeName,           // Scope name
@@ -321,6 +326,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 
 		metricKey := metricIdentity.Hash()
 
+		// Find or create scope
 		var scope pmetric.ScopeMetrics
 		var foundScope bool
 		for i := 0; i < rm.ScopeMetrics().Len(); i++ {
@@ -337,8 +343,8 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 			scope.Scope().SetVersion(scopeVersion)
 		}
 
+		// Get or create metric
 		metric, exists := metricCache[metricKey]
-		// If the metric does not exist, we create an empty metric and add it to the cache.
 		if !exists {
 			switch ts.Metadata.Type {
 			case writev2.Metadata_METRIC_TYPE_GAUGE:
@@ -349,15 +355,6 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 				sum := metric.SetEmptySum()
 				sum.SetIsMonotonic(true)
 				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-			case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
-				// Histograms that comes with samples are considered as classic histograms and are not supported.
-				if len(ts.Samples) != 0 {
-					// Drop classic histogram series as we will not handle them.
-					continue
-				}
-				metric = setMetric(scope, metricName, unit, description)
-				hist := metric.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			case writev2.Metadata_METRIC_TYPE_SUMMARY:
 				// Drop summary series as we will not handle them.
 				continue
@@ -365,28 +362,18 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 				badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, metricName))
 				continue
 			}
-
 			metricCache[metricKey] = metric
-		}
-
-		// When the new description is longer than the existing one, we should update the metric description.
-		// Reference to this behavior: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations
-		if len(metric.Description()) < len(description) {
+		} else if len(metric.Description()) < len(description) {
+			// When the new description is longer than the existing one, we should update the metric description.
+			// Reference to this behavior: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations
 			metric.SetDescription(description)
 		}
 
-		// Otherwise, we append the samples to the existing metric.
 		switch ts.Metadata.Type {
 		case writev2.Metadata_METRIC_TYPE_GAUGE:
 			addNumberDatapoints(metric.Gauge().DataPoints(), ls, ts, &stats)
 		case writev2.Metadata_METRIC_TYPE_COUNTER:
 			addNumberDatapoints(metric.Sum().DataPoints(), ls, ts, &stats)
-		case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
-			if len(ts.Samples) != 0 {
-				// Drop classic histogram series as we will not handle them.
-				continue
-			}
-			addExponentialHistogramDatapoints(metric.ExponentialHistogram().DataPoints(), ls, ts, &stats)
 		case writev2.Metadata_METRIC_TYPE_SUMMARY:
 			// Drop summary series as we will not handle them.
 			continue
@@ -396,6 +383,109 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 	}
 
 	return otelMetrics, stats, badRequestErrors
+}
+
+// processHistogramTimeSeries handles all histogram processing, including validation and mixed schemas.
+func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
+	otelMetrics pmetric.Metrics,
+	ls labels.Labels,
+	ts writev2.TimeSeries,
+	scopeName, scopeVersion, metricName, unit, description string,
+	metricCache map[uint64]pmetric.Metric,
+	stats *promremote.WriteResponseStats,
+) {
+	// Drop classic histogram series (those with samples)
+	if len(ts.Samples) != 0 {
+		return
+	}
+
+	var rm pmetric.ResourceMetrics
+	var hashedLabels uint64
+	var resourceID identity.Resource
+	var scope pmetric.ScopeMetrics
+
+	for _, histogram := range ts.Histograms {
+		if histogram.ResetHint == writev2.Histogram_RESET_HINT_GAUGE {
+			continue
+		}
+
+		var histogramType string
+
+		// Determine histogram type based on schema
+		switch histogram.Schema {
+		case -53:
+			histogramType = "cbnh"
+		case -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8:
+			histogramType = "exponential"
+		default:
+			// Skip invalid schema
+			continue
+		}
+		// Create resource if needed (only for the first valid histogram)
+		if hashedLabels == 0 {
+			hashedLabels = xxhash.Sum64String(ls.Get("job") + string([]byte{'\xff'}) + ls.Get("instance"))
+			existingRM, ok := prw.rmCache.Get(hashedLabels)
+			if ok {
+				rm = existingRM
+			} else {
+				rm = otelMetrics.ResourceMetrics().AppendEmpty()
+				parseJobAndInstance(rm.Resource().Attributes(), ls.Get("job"), ls.Get("instance"))
+				prw.rmCache.Add(hashedLabels, rm)
+			}
+			resourceID = identity.OfResource(rm.Resource())
+		}
+
+		// Find or create scope (search each time since different histograms might need different scopes)
+		var foundScope bool
+		for i := 0; i < rm.ScopeMetrics().Len(); i++ {
+			s := rm.ScopeMetrics().At(i)
+			if s.Scope().Name() == scopeName && s.Scope().Version() == scopeVersion {
+				scope = s
+				foundScope = true
+				break
+			}
+		}
+		if !foundScope {
+			scope = rm.ScopeMetrics().AppendEmpty()
+			scope.Scope().SetName(scopeName)
+			scope.Scope().SetVersion(scopeVersion)
+		}
+
+		metricIdentity := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%s",
+			resourceID.String(),
+			scopeName,
+			scopeVersion,
+			metricName,
+			unit,
+			fmt.Sprintf("%d", ts.Metadata.Type),
+			histogramType,
+		)
+		metricKeyHashForSchema := xxhash.Sum64String(metricIdentity)
+
+		histMetric, exists := metricCache[metricKeyHashForSchema]
+		if !exists {
+			histMetric = setMetric(scope, metricName, unit, description)
+			if histogramType == "cbnh" {
+				hist := histMetric.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			} else {
+				hist := histMetric.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+			}
+			metricCache[metricKeyHashForSchema] = histMetric
+		} else if len(histMetric.Description()) < len(description) {
+			// When the new description is longer than the existing one, we should update the metric description.
+			// Reference to this behavior: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations
+			histMetric.SetDescription(description)
+		}
+
+		// Process the individual histogram
+		if histogramType == "cbnh" {
+			addCBNHDatapoint(histMetric.Histogram().DataPoints(), histogram, ls, ts.CreatedTimestamp, stats)
+		} else {
+			addExponentialHistogramDatapoint(histMetric.ExponentialHistogram().DataPoints(), histogram, ls, ts.CreatedTimestamp, stats)
+		}
+	}
 }
 
 // setMetric append a new empty metric and assign the name, unit and description to it.
@@ -440,62 +530,53 @@ func addNumberDatapoints(datapoints pmetric.NumberDataPointSlice, ls labels.Labe
 	stats.Samples += len(ts.Samples)
 }
 
-func addExponentialHistogramDatapoints(datapoints pmetric.ExponentialHistogramDataPointSlice, ls labels.Labels, ts writev2.TimeSeries, stats *promremote.WriteResponseStats) {
-	for _, histogram := range ts.Histograms {
-		// Drop histograms with RESET_HINT_GAUGE or negative counts.
-		if histogram.ResetHint == writev2.Histogram_RESET_HINT_GAUGE || hasNegativeCounts(histogram) {
-			continue
-		}
-
-		// If we reach here, the histogram passed validation - proceed with conversion
-		dp := datapoints.AppendEmpty()
-		dp.SetStartTimestamp(pcommon.Timestamp(ts.CreatedTimestamp * int64(time.Millisecond)))
-		dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
-
-		// The difference between float and integer histograms is that float histograms are stored as absolute counts
-		// while integer histograms are stored as deltas.
-		if histogram.IsFloatHistogram() {
-			// Float histograms
-			if len(histogram.PositiveSpans) > 0 {
-				dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-				convertAbsoluteBuckets(histogram.PositiveSpans, histogram.PositiveCounts, dp.Positive().BucketCounts())
-			}
-			if len(histogram.NegativeSpans) > 0 {
-				dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-				convertAbsoluteBuckets(histogram.NegativeSpans, histogram.NegativeCounts, dp.Negative().BucketCounts())
-			}
-
-			dp.SetScale(histogram.Schema)
-			dp.SetZeroThreshold(histogram.ZeroThreshold)
-			zeroCountFloat := histogram.GetZeroCountFloat()
-			dp.SetZeroCount(uint64(zeroCountFloat))
-			dp.SetSum(histogram.Sum)
-			countFloat := histogram.GetCountFloat()
-			dp.SetCount(uint64(countFloat))
-		} else {
-			// Integer histograms
-			if len(histogram.PositiveSpans) > 0 {
-				dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-				convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive().BucketCounts())
-			}
-			if len(histogram.NegativeSpans) > 0 {
-				dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
-				convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative().BucketCounts())
-			}
-
-			dp.SetScale(histogram.Schema)
-			dp.SetZeroThreshold(histogram.ZeroThreshold)
-			zeroCountInt := histogram.GetZeroCountInt()
-			dp.SetZeroCount(zeroCountInt)
-			dp.SetSum(histogram.Sum)
-			countInt := histogram.GetCountInt()
-			dp.SetCount(countInt)
-		}
-
-		attributes := dp.Attributes()
-		stats.Histograms++
-		extractAttributes(ls).CopyTo(attributes)
+func addExponentialHistogramDatapoint(datapoints pmetric.ExponentialHistogramDataPointSlice, histogram writev2.Histogram, ls labels.Labels, createdTimestamp int64, stats *promremote.WriteResponseStats) {
+	// Drop NH with negative counts
+	if hasNegativeCounts(histogram) {
+		return
 	}
+
+	dp := datapoints.AppendEmpty()
+	dp.SetStartTimestamp(pcommon.Timestamp(createdTimestamp * int64(time.Millisecond)))
+	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
+	dp.SetScale(histogram.Schema)
+	dp.SetZeroThreshold(histogram.ZeroThreshold)
+
+	// Set count and sum using common helper
+	setCountAndSum(histogram, dp)
+
+	// The difference between float and integer histograms is that float histograms are stored as absolute counts
+	// while integer histograms are stored as deltas.
+	if histogram.IsFloatHistogram() {
+		// Float histograms
+		zeroCountFloat := histogram.GetZeroCountFloat()
+		dp.SetZeroCount(uint64(zeroCountFloat))
+
+		if len(histogram.PositiveSpans) > 0 {
+			dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
+			convertAbsoluteBuckets(histogram.PositiveSpans, histogram.PositiveCounts, dp.Positive().BucketCounts())
+		}
+		if len(histogram.NegativeSpans) > 0 {
+			dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
+			convertAbsoluteBuckets(histogram.NegativeSpans, histogram.NegativeCounts, dp.Negative().BucketCounts())
+		}
+	} else {
+		// Integer histograms
+		zeroCountInt := histogram.GetZeroCountInt()
+		dp.SetZeroCount(zeroCountInt)
+
+		if len(histogram.PositiveSpans) > 0 {
+			dp.Positive().SetOffset(histogram.PositiveSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
+			convertDeltaBuckets(histogram.PositiveSpans, histogram.PositiveDeltas, dp.Positive().BucketCounts())
+		}
+		if len(histogram.NegativeSpans) > 0 {
+			dp.Negative().SetOffset(histogram.NegativeSpans[0].Offset - 1) // -1 because OTEL offset are for the lower bound, not the upper bound
+			convertDeltaBuckets(histogram.NegativeSpans, histogram.NegativeDeltas, dp.Negative().BucketCounts())
+		}
+	}
+
+	extractAttributes(ls).CopyTo(dp.Attributes())
+	stats.Histograms++
 }
 
 // hasNegativeCounts checks if a histogram has any negative counts
@@ -624,4 +705,125 @@ func (prw *prometheusRemoteWriteReceiver) extractScopeInfo(ls labels.Labels) (st
 		scopeVersion = sVersion
 	}
 	return scopeName, scopeVersion
+}
+
+// addCBNHDatapoint converts a single Custom Buckets Native Histogram (CBNH) to OpenTelemetry histogram datapoints
+func addCBNHDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram writev2.Histogram, ls labels.Labels, createdTimestamp int64, stats *promremote.WriteResponseStats) {
+	if len(histogram.CustomValues) == 0 {
+		return
+	}
+
+	dp := datapoints.AppendEmpty()
+	dp.SetStartTimestamp(pcommon.Timestamp(createdTimestamp * int64(time.Millisecond)))
+	dp.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * int64(time.Millisecond)))
+
+	if value.IsStaleNaN(histogram.Sum) {
+		dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+	} else {
+		setCountAndSum(histogram, dp)
+	}
+
+	dp.ExplicitBounds().FromRaw(histogram.CustomValues)
+	bucketCounts := convertCBNHBuckets(histogram)
+	dp.BucketCounts().FromRaw(bucketCounts)
+
+	extractAttributes(ls).CopyTo(dp.Attributes())
+	stats.Histograms++
+}
+
+// convertCBNHBuckets converts CBNH bucket data to OpenTelemetry bucket counts
+func convertCBNHBuckets(histogram writev2.Histogram) []uint64 {
+	// For CBNH, we need numExplicitBounds + 1 buckets (including the final +inf bucket)
+	bucketCounts := make([]uint64, len(histogram.CustomValues)+1)
+
+	// CBNH uses the positive bucket list and spans for all buckets
+	if len(histogram.PositiveSpans) == 0 {
+		return bucketCounts
+	}
+
+	if histogram.IsFloatHistogram() {
+		// Float histograms: values are absolute counts
+		bucketIdx := 0
+		for _, span := range histogram.PositiveSpans {
+			// Skip empty buckets based on offset
+			bucketIdx += int(span.Offset)
+
+			// Fill buckets for this span
+			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && i < uint32(len(histogram.PositiveCounts)); i++ {
+				if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
+					bucketCounts[bucketIdx] = uint64(histogram.PositiveCounts[i])
+				}
+				bucketIdx++
+			}
+		}
+
+		// Convert from cumulative to delta buckets (like classic histograms)
+		for i := len(bucketCounts) - 1; i > 0; i-- {
+			bucketCounts[i] -= bucketCounts[i-1]
+		}
+	} else {
+		// Integer histograms: values are deltas between buckets
+		bucketIdx := 0
+		bucketCount := int64(0)
+		deltaIdx := 0
+
+		for _, span := range histogram.PositiveSpans {
+			// Skip empty buckets based on offset
+			bucketIdx += int(span.Offset)
+
+			// Fill buckets for this span
+			for i := uint32(0); i < span.Length && bucketIdx < len(bucketCounts) && deltaIdx < len(histogram.PositiveDeltas); i++ {
+				bucketCount += histogram.PositiveDeltas[deltaIdx]
+				deltaIdx++
+
+				if bucketIdx >= 0 && bucketIdx < len(bucketCounts) {
+					bucketCounts[bucketIdx] = uint64(bucketCount)
+				}
+				bucketIdx++
+			}
+		}
+
+		// Convert from cumulative to delta buckets (like classic histograms)
+		for i := len(bucketCounts) - 1; i > 0; i-- {
+			bucketCounts[i] -= bucketCounts[i-1]
+		}
+	}
+
+	// Ensure the final (+inf) bucket count so that sum of bucket counts equals overall count
+	totalBucketCount := uint64(0)
+	for i := 0; i < len(bucketCounts)-1; i++ {
+		totalBucketCount += bucketCounts[i]
+	}
+
+	var overallCount uint64
+	if histogram.IsFloatHistogram() {
+		overallCount = uint64(histogram.GetCountFloat())
+	} else {
+		overallCount = histogram.GetCountInt()
+	}
+
+	// Set the final bucket count to make the total equal to overall count
+	if overallCount >= totalBucketCount {
+		bucketCounts[len(bucketCounts)-1] = overallCount - totalBucketCount
+	}
+
+	return bucketCounts
+}
+
+// setCountAndSum sets count and sum for histogram datapoints (common interface)
+type countSumSetter interface {
+	SetSum(float64)
+	SetCount(uint64)
+}
+
+func setCountAndSum(histogram writev2.Histogram, dp countSumSetter) {
+	dp.SetSum(histogram.Sum)
+
+	if histogram.IsFloatHistogram() {
+		countFloat := histogram.GetCountFloat()
+		dp.SetCount(uint64(countFloat))
+	} else {
+		countInt := histogram.GetCountInt()
+		dp.SetCount(countInt)
+	}
 }

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -370,7 +370,7 @@ func TestTranslateV2(t *testing.T) {
 						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
 					},
 					{
-						// CBNH histogram with scope1
+						// NHCB histogram with scope1
 						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
 						Histograms: []writev2.Histogram{
@@ -433,7 +433,7 @@ func TestTranslateV2(t *testing.T) {
 				dp2.SetDoubleValue(2.0)
 				dp2.Attributes().PutStr("d", "e")
 
-				// Add CBNH histogram to scope1
+				// Add NHCB histogram to scope1
 				cbneMetric := sm1.Metrics().AppendEmpty()
 				cbneMetric.SetName("test_metric")
 				cbneMetric.SetUnit("")
@@ -1083,22 +1083,22 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "CBNH translation",
+			name: "NHCB translation",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
 					"__name__",
-					"test_cbnh_histogram",
+					"test_hncb_histogram",
 					"job",
 					"test",
 					"instance",
 					"localhost:8080",
 					"seconds",
-					"Test CBNH histogram",
+					"Test NHCB histogram",
 				},
 				Timeseries: []writev2.TimeSeries{
 					{
-						LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_cbnh_histogram, job=test, instance=localhost:8080
+						LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_hncb_histogram, job=test, instance=localhost:8080
 						CreatedTimestamp: 123456000,
 						Metadata: writev2.Metadata{
 							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
@@ -1106,7 +1106,7 @@ func TestTranslateV2(t *testing.T) {
 						Histograms: []writev2.Histogram{
 							{
 								Timestamp:    123456789,
-								Schema:       -53, // CBNH schema
+								Schema:       -53, // NHCB schema
 								Sum:          100.5,
 								Count:        &writev2.Histogram_CountInt{CountInt: 50},
 								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
@@ -1136,7 +1136,7 @@ func TestTranslateV2(t *testing.T) {
 				sm.Scope().SetName("OpenTelemetry Collector")
 				sm.Scope().SetVersion("latest")
 				m1 := sm.Metrics().AppendEmpty()
-				m1.SetName("test_cbnh_histogram")
+				m1.SetName("test_hncb_histogram")
 				m1.SetUnit("")
 				m1.SetDescription("")
 				hist := m1.SetEmptyHistogram()
@@ -1154,29 +1154,29 @@ func TestTranslateV2(t *testing.T) {
 			}(),
 		},
 		{
-			name: "CBNH translation with stale NaN",
+			name: "NHCB translation with stale NaN",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
 					"__name__",
-					"test_cbnh_histogram_stale",
+					"test_hncb_histogram_stale",
 					"job",
 					"test",
 					"instance",
 					"localhost:8080",
 					"seconds",
-					"Test CBNH histogram with stale NaN",
+					"Test NHCB histogram with stale NaN",
 				},
 				Timeseries: []writev2.TimeSeries{
 					{
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_cbnh_histogram_stale, job=test, instance=localhost:8080
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_hncb_histogram_stale, job=test, instance=localhost:8080
 						Metadata: writev2.Metadata{
 							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
 						},
 						Histograms: []writev2.Histogram{
 							{
 								Timestamp:    123456789,
-								Schema:       -53, // CBNH schema
+								Schema:       -53, // NHCB schema
 								Sum:          math.Float64frombits(value.StaleNaN),
 								Count:        &writev2.Histogram_CountInt{CountInt: 50},
 								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
@@ -1206,7 +1206,7 @@ func TestTranslateV2(t *testing.T) {
 				sm.Scope().SetName("OpenTelemetry Collector")
 				sm.Scope().SetVersion("latest")
 				m1 := sm.Metrics().AppendEmpty()
-				m1.SetName("test_cbnh_histogram_stale")
+				m1.SetName("test_hncb_histogram_stale")
 				m1.SetUnit("")
 				m1.SetDescription("")
 				hist := m1.SetEmptyHistogram()
@@ -1273,7 +1273,7 @@ func TestTranslateV2(t *testing.T) {
 			expectedMetrics: pmetric.NewMetrics(), // When all histograms have invalid schemas, no metrics should be created
 		},
 		{
-			name: "mixed schema histograms - CBNH and exponential",
+			name: "mixed schema histograms - NHCB and exponential",
 			request: &writev2.Request{
 				Symbols: []string{
 					"",
@@ -1295,7 +1295,7 @@ func TestTranslateV2(t *testing.T) {
 						},
 						Histograms: []writev2.Histogram{
 							{
-								// First histogram - CBNH
+								// First histogram - NHCB
 								Timestamp:    123456789,
 								Schema:       -53,
 								Sum:          100.5,
@@ -1340,7 +1340,7 @@ func TestTranslateV2(t *testing.T) {
 				sm.Scope().SetName("OpenTelemetry Collector")
 				sm.Scope().SetVersion("latest")
 
-				// First metric - CBNH (regular histogram)
+				// First metric - NHCB (regular histogram)
 				m1 := sm.Metrics().AppendEmpty()
 				m1.SetName("test_mixed_histogram")
 				m1.SetUnit("")

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -376,11 +376,11 @@ func TestTranslateV2(t *testing.T) {
 						Histograms: []writev2.Histogram{
 							{
 								Schema:         -53,
-								Count:          &writev2.Histogram_CountInt{CountInt: 1},
+								Count:          &writev2.Histogram_CountInt{CountInt: 4},
 								Sum:            1,
 								Timestamp:      1,
 								CustomValues:   []float64{1.0},
-								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 4}},
 								PositiveDeltas: []int64{1, 2},
 							},
 						},
@@ -393,7 +393,7 @@ func TestTranslateV2(t *testing.T) {
 						Histograms: []writev2.Histogram{
 							{
 								Schema:        0,
-								Count:         &writev2.Histogram_CountInt{CountInt: 1},
+								Count:         &writev2.Histogram_CountInt{CountInt: 6},
 								Sum:           1,
 								Timestamp:     1,
 								ZeroThreshold: 1,
@@ -443,10 +443,10 @@ func TestTranslateV2(t *testing.T) {
 
 				cbneDP := hist.DataPoints().AppendEmpty()
 				cbneDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				cbneDP.SetCount(1)
+				cbneDP.SetCount(4)
 				cbneDP.SetSum(1)
 				cbneDP.ExplicitBounds().FromRaw([]float64{1.0})
-				cbneDP.BucketCounts().FromRaw([]uint64{1, 0})
+				cbneDP.BucketCounts().FromRaw([]uint64{1, 3})
 				cbneDP.Attributes().PutStr("d", "e")
 
 				sm2 := rm1.ScopeMetrics().AppendEmpty()
@@ -473,7 +473,7 @@ func TestTranslateV2(t *testing.T) {
 				expDP := expHist.DataPoints().AppendEmpty()
 				expDP.SetStartTimestamp(pcommon.Timestamp(150 * int64(time.Millisecond)))
 				expDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				expDP.SetCount(1)
+				expDP.SetCount(6)
 				expDP.SetSum(1)
 				expDP.SetScale(0)
 				expDP.SetZeroThreshold(1)
@@ -1108,7 +1108,7 @@ func TestTranslateV2(t *testing.T) {
 								Timestamp:    123456789,
 								Schema:       -53, // NHCB schema
 								Sum:          100.5,
-								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								Count:        &writev2.Histogram_CountInt{CountInt: 180},
 								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
 								PositiveSpans: []writev2.BucketSpan{
 									{Offset: 0, Length: 5}, // 5 buckets: 4 custom + 1 overflow
@@ -1146,9 +1146,9 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
 				dp.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
 				dp.SetSum(100.5)
-				dp.SetCount(50)
+				dp.SetCount(180)
 				dp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
-				dp.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0}) // Delta counts
+				dp.BucketCounts().FromRaw([]uint64{10, 25, 45, 50, 50})
 
 				return metrics
 			}(),
@@ -1178,12 +1178,8 @@ func TestTranslateV2(t *testing.T) {
 								Timestamp:    123456789,
 								Schema:       -53, // NHCB schema
 								Sum:          math.Float64frombits(value.StaleNaN),
-								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								Count:        &writev2.Histogram_CountInt{CountInt: 0},
 								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
-								PositiveSpans: []writev2.BucketSpan{
-									{Offset: 0, Length: 5}, // 5 buckets: 4 custom + 1 overflow
-								},
-								PositiveDeltas: []int64{10, 15, 20, 5, 0}, // Delta counts for each bucket
 							},
 						},
 					},
@@ -1216,7 +1212,7 @@ func TestTranslateV2(t *testing.T) {
 				dp.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
 				dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
 				dp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
-				dp.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0}) // Delta counts
+				dp.BucketCounts().FromRaw([]uint64{0, 0, 0, 0, 0})
 
 				return metrics
 			}(),
@@ -1299,7 +1295,7 @@ func TestTranslateV2(t *testing.T) {
 								Timestamp:    123456789,
 								Schema:       -53,
 								Sum:          100.5,
-								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								Count:        &writev2.Histogram_CountInt{CountInt: 180},
 								CustomValues: []float64{1.0, 2.0, 5.0, 10.0},
 								PositiveSpans: []writev2.BucketSpan{
 									{Offset: 0, Length: 5},
@@ -1352,9 +1348,9 @@ func TestTranslateV2(t *testing.T) {
 				dp1.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
 				dp1.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
 				dp1.SetSum(100.5)
-				dp1.SetCount(50)
+				dp1.SetCount(180)
 				dp1.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
-				dp1.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0})
+				dp1.BucketCounts().FromRaw([]uint64{10, 25, 45, 50, 50})
 
 				// Second metric - Exponential histogram
 				m2 := sm.Metrics().AppendEmpty()

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/value"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
@@ -367,6 +369,42 @@ func TestTranslateV2(t *testing.T) {
 						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18},
 						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
 					},
+					{
+						// CBNH histogram with scope1
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
+						Histograms: []writev2.Histogram{
+							{
+								Schema:         -53,
+								Count:          &writev2.Histogram_CountInt{CountInt: 1},
+								Sum:            1,
+								Timestamp:      1,
+								CustomValues:   []float64{1.0},
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 0, Length: 2}},
+								PositiveDeltas: []int64{1, 2},
+							},
+						},
+					},
+					{
+						// Exponential histogram with scope2
+						Metadata:         writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM},
+						LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18},
+						CreatedTimestamp: 150,
+						Histograms: []writev2.Histogram{
+							{
+								Schema:        0,
+								Count:         &writev2.Histogram_CountInt{CountInt: 1},
+								Sum:           1,
+								Timestamp:     1,
+								ZeroThreshold: 1,
+								ZeroCount:     &writev2.Histogram_ZeroCountInt{ZeroCountInt: 1},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 2},
+								},
+								PositiveDeltas: []int64{2, 2},
+							},
+						},
+					},
 				},
 			},
 			expectedMetrics: func() pmetric.Metrics {
@@ -395,6 +433,22 @@ func TestTranslateV2(t *testing.T) {
 				dp2.SetDoubleValue(2.0)
 				dp2.Attributes().PutStr("d", "e")
 
+				// Add CBNH histogram to scope1
+				cbneMetric := sm1.Metrics().AppendEmpty()
+				cbneMetric.SetName("test_metric")
+				cbneMetric.SetUnit("")
+				cbneMetric.SetDescription("")
+				hist := cbneMetric.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				cbneDP := hist.DataPoints().AppendEmpty()
+				cbneDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				cbneDP.SetCount(1)
+				cbneDP.SetSum(1)
+				cbneDP.ExplicitBounds().FromRaw([]float64{1.0})
+				cbneDP.BucketCounts().FromRaw([]uint64{1, 0})
+				cbneDP.Attributes().PutStr("d", "e")
+
 				sm2 := rm1.ScopeMetrics().AppendEmpty()
 				sm2.Scope().SetName("scope2")
 				sm2.Scope().SetVersion("v2")
@@ -408,12 +462,32 @@ func TestTranslateV2(t *testing.T) {
 				dp3.SetDoubleValue(3.0)
 				dp3.Attributes().PutStr("foo", "bar")
 
+				// Add exponential histogram to scope2
+				expMetric := sm2.Metrics().AppendEmpty()
+				expMetric.SetName("test_metric")
+				expMetric.SetUnit("")
+				expMetric.SetDescription("")
+				expHist := expMetric.SetEmptyExponentialHistogram()
+				expHist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				expDP := expHist.DataPoints().AppendEmpty()
+				expDP.SetStartTimestamp(pcommon.Timestamp(150 * int64(time.Millisecond)))
+				expDP.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				expDP.SetCount(1)
+				expDP.SetSum(1)
+				expDP.SetScale(0)
+				expDP.SetZeroThreshold(1)
+				expDP.SetZeroCount(1)
+				expDP.Positive().SetOffset(-1)
+				expDP.Positive().BucketCounts().FromRaw([]uint64{2, 4})
+				expDP.Attributes().PutStr("foo", "bar")
+
 				return expected
 			}(),
 			expectedStats: remote.WriteResponseStats{
 				Confirmed:  true,
 				Samples:    3,
-				Histograms: 0,
+				Histograms: 2,
 				Exemplars:  0,
 			},
 		},
@@ -922,26 +996,7 @@ func TestTranslateV2(t *testing.T) {
 				Histograms: 0,
 				Exemplars:  0,
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				m := sm.Metrics().AppendEmpty()
-				m.SetName("test_metric")
-
-				hist := m.SetEmptyExponentialHistogram()
-				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-
-				return metrics
-			}(),
+			expectedMetrics: pmetric.NewMetrics(), // Reset hint gauge should be dropped completely, no resources should be created
 		},
 		{
 			name: "classic histogram - should be dropped",
@@ -978,20 +1033,7 @@ func TestTranslateV2(t *testing.T) {
 				Histograms: 0,
 				Exemplars:  0,
 			},
-			expectedMetrics: func() pmetric.Metrics {
-				metrics := pmetric.NewMetrics()
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				attrs := rm.Resource().Attributes()
-				attrs.PutStr("service.namespace", "service-x")
-				attrs.PutStr("service.name", "test")
-				attrs.PutStr("service.instance.id", "107cn001")
-
-				sm := rm.ScopeMetrics().AppendEmpty()
-				sm.Scope().SetName("scope1")
-				sm.Scope().SetVersion("v1")
-
-				return metrics
-			}(),
+			expectedMetrics: pmetric.NewMetrics(), // Classic histograms should be dropped completely, no resources should be created
 		},
 		{
 			name: "summary - should be dropped",
@@ -1036,6 +1078,302 @@ func TestTranslateV2(t *testing.T) {
 				sm := rm.ScopeMetrics().AppendEmpty()
 				sm.Scope().SetName("scope1")
 				sm.Scope().SetVersion("v1")
+
+				return metrics
+			}(),
+		},
+		{
+			name: "CBNH translation",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__",
+					"test_cbnh_histogram",
+					"job",
+					"test",
+					"instance",
+					"localhost:8080",
+					"seconds",
+					"Test CBNH histogram",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_cbnh_histogram, job=test, instance=localhost:8080
+						CreatedTimestamp: 123456000,
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Timestamp:    123456789,
+								Schema:       -53, // CBNH schema
+								Sum:          100.5,
+								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 5}, // 5 buckets: 4 custom + 1 overflow
+								},
+								PositiveDeltas: []int64{10, 15, 20, 5, 0}, // Delta counts for each bucket
+							},
+						},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 1,
+				Exemplars:  0,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "localhost:8080")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+				m1 := sm.Metrics().AppendEmpty()
+				m1.SetName("test_cbnh_histogram")
+				m1.SetUnit("")
+				m1.SetDescription("")
+				hist := m1.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
+				dp.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
+				dp.SetSum(100.5)
+				dp.SetCount(50)
+				dp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
+				dp.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0}) // Delta counts
+
+				return metrics
+			}(),
+		},
+		{
+			name: "CBNH translation with stale NaN",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__",
+					"test_cbnh_histogram_stale",
+					"job",
+					"test",
+					"instance",
+					"localhost:8080",
+					"seconds",
+					"Test CBNH histogram with stale NaN",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_cbnh_histogram_stale, job=test, instance=localhost:8080
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Timestamp:    123456789,
+								Schema:       -53, // CBNH schema
+								Sum:          math.Float64frombits(value.StaleNaN),
+								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								CustomValues: []float64{1.0, 2.0, 5.0, 10.0}, // Custom bucket boundaries
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 5}, // 5 buckets: 4 custom + 1 overflow
+								},
+								PositiveDeltas: []int64{10, 15, 20, 5, 0}, // Delta counts for each bucket
+							},
+						},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 1,
+				Exemplars:  0,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "localhost:8080")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+				m1 := sm.Metrics().AppendEmpty()
+				m1.SetName("test_cbnh_histogram_stale")
+				m1.SetUnit("")
+				m1.SetDescription("")
+				hist := m1.SetEmptyHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
+				dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(true))
+				dp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
+				dp.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0}) // Delta counts
+
+				return metrics
+			}(),
+		},
+		{
+			name: "invalid schema histogram dropped",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__",
+					"test_invalid_schema_histogram",
+					"job",
+					"test",
+					"instance",
+					"localhost:8080",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_invalid_schema_histogram, job=test, instance=localhost:8080
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Timestamp: 123456789,
+								Schema:    -10, // Invalid schema (outside -4 to 8 range)
+								Sum:       100.5,
+								Count:     &writev2.Histogram_CountInt{CountInt: 50},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 2},
+								},
+								PositiveDeltas: []int64{10, 15},
+							},
+							{
+								Timestamp: 123456789,
+								Schema:    15, // Invalid schema (outside -4 to 8 range)
+								Sum:       200.5,
+								Count:     &writev2.Histogram_CountInt{CountInt: 100},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 2},
+								},
+								PositiveDeltas: []int64{20, 25},
+							},
+						},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 0,
+				Exemplars:  0,
+			},
+			expectedMetrics: pmetric.NewMetrics(), // When all histograms have invalid schemas, no metrics should be created
+		},
+		{
+			name: "mixed schema histograms - CBNH and exponential",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__",
+					"test_mixed_histogram",
+					"job",
+					"test",
+					"instance",
+					"localhost:8080",
+					"seconds",
+					"Test mixed histogram",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						LabelsRefs:       []uint32{1, 2, 3, 4, 5, 6}, // __name__=test_mixed_histogram, job=test, instance=localhost:8080
+						CreatedTimestamp: 123456000,
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_HISTOGRAM,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								// First histogram - CBNH
+								Timestamp:    123456789,
+								Schema:       -53,
+								Sum:          100.5,
+								Count:        &writev2.Histogram_CountInt{CountInt: 50},
+								CustomValues: []float64{1.0, 2.0, 5.0, 10.0},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 0, Length: 5},
+								},
+								PositiveDeltas: []int64{10, 15, 20, 5, 0},
+							},
+							{
+								// Second histogram - Exponential
+								Timestamp:     123456790,
+								Schema:        -4,
+								Sum:           200.0,
+								Count:         &writev2.Histogram_CountInt{CountInt: 100},
+								ZeroThreshold: 1.0,
+								ZeroCount:     &writev2.Histogram_ZeroCountInt{ZeroCountInt: 5},
+								PositiveSpans: []writev2.BucketSpan{
+									{Offset: 1, Length: 2},
+								},
+								PositiveDeltas: []int64{30, 40},
+							},
+						},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 2,
+				Exemplars:  0,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "localhost:8080")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("OpenTelemetry Collector")
+				sm.Scope().SetVersion("latest")
+
+				// First metric - CBNH (regular histogram)
+				m1 := sm.Metrics().AppendEmpty()
+				m1.SetName("test_mixed_histogram")
+				m1.SetUnit("")
+				m1.SetDescription("")
+				hist1 := m1.SetEmptyHistogram()
+				hist1.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp1 := hist1.DataPoints().AppendEmpty()
+				dp1.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
+				dp1.SetTimestamp(pcommon.Timestamp(123456789 * int64(time.Millisecond)))
+				dp1.SetSum(100.5)
+				dp1.SetCount(50)
+				dp1.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 5.0, 10.0})
+				dp1.BucketCounts().FromRaw([]uint64{10, 15, 20, 5, 0})
+
+				// Second metric - Exponential histogram
+				m2 := sm.Metrics().AppendEmpty()
+				m2.SetName("test_mixed_histogram")
+				m2.SetUnit("")
+				m2.SetDescription("")
+				hist2 := m2.SetEmptyExponentialHistogram()
+				hist2.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp2 := hist2.DataPoints().AppendEmpty()
+				dp2.SetStartTimestamp(pcommon.Timestamp(123456000 * int64(time.Millisecond)))
+				dp2.SetTimestamp(pcommon.Timestamp(123456790 * int64(time.Millisecond)))
+				dp2.SetScale(-4)
+				dp2.SetSum(200.0)
+				dp2.SetCount(100)
+				dp2.SetZeroCount(5)
+				dp2.SetZeroThreshold(1.0)
+				dp2.Positive().SetOffset(0)
+				dp2.Positive().BucketCounts().FromRaw([]uint64{30, 70})
 
 				return metrics
 			}(),


### PR DESCRIPTION
#### Description
Adds support for Native Histograms Custom Buckets (NHCB).

CBNH is a feature in Prometheus that brings Classic Histograms to the same struct used by Native Histograms. It serves as a migration step from Classic Histograms to Native Histograms.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41043 
