### PR TITLE
[receiver/mysql] Collect 'fsync' log operations

### DIFF
--- a/.chloggen/mysql-fsync-ops.yaml
+++ b/.chloggen/mysql-fsync-ops.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: Collect 'fsync' log operations.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [41175]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/mysql-fsync-ops.yaml
+++ b/.chloggen/mysql-fsync-ops.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Collect 'fsync' log operations.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -172,7 +172,7 @@ The number of InnoDB log operations.
 
 | Name | Description | Values | Optional |
 | ---- | ----------- | ------ | -------- |
-| operation | The log operation types. | Str: ``waits``, ``write_requests``, ``writes`` | false |
+| operation | The log operation types. | Str: ``waits``, ``write_requests``, ``writes``, ``fsyncs`` | false |
 
 ### mysql.mysqlx_connections
 

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -172,7 +172,7 @@ The number of InnoDB log operations.
 
 | Name | Description | Values | Optional |
 | ---- | ----------- | ------ | -------- |
-| operation | The log operation types. | Str: ``waits``, ``write_requests``, ``writes``, ``fsyncs`` | false |
+| operation | The log operation types. 'fsyncs' aren't available in MariaDB 10.8 or later. | Str: ``waits``, ``write_requests``, ``writes``, ``fsyncs`` | false |
 
 ### mysql.mysqlx_connections
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -578,6 +578,7 @@ const (
 	AttributeLogOperationsWaits
 	AttributeLogOperationsWriteRequests
 	AttributeLogOperationsWrites
+	AttributeLogOperationsFsyncs
 )
 
 // String returns the string representation of the AttributeLogOperations.
@@ -589,6 +590,8 @@ func (av AttributeLogOperations) String() string {
 		return "write_requests"
 	case AttributeLogOperationsWrites:
 		return "writes"
+	case AttributeLogOperationsFsyncs:
+		return "fsyncs"
 	}
 	return ""
 }
@@ -598,6 +601,7 @@ var MapAttributeLogOperations = map[string]AttributeLogOperations{
 	"waits":          AttributeLogOperationsWaits,
 	"write_requests": AttributeLogOperationsWriteRequests,
 	"writes":         AttributeLogOperationsWrites,
+	"fsyncs":         AttributeLogOperationsFsyncs,
 }
 
 // AttributeMysqlxThreads specifies the value mysqlx_threads attribute.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -58,7 +58,7 @@ attributes:
     enum: [pages_written, writes]
   log_operations:
     name_override: operation
-    description: The log operation types.
+    description: The log operation types. 'fsyncs' aren't available in MariaDB 10.8 or later.
     type: string
     enum: [waits, write_requests, writes, fsyncs]
   operations:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -60,7 +60,7 @@ attributes:
     name_override: operation
     description: The log operation types.
     type: string
-    enum: [waits, write_requests, writes]
+    enum: [waits, write_requests, writes, fsyncs]
   operations:
     name_override: operation
     description: The operation types.

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -301,6 +301,8 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWriteRequests))
 		case "Innodb_log_writes":
 			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsWrites))
+		case "Innodb_os_log_fsyncs":
+			addPartialIfError(errs, m.mb.RecordMysqlLogOperationsDataPoint(now, v, metadata.AttributeLogOperationsFsyncs))
 
 		// operations
 		case "Innodb_data_fsyncs":

--- a/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
@@ -349,6 +349,14 @@ resourceMetrics:
                         stringValue: writes
                   startTimeUnixNano: "1739268134589730000"
                   timeUnixNano: "1739268193591792000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fsyncs
+                  startTimeUnixNano: "1739268134589730000"
+                  timeUnixNano: "1739268193591792000"
+
               isMonotonic: true
             unit: "1"
           - description: The number of opened resources.

--- a/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
@@ -349,14 +349,6 @@ resourceMetrics:
                         stringValue: writes
                   startTimeUnixNano: "1739268134589730000"
                   timeUnixNano: "1739268193591792000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fsyncs
-                  startTimeUnixNano: "1739268134589730000"
-                  timeUnixNano: "1739268193591792000"
-
               isMonotonic: true
             unit: "1"
           - description: The number of opened resources.

--- a/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
@@ -349,6 +349,13 @@ resourceMetrics:
                         stringValue: writes
                   startTimeUnixNano: "1674545255370693000"
                   timeUnixNano: "1674545265375344000"
+                - asInt: "78"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fsyncs
+                  startTimeUnixNano: "1674545255370693000"
+                  timeUnixNano: "1674545265375344000"
               isMonotonic: true
             unit: "1"
           - description: The number of mysqlx connections.

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -683,6 +683,13 @@ resourceMetrics:
                         stringValue: writes
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+                - asInt: "256"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fsyncs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: The number of mysqlx connections.

--- a/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
@@ -333,6 +333,13 @@ resourceMetrics:
                         stringValue: writes
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+                - asInt: "256"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fsyncs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: The number of mysqlx connections.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Collect `fsync` log operations. Tracking `fsync` operations is important for understanding performance of the redo logs. 
