### PR TITLE
(pkg/ottl) Extract OS info from UserAgent string

### DIFF
--- a/.chloggen/feature-i-useragent-osinfo-2.yaml
+++ b/.chloggen/feature-i-useragent-osinfo-2.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add OS name and version attributes in the `UserAgent` function output.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35458]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1159,6 +1159,7 @@ func Test_e2e_converters(t *testing.T) {
 				m.PutStr("user_agent.original", "curl/7.81.0")
 				m.PutStr("user_agent.name", "curl")
 				m.PutStr("user_agent.version", "7.81.0")
+				m.PutStr("os.name", "Other")
 			},
 		},
 		{

--- a/pkg/ottl/e2e/profiles/e2e_test.go
+++ b/pkg/ottl/e2e/profiles/e2e_test.go
@@ -1140,6 +1140,7 @@ func Test_e2e_converters(t *testing.T) {
 					"user_agent.original": "curl/7.81.0",
 					"user_agent.name":     "curl",
 					"user_agent.version":  "7.81.0",
+					"os.name":             "Other",
 				})
 			},
 		},

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2422,7 +2422,8 @@ The `UserAgent` Converter parses the string argument trying to match it against 
 
 `value` is a string or a path to a string.  If `value` is not a string an error is returned.
 
-The results of the parsing are returned as a map containing `user_agent.name`, `user_agent.version`, `user_agent.original`, `os.name` and `os.version` as defined in semconv v1.34.0.
+The results of the parsing are returned as a map containing `user_agent.name`, `user_agent.version`, `user_agent.original`, `os.name`, and `os.version` as defined in semconv v1.34.0. `os.name` and `os.version` are omitted if empty.
+
 
 Parsing is done using the [uap-go package](https://github.com/ua-parser/uap-go). The specific formats it recognizes can be found [here](https://github.com/ua-parser/uap-core/blob/master/regexes.yaml).
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2422,8 +2422,7 @@ The `UserAgent` Converter parses the string argument trying to match it against 
 
 `value` is a string or a path to a string.  If `value` is not a string an error is returned.
 
-The results of the parsing are returned as a map containing `user_agent.name`, `user_agent.version` and `user_agent.original`
-as defined in semconv v1.25.0.
+The results of the parsing are returned as a map containing `user_agent.name`, `user_agent.version`, `user_agent.original`, `os.name` and `os.version` as defined in semconv v1.34.0.
 
 Parsing is done using the [uap-go package](https://github.com/ua-parser/uap-go). The specific formats it recognizes can be found [here](https://github.com/ua-parser/uap-core/blob/master/regexes.yaml).
 
@@ -2433,13 +2432,23 @@ Examples:
   ```yaml
   "user_agent.name": "curl"
   "user_agent.version": "7.81.0"
-  "user_agent.original": "curl/7.81.0"
+  "user_agent.original": "curl/7.81.0",
+  "os.name": "Other",
   ```
 - `Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0`
   ```yaml
   "user_agent.name": "Firefox"
   "user_agent.version": "126.0"
-  "user_agent.original": "Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0"
+  "user_agent.original": "Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0",
+  "os.name": "Linux",
+  ```
+- `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59`
+  ```yaml
+  "user_agent.name": "Edge"
+  "user_agent.version": "91.0.864"
+  "user_agent.original": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59",
+  "os.name": "Windows",
+  "os.version": "10"
   ```
 
 ### URL

--- a/pkg/ottl/ottlfuncs/func_useragent.go
+++ b/pkg/ottl/ottlfuncs/func_useragent.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 
 	"github.com/ua-parser/uap-go/uaparser"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -38,10 +38,23 @@ func userAgent[K any](userAgentSource ottl.StringGetter[K]) ottl.ExprFunc[K] { /
 			return nil, err
 		}
 		parsedUserAgent := parser.ParseUserAgent(userAgentString)
-		return map[string]any{
+		parsedOS := parser.ParseOs(userAgentString)
+		result := map[string]any{
 			string(semconv.UserAgentNameKey):     parsedUserAgent.Family,
 			string(semconv.UserAgentOriginalKey): userAgentString,
 			string(semconv.UserAgentVersionKey):  parsedUserAgent.ToVersionString(),
-		}, nil
+		}
+
+		osName := parsedOS.Family
+		if osName != "" {
+			result[string(semconv.OSNameKey)] = osName
+		}
+
+		osVersion := parsedOS.ToVersionString()
+		if osVersion != "" {
+			result[string(semconv.OSVersionKey)] = osVersion
+		}
+
+		return result, nil
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_useragent_test.go
+++ b/pkg/ottl/ottlfuncs/func_useragent_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -20,12 +20,24 @@ func TestUserAgentParser(t *testing.T) {
 		ExpectedMap map[string]any
 	}{
 		{
+			Name:     "Firefox-Android",
+			UAString: "Mozilla/5.0 (Linux; Android 4.1.1; SPH-L710 Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19",
+			ExpectedMap: map[string]any{
+				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (Linux; Android 4.1.1; SPH-L710 Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19",
+				string(semconv.UserAgentNameKey):     "Chrome Mobile",
+				string(semconv.UserAgentVersionKey):  "18.0.1025",
+				string(semconv.OSNameKey):            "Android",
+				string(semconv.OSVersionKey):         "4.1.1",
+			},
+		},
+		{
 			Name:     "Firefox",
 			UAString: "Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0",
 			ExpectedMap: map[string]any{
 				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0",
 				string(semconv.UserAgentNameKey):     "Firefox",
 				string(semconv.UserAgentVersionKey):  "126.0",
+				string(semconv.OSNameKey):            "Linux",
 			},
 		},
 		{
@@ -35,6 +47,7 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
 				string(semconv.UserAgentNameKey):     "Chrome",
 				string(semconv.UserAgentVersionKey):  "51.0.2704",
+				string(semconv.OSNameKey):            "Linux",
 			},
 		},
 		{
@@ -44,6 +57,8 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1",
 				string(semconv.UserAgentNameKey):     "Mobile Safari",
 				string(semconv.UserAgentVersionKey):  "13.1.1",
+				string(semconv.OSNameKey):            "iOS",
+				string(semconv.OSVersionKey):         "13.5.1",
 			},
 		},
 		{
@@ -53,6 +68,8 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59",
 				string(semconv.UserAgentNameKey):     "Edge",
 				string(semconv.UserAgentVersionKey):  "91.0.864",
+				string(semconv.OSNameKey):            "Windows",
+				string(semconv.OSVersionKey):         "10",
 			},
 		},
 		{
@@ -62,6 +79,7 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41",
 				string(semconv.UserAgentNameKey):     "Opera",
 				string(semconv.UserAgentVersionKey):  "38.0.2220",
+				string(semconv.OSNameKey):            "Linux",
 			},
 		},
 		{
@@ -71,6 +89,7 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "curl/7.81.0",
 				string(semconv.UserAgentNameKey):     "curl",
 				string(semconv.UserAgentVersionKey):  "7.81.0",
+				string(semconv.OSNameKey):            "Other",
 			},
 		},
 		{
@@ -80,6 +99,7 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "foobar/1.2.3 (foo; bar baz)",
 				string(semconv.UserAgentNameKey):     "Other",
 				string(semconv.UserAgentVersionKey):  "",
+				string(semconv.OSNameKey):            "Other",
 			},
 		},
 		{
@@ -89,6 +109,29 @@ func TestUserAgentParser(t *testing.T) {
 				string(semconv.UserAgentOriginalKey): "OpenTelemetry Collector Contrib/0.106.1 (linux/amd64)",
 				string(semconv.UserAgentNameKey):     "Other",
 				string(semconv.UserAgentVersionKey):  "",
+				string(semconv.OSNameKey):            "Linux",
+			},
+		},
+		{
+			Name:     "ViaFree iOS",
+			UAString: "ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0",
+			ExpectedMap: map[string]any{
+				string(semconv.UserAgentOriginalKey): "ViaFree-DK/3.8.3 (com.MTGx.ViaFree.dk; build:7383; iOS 12.1.0) Alamofire/4.7.0",
+				string(semconv.UserAgentNameKey):     "ViaFree",
+				string(semconv.UserAgentVersionKey):  "3.8.3",
+				string(semconv.OSNameKey):            "iOS",
+				string(semconv.OSVersionKey):         "12.1.0",
+			},
+		},
+		{
+			Name:     "Java SDK Linux",
+			UAString: "ibm-cos-sdk-java/2.3.0 Linux/4.9.0-8-amd64 Java_HotSpot(TM)_64-Bit_Server_VM/9.0.4+11/9.0.4'",
+			ExpectedMap: map[string]any{
+				string(semconv.UserAgentOriginalKey): "ibm-cos-sdk-java/2.3.0 Linux/4.9.0-8-amd64 Java_HotSpot(TM)_64-Bit_Server_VM/9.0.4+11/9.0.4'",
+				string(semconv.UserAgentNameKey):     "ibm-cos-sdk-java",
+				string(semconv.UserAgentVersionKey):  "2.3.0",
+				string(semconv.OSNameKey):            "Linux",
+				string(semconv.OSVersionKey):         "4.9.0",
 			},
 		},
 	}


### PR DESCRIPTION
#### Description
Add [OS](https://opentelemetry.io/docs/specs/semconv/attributes-registry/os/) attributes about name and version from the (parsed) User Agent string.

Use [semconv](https://pkg.go.dev/go.opentelemetry.io/otel/semconv) newer than `v1.31.0` to reuse OS-related attributes.

*Note*: This is a second attempt after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35886 was closed due to missing `semconv` attributes.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35458

#### Testing
Run TestUserAgentParser(), add new fields to expected map, add new testcases taken from https://github.com/ua-parser/uap-core/blob/master/tests/test_os.yaml.

#### Documentation

1. Update existing examples in [ottlfuncs/README.md](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#useragent) with newly added attributes
2. Add new example in [ottlfuncs/README.md](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs/README.md#useragent) that populates all newly added attributes
