### PR TITLE
[exporter/elasticsearch] Update batcher config to adopt changes in core

### DIFF
--- a/.chloggen/elasticsearchexporter-update-batcher-cfg-api.yaml
+++ b/.chloggen/elasticsearchexporter-update-batcher-cfg-api.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update 'batcher' config to use internal struct instead of the one removed from the core.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41225]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -99,6 +99,7 @@ type Config struct {
 	// Batcher is unused by default, in which case Flush will be used.
 	// If Batcher.Enabled is non-nil (i.e. batcher::enabled is specified),
 	// then the Flush will be ignored even if Batcher.Enabled is false.
+	// TODO: Deprecate and remove this section in favor of sending_queue::batch.
 	Batcher BatcherConfig `mapstructure:"batcher"`
 }
 
@@ -107,7 +108,11 @@ type Config struct {
 // This is a slightly modified version of exporterbatcher.Config,
 // to enable tri-state Enabled: unset, false, true.
 type BatcherConfig struct {
-	exporterhelper.BatcherConfig `mapstructure:",squash"`
+	Enabled      bool                            `mapstructure:"enabled"`
+	FlushTimeout time.Duration                   `mapstructure:"flush_timeout"`
+	Sizer        exporterhelper.RequestSizerType `mapstructure:"sizer"`
+	MinSize      int64                           `mapstructure:"min_size"`
+	MaxSize      int64                           `mapstructure:"max_size"`
 
 	// enabledSet tracks whether Enabled has been specified.
 	// If enabledSet is false, the exporter will perform its

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -119,13 +119,9 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					BatcherConfig: exporterhelper.BatcherConfig{ //nolint:staticcheck
-						FlushTimeout: 30 * time.Second,
-						SizeConfig: exporterhelper.SizeConfig{ //nolint:staticcheck
-							Sizer:   exporterhelper.RequestSizerTypeItems,
-							MinSize: defaultBatcherMinSizeItems,
-						},
-					},
+					FlushTimeout: 30 * time.Second,
+					Sizer:        exporterhelper.RequestSizerTypeItems,
+					MinSize:      defaultBatcherMinSizeItems,
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,
@@ -199,13 +195,9 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					BatcherConfig: exporterhelper.BatcherConfig{ //nolint:staticcheck
-						FlushTimeout: 30 * time.Second,
-						SizeConfig: exporterhelper.SizeConfig{ //nolint:staticcheck
-							Sizer:   exporterhelper.RequestSizerTypeItems,
-							MinSize: defaultBatcherMinSizeItems,
-						},
-					},
+					FlushTimeout: 30 * time.Second,
+					Sizer:        exporterhelper.RequestSizerTypeItems,
+					MinSize:      defaultBatcherMinSizeItems,
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,
@@ -279,13 +271,9 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					BatcherConfig: exporterhelper.BatcherConfig{ //nolint:staticcheck
-						FlushTimeout: 30 * time.Second,
-						SizeConfig: exporterhelper.SizeConfig{ //nolint:staticcheck
-							Sizer:   exporterhelper.RequestSizerTypeItems,
-							MinSize: defaultBatcherMinSizeItems,
-						},
-					},
+					FlushTimeout: 30 * time.Second,
+					Sizer:        exporterhelper.RequestSizerTypeItems,
+					MinSize:      defaultBatcherMinSizeItems,
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -205,6 +205,7 @@ func exporterhelperOptions(
 	}
 	qs := cfg.QueueSettings
 	if cfg.Batcher.enabledSet {
+		qs.Sizer = exporterhelper.RequestSizerTypeItems // TODO: Delete once core dependency updated.
 		if cfg.Batcher.Enabled {
 			qs.Batch = &exporterhelper.BatchConfig{
 				FlushTimeout: cfg.Batcher.FlushTimeout,

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -83,13 +83,9 @@ func createDefaultConfig() component.Config {
 		},
 		IncludeSourceOnError: nil,
 		Batcher: BatcherConfig{
-			BatcherConfig: exporterhelper.BatcherConfig{ //nolint:staticcheck
-				FlushTimeout: 30 * time.Second,
-				SizeConfig: exporterhelper.SizeConfig{ //nolint:staticcheck
-					Sizer:   exporterhelper.RequestSizerTypeItems,
-					MinSize: defaultBatcherMinSizeItems,
-				},
-			},
+			FlushTimeout: 30 * time.Second,
+			Sizer:        exporterhelper.RequestSizerTypeItems,
+			MinSize:      defaultBatcherMinSizeItems,
 		},
 		Flush: FlushSettings{
 			Bytes:    5e+6,
@@ -206,10 +202,25 @@ func exporterhelperOptions(
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithStart(start),
 		exporterhelper.WithShutdown(shutdown),
-		exporterhelper.WithQueue(cfg.QueueSettings),
 	}
+	qs := cfg.QueueSettings
 	if cfg.Batcher.enabledSet {
-		opts = append(opts, exporterhelper.WithBatcher(cfg.Batcher.BatcherConfig)) //nolint:staticcheck
+		if cfg.Batcher.Enabled {
+			qs.Batch = &exporterhelper.BatchConfig{
+				FlushTimeout: cfg.Batcher.FlushTimeout,
+				MinSize:      cfg.Batcher.MinSize,
+				MaxSize:      cfg.Batcher.MaxSize,
+				// TODO: Uncomment once core dependency updated.
+				// Sizer:        cfg.Batcher.Sizer,
+			}
+
+			// If the deprecated batcher is enabled without a queue, enable blocking queue to replicate the
+			// behavior of the deprecated batcher.
+			if !qs.Enabled {
+				qs.Enabled = true
+				qs.WaitForResult = true
+			}
+		}
 
 		// Effectively disable timeout_sender because timeout is enforced in bulk indexer.
 		//
@@ -217,5 +228,6 @@ func exporterhelperOptions(
 		// to ensure sending data to the background workers will not block indefinitely.
 		opts = append(opts, exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}))
 	}
+	opts = append(opts, exporterhelper.WithQueue(qs))
 	return opts
 }


### PR DESCRIPTION
Adopt to https://github.com/open-telemetry/opentelemetry-collector/pull/13338 to unblock the core dependency upgrade

For the end user, everything stays as is for now. Going forward, the `batcher` section should be deprecated and removed. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41224 as an example. I'm leaving that part to the code owners.