### PR TITLE
Exporter tinybird traces implementation

### DIFF
--- a/.chloggen/exporter-tinybird-traces-implementation.yaml
+++ b/.chloggen/exporter-tinybird-traces-implementation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/exporter-tinybird-traces-implementation.yaml
+++ b/.chloggen/exporter-tinybird-traces-implementation.yaml
@@ -1,16 +1,16 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component:
+component: tinybirdexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: Add traces implementation
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [40475]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/exporter/tinybirdexporter/exporter.go
+++ b/exporter/tinybirdexporter/exporter.go
@@ -60,8 +60,18 @@ func (e *tinybirdExporter) start(ctx context.Context, host component.Host) error
 	return err
 }
 
-func (e *tinybirdExporter) pushTraces(_ context.Context, _ ptrace.Traces) error {
-	return errors.New("this component is under development and traces are not yet supported, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40475 to track development progress")
+func (e *tinybirdExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
+	buffer := bytes.NewBuffer(nil)
+	encoder := json.NewEncoder(buffer)
+	err := internal.ConvertTraces(td, encoder)
+	if err != nil {
+		return consumererror.NewPermanent(err)
+	}
+
+	if buffer.Len() > 0 {
+		return e.export(ctx, e.config.Traces.Datasource, buffer)
+	}
+	return nil
 }
 
 func (e *tinybirdExporter) pushMetrics(_ context.Context, _ pmetric.Metrics) error {

--- a/exporter/tinybirdexporter/internal/traces.go
+++ b/exporter/tinybirdexporter/internal/traces.go
@@ -28,9 +28,9 @@ type traceSignal struct {
 	SpanKind           string            `json:"span_kind"`
 	SpanAttributes     map[string]string `json:"span_attributes"`
 	StartTime          string            `json:"start_time"`
-	// Format start-end
+	// used when users choose the StartTime-to-EndTime approach
 	EndTime string `json:"end_time,omitempty"`
-	// format start-duration
+	// used when users choose the StartTime-plus-Duration approach
 	Duration         int64               `json:"duration,omitempty"`
 	StatusCode       string              `json:"status_code"`
 	StatusMessage    string              `json:"status_message"`

--- a/exporter/tinybirdexporter/internal/traces.go
+++ b/exporter/tinybirdexporter/internal/traces.go
@@ -43,10 +43,10 @@ type traceSignal struct {
 	LinksAttributes  []map[string]string `json:"links_attributes"`
 }
 
-func convertEvents(events ptrace.SpanEventSlice) ([]string, []string, []map[string]string) {
-	timestamps := make([]string, events.Len())
-	names := make([]string, events.Len())
-	attributes := make([]map[string]string, events.Len())
+func convertEvents(events ptrace.SpanEventSlice) (timestamps []string, names []string, attributes []map[string]string) {
+	timestamps = make([]string, events.Len())
+	names = make([]string, events.Len())
+	attributes = make([]map[string]string, events.Len())
 	for i := 0; i < events.Len(); i++ {
 		event := events.At(i)
 		timestamps[i] = event.Timestamp().AsTime().Format(time.RFC3339Nano)
@@ -56,11 +56,11 @@ func convertEvents(events ptrace.SpanEventSlice) ([]string, []string, []map[stri
 	return timestamps, names, attributes
 }
 
-func convertLinks(links ptrace.SpanLinkSlice) ([]string, []string, []string, []map[string]string) {
-	traceIDs := make([]string, links.Len())
-	spanIDs := make([]string, links.Len())
-	states := make([]string, links.Len())
-	attrs := make([]map[string]string, links.Len())
+func convertLinks(links ptrace.SpanLinkSlice) (traceIDs []string, spanIDs []string, states []string, attrs []map[string]string) {
+	traceIDs = make([]string, links.Len())
+	spanIDs = make([]string, links.Len())
+	states = make([]string, links.Len())
+	attrs = make([]map[string]string, links.Len())
 	for i := 0; i < links.Len(); i++ {
 		link := links.At(i)
 		traceIDs[i] = traceutil.TraceIDToHexOrEmptyString(link.TraceID())

--- a/exporter/tinybirdexporter/internal/traces.go
+++ b/exporter/tinybirdexporter/internal/traces.go
@@ -1,0 +1,125 @@
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
+)
+
+type traceSignal struct {
+	ResourceSchemaUrl  string            `json:"resource_schema_url"`
+	ResourceAttributes map[string]string `json:"resource_attributes"`
+	ServiceName        string            `json:"service_name"`
+	ScopeSchemaUrl     string            `json:"scope_schema_url"`
+	ScopeName          string            `json:"scope_name"`
+	ScopeVersion       string            `json:"scope_version"`
+	ScopeAttributes    map[string]string `json:"scope_attributes"`
+	TraceID            string            `json:"trace_id"`
+	SpanID             string            `json:"span_id"`
+	ParentSpanID       string            `json:"parent_span_id"`
+	TraceState         string            `json:"trace_state"`
+	TraceFlags         uint32            `json:"trace_flags"`
+	SpanName           string            `json:"span_name"`
+	SpanKind           string            `json:"span_kind"`
+	SpanAttributes     map[string]string `json:"span_attributes"`
+	StartTime          string            `json:"start_time"`
+	// Format start-end
+	EndTime string `json:"end_time,omitempty"`
+	// format start-duration
+	Duration         int64               `json:"duration,omitempty"`
+	StatusCode       string              `json:"status_code"`
+	StatusMessage    string              `json:"status_message"`
+	EventsTimestamp  []string            `json:"events_timestamp"`
+	EventsName       []string            `json:"events_name"`
+	EventsAttributes []map[string]string `json:"events_attributes"`
+	LinksTraceID     []string            `json:"links_trace_id"`
+	LinksSpanID      []string            `json:"links_span_id"`
+	LinksTraceState  []string            `json:"links_trace_state"`
+	LinksAttributes  []map[string]string `json:"links_attributes"`
+}
+
+func convertEvents(events ptrace.SpanEventSlice) ([]string, []string, []map[string]string) {
+	timestamps := make([]string, events.Len())
+	names := make([]string, events.Len())
+	attributes := make([]map[string]string, events.Len())
+	for i := 0; i < events.Len(); i++ {
+		event := events.At(i)
+		timestamps[i] = event.Timestamp().AsTime().Format(time.RFC3339Nano)
+		names[i] = event.Name()
+		attributes[i] = convertAttributes(event.Attributes())
+	}
+	return timestamps, names, attributes
+}
+
+func convertLinks(links ptrace.SpanLinkSlice) ([]string, []string, []string, []map[string]string) {
+	traceIDs := make([]string, links.Len())
+	spanIDs := make([]string, links.Len())
+	states := make([]string, links.Len())
+	attrs := make([]map[string]string, links.Len())
+	for i := 0; i < links.Len(); i++ {
+		link := links.At(i)
+		traceIDs[i] = traceutil.TraceIDToHexOrEmptyString(link.TraceID())
+		spanIDs[i] = traceutil.SpanIDToHexOrEmptyString(link.SpanID())
+		states[i] = link.TraceState().AsRaw()
+		attrs[i] = convertAttributes(link.Attributes())
+	}
+	return traceIDs, spanIDs, states, attrs
+}
+
+func ConvertTraces(td ptrace.Traces, encoder Encoder) error {
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rs := td.ResourceSpans().At(i)
+		schemaUrl := rs.SchemaUrl()
+		resource := rs.Resource()
+		resourceAttributesMap := resource.Attributes()
+		resourceAttributes := convertAttributes(resourceAttributesMap)
+		serviceName := getServiceName(resourceAttributesMap)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			scopeSchemaUrl := ss.SchemaUrl()
+			scope := ss.Scope()
+			scopeAttributes := convertAttributes(scope.Attributes())
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				attributes := span.Attributes()
+				eventsTimestamp, eventsName, eventsAttributes := convertEvents(span.Events())
+				linksTraceID, linksSpanID, linksTraceState, linksAttributes := convertLinks(span.Links())
+				traceSignal := traceSignal{
+					ResourceSchemaUrl:  schemaUrl,
+					ResourceAttributes: resourceAttributes,
+					ServiceName:        serviceName,
+					ScopeSchemaUrl:     scopeSchemaUrl,
+					ScopeName:          scope.Name(),
+					ScopeVersion:       scope.Version(),
+					ScopeAttributes:    scopeAttributes,
+					TraceID:            traceutil.TraceIDToHexOrEmptyString(span.TraceID()),
+					SpanID:             traceutil.SpanIDToHexOrEmptyString(span.SpanID()),
+					ParentSpanID:       traceutil.SpanIDToHexOrEmptyString(span.ParentSpanID()),
+					TraceState:         span.TraceState().AsRaw(),
+					TraceFlags:         span.Flags(),
+					SpanName:           span.Name(),
+					SpanKind:           span.Kind().String(),
+					SpanAttributes:     convertAttributes(attributes),
+					StartTime:          span.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+					EndTime:            span.EndTimestamp().AsTime().Format(time.RFC3339Nano),
+					Duration:           span.EndTimestamp().AsTime().Sub(span.StartTimestamp().AsTime()).Nanoseconds(),
+					StatusCode:         span.Status().Code().String(),
+					StatusMessage:      span.Status().Message(),
+					EventsTimestamp:    eventsTimestamp,
+					EventsName:         eventsName,
+					EventsAttributes:   eventsAttributes,
+					LinksTraceID:       linksTraceID,
+					LinksSpanID:        linksSpanID,
+					LinksTraceState:    linksTraceState,
+					LinksAttributes:    linksAttributes,
+				}
+				if err := encoder.Encode(traceSignal); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/exporter/tinybirdexporter/internal/traces.go
+++ b/exporter/tinybirdexporter/internal/traces.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal"
 
 import (
@@ -9,10 +12,10 @@ import (
 )
 
 type traceSignal struct {
-	ResourceSchemaUrl  string            `json:"resource_schema_url"`
+	ResourceSchemaURL  string            `json:"resource_schema_url"`
 	ResourceAttributes map[string]string `json:"resource_attributes"`
 	ServiceName        string            `json:"service_name"`
-	ScopeSchemaUrl     string            `json:"scope_schema_url"`
+	ScopeSchemaURL     string            `json:"scope_schema_url"`
 	ScopeName          string            `json:"scope_name"`
 	ScopeVersion       string            `json:"scope_version"`
 	ScopeAttributes    map[string]string `json:"scope_attributes"`
@@ -71,14 +74,14 @@ func convertLinks(links ptrace.SpanLinkSlice) ([]string, []string, []string, []m
 func ConvertTraces(td ptrace.Traces, encoder Encoder) error {
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		rs := td.ResourceSpans().At(i)
-		schemaUrl := rs.SchemaUrl()
+		schemaURL := rs.SchemaUrl()
 		resource := rs.Resource()
 		resourceAttributesMap := resource.Attributes()
 		resourceAttributes := convertAttributes(resourceAttributesMap)
 		serviceName := getServiceName(resourceAttributesMap)
 		for j := 0; j < rs.ScopeSpans().Len(); j++ {
 			ss := rs.ScopeSpans().At(j)
-			scopeSchemaUrl := ss.SchemaUrl()
+			ScopeSchemaURL := ss.SchemaUrl()
 			scope := ss.Scope()
 			scopeAttributes := convertAttributes(scope.Attributes())
 			for k := 0; k < ss.Spans().Len(); k++ {
@@ -86,11 +89,11 @@ func ConvertTraces(td ptrace.Traces, encoder Encoder) error {
 				attributes := span.Attributes()
 				eventsTimestamp, eventsName, eventsAttributes := convertEvents(span.Events())
 				linksTraceID, linksSpanID, linksTraceState, linksAttributes := convertLinks(span.Links())
-				traceSignal := traceSignal{
-					ResourceSchemaUrl:  schemaUrl,
+				traceEntry := traceSignal{
+					ResourceSchemaURL:  schemaURL,
 					ResourceAttributes: resourceAttributes,
 					ServiceName:        serviceName,
-					ScopeSchemaUrl:     scopeSchemaUrl,
+					ScopeSchemaURL:     ScopeSchemaURL,
 					ScopeName:          scope.Name(),
 					ScopeVersion:       scope.Version(),
 					ScopeAttributes:    scopeAttributes,
@@ -115,7 +118,7 @@ func ConvertTraces(td ptrace.Traces, encoder Encoder) error {
 					LinksTraceState:    linksTraceState,
 					LinksAttributes:    linksAttributes,
 				}
-				if err := encoder.Encode(traceSignal); err != nil {
+				if err := encoder.Encode(traceEntry); err != nil {
 					return err
 				}
 			}

--- a/exporter/tinybirdexporter/internal/traces_test.go
+++ b/exporter/tinybirdexporter/internal/traces_test.go
@@ -1,0 +1,261 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type traceEncoderMock struct {
+	traces []traceSignal
+}
+
+func (e *traceEncoderMock) Encode(v any) error {
+	e.traces = append(e.traces, v.(traceSignal))
+	return nil
+}
+
+func TestConvertTraces(t *testing.T) {
+	type args struct {
+		td      ptrace.Traces
+		encoder Encoder
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []traceSignal
+		wantErr bool
+	}{
+		{
+			name: "empty traces",
+			args: args{
+				td:      ptrace.NewTraces(),
+				encoder: &traceEncoderMock{traces: []traceSignal{}},
+			},
+			want: []traceSignal{},
+		},
+		{
+			name: "basic trace",
+			args: args{
+				td: func() ptrace.Traces {
+					td := ptrace.NewTraces()
+					resourceSpans := td.ResourceSpans().AppendEmpty()
+					resourceSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+					scopeSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeSpans.Scope().SetName("test-scope")
+					scopeSpans.Scope().SetVersion("1.0.0")
+					span := scopeSpans.Spans().AppendEmpty()
+					span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+					span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+					span.SetParentSpanID(pcommon.SpanID([8]byte{9, 10, 11, 12, 13, 14, 15, 16}))
+					span.SetName("test-span")
+					span.SetKind(ptrace.SpanKindServer)
+					span.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					span.SetEndTimestamp(pcommon.Timestamp(1719158401000000000))
+					span.Status().SetCode(ptrace.StatusCodeOk)
+					span.Status().SetMessage("success")
+					return td
+				}(),
+				encoder: &traceEncoderMock{traces: []traceSignal{}},
+			},
+			want: []traceSignal{
+				{
+					ResourceSchemaUrl:  "https://opentelemetry.io/schemas/1.20.0",
+					ResourceAttributes: map[string]string{},
+					ServiceName:        "",
+					ScopeSchemaUrl:     "https://opentelemetry.io/schemas/1.20.0",
+					ScopeName:          "test-scope",
+					ScopeVersion:       "1.0.0",
+					ScopeAttributes:    map[string]string{},
+					TraceID:            "0102030405060708090a0b0c0d0e0f10",
+					SpanID:             "0102030405060708",
+					ParentSpanID:       "090a0b0c0d0e0f10",
+					TraceState:         "",
+					TraceFlags:         0,
+					SpanName:           "test-span",
+					SpanKind:           "Server",
+					SpanAttributes:     map[string]string{},
+					StartTime:          "2024-06-23T16:00:00Z",
+					EndTime:            "2024-06-23T16:00:01Z",
+					Duration:           1000000000,
+					StatusCode:         "Ok",
+					StatusMessage:      "success",
+					EventsTimestamp:    []string{},
+					EventsName:         []string{},
+					EventsAttributes:   []map[string]string{},
+					LinksTraceID:       []string{},
+					LinksSpanID:        []string{},
+					LinksTraceState:    []string{},
+					LinksAttributes:    []map[string]string{},
+				},
+			},
+		},
+		{
+			name: "trace with attributes",
+			args: args{
+				td: func() ptrace.Traces {
+					td := ptrace.NewTraces()
+					resourceSpans := td.ResourceSpans().AppendEmpty()
+					resourceSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceSpans.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+					scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+					scopeSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeSpans.Scope().SetName("test-scope")
+					scopeSpans.Scope().SetVersion("1.0.0")
+					scopeSpans.Scope().Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+					span := scopeSpans.Spans().AppendEmpty()
+					span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+					span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+					span.SetParentSpanID(pcommon.SpanID([8]byte{9, 10, 11, 12, 13, 14, 15, 16}))
+					span.SetName("test-span")
+					span.SetKind(ptrace.SpanKindClient)
+					span.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					span.SetEndTimestamp(pcommon.Timestamp(1719158401000000000))
+					span.Status().SetCode(ptrace.StatusCodeError)
+					span.Status().SetMessage("connection failed")
+					span.Attributes().PutStr("http.method", "GET")
+					span.Attributes().PutStr("http.url", "http://example.com")
+					return td
+				}(),
+				encoder: &traceEncoderMock{traces: []traceSignal{}},
+			},
+			want: []traceSignal{
+				{
+					ResourceSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ResourceAttributes: map[string]string{
+						"service.name": "test-service",
+						"environment":  "production",
+					},
+					ServiceName:    "test-service",
+					ScopeSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ScopeName:      "test-scope",
+					ScopeVersion:   "1.0.0",
+					ScopeAttributes: map[string]string{
+						"telemetry.sdk.name": "opentelemetry",
+					},
+					TraceID:      "0102030405060708090a0b0c0d0e0f10",
+					SpanID:       "0102030405060708",
+					ParentSpanID: "090a0b0c0d0e0f10",
+					TraceState:   "",
+					TraceFlags:   0,
+					SpanName:     "test-span",
+					SpanKind:     "Client",
+					SpanAttributes: map[string]string{
+						"http.method": "GET",
+						"http.url":    "http://example.com",
+					},
+					StartTime:        "2024-06-23T16:00:00Z",
+					EndTime:          "2024-06-23T16:00:01Z",
+					Duration:         1000000000,
+					StatusCode:       "Error",
+					StatusMessage:    "connection failed",
+					EventsTimestamp:  []string{},
+					EventsName:       []string{},
+					EventsAttributes: []map[string]string{},
+					LinksTraceID:     []string{},
+					LinksSpanID:      []string{},
+					LinksTraceState:  []string{},
+					LinksAttributes:  []map[string]string{},
+				},
+			},
+		},
+		{
+			name: "trace with events and links",
+			args: args{
+				td: func() ptrace.Traces {
+					td := ptrace.NewTraces()
+					resourceSpans := td.ResourceSpans().AppendEmpty()
+					resourceSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceSpans.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+					scopeSpans.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeSpans.Scope().SetName("test-scope")
+					scopeSpans.Scope().SetVersion("1.0.0")
+					span := scopeSpans.Spans().AppendEmpty()
+					span.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+					span.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+					span.SetName("test-span")
+					span.SetKind(ptrace.SpanKindInternal)
+					span.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					span.SetEndTimestamp(pcommon.Timestamp(1719158401000000000))
+					span.Status().SetCode(ptrace.StatusCodeOk)
+
+					// Add span event
+					event := span.Events().AppendEmpty()
+					event.SetName("exception")
+					event.SetTimestamp(pcommon.Timestamp(1719158400500000000))
+					event.Attributes().PutStr("exception.type", "RuntimeException")
+					event.Attributes().PutStr("exception.message", "Something went wrong")
+
+					// Add span link
+					link := span.Links().AppendEmpty()
+					link.SetTraceID(pcommon.TraceID([16]byte{17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}))
+					link.SetSpanID(pcommon.SpanID([8]byte{17, 18, 19, 20, 21, 22, 23, 24}))
+					link.TraceState().FromRaw("sampled=true")
+					link.Attributes().PutStr("link.type", "child")
+
+					return td
+				}(),
+				encoder: &traceEncoderMock{traces: []traceSignal{}},
+			},
+			want: []traceSignal{
+				{
+					ResourceSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ResourceAttributes: map[string]string{
+						"service.name": "test-service",
+					},
+					ServiceName:     "test-service",
+					ScopeSchemaUrl:  "https://opentelemetry.io/schemas/1.20.0",
+					ScopeName:       "test-scope",
+					ScopeVersion:    "1.0.0",
+					ScopeAttributes: map[string]string{},
+					TraceID:         "0102030405060708090a0b0c0d0e0f10",
+					SpanID:          "0102030405060708",
+					ParentSpanID:    "",
+					TraceState:      "",
+					TraceFlags:      0,
+					SpanName:        "test-span",
+					SpanKind:        "Internal",
+					SpanAttributes:  map[string]string{},
+					StartTime:       "2024-06-23T16:00:00Z",
+					EndTime:         "2024-06-23T16:00:01Z",
+					Duration:        1000000000,
+					StatusCode:      "Ok",
+					StatusMessage:   "",
+					EventsTimestamp: []string{"2024-06-23T16:00:00.5Z"},
+					EventsName:      []string{"exception"},
+					EventsAttributes: []map[string]string{
+						{
+							"exception.type":    "RuntimeException",
+							"exception.message": "Something went wrong",
+						},
+					},
+					LinksTraceID:    []string{"1112131415161718191a1b1c1d1e1f20"},
+					LinksSpanID:     []string{"1112131415161718"},
+					LinksTraceState: []string{"sampled=true"},
+					LinksAttributes: []map[string]string{
+						{
+							"link.type": "child",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ConvertTraces(tt.args.td, tt.args.encoder); (err != nil) != tt.wantErr {
+				t.Errorf("ConvertTraces() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(tt.args.encoder.(*traceEncoderMock).traces, tt.want) {
+				t.Errorf("ConvertTraces() traces = %v, want %v", tt.args.encoder.(*traceEncoderMock).traces, tt.want)
+			}
+		})
+	}
+}

--- a/exporter/tinybirdexporter/internal/traces_test.go
+++ b/exporter/tinybirdexporter/internal/traces_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package internal
 
 import (
@@ -63,10 +66,10 @@ func TestConvertTraces(t *testing.T) {
 			},
 			want: []traceSignal{
 				{
-					ResourceSchemaUrl:  "https://opentelemetry.io/schemas/1.20.0",
+					ResourceSchemaURL:  "https://opentelemetry.io/schemas/1.20.0",
 					ResourceAttributes: map[string]string{},
 					ServiceName:        "",
-					ScopeSchemaUrl:     "https://opentelemetry.io/schemas/1.20.0",
+					ScopeSchemaURL:     "https://opentelemetry.io/schemas/1.20.0",
 					ScopeName:          "test-scope",
 					ScopeVersion:       "1.0.0",
 					ScopeAttributes:    map[string]string{},
@@ -126,13 +129,13 @@ func TestConvertTraces(t *testing.T) {
 			},
 			want: []traceSignal{
 				{
-					ResourceSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ResourceSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
 					ResourceAttributes: map[string]string{
 						"service.name": "test-service",
 						"environment":  "production",
 					},
 					ServiceName:    "test-service",
-					ScopeSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ScopeSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
 					ScopeName:      "test-scope",
 					ScopeVersion:   "1.0.0",
 					ScopeAttributes: map[string]string{
@@ -206,12 +209,12 @@ func TestConvertTraces(t *testing.T) {
 			},
 			want: []traceSignal{
 				{
-					ResourceSchemaUrl: "https://opentelemetry.io/schemas/1.20.0",
+					ResourceSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
 					ResourceAttributes: map[string]string{
 						"service.name": "test-service",
 					},
 					ServiceName:     "test-service",
-					ScopeSchemaUrl:  "https://opentelemetry.io/schemas/1.20.0",
+					ScopeSchemaURL:  "https://opentelemetry.io/schemas/1.20.0",
 					ScopeName:       "test-scope",
 					ScopeVersion:    "1.0.0",
 					ScopeAttributes: map[string]string{},


### PR DESCRIPTION
#### Description
Implement traces propagation for the new Tinybird Exporter. The exporter iterates over the ptraces data, extracts the required fields (service name, attributes, spanID, etc.), generates an NDJSON, and performs a request to the Tinybird [EventsAPI](https://www.tinybird.co/docs/forward/get-data-in/events-api) with all the data.

It's the same implementation done in [logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40993) but this time focused on traces.


#### Link to tracking issue
Related to #40475


#### Testing
Included traces conversion tests and HTTP request tests.