### PR TITLE
[receiver/postgresql] Enable connection pooling by default

### DIFF
--- a/.chloggen/postgres-client-pool-fg-alpha.yaml
+++ b/.chloggen/postgres-client-pool-fg-alpha.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/postgresql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move receiver.postgresql.connectionPool feature gate to alpha
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30831]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This change updates the receiver to use the connection pooling for performance benefits.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/postgresqlreceiver/client_factory.go
+++ b/receiver/postgresqlreceiver/client_factory.go
@@ -16,7 +16,7 @@ const connectionPoolGateID = "receiver.postgresql.connectionPool"
 
 var connectionPoolGate = featuregate.GlobalRegistry().MustRegister(
 	connectionPoolGateID,
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("Use of connection pooling"),
 	featuregate.WithRegisterFromVersion("0.96.0"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831"),


### PR DESCRIPTION
Move `receiver.postgresql.connectionPool` feature gate to alpha. It's been a while since it was introduced.

This change updates the receiver to use the connection pooling for performance benefits.
