### PR TITLE
[chore][receiver/prometheus]: remove workaround for Prom issue 16217

### DIFF
--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -278,12 +278,6 @@ func (t *transaction) AppendExemplar(_ storage.SeriesRef, l labels.Labels, e exe
 	}
 
 	mf := t.getOrCreateMetricFamily(*rKey, getScopeID(l), mn)
-
-	// Workaround for https://github.com/prometheus/prometheus/issues/16217
-	if !t.enableNativeHistograms && mf.mtype == pmetric.MetricTypeHistogram && l.Get(model.MetricNameLabel) == mf.name {
-		return 0, nil
-	}
-
 	mf.addExemplar(t.getSeriesRef(l, mf.mtype), e)
 
 	return 0, nil


### PR DESCRIPTION
#### Description

Upstream has the fix for https://github.com/prometheus/prometheus/issues/16217 , so time to remove the workaround.

I didn't remember if I had a test for this, so reverted to 929f5f9593c6ad56e187dc69bdd881f14b22f58a before
Bump prometheus to 0.304.1 (#40397)

There tests fail without the fix in
```
TestNativeVsClassicHistogramScrapeViaProtobuf/feature_disabled_scrape_classic_on/target1/target1 (re-run 1) (0.00s)
    metrics_receiver_protobuf_test.go:312:
Error:      	Not equal:
            	expected: 1
              	actual  : 3
```

Now tests don't fail without the workaround anymore.

#### Link to tracking issue

N/A

#### Testing

Unit tests pass.

#### Documentation

N/A
