### PR TITLE
[chore] ensure the generated profiles test data is valid

### DIFF
--- a/cmd/golden/go.sum
+++ b/cmd/golden/go.sum
@@ -140,8 +140,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/connector/countconnector/go.sum
+++ b/connector/countconnector/go.sum
@@ -121,8 +121,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/connector/exceptionsconnector/go.sum
+++ b/connector/exceptionsconnector/go.sum
@@ -88,8 +88,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/connector/otlpjsonconnector/go.sum
+++ b/connector/otlpjsonconnector/go.sum
@@ -86,8 +86,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/connector/routingconnector/go.sum
+++ b/connector/routingconnector/go.sum
@@ -125,8 +125,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/connector/signaltometricsconnector/go.sum
+++ b/connector/signaltometricsconnector/go.sum
@@ -123,8 +123,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/connector/sumconnector/go.sum
+++ b/connector/sumconnector/go.sum
@@ -123,8 +123,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:4KGysEB3LSv0bRZ3it/fvgKZIegOCJuoK281aYnzffQ=

--- a/exporter/elasticsearchexporter/go.sum
+++ b/exporter/elasticsearchexporter/go.sum
@@ -208,8 +208,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -175,8 +175,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/exporter/splunkhecexporter/go.sum
+++ b/exporter/splunkhecexporter/go.sum
@@ -226,8 +226,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/internal/coreinternal/go.sum
+++ b/internal/coreinternal/go.sum
@@ -156,8 +156,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/pkg/ottl/go.sum
+++ b/pkg/ottl/go.sum
@@ -91,6 +91,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 h1:FGre0nZh5BSw7G73VpT3xs38HchsfPsa2aZtMp0NPOs=

--- a/pkg/pdatatest/go.mod
+++ b/pkg/pdatatest/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19
 	go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19
+	go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/pdatatest/go.sum
+++ b/pkg/pdatatest/go.sum
@@ -45,6 +45,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel/metric v1.35.0 h1:0znxYu2SNyuMSQT4Y9WDWej0VpcsxkuklLa4/siN90M=

--- a/pkg/pdatatest/pprofiletest/validate_test.go
+++ b/pkg/pdatatest/pprofiletest/validate_test.go
@@ -4,11 +4,14 @@
 package pprofiletest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pprofile"
+	"go.opentelemetry.io/collector/pdata/testdata"
 )
 
 func Test_validateProfile(t *testing.T) {
@@ -841,5 +844,24 @@ func Test_validateAttributeUnitAt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.wantErr(t, validateAttributeUnit(tt.dictionary, tt.attrUnit))
 		})
+	}
+}
+
+func TestGeneratedData(t *testing.T) {
+	data := testdata.GenerateProfiles(3)
+
+	for i := range data.ResourceProfiles().Len() {
+		rp := data.ResourceProfiles().At(i)
+		for j := range rp.ScopeProfiles().Len() {
+			sp := rp.ScopeProfiles().At(j)
+			for k := range sp.Profiles().Len() {
+				p := sp.Profiles().At(k)
+				err := ValidateProfile(data.ProfilesDictionary(), p)
+				if err != nil {
+					err = fmt.Errorf("profile ResourceProfiles[%d]ScopeProfiles[%d]Profiles[%d]: %w", i, j, k, err)
+				}
+				require.NoError(t, err)
+			}
+		}
 	}
 }

