### PR TITLE
[exporter/loadbalancing] Use Linear probing to deal with hash collisions, and increase uniformity of endpoint distribution

### DIFF
--- a/.chloggen/jmoe_41200-improve-variance.yaml
+++ b/.chloggen/jmoe_41200-improve-variance.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: loadbalancingexporter
+note: Use a linear probe to decrease variance caused by hash collisions, which was causing a non-uniform distribution of loadbalancing.
+issues: [41200]
+change_logs: [user]

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -31,10 +31,10 @@ func TestEndpointFor(t *testing.T) {
 		expected string
 	}{
 		// check that we are indeed alternating endpoints for different inputs
-		{[]byte{1, 2, 0, 0}, "endpoint-1"},
-		{[]byte{128, 128, 0, 0}, "endpoint-2"},
-		{[]byte("ad-service-7"), "endpoint-1"},
-		{[]byte("get-recommendations-1"), "endpoint-2"},
+		{[]byte{1, 2, 0, 0}, "endpoint-2"},
+		{[]byte{128, 128, 0, 0}, "endpoint-1"},
+		{[]byte("ad-service-7"), "endpoint-2"},
+		{[]byte("get-recommendations-1"), "endpoint-1"},
 	} {
 		t.Run(fmt.Sprintf("Endpoint for id %s", string(tt.id)), func(t *testing.T) {
 			// test
@@ -106,40 +106,47 @@ func TestPositionsForEndpoints(t *testing.T) {
 			[]string{"endpoint-1"},
 			[]ringItem{
 				// this was first calculated by running the algorithm and taking its output
-				{pos: 1401, endpoint: "endpoint-1"},
-				{pos: 4175, endpoint: "endpoint-1"},
-				{pos: 14133, endpoint: "endpoint-1"},
-				{pos: 17836, endpoint: "endpoint-1"},
-				{pos: 21667, endpoint: "endpoint-1"},
+				{pos: 0x21ca, endpoint: "endpoint-1"},
+				{pos: 0x29d3, endpoint: "endpoint-1"},
+				{pos: 0x3984, endpoint: "endpoint-1"},
+				{pos: 0x5eaf, endpoint: "endpoint-1"},
+				{pos: 0x8bc1, endpoint: "endpoint-1"},
 			},
 		},
 		{
 			"Duplicate Endpoint",
 			[]string{"endpoint-1", "endpoint-1"},
 			[]ringItem{
-				// we expect to not have duplicate items
-				{pos: 1401, endpoint: "endpoint-1"},
-				{pos: 4175, endpoint: "endpoint-1"},
-				{pos: 14133, endpoint: "endpoint-1"},
-				{pos: 17836, endpoint: "endpoint-1"},
-				{pos: 21667, endpoint: "endpoint-1"},
+				// We expect to not have duplicate items.
+				// When a clash occurs, the next free positions should be taken. In this case, there will always be
+				// exactly one clash because of duplicate endpoints. So, the pos will always be i and i+1.
+				{pos: 0x21ca, endpoint: "endpoint-1"},
+				{pos: 0x21cb, endpoint: "endpoint-1"},
+				{pos: 0x29d3, endpoint: "endpoint-1"},
+				{pos: 0x29d4, endpoint: "endpoint-1"},
+				{pos: 0x3984, endpoint: "endpoint-1"},
+				{pos: 0x3985, endpoint: "endpoint-1"},
+				{pos: 0x5eaf, endpoint: "endpoint-1"},
+				{pos: 0x5eb0, endpoint: "endpoint-1"},
+				{pos: 0x8bc1, endpoint: "endpoint-1"},
+				{pos: 0x8bc2, endpoint: "endpoint-1"},
 			},
 		},
 		{
 			"Multiple Endpoints",
-			[]string{"endpoint-1", "endpoint-2"},
+			[]string{"endpoint-A", "endpoint-B"},
 			[]ringItem{
 				// we expect to have 5 positions for each endpoint
-				{pos: 1401, endpoint: "endpoint-1"},
-				{pos: 4175, endpoint: "endpoint-1"},
-				{pos: 10240, endpoint: "endpoint-2"},
-				{pos: 14133, endpoint: "endpoint-1"},
-				{pos: 15002, endpoint: "endpoint-2"},
-				{pos: 17836, endpoint: "endpoint-1"},
-				{pos: 21263, endpoint: "endpoint-2"},
-				{pos: 21667, endpoint: "endpoint-1"},
-				{pos: 26806, endpoint: "endpoint-2"},
-				{pos: 27020, endpoint: "endpoint-2"},
+				{pos: 0xdde, endpoint: "endpoint-B"},
+				{pos: 0x162e, endpoint: "endpoint-A"},
+				{pos: 0x21f5, endpoint: "endpoint-B"},
+				{pos: 0x34e5, endpoint: "endpoint-A"},
+				{pos: 0x61fb, endpoint: "endpoint-B"},
+				{pos: 0x6910, endpoint: "endpoint-B"},
+				{pos: 0x76a0, endpoint: "endpoint-A"},
+				{pos: 0x7e2b, endpoint: "endpoint-A"},
+				{pos: 0x7f7c, endpoint: "endpoint-A"},
+				{pos: 0x85ac, endpoint: "endpoint-B"},
 			},
 		},
 	} {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -399,14 +399,14 @@ func TestFailedExporterInRing(t *testing.T) {
 
 	// test
 	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info
-	_, _, err = p.exporterAndEndpoint([]byte{128, 128, 0, 0})
+	_, _, err = p.exporterAndEndpoint([]byte{128, 128, 1, 0})
 
 	// verify
 	assert.Error(t, err)
 
 	// test
 	// this service name will reach the endpoint-2 -- see the consistent hashing tests for more info
-	_, _, err = p.exporterAndEndpoint([]byte("get-recommendations-1"))
+	_, _, err = p.exporterAndEndpoint([]byte("get-recommendations-2"))
 
 	// verify
 	assert.Error(t, err)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -50,8 +50,8 @@ const (
 	signal1Attr3Value = true
 	signal1Attr4Key   = "sigattr4k"
 	signal1Attr4Value = 3.3
-	serviceName1      = "service-name-1"
-	serviceName2      = "service-name-2"
+	serviceName1      = "service-name-01"
+	serviceName2      = "service-name-02"
 )
 
 func TestNewMetricsExporter(t *testing.T) {

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/output.yaml
@@ -55,6 +55,8 @@ endpoint-1:
                         value:
                           stringValue: bbb
 endpoint-2:
+  resourceMetrics: []
+endpoint-3:
   resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
@@ -79,6 +81,17 @@ endpoint-2:
                 dataPoints:
                   - timeUnixNano: 50
                     asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 945
                     attributes:
                       - key: aaa
                         value:
@@ -110,51 +123,6 @@ endpoint-2:
                       - key: aaa
                         value:
                           stringValue: bbb
-endpoint-3:
-  resourceMetrics:
-    - schemaUrl: https://test-res-schema.com/schema
-      resource:
-        attributes:
-          - key: resource_key
-            value:
-              stringValue: foo
-      scopeMetrics:
-        - schemaUrl: https://test-scope-schema.com/schema
-          scope:
-            name: MyTestInstrument
-            version: "1.2.3"
-            attributes:
-              - key: scope_key
-                value:
-                  stringValue: foo
-          metrics:
-            - name: second.monotonic.sum
-              sum:
-                aggregationTemporality: 2
-                isMonotonic: true
-                dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 945
-                    attributes:
-                      - key: aaa
-                        value:
-                          stringValue: bbb
-    - schemaUrl: https://test-res-schema.com/schema
-      resource:
-        attributes:
-          - key: resource_key
-            value:
-              stringValue: bar
-      scopeMetrics:
-        - schemaUrl: https://test-scope-schema.com/schema
-          scope:
-            name: MyTestInstrument
-            version: "1.2.3"
-            attributes:
-              - key: scope_key
-                value:
-                  stringValue: foo
-          metrics:
             - name: second.monotonic.sum
               sum:
                 aggregationTemporality: 2

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/output.yaml
@@ -1,11 +1,13 @@
 endpoint-1:
+  resourceMetrics: []
+endpoint-2:
   resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
         attributes:
           - key: resource_key
             value:
-              stringValue: asdf
+              stringValue: foo
       scopeMetrics:
         - schemaUrl: https://test-scope-schema.com/schema
           scope:
@@ -21,13 +23,13 @@ endpoint-1:
                 aggregationTemporality: 2
                 isMonotonic: true
                 dataPoints:
-                  - timeUnixNano: 90
-                    asDouble: 666
+                  - timeUnixNano: 50
+                    asDouble: 333
                     attributes:
                       - key: aaa
                         value:
                           stringValue: bbb
-endpoint-2:
+endpoint-3:
   resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
@@ -56,14 +58,12 @@ endpoint-2:
                       - key: aaa
                         value:
                           stringValue: bbb
-endpoint-3:
-  resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
         attributes:
           - key: resource_key
             value:
-              stringValue: foo
+              stringValue: asdf
       scopeMetrics:
         - schemaUrl: https://test-scope-schema.com/schema
           scope:
@@ -79,8 +79,8 @@ endpoint-3:
                 aggregationTemporality: 2
                 isMonotonic: true
                 dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 333
+                  - timeUnixNano: 90
+                    asDouble: 666
                     attributes:
                       - key: aaa
                         value:

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/input.yaml
@@ -4,7 +4,7 @@ resourceMetrics:
       attributes:
         - key: service.name
           value:
-            stringValue: serviceA
+            stringValue: service-alpha
     scopeMetrics:
       - schemaUrl: https://test-scope-schema.com/schema
         scope:
@@ -31,7 +31,7 @@ resourceMetrics:
       attributes:
         - key: service.name
           value:
-            stringValue: serviceB
+            stringValue: service-beta
     scopeMetrics:
       - schemaUrl: https://test-scope-schema.com/schema
         scope:
@@ -58,7 +58,7 @@ resourceMetrics:
       attributes:
         - key: service.name
           value:
-            stringValue: serviceC
+            stringValue: service-gamma
     scopeMetrics:
       - schemaUrl: https://test-scope-schema.com/schema
         scope:

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/output.yaml
@@ -5,7 +5,7 @@ endpoint-1:
         attributes:
           - key: service.name
             value:
-              stringValue: serviceA
+              stringValue: service-gamma
       scopeMetrics:
         - schemaUrl: https://test-scope-schema.com/schema
           scope:
@@ -21,18 +21,20 @@ endpoint-1:
                 aggregationTemporality: 2
                 isMonotonic: true
                 dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 333
+                  - timeUnixNano: 90
+                    asDouble: 666
                     attributes:
                       - key: aaa
                         value:
                           stringValue: bbb
+endpoint-2:
+  resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
         attributes:
           - key: service.name
             value:
-              stringValue: serviceB
+              stringValue: service-beta
       scopeMetrics:
         - schemaUrl: https://test-scope-schema.com/schema
           scope:
@@ -54,8 +56,6 @@ endpoint-1:
                       - key: aaa
                         value:
                           stringValue: bbb
-endpoint-2:
-  resourceMetrics: []
 endpoint-3:
   resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
@@ -63,7 +63,7 @@ endpoint-3:
         attributes:
           - key: service.name
             value:
-              stringValue: serviceC
+              stringValue: service-alpha
       scopeMetrics:
         - schemaUrl: https://test-scope-schema.com/schema
           scope:
@@ -79,8 +79,8 @@ endpoint-3:
                 aggregationTemporality: 2
                 isMonotonic: true
                 dataPoints:
-                  - timeUnixNano: 90
-                    asDouble: 666
+                  - timeUnixNano: 50
+                    asDouble: 333
                     attributes:
                       - key: aaa
                         value:

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/output.yaml
@@ -21,72 +21,13 @@ endpoint-1:
                 aggregationTemporality: 2
                 isMonotonic: true
                 dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 333
-                    attributes:
-                      - key: aaa
-                        value:
-                          stringValue: bbb
                   - timeUnixNano: 80
                     asDouble: 444
                     attributes:
                       - key: bbb
                         value:
                           stringValue: ccc
-
-            - name: second.monotonic.sum
-              sum:
-                aggregationTemporality: 2
-                isMonotonic: true
-                dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 555
-                    attributes:
-                      - key: aaa
-                        value:
-                          stringValue: bbb
-                  - timeUnixNano: 80
-                    asDouble: 666
-                    attributes:
-                      - key: bbb
-                        value:
-                          stringValue: ccc
 endpoint-2:
-  resourceMetrics:
-    - schemaUrl: https://test-res-schema.com/schema
-      resource:
-        attributes:
-          - key: resource_key
-            value:
-              stringValue: bar
-      scopeMetrics:
-        - schemaUrl: https://test-scope-schema.com/schema
-          scope:
-            name: MyTestInstrument
-            version: "1.2.3"
-            attributes:
-              - key: scope_key
-                value:
-                  stringValue: foo
-          metrics:
-            - name: second.monotonic.sum
-              sum:
-                aggregationTemporality: 2
-                isMonotonic: true
-                dataPoints:
-                  - timeUnixNano: 50
-                    asDouble: 555
-                    attributes:
-                      - key: aaa
-                        value:
-                          stringValue: bbb
-                  - timeUnixNano: 80
-                    asDouble: 666
-                    attributes:
-                      - key: bbb
-                        value:
-                          stringValue: ccc
-endpoint-3:
   resourceMetrics:
     - schemaUrl: https://test-res-schema.com/schema
       resource:
@@ -121,3 +62,66 @@ endpoint-3:
                       - key: aaa
                         value:
                           stringValue: bbb
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+endpoint-3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc


### PR DESCRIPTION
#### Description

Updates the ring hash algorithm to use linear probing to decrease the variance of endpoints chosen due to hash collisions.
 
Also updates it to use 4 bytes instead of one - this would cause collision when using more than 256 endpoints, since the byte would overflow.

These changes are discussed and benchmarked in: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41200. The benchmarks showed clear benefits for negligible resource consumption.

The only actual changes to main code in the PR is that in `consistent_hashing.go`. The rest is just changing the expectations of the test to match the altered hashing algorithm.

#### Link to tracking issue

Partially fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41200 

#### Testing

The tests needed to be re-arranged. This was really quite tedious, since they all depend on the specific randomness of the existing hashing algorithm. So I had to re arrange some of the test's expectations with that, too. At some point, they should be redesigned to be more deterministic so more work can easily be done on the hash ring in the future.