### PR TITLE
[receiver/awscloudwatchreceiver]: Improve logs polling performance when handling multiple log groups

### DIFF
--- a/.chloggen/awscloudwatchrecevier-poll-log-groups-parellel.yaml
+++ b/.chloggen/awscloudwatchrecevier-poll-log-groups-parellel.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improves performance of the receiver when handling multiple log groups
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41115]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -262,8 +262,8 @@ func (l *logsReceiver) poll(ctx context.Context) error {
 				}
 			}
 		}()
-		wg.Wait()
 	}
+	wg.Wait()
 
 	// Update the receiver's nextStartTime for the next poll cycle
 	l.nextStartTime = endTime


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The awscloudwatchreceiver receiver is synchronously polling the logs from each log group. As the number of logs increases and as more log groups are added the receiver is unable to use the entire CPU to keep up. 
This PR simply makes the receiver poll logs in an async manner.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
No issue related related to this