### PR TITLE
kafkareceiver:franz-go: Fix race on lost partition

### DIFF
--- a/.chloggen/b_fix-consumer-lost-consume-race-on-wg.yaml
+++ b/.chloggen/b_fix-consumer-lost-consume-race-on-wg.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver (franz-go client)
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix race on lost partition
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41239]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When using the franz-go client, fixes an edge case where a consumer could
+  lose a partition while it is consuming messages. This leads to unexpected
+  behavior due to the race and likely cause the consumer to malfunction.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -75,8 +75,42 @@ type pc struct {
 	// Not safe for concurrent use, this field is never accessed concurrently.
 	backOff *backoff.ExponentialBackOff
 
+	mu sync.RWMutex // protects the fields below
+	// wg tracks the number of in-flight message processing goroutines for this
+	// partition. The wg must not be used directly; instead, the helper methods
+	// add() and done() should be called to safely mutate it. These methods ensure
+	// that no new goroutines are added once the partition consumer is stopping
+	// (i.e. after the partition is lost / revoked).
 	wg sync.WaitGroup
 }
+
+// add increments the wait group counter if the partition consumer is not
+// stopping. It returns true if the counter was incremented, false otherwise.
+func (p *pc) add(delta int) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	select {
+	case <-p.ctx.Done():
+		return false
+	default:
+	}
+	p.wg.Add(delta)
+	return true
+}
+
+// cancelContext cancels the partition consumer context while holding the write
+// lock.
+func (p *pc) cancelContext(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancel(err)
+}
+
+// done decrements the wait group counter.
+func (p *pc) done() { p.wg.Done() }
+
+// wait waits for all in-flight goroutines to finish.
+func (p *pc) wait() { p.wg.Wait() }
 
 // newFranzKafkaConsumer creates a new franz-go based Kafka consumer
 func newFranzKafkaConsumer(
@@ -224,8 +258,13 @@ func (c *franzConsumer) consume(ctx context.Context, size int) bool {
 			)
 			return
 		}
+		// Try to add a new in-flight message processing goroutine to the
+		// partition consumer. Return immediately if the partition has been
+		// lost or reassigned.
+		if !assign.add(1) {
+			return
+		}
 		wg.Add(1)
-		assign.wg.Add(1)
 		assign.logger.Debug("processing fetched records",
 			zap.Int("count", count),
 			zap.Int64("start_offset", p.Records[0].Offset),
@@ -233,7 +272,7 @@ func (c *franzConsumer) consume(ctx context.Context, size int) bool {
 		)
 		go func(pc *pc, msgs []*kgo.Record) {
 			defer wg.Done()
-			defer pc.wg.Done()
+			defer pc.done()
 			fatalOffset := int64(-1)
 			var lastProcessed *kgo.Record
 			for _, msg := range msgs {
@@ -387,13 +426,16 @@ func (c *franzConsumer) lost(ctx context.Context, _ *kgo.Client,
 			// balancer on topic lost/deleted.
 			if pc, ok := c.assignments[tp]; ok {
 				delete(c.assignments, tp)
-				pc.cancel(errors.New(
+				// Cancel also locks the partition consumer. This ensures that
+				// the partition consumer is not processing messages when the
+				// partition is lost or reassigned.
+				pc.cancelContext(errors.New(
 					"stopping processing: partition reassigned or lost",
 				))
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					pc.wg.Wait()
+					pc.wait()
 				}()
 				c.telemetryBuilder.KafkaReceiverPartitionClose.Add(context.Background(), 1)
 			}

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -427,7 +427,7 @@ func (c *franzConsumer) lost(ctx context.Context, _ *kgo.Client,
 			if pc, ok := c.assignments[tp]; ok {
 				delete(c.assignments, tp)
 				// Cancel also locks the partition consumer. This ensures that
-				// the partition consumer is not processing messages when the
+				// the partition consumer stops processing messages when the
 				// partition is lost or reassigned.
 				pc.cancelContext(errors.New(
 					"stopping processing: partition reassigned or lost",

--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -244,6 +244,61 @@ func TestConsumerShutdownNotStarted(t *testing.T) {
 	}
 }
 
+// TestRaceLostVsConsume verifies no data race occurs between concurrent
+// message processing (which calls pc.add / pc.done) and partition revocation
+// handling (lost() → pc.wait). It spins up a kfake cluster, floods them with
+// records, and repeatedly invokes lost() while consumption is in-flight.
+func TestRaceLostVsConsume(t *testing.T) {
+	setFranzGo(t, true)
+	topic := "otlp_spans"
+	kafkaClient, cfg := mustNewFakeCluster(t, kfake.SeedTopics(1, topic))
+	cfg.ConsumerConfig = configkafka.ConsumerConfig{
+		GroupID:      t.Name(),
+		MaxFetchSize: 1, // Force a lot of iterations of consume()
+		AutoCommit: configkafka.AutoCommitConfig{
+			Enable: true, Interval: 100 * time.Millisecond,
+		},
+	}
+
+	// Produce records.
+	var rs []*kgo.Record
+	for i := 0; i < 500; i++ {
+		traces := testdata.GenerateTraces(5)
+		data, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(traces)
+		require.NoError(t, err)
+		rs = append(rs, &kgo.Record{Topic: topic, Value: data})
+	}
+	require.NoError(t, kafkaClient.ProduceSync(context.Background(), rs...).FirstErr())
+	settings, _, _ := mustNewSettings(t)
+
+	// Noop consume function.
+	consumeFn := func(component.Host, *receiverhelper.ObsReport, *metadata.TelemetryBuilder) (consumeMessageFunc, error) {
+		return func(context.Context, kafkaMessage, attribute.Set) error {
+			return nil
+		}, nil
+	}
+
+	c, err := newFranzKafkaConsumer(cfg, settings, []string{topic}, consumeFn)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(context.Background(), componenttest.NewNopHost()))
+
+	done := make(chan struct{})
+	// Hammer lost/assigned and rebalance in a goroutine.
+	go func() {
+		defer close(done)
+		topicMap := map[string][]int32{topic: {0}}
+		for i := 0; i < 2000; i++ {
+			c.lost(context.Background(), nil, topicMap, false)
+			c.assigned(context.Background(), kafkaClient, topicMap)
+			c.client.ForceRebalance()
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	<-done
+	require.NoError(t, c.Shutdown(context.Background()))
+}
+
 func TestLost(t *testing.T) {
 	// It is possible that lost is called multiple times for the same partition
 	// or called with a topic/partition that hasn't been assigned. This test


### PR DESCRIPTION
#### Description
Fixes an edge case where a consumer could lose a partition while it is consuming messages. This leads to unexpected behavior due to the race and likely cause the consumer to malfunction.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41239

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tested

<!--Describe the documentation added.-->
#### Documentation

Added chlog.

<!--Please delete paragraphs that you did not use before submitting.-->
