### PR TITLE
[chore][sqlserver/receiver] Correct 'CompareMetrics' parameters order

### DIFF
--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -173,7 +173,7 @@ func TestSuccessfulScrape(t *testing.T) {
 				expectedMetrics, err := golden.ReadMetrics(expectedFile)
 				assert.NoError(t, err)
 
-				assert.NoError(t, pmetrictest.CompareMetrics(actualMetrics, expectedMetrics,
+				assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
 					pmetrictest.IgnoreMetricDataPointsOrder(),
 					pmetrictest.IgnoreStartTimestamp(),
 					pmetrictest.IgnoreTimestamp(),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The `pmetrictest.CompareMetrics` function expects expected metrics first and actual metrics second. However, in the SQL Server receiver tests, the arguments are reversed — actual metrics are passed first, and expected metrics second.
This causes confusing test failure messages, such as: number of metrics doesn't match expected: `47`, actual: `46` — when in reality, the actual metrics are `47` and the expected are `46`.