--- a/receiver/activedirectorydsreceiver/go.sum
+++ b/receiver/activedirectorydsreceiver/go.sum
@@ -82,8 +82,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/aerospikereceiver/go.sum
+++ b/receiver/aerospikereceiver/go.sum
@@ -196,8 +196,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/apachereceiver/go.sum
+++ b/receiver/apachereceiver/go.sum
@@ -212,8 +212,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/apachesparkreceiver/go.sum
+++ b/receiver/apachesparkreceiver/go.sum
@@ -210,8 +210,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/awscloudwatchreceiver/go.sum
+++ b/receiver/awscloudwatchreceiver/go.sum
@@ -135,8 +135,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/awsfirehosereceiver/go.sum
+++ b/receiver/awsfirehosereceiver/go.sum
@@ -136,8 +136,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/awsxrayreceiver/go.sum
+++ b/receiver/awsxrayreceiver/go.sum
@@ -132,8 +132,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/azuremonitorreceiver/go.sum
+++ b/receiver/azuremonitorreceiver/go.sum
@@ -120,8 +120,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/bigipreceiver/go.sum
+++ b/receiver/bigipreceiver/go.sum
@@ -210,8 +210,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/cloudflarereceiver/go.sum
+++ b/receiver/cloudflarereceiver/go.sum
@@ -98,8 +98,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/collectdreceiver/go.sum
+++ b/receiver/collectdreceiver/go.sum
@@ -130,8 +130,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/couchdbreceiver/go.sum
+++ b/receiver/couchdbreceiver/go.sum
@@ -132,8 +132,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/dockerstatsreceiver/go.sum
+++ b/receiver/dockerstatsreceiver/go.sum
@@ -172,8 +172,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/elasticsearchreceiver/go.sum
+++ b/receiver/elasticsearchreceiver/go.sum
@@ -212,8 +212,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/envoyalsreceiver/go.sum
+++ b/receiver/envoyalsreceiver/go.sum
@@ -136,8 +136,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/expvarreceiver/go.sum
+++ b/receiver/expvarreceiver/go.sum
@@ -128,8 +128,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/faroreceiver/go.sum
+++ b/receiver/faroreceiver/go.sum
@@ -154,8 +154,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/filelogreceiver/go.sum
+++ b/receiver/filelogreceiver/go.sum
@@ -109,8 +109,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/filestatsreceiver/go.sum
+++ b/receiver/filestatsreceiver/go.sum
@@ -170,8 +170,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/flinkmetricsreceiver/go.sum
+++ b/receiver/flinkmetricsreceiver/go.sum
@@ -130,8 +130,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/fluentforwardreceiver/go.sum
+++ b/receiver/fluentforwardreceiver/go.sum
@@ -86,8 +86,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/googlecloudmonitoringreceiver/go.sum
+++ b/receiver/googlecloudmonitoringreceiver/go.sum
@@ -96,8 +96,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/haproxyreceiver/go.sum
+++ b/receiver/haproxyreceiver/go.sum
@@ -210,8 +210,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/hostmetricsreceiver/go.sum
+++ b/receiver/hostmetricsreceiver/go.sum
@@ -177,8 +177,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/httpcheckreceiver/go.sum
+++ b/receiver/httpcheckreceiver/go.sum
@@ -126,8 +126,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/huaweicloudcesreceiver/go.sum
+++ b/receiver/huaweicloudcesreceiver/go.sum
@@ -177,8 +177,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/iisreceiver/go.sum
+++ b/receiver/iisreceiver/go.sum
@@ -168,8 +168,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/jmxreceiver/go.sum
+++ b/receiver/jmxreceiver/go.sum
@@ -236,8 +236,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/receiver/k8sclusterreceiver/go.sum
+++ b/receiver/k8sclusterreceiver/go.sum
@@ -232,8 +232,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/k8sobjectsreceiver/go.sum
+++ b/receiver/k8sobjectsreceiver/go.sum
@@ -228,8 +228,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/kubeletstatsreceiver/go.sum
+++ b/receiver/kubeletstatsreceiver/go.sum
@@ -228,8 +228,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/lokireceiver/go.sum
+++ b/receiver/lokireceiver/go.sum
@@ -227,8 +227,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/memcachedreceiver/go.sum
+++ b/receiver/memcachedreceiver/go.sum
@@ -170,8 +170,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/mongodbatlasreceiver/go.sum
+++ b/receiver/mongodbatlasreceiver/go.sum
@@ -134,8 +134,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/mongodbreceiver/go.sum
+++ b/receiver/mongodbreceiver/go.sum
@@ -199,8 +199,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/mysqlreceiver/go.sum
+++ b/receiver/mysqlreceiver/go.sum
@@ -190,8 +190,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/nginxreceiver/go.sum
+++ b/receiver/nginxreceiver/go.sum
@@ -212,8 +212,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/nsxtreceiver/go.sum
+++ b/receiver/nsxtreceiver/go.sum
@@ -138,8 +138,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/oracledbreceiver/go.sum
+++ b/receiver/oracledbreceiver/go.sum
@@ -120,8 +120,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/postgresqlreceiver/go.sum
+++ b/receiver/postgresqlreceiver/go.sum
@@ -223,8 +223,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/rabbitmqreceiver/go.sum
+++ b/receiver/rabbitmqreceiver/go.sum
@@ -130,8 +130,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/redisreceiver/go.sum
+++ b/receiver/redisreceiver/go.sum
@@ -192,8 +192,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/riakreceiver/go.sum
+++ b/receiver/riakreceiver/go.sum
@@ -130,8 +130,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/saphanareceiver/go.sum
+++ b/receiver/saphanareceiver/go.sum
@@ -104,8 +104,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/signalfxreceiver/go.sum
+++ b/receiver/signalfxreceiver/go.sum
@@ -179,8 +179,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/receiver/snowflakereceiver/go.sum
+++ b/receiver/snowflakereceiver/go.sum
@@ -211,8 +211,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/splunkenterprisereceiver/go.sum
+++ b/receiver/splunkenterprisereceiver/go.sum
@@ -126,8 +126,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/splunkhecreceiver/go.sum
+++ b/receiver/splunkhecreceiver/go.sum
@@ -220,8 +220,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:2dMn9/HgEgntIeMe+kptP8luoe4BT1SOZ+MzCAgJekY=
 go.opentelemetry.io/collector/pdata/xpdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:5MYQcz1M6jsbpHG6IprjLroTmmgN435AYByr8zosclU=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=

