### PR TITLE
[chore] Make Test_WindowsPerfCounterScraper more resilient

### DIFF
--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -235,8 +235,11 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 			require.Equal(t, 0, obs.Len())
 			require.NoError(t, err)
 
-			actualMetrics, err := scraper.scrape(context.Background())
-			require.NoError(t, err)
+			var actualMetrics pmetric.Metrics
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				actualMetrics, err = scraper.scrape(context.Background())
+				assert.NoError(c, err)
+			}, 20*time.Second, 1*time.Second)
 
 			err = scraper.shutdown(context.Background())
 


### PR DESCRIPTION
The test has some sporadic failures when it hits `A counter with a negative denominator value was detected.` - this is typically a transient error when collecting performance counters on Windows. Similar transient errors could also happen. Making the test more resilient by testing a few times before giving up.

Fixes #41136 
