### PR TITLE
[chore][pkg/pdatatest] Improve validation of ProfilesDictionary

### DIFF
--- a/pkg/ottl/e2e/profiles/e2e_test.go
+++ b/pkg/ottl/e2e/profiles/e2e_test.go
@@ -1581,6 +1581,11 @@ func constructProfileTransformContext() ottlprofile.TransformContext {
 	}
 
 	dic := pprofile.NewProfilesDictionary()
+	// initialize the must-have default table entries
+	dic.LinkTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.StringTable().Append("")
+
 	scopeProfiles := pprofile.NewScopeProfiles()
 	return ottlprofile.NewTransformContext(profile.Transform(dic, scopeProfiles), dic, scope, resource, scopeProfiles, pprofile.NewResourceProfiles())
 }
@@ -1615,6 +1620,11 @@ func constructProfileTransformContextEditors() ottlprofile.TransformContext {
 	}
 
 	dic := pprofile.NewProfilesDictionary()
+	// initialize the must-have default table entries
+	dic.LinkTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.StringTable().Append("")
+
 	scopeProfiles := pprofile.NewScopeProfiles()
 	return ottlprofile.NewTransformContext(profile.Transform(dic, scopeProfiles), dic, scope, resource, scopeProfiles, pprofile.NewResourceProfiles())
 }

--- a/pkg/pdatatest/pprofiletest/types.go
+++ b/pkg/pdatatest/pprofiletest/types.go
@@ -15,6 +15,13 @@ type Profiles struct {
 
 func (p Profiles) Transform() pprofile.Profiles {
 	pp := pprofile.NewProfiles()
+
+	dic := pp.ProfilesDictionary()
+	// initialize the must-have default table entries
+	dic.LinkTable().AppendEmpty()
+	dic.MappingTable().AppendEmpty()
+	dic.StringTable().Append("")
+
 	for _, rp := range p.ResourceProfiles {
 		rp.Transform(pp)
 	}
@@ -104,7 +111,7 @@ func (p *Profile) Transform(dic pprofile.ProfilesDictionary, psp pprofile.ScopeP
 	pp := psp.Profiles().AppendEmpty()
 
 	// Avoids that 0 (default) string indices point to nowhere.
-	addString(dic, "")
+	// addString(dic, "")
 
 	// If valueTypes are not set, set them to the default value.
 	defaultValueType := ValueType{Typ: "samples", Unit: "count", AggregationTemporality: pprofile.AggregationTemporalityDelta}


### PR DESCRIPTION
#### Description
Improve validation of ProfilesDictionary by taking the must-have default table entries into account.

The .proto definition says
```
// mapping_table[0] must always be set to a zero value default mapping,
// so that _index fields can use 0 to indicate null/unset.

// link_table[0] must always be set to a zero value default link,
// so that _index fields can use 0 to indicate null/unset.

// A common table for strings referenced by various messages.
// string_table[0] must always be "".
```
