### PR TITLE
feat(prometheusremotewriter): introduce pipeline lag metric

### DIFF
--- a/.chloggen/nickange_prometheusremotewriteexporter_feat-add-wal-pipeline-lag-metrics.yaml
+++ b/.chloggen/nickange_prometheusremotewriteexporter_feat-add-wal-pipeline-lag-metrics.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexproter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Adds wal pipeline lag metric to the Prometheus Remote Write Exporter. The new metric is:
+  - `otelcol_exporter_prometheusremotewrite_wal_lag`: WAL pipeline lag.
+  
+  The frequency of recording pipeline lag can be configured with `lag_record_frequency`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39556]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/documentation.md
+++ b/exporter/prometheusremotewriteexporter/documentation.md
@@ -56,7 +56,7 @@ Total number of bytes written to the WAL
 
 ### otelcol_exporter_prometheusremotewrite_wal_lag
 
-Index-based WAL lag
+WAL lag
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/exporter/prometheusremotewriteexporter/documentation.md
+++ b/exporter/prometheusremotewriteexporter/documentation.md
@@ -54,6 +54,14 @@ Total number of bytes written to the WAL
 | ---- | ----------- | ---------- | --------- |
 | By | Sum | Int | true |
 
+### otelcol_exporter_prometheusremotewrite_wal_lag
+
+Index-based WAL lag
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Int |
+
 ### otelcol_exporter_prometheusremotewrite_wal_read_latency
 
 Response latency in ms for the WAL reads.

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
@@ -32,6 +32,7 @@ type TelemetryBuilder struct {
 	ExporterPrometheusremotewriteTranslatedTimeSeries metric.Int64Counter
 	ExporterPrometheusremotewriteWalBytesRead         metric.Int64Counter
 	ExporterPrometheusremotewriteWalBytesWritten      metric.Int64Counter
+	ExporterPrometheusremotewriteWalLag               metric.Int64Gauge
 	ExporterPrometheusremotewriteWalReadLatency       metric.Int64Histogram
 	ExporterPrometheusremotewriteWalReads             metric.Int64Counter
 	ExporterPrometheusremotewriteWalReadsFailures     metric.Int64Counter
@@ -103,6 +104,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_exporter_prometheusremotewrite_wal_bytes_written",
 		metric.WithDescription("Total number of bytes written to the WAL"),
 		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ExporterPrometheusremotewriteWalLag, err = builder.meter.Int64Gauge(
+		"otelcol_exporter_prometheusremotewrite_wal_lag",
+		metric.WithDescription("Index-based WAL lag"),
+		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalReadLatency, err = builder.meter.Int64Histogram(

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
@@ -108,7 +108,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalLag, err = builder.meter.Int64Gauge(
 		"otelcol_exporter_prometheusremotewrite_wal_lag",
-		metric.WithDescription("Index-based WAL lag"),
+		metric.WithDescription("WAL lag"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
@@ -120,7 +120,7 @@ func AssertEqualExporterPrometheusremotewriteWalBytesWritten(t *testing.T, tt *c
 func AssertEqualExporterPrometheusremotewriteWalLag(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_lag",
-		Description: "Index-based WAL lag",
+		Description: "WAL lag",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
@@ -117,6 +117,20 @@ func AssertEqualExporterPrometheusremotewriteWalBytesWritten(t *testing.T, tt *c
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualExporterPrometheusremotewriteWalLag(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_exporter_prometheusremotewrite_wal_lag",
+		Description: "Index-based WAL lag",
+		Unit:        "1",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_exporter_prometheusremotewrite_wal_lag")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualExporterPrometheusremotewriteWalReadLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_read_latency",

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -26,6 +26,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ExporterPrometheusremotewriteTranslatedTimeSeries.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalBytesRead.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalBytesWritten.Add(context.Background(), 1)
+	tb.ExporterPrometheusremotewriteWalLag.Record(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalReadLatency.Record(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalReads.Add(context.Background(), 1)
 	tb.ExporterPrometheusremotewriteWalReadsFailures.Add(context.Background(), 1)
@@ -48,6 +49,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPrometheusremotewriteWalBytesWritten(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualExporterPrometheusremotewriteWalLag(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualExporterPrometheusremotewriteWalReadLatency(t, testTel,

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -95,7 +95,6 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-
     exporter_prometheusremotewrite_wal_bytes_read:
       enabled: true
       description: Total number of bytes read from the WAL
@@ -103,3 +102,9 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    exporter_prometheusremotewrite_wal_lag:
+      enabled: true
+      description: Index-based WAL lag
+      unit: "1"
+      gauge:
+        value_type: int

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -104,7 +104,7 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_lag:
       enabled: true
-      description: Index-based WAL lag
+      description: WAL lag
       unit: "1"
       gauge:
         value_type: int

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -290,7 +290,7 @@ func (prweWAL *prweWAL) recordLagLoop(ctx context.Context, logger *zap.Logger) {
 		case <-ticker.C:
 			// In normal state, wIndex and rIndex will differ by one. To avoid having -1 as a final value, we set it to 0 as minimum.
 			lag := max(0, int64(prweWAL.wWALIndex.Load()-prweWAL.rWALIndex.Load()))
-			logger.Info("recording lag log", zap.Int64("wIndex", int64(prweWAL.wWALIndex.Load())), zap.Int64("rIndex", int64(prweWAL.wWALIndex.Load())), zap.Int64("lag", int64(lag)))
+			logger.Info("recording lag log", zap.Int64("wIndex", int64(prweWAL.wWALIndex.Load())), zap.Int64("rIndex", int64(prweWAL.wWALIndex.Load())), zap.Int64("lag", lag))
 			prweWAL.telemetry.recordWALLag(ctx, lag)
 		}
 	}

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -380,3 +380,62 @@ func TestWALRead_Telemetry(t *testing.T) {
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_bytes_read")
 	require.NoError(t, err)
 }
+
+func TestWALLag_Telemetry(t *testing.T) {
+	tel := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, tel.Shutdown(context.Background()))
+	})
+	set := metadatatest.NewSettings(tel)
+
+	cfg := &Config{
+		WAL: &WALConfig{
+			Directory:          t.TempDir(),
+			BufferSize:         1,
+			LagRecordFrequency: 10 * time.Millisecond, // Very short interval for testing
+		},
+		TargetInfo:          &TargetInfo{},
+		RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV2,
+	}
+
+	// Create a server that will be slow to process requests (to create lag)
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// Do nothing
+	}))
+	defer server.Close()
+
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	cfg.ClientConfig = clientConfig
+
+	prw, err := newPRWExporter(cfg, set)
+	require.NotNil(t, prw)
+	require.NoError(t, err)
+
+	err = prw.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, prw.Shutdown(context.Background()))
+	})
+
+	// Create test data to write to WAL
+	metrics := map[string]*prompb.TimeSeries{
+		"test_metric_1": {
+			Labels:  []prompb.Label{{Name: "__name__", Value: "test_metric_1"}},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
+		},
+	}
+
+	// Write multiple metrics to create lag (wIndex will be ahead of rIndex)
+	err = prw.handleExport(context.Background(), metrics, nil)
+	require.NoError(t, err)
+
+	// Wait for lag recording to happen (longer than lagRecordFrequency)
+	time.Sleep(5 * cfg.WAL.LagRecordFrequency)
+
+	metadatatest.AssertEqualExporterPrometheusremotewriteWalLag(t, tel,
+		[]metricdata.DataPoint[int64]{{Value: 0}},
+		metricdatatest.IgnoreTimestamp())
+	require.NoError(t, err)
+
+}

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -437,5 +437,4 @@ func TestWALLag_Telemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 0}},
 		metricdatatest.IgnoreTimestamp())
 	require.NoError(t, err)
-
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39556
 
Adds telemetry to track Write-Ahead Log (WAL) processing lag, providing visibility into pipeline performance and helping identify bottlenecks.
- `exporter_prometheusremotewrite_wal_lag` (type: Gauge): Records the difference between WAL write and read indices, indicating how many entries are pending processing
- `lag_record_frequency: Controls how often lag is recorded (default: 15 seconds). Part of walConfig


Metric

```
# HELP otelcol_exporter_prometheusremotewrite_wal_lag_ratio WAL lag
# TYPE otelcol_exporter_prometheusremotewrite_wal_lag_ratio gauge
otelcol_exporter_prometheusremotewrite_wal_lag_ratio{otel_scope_name="github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter",otel_scope_version=""} 26
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
