### PR TITLE
[receiver/prometheus] Cleanup and restructure README

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -59,54 +59,7 @@ you must escape them using `$$`.
 prometheus --config.file=prom.yaml
 ```
 
-**Feature gates**:
-
-- `receiver.prometheusreceiver.UseCreatedMetric`: Start time for Summary, Histogram 
-  and Sum metrics can be retrieved from `_created` metrics. Currently, this behaviour
-  is disabled by default. To enable it, use the following feature gate option:
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.UseCreatedMetric"
-```
-- `receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion`: Enables the Prometheus feature flag [created-timestamps-zero-injection](https://prometheus.io/docs/prometheus/latest/feature_flags/#created-timestamps-zero-injection). Currently, this behaviour is disabled by default due to worse CPU performance with higher metric volumes. To enable it, use the following feature gate option:
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion"
-```
-- `receiver.prometheusreceiver.UseCollectorStartTimeFallback`:  enables using
-  the collector start time as the metric start time if the
-  process_start_time_seconds metric yields no result (for example if targets
-  expose no process_start_time_seconds metric). This is useful when the collector
-  start time is a good approximation of the process start time - for example in
-  serverless workloads when the collector is deployed as a sidecar. To enable it,
-  use the following feature gate option:
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.UseCollectorStartTimeFallback"
-```
-- `receiver.prometheusreceiver.EnableNativeHistograms`: process and turn native histogram metrics into OpenTelemetry exponential histograms. For more details consult the [Prometheus native histograms](#prometheus-native-histograms) section.
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.EnableNativeHistograms"
-```
-
-- `receiver.prometheusreceiver.RemoveStartTimeAdjustment`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
-
-```shell
-"--feature-gates=receiver.prometheusreceiver.RemoveStartTimeAdjustment"
-```
-
-- `report_extra_scrape_metrics`: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`
-
-You can copy and paste that same configuration under:
-
-```yaml
-receivers:
-  prometheus:
-    config:
-```
-
-For example:
+You can copy and paste that same configuration under the `config` attribute:
 
 ```yaml
 receivers:
@@ -135,14 +88,16 @@ The prometheus receiver also supports additional top-level options:
 - **trim_metric_suffixes**: [**Experimental**] When set to true, this enables trimming unit and some counter type suffixes from metric names. For example, it would cause `singing_duration_seconds_total` to be trimmed to `singing_duration`. This can be useful when trying to restore the original metric names used in OpenTelemetry instrumentation. Defaults to false.
 - **use_start_time_metric**: When set to true, this enables retrieving the start time of all counter metrics from the process_start_time_seconds metric. This is only correct if all counters on that endpoint started after the process start time, and the process is the only actor exporting the metric after the process started. It should not be used in "exporters" which export counters that may have started before the process itself. Use only if you know what you are doing, as this may result in incorrect rate calculations. Defaults to false.
 - **start_time_metric_regex**: The regular expression for the start time metric, and is only applied when use_start_time_metric is enabled.  Defaults to process_start_time_seconds.
+- **report_extra_scrape_metrics**: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`
 
-For example,
+Example configuration:
 
 ```yaml
 receivers:
     prometheus:
       trim_metric_suffixes: true
       use_start_time_metric: true
+      report_extra_scrape_metrics: true
       start_time_metric_regex: foo_bar_.*
       config:
         scrape_configs:
@@ -225,3 +180,39 @@ The API server hosts the same paths as the Prometheus agent-mode API. These incl
 More info about querying `/api/v1/` and the data format that is returned can be found in the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/querying/api/).
 
 
+## Feature gates
+
+- `receiver.prometheusreceiver.UseCreatedMetric`: Start time for Summary, Histogram 
+  and Sum metrics can be retrieved from `_created` metrics. Currently, this behaviour
+  is disabled by default. To enable it, use the following feature gate option:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.UseCreatedMetric"
+```
+- `receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion`: Enables the Prometheus feature flag [created-timestamps-zero-injection](https://prometheus.io/docs/prometheus/latest/feature_flags/#created-timestamps-zero-injection). Currently, this behaviour is disabled by default due to worse CPU performance with higher metric volumes. To enable it, use the following feature gate option:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.EnableCreatedTimestampZeroIngestion"
+```
+- `receiver.prometheusreceiver.UseCollectorStartTimeFallback`:  enables using
+  the collector start time as the metric start time if the
+  process_start_time_seconds metric yields no result (for example if targets
+  expose no process_start_time_seconds metric). This is useful when the collector
+  start time is a good approximation of the process start time - for example in
+  serverless workloads when the collector is deployed as a sidecar. To enable it,
+  use the following feature gate option:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.UseCollectorStartTimeFallback"
+```
+- `receiver.prometheusreceiver.EnableNativeHistograms`: process and turn native histogram metrics into OpenTelemetry exponential histograms. For more details consult the [Prometheus native histograms](#prometheus-native-histograms) section.
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.EnableNativeHistograms"
+```
+
+- `receiver.prometheusreceiver.RemoveStartTimeAdjustment`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.RemoveStartTimeAdjustment"
+```


### PR DESCRIPTION
#### Description

The README of this receiver is really hard to read. It seems like, over time, new sections have been inserted at really bad places, disrupting the flow of existing text.

For example, just below the `Feature gates` section there was this text:

```
- `report_extra_scrape_metrics`: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`

You can copy and paste that same configuration under:

``yaml
receivers:
  prometheus:
    config:
``
```

* What is `report_extra_scrape_metrics` talking about? What does this have to do with the `RemoveStartTimeAdjustment` feature gate?
* What is `You can copy and paste that same configuration under:` talking about? What "configuration"? The Feature gates?

It took a while to figure out what the README tries to tell me.

I've moved the "Feature Gates" paragraph as its own section to the end of the file, to be more in line with the other READMEs.