### PR TITLE
[chore] [receiver/sqlserver] Streamline obfuscate usage

### DIFF
--- a/receiver/sqlserverreceiver/obfuscate.go
+++ b/receiver/sqlserverreceiver/obfuscate.go
@@ -1,13 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// source(Apache 2.0): https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/python/datadog_agent.go
-
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 
 import (
@@ -15,43 +8,36 @@ import (
 	"encoding/xml"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 )
 
 var (
-	obfuscator       *obfuscate.Obfuscator
-	obfuscatorLoader sync.Once
+	xmlPlanObfuscationAttrs = []string{
+		"StatementText",
+		"ConstValue",
+		"ScalarString",
+		"ParameterCompiledValue",
+	}
+	obfuscateSQLConfig = obfuscate.SQLConfig{DBMS: "mssql"}
 )
 
-// lazyInitObfuscator initializes the obfuscator the first time it is used.
-func lazyInitObfuscator() *obfuscate.Obfuscator {
-	obfuscatorLoader.Do(func() { obfuscator = obfuscate.NewObfuscator(obfuscate.Config{}) })
-	return obfuscator
+type obfuscator obfuscate.Obfuscator
+
+func newObfuscator() *obfuscator {
+	return (*obfuscator)(obfuscate.NewObfuscator(obfuscate.Config{}))
 }
 
-// ObfuscateSQL obfuscates & normalizes the provided SQL query, writing the error into errResult if the operation fails.
-func obfuscateSQL(rawQuery string) (string, error) {
-	obfuscatedQuery, err := lazyInitObfuscator().ObfuscateSQLStringWithOptions(rawQuery, &obfuscate.SQLConfig{DBMS: "mssql"})
+func (o *obfuscator) obfuscateSQLString(sql string) (string, error) {
+	obfuscatedQuery, err := (*obfuscate.Obfuscator)(o).ObfuscateSQLStringWithOptions(sql, &obfuscateSQLConfig)
 	if err != nil {
 		return "", err
 	}
-
 	return obfuscatedQuery.Query, nil
 }
 
-// Ending source(Apache 2.0): https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/python/datadog_agent.go
-
-var xmlPlanObfuscationAttrs = []string{
-	"StatementText",
-	"ConstValue",
-	"ScalarString",
-	"ParameterCompiledValue",
-}
-
 // obfuscateXMLPlan obfuscates SQL text & parameters from the provided SQL Server XML Plan
-func obfuscateXMLPlan(rawPlan string) (string, error) {
+func (o *obfuscator) obfuscateXMLPlan(rawPlan string) (string, error) {
 	decoder := xml.NewDecoder(strings.NewReader(rawPlan))
 	var buffer bytes.Buffer
 	encoder := xml.NewEncoder(&buffer)
@@ -73,7 +59,7 @@ func obfuscateXMLPlan(rawPlan string) (string, error) {
 						if elem.Attr[i].Value == "" {
 							continue
 						}
-						val, err := obfuscateSQL(elem.Attr[i].Value)
+						val, err := o.obfuscateSQLString(elem.Attr[i].Value)
 						if err != nil {
 							fmt.Println("Unable to obfuscate SQL statement in query plan, skipping: " + elem.Attr[i].Value)
 							return "", nil

--- a/receiver/sqlserverreceiver/obfuscate_test.go
+++ b/receiver/sqlserverreceiver/obfuscate_test.go
@@ -20,21 +20,22 @@ func TestObfuscateSQL(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "inputSQL.sql"))
 	assert.NoError(t, err)
 
-	result, err := obfuscateSQL(string(input))
+	result, err := newObfuscator().obfuscateSQLString(string(input))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSQL, result)
 }
 
 func TestObfuscateInvalidSQL(t *testing.T) {
+	obf := newObfuscator()
 	sql := "SELECT cpu_time AS [CPU Usage (time)"
-	result, err := obfuscateSQL(sql)
+	result, err := obf.obfuscateSQLString(sql)
 
 	assert.Error(t, err)
 	assert.Empty(t, result)
 
 	sql = "SELECT cpu_time AS [CPU Usage Time]"
 	expected := "SELECT cpu_time"
-	result, err = obfuscateSQL(sql)
+	result, err = obf.obfuscateSQLString(sql)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
@@ -47,44 +48,48 @@ func TestObfuscateQueryPlan(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "inputQueryPlan.xml"))
 	assert.NoError(t, err)
 
-	result, err := obfuscateXMLPlan(string(input))
+	result, err := newObfuscator().obfuscateXMLPlan(string(input))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedQueryPlan, result)
 }
 
 func TestInvalidQueryPlans(t *testing.T) {
+	obf := newObfuscator()
+
 	plan := `<ShowPlanXml</ShowPlanXML>`
-	result, err := obfuscateXMLPlan(plan)
+	result, err := obf.obfuscateXMLPlan(plan)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
 	plan = `<ShowPlanXML></ShowPlanXML`
-	result, err = obfuscateXMLPlan(plan)
+	result, err = obf.obfuscateXMLPlan(plan)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
 	plan = `<ShowPlanXML></ShowPlan>`
-	result, err = obfuscateXMLPlan(plan)
+	result, err = obf.obfuscateXMLPlan(plan)
 	assert.Empty(t, result)
 	assert.Error(t, err)
 
 	// obfuscate failure, return empty string
 	plan = `<ShowPlanXML StatementText="[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]/(10000)*(3600)+[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]%(10000)/(100)*(60)+[msdb].[dbo].[sysjobhistory].[run_duration] as [sjh].[run_duration]%(100)"></ShowPlanXML>`
-	result, err = obfuscateXMLPlan(plan)
+	result, err = obf.obfuscateXMLPlan(plan)
 	assert.Empty(t, result)
 	assert.NoError(t, err)
 }
 
 func TestValidQueryPlans(t *testing.T) {
+	obf := newObfuscator()
+
 	plan := `<ShowPlanXML value="abc"></ShowPlanXML>`
-	_, err := obfuscateXMLPlan(plan)
+	_, err := obf.obfuscateXMLPlan(plan)
 	assert.NoError(t, err)
 
 	plan = `<ShowPlanXML StatementText=""></ShowPlanXML>`
-	_, err = obfuscateXMLPlan(plan)
+	_, err = obf.obfuscateXMLPlan(plan)
 	assert.NoError(t, err)
 
 	plan = `<ShowPlanXML StatementText="SELECT * FROM table"><!-- comment --></ShowPlanXML>`
-	_, err = obfuscateXMLPlan(plan)
+	_, err = obf.obfuscateXMLPlan(plan)
 	assert.NoError(t, err)
 }

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -63,6 +63,7 @@ type sqlServerScraperHelper struct {
 	lb                     *metadata.LogsBuilder
 	cache                  *lru.Cache[string, int64]
 	lastExecutionTimestamp time.Time
+	obfuscator             *obfuscator
 }
 
 var (
@@ -91,6 +92,7 @@ func newSQLServerScraper(id component.ID,
 		lb:                     metadata.NewLogsBuilder(cfg.LogsBuilderConfig, params),
 		cache:                  cache,
 		lastExecutionTimestamp: time.Unix(0, 0),
+		obfuscator:             newObfuscator(),
 	}
 }
 
@@ -698,7 +700,7 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 
 		queryTextVal := s.retrieveValue(row, queryText, &errs, func(row sqlquery.StringMap, columnName string) (any, error) {
 			statement := row[columnName]
-			obfuscated, err := obfuscateSQL(statement)
+			obfuscated, err := s.obfuscator.obfuscateSQLString(statement)
 			if err != nil {
 				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement: %v", statement))
 				return "", nil
@@ -731,7 +733,9 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 			physicalReadsVal = int64(0)
 		}
 
-		queryPlanVal := s.retrieveValue(row, queryPlan, &errs, func(row sqlquery.StringMap, columnName string) (any, error) { return obfuscateXMLPlan(row[columnName]) })
+		queryPlanVal := s.retrieveValue(row, queryPlan, &errs, func(row sqlquery.StringMap, columnName string) (any, error) {
+			return s.obfuscator.obfuscateXMLPlan(row[columnName])
+		})
 
 		rowsReturnedVal := s.retrieveValue(row, rowsReturned, &errs, retrieveInt)
 		cached, rowsReturnedVal = s.cacheAndDiff(queryHashVal, queryPlanHashVal, rowsReturned, rowsReturnedVal.(int64))
@@ -994,7 +998,7 @@ func (s *sqlServerScraperHelper) recordDatabaseSampleQuery(ctx context.Context) 
 		dbNamespaceVal := row[dbName]
 		queryTextVal := s.retrieveValue(row, statementText, &errs, func(row sqlquery.StringMap, columnName string) (any, error) {
 			statement := row[columnName]
-			obfuscated, err := obfuscateSQL(statement)
+			obfuscated, err := s.obfuscator.obfuscateSQLString(statement)
 			if err != nil {
 				s.logger.Error(fmt.Sprintf("failed to obfuscate SQL statement: %v", statement))
 				return "", nil


### PR DESCRIPTION
Don't use sync.Once, maintain the instance explicitly as part of the scraper