--- a/receiver/sqlqueryreceiver/go.sum
+++ b/receiver/sqlqueryreceiver/go.sum
@@ -351,8 +351,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/sqlserverreceiver/go.sum
+++ b/receiver/sqlserverreceiver/go.sum
@@ -246,8 +246,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/sshcheckreceiver/go.sum
+++ b/receiver/sshcheckreceiver/go.sum
@@ -97,8 +97,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/tcpcheckreceiver/go.sum
+++ b/receiver/tcpcheckreceiver/go.sum
@@ -88,8 +88,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/vcenterreceiver/go.sum
+++ b/receiver/vcenterreceiver/go.sum
@@ -190,8 +190,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/windowsperfcountersreceiver/go.sum
+++ b/receiver/windowsperfcountersreceiver/go.sum
@@ -82,8 +82,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=

--- a/receiver/zookeeperreceiver/go.sum
+++ b/receiver/zookeeperreceiver/go.sum
@@ -170,8 +170,8 @@ go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19 h1:6mY
 go.opentelemetry.io/collector/pdata v1.36.1-0.20250715222903-0a7598ec1e19/go.mod h1:pttpb089864qG1k0DMeXLgwwTFLk+o3fAW9I6MF9tzw=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19 h1:pPxlmvyHf9pfIxCoh1rp6RMr20VSS0Fopp0G85y8iMU=
 go.opentelemetry.io/collector/pdata/pprofile v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:HB7W9u+Wn4+2U9hPXK/0Mqzu/gaxFbwln59fM0Tkcb0=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0 h1:AwHz3z+rWzRbh720KjMxprnB7WSe6CBE4IizuhRKD50=
-go.opentelemetry.io/collector/pdata/testdata v0.130.0/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19 h1:uC9JGy1RNfzwe1r45Jg0rYfQhr0zIstemlcYSIUWF2w=
+go.opentelemetry.io/collector/pdata/testdata v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:QYqBQJq0duCalwvPr8rSe3vC6sXAMbNtsC4166Gx208=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19 h1:2F7NFfqxmMx53mwEx54Arc99lvkwBkerjq6kQZ1r990=
 go.opentelemetry.io/collector/pipeline v0.130.1-0.20250715222903-0a7598ec1e19/go.mod h1:TO02zju/K6E+oFIOdi372Wk0MXd+Szy72zcTsFQwXl4=
 go.opentelemetry.io/collector/receiver v1.36.1-0.20250715222903-0a7598ec1e19 h1:zkuVe+C9NbDF56JRBVA8CU2BgaTKNl/nhvWSQ7Yan00=


### PR DESCRIPTION
#### Description

This ensures the data generated in `testdata.GenerateProfiles` is valid with the data validation in this package.

This change needs https://github.com/open-telemetry/opentelemetry-collector/pull/13375 for the CI to pass.