### PR TITLE
[receiver/simpleprometheus] Document `labels` config attribute

### DIFF
--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -29,8 +29,9 @@ The following settings are optional:
 
 - `collection_interval` (default = `10s`): The internal at which metrics should
 be emitted by this receiver.
-- `metrics_path` (default = `/metrics`): The path to the metrics endpoint.
 - `job_name` (default = `prometheus_simple/${endpoint}`): Prometheus scrape job name.
+- `labels` (default = `{}`): Static prometheus labels to assign to all metrics scraped from this endpoint.
+- `metrics_path` (default = `/metrics`): The path to the metrics endpoint.
 - `params` (default = `{}`): The query parameters to pass to the metrics endpoint. If specified, params are appended to `metrics_path` to form the URL with which the target is scraped.
 - `use_service_account` (default = `false`): Whether or not to use the
 Kubernetes Pod service account for authentication.

--- a/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
+++ b/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
@@ -8,6 +8,9 @@ receivers:
     metrics_path: /federate
     params:
       match[]: '{job="counter"}'
+    labels:
+      # custom static label for all metrics
+      deployment_tier: staging
   otlp:
     protocols:
       grpc:


### PR DESCRIPTION
#### Description

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7908 introduced the `labels` configuration, but it didn't include any kind of documentation.

Since I recently needed this feature, but it was unnecessarily hard to discover, some documentation may save others a bit of time.