### PR TITLE
[exporter/splunk_hec] Deprecate 'batcher' config for now

### DIFF
--- a/.chloggen/deprecated-batcher-splunkhec.yaml
+++ b/.chloggen/deprecated-batcher-splunkhec.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: deprecation
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: splunkhecexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate 'batcher' config, use 'sending_queue::batch' instead
+note: Update 'batcher' config to use internal deprecated struct instead of the one removed from the core.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [41224]
@@ -17,4 +17,4 @@ issues: [41224]
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user]
+change_logs: [api]

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -62,11 +63,22 @@ type HecTelemetry struct {
 	ExtraAttributes map[string]string `mapstructure:"extra_attributes"`
 }
 
+type DeprecatedBatchConfig struct {
+	Enabled      bool                            `mapstructure:"enabled"`
+	FlushTimeout time.Duration                   `mapstructure:"flush_timeout"`
+	Sizer        exporterhelper.RequestSizerType `mapstructure:"sizer"`
+	MinSize      int64                           `mapstructure:"min_size"`
+	MaxSize      int64                           `mapstructure:"max_size"`
+	isSet        bool                            `mapstructure:"-"`
+}
+
 // Config defines configuration for Splunk exporter.
 type Config struct {
 	confighttp.ClientConfig   `mapstructure:",squash"`
 	QueueSettings             exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	// DeprecatedBatcher is the deprecated batcher configuration.
+	DeprecatedBatcher DeprecatedBatchConfig `mapstructure:"batcher"`
 
 	// LogDataEnabled can be used to disable sending logs by the exporter.
 	LogDataEnabled bool `mapstructure:"log_data_enabled"`
@@ -138,6 +150,36 @@ type Config struct {
 
 	// Telemetry is the configuration for splunk hec exporter telemetry
 	Telemetry HecTelemetry `mapstructure:"telemetry"`
+}
+
+func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	if err := conf.Unmarshal(cfg); err != nil {
+		return err
+	}
+	if conf.IsSet("batcher") {
+		cfg.DeprecatedBatcher.isSet = true
+		if cfg.QueueSettings.Batch != nil {
+			return errors.New(`deprecated "batcher" cannot be set along with "sending_queue::batch"`)
+		}
+		if cfg.DeprecatedBatcher.Enabled {
+			cfg.QueueSettings.Batch = &exporterhelper.BatchConfig{
+				FlushTimeout: cfg.DeprecatedBatcher.FlushTimeout,
+				// TODO: uncomment once core dependency is updated
+				// Sizer:   cfg.DeprecatedBatcher.Sizer,
+				MinSize: cfg.DeprecatedBatcher.MinSize,
+				MaxSize: cfg.DeprecatedBatcher.MaxSize,
+			}
+
+			// If the deprecated batcher is enabled without a queue, enable blocking queue to replicate the
+			// behavior of the deprecated batcher.
+			if !cfg.QueueSettings.Enabled {
+				cfg.QueueSettings.Enabled = true
+				cfg.QueueSettings.WaitForResult = true
+			}
+		}
+	}
+
+	return nil
 }
 
 func (cfg *Config) getURL() (out *url.URL, err error) {

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -242,7 +242,7 @@ func TestConfig_Validate(t *testing.T) {
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErr)
 			}
 		})
 	}

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -114,7 +115,7 @@ func createTracesExporter(
 	config component.Config,
 ) (exporter.Traces, error) {
 	cfg := config.(*Config)
-
+	showDeprecationWarnings(cfg, set.Logger)
 	c := newTracesClient(set, cfg)
 
 	e, err := exporterhelper.NewTraces(
@@ -147,7 +148,7 @@ func createMetricsExporter(
 	config component.Config,
 ) (exporter.Metrics, error) {
 	cfg := config.(*Config)
-
+	showDeprecationWarnings(cfg, set.Logger)
 	c := newMetricsClient(set, cfg)
 
 	e, err := exporterhelper.NewMetrics(
@@ -180,7 +181,7 @@ func createLogsExporter(
 	config component.Config,
 ) (exporter exporter.Logs, err error) {
 	cfg := config.(*Config)
-
+	showDeprecationWarnings(cfg, set.Logger)
 	c := newLogsClient(set, cfg)
 
 	logsExporter, err := exporterhelper.NewLogs(
@@ -210,4 +211,10 @@ func createLogsExporter(
 	}
 
 	return wrapped, nil
+}
+
+func showDeprecationWarnings(cfg *Config, logger *zap.Logger) {
+	if cfg.DeprecatedBatcher.isSet {
+		logger.Warn("The 'batcher' field is deprecated and will be removed in a future release. Use 'sending_queue::batch' instead.")
+	}
 }


### PR DESCRIPTION
Deprecate 'batcher' config with a warning, do not remove the section  yet.
