### PR TITLE
[exporter/loadbalancing] small refactor of k8s resolver tests

### DIFF
--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -6,6 +6,7 @@ package loadbalancingexporter
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -82,11 +84,11 @@ func TestK8sResolve(t *testing.T) {
 			}
 	}
 	tests := []struct {
-		name       string
-		args       args
-		simulateFn func(*suiteContext, args) error
-		onChangeFn func([]string)
-		verifyFn   func(*suiteContext, args) error
+		name              string
+		args              args
+		simulateFn        func(*suiteContext, args) error
+		onChangeFn        func([]string)
+		expectedEndpoints []string
 	}{
 		{
 			name: "add new IP to existing backends",
@@ -110,19 +112,11 @@ func TestK8sResolve(t *testing.T) {
 					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
 				return err
 			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"10.10.0.11:8080",
-					"10.10.0.11:9090",
-					"192.168.10.100:8080",
-					"192.168.10.100:9090",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
+			expectedEndpoints: []string{
+				"10.10.0.11:8080",
+				"10.10.0.11:9090",
+				"192.168.10.100:8080",
+				"192.168.10.100:9090",
 			},
 		},
 		{
@@ -147,17 +141,9 @@ func TestK8sResolve(t *testing.T) {
 			onChangeFn: func([]string) {
 				assert.Fail(t, "should not call onChange")
 			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"192.168.10.100:8080",
-					"192.168.10.100:9090",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
+			expectedEndpoints: []string{
+				"192.168.10.100:8080",
+				"192.168.10.100:9090",
 			},
 		},
 		{
@@ -183,19 +169,11 @@ func TestK8sResolve(t *testing.T) {
 					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
 				return err
 			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"pod-0.lb.default:8080",
-					"pod-0.lb.default:9090",
-					"pod-1.lb.default:8080",
-					"pod-1.lb.default:9090",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
+			expectedEndpoints: []string{
+				"pod-0.lb.default:8080",
+				"pod-0.lb.default:9090",
+				"pod-1.lb.default:8080",
+				"pod-1.lb.default:9090",
 			},
 		},
 		{
@@ -220,16 +198,8 @@ func TestK8sResolve(t *testing.T) {
 					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
 				return err
 			},
-			verifyFn: func(ctx *suiteContext, _ args) error {
-				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-
-				assert.Equal(t, []string{
-					"10.10.0.11:4317",
-				}, ctx.resolver.Endpoints(), "resolver failed, endpoints not equal")
-
-				return nil
+			expectedEndpoints: []string{
+				"10.10.0.11:4317",
 			},
 		},
 		{
@@ -244,13 +214,7 @@ func TestK8sResolve(t *testing.T) {
 				return suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
 					Delete(context.TODO(), args.service, metav1.DeleteOptions{})
 			},
-			verifyFn: func(suiteCtx *suiteContext, _ args) error {
-				if _, err := suiteCtx.resolver.resolve(context.Background()); err != nil {
-					return err
-				}
-				assert.Empty(t, suiteCtx.resolver.Endpoints(), "resolver failed, endpoints should empty")
-				return nil
-			},
+			expectedEndpoints: nil,
 		},
 	}
 
@@ -266,13 +230,31 @@ func TestK8sResolve(t *testing.T) {
 			err := tt.simulateFn(suiteCtx, tt.args)
 			assert.NoError(t, err)
 
-			assert.Eventually(t, func() bool {
-				err := tt.verifyFn(suiteCtx, tt.args)
-				assert.NoError(t, err)
-				return true
-			}, time.Second, 20*time.Millisecond)
+			slices.Sort(tt.expectedEndpoints)
+
+			err = waitForCondition(t, 1200*time.Millisecond, 20*time.Millisecond, func(ctx context.Context) (bool, error) {
+				if _, err := suiteCtx.resolver.resolve(ctx); err != nil {
+					return false, err
+				}
+				got := suiteCtx.resolver.Endpoints()
+				return slices.Equal(tt.expectedEndpoints, got), nil
+			})
+			if err != nil {
+				t.Logf("waitForCondition: timed out waiting for resolver endpoints to match expected: %v", err)
+			}
+			assert.Equal(t, tt.expectedEndpoints, suiteCtx.resolver.Endpoints(), "resolver returned unexpected endpoints after update")
 		})
 	}
+}
+
+// waitForCondition will poll the condition function until it returns true or times out.
+// Any errors returned from the condition are treated as test failures.
+func waitForCondition(t *testing.T, timeout, interval time.Duration, condition func(context.Context) (bool, error)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	t.Helper()
+
+	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, condition)
 }
 
 func Test_newK8sResolver(t *testing.T) {

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -232,15 +232,15 @@ func TestK8sResolve(t *testing.T) {
 
 			slices.Sort(tt.expectedEndpoints)
 
-			err = waitForCondition(t, 1200*time.Millisecond, 20*time.Millisecond, func(ctx context.Context) (bool, error) {
+			cErr := waitForCondition(t, 1200*time.Millisecond, 20*time.Millisecond, func(ctx context.Context) (bool, error) {
 				if _, err := suiteCtx.resolver.resolve(ctx); err != nil {
 					return false, err
 				}
 				got := suiteCtx.resolver.Endpoints()
 				return slices.Equal(tt.expectedEndpoints, got), nil
 			})
-			if err != nil {
-				t.Logf("waitForCondition: timed out waiting for resolver endpoints to match expected: %v", err)
+			if cErr != nil {
+				t.Logf("waitForCondition: timed out waiting for resolver endpoints to match expected: %v", cErr)
 			}
 			assert.Equal(t, tt.expectedEndpoints, suiteCtx.resolver.Endpoints(), "resolver returned unexpected endpoints after update")
 		})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
I've simplified the k8s resolver tests to improve reliability and clarity. I replaced the `verifyFn` with `expectedEndpoints` for simpler assertions. I also replaced the `assert.Eventually` polling with a `waitForCondition` helper. 

I had a tough time reproducing these flaky tests, but I think this refactor should help. I've also increased the condition wait time by 200 milliseconds.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #40966
Fixes #40778
Fixes #40087 

