### PR TITLE
pkg/ottl: drop WithCache from Profile

### DIFF
--- a/.chloggen/ottl-profile-with-cache.yaml
+++ b/.chloggen/ottl-profile-with-cache.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove experimental transform context option `WithCache` from OTTL Profile context.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41277]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/ottl/contexts/ottlprofile/profile.go
+++ b/pkg/ottl/contexts/ottlprofile/profile.go
@@ -73,16 +73,6 @@ func NewTransformContext(profile pprofile.Profile, dictionary pprofile.ProfilesD
 	return tc
 }
 
-// WithCache sets the cache for the TransformContext.
-// Experimental: *NOTE* this option is subject to change or removal in the future.
-func WithCache(cache *pcommon.Map) TransformContextOption {
-	return func(p *TransformContext) {
-		if cache != nil {
-			p.cache = *cache
-		}
-	}
-}
-
 // GetProfile returns the profile from the TransformContext.
 func (tCtx TransformContext) GetProfile() pprofile.Profile {
 	return tCtx.profile


### PR DESCRIPTION
#### Description

Follow up to #39338, that removed WithCache() from all other OTTL contexts.