### PR TITLE
Shutdown telemetry builder on expoter shutdown

### DIFF
--- a/.chloggen/esexporter-telemetrybuilder-shutdown.yaml
+++ b/.chloggen/esexporter-telemetrybuilder-shutdown.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Shutdown `TelemetryBuilder` on expoter shutdown
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -42,6 +42,8 @@ type elasticsearchExporter struct {
 	documentEncoders         [NumMappingModes]documentEncoder
 	documentRouters          [NumMappingModes]documentRouter
 	spanEventDocumentRouters [NumMappingModes]documentRouter
+
+	telemetryBuilder *metadata.TelemetryBuilder
 }
 
 func newExporter(cfg *Config, set exporter.Settings, index string) (*elasticsearchExporter, error) {
@@ -61,6 +63,7 @@ func newExporter(cfg *Config, set exporter.Settings, index string) (*elasticsear
 		defaultMappingMode:  defaultMappingMode,
 		bufferPool:          pool.NewBufferPool(),
 		bulkIndexers:        bulkIndexers{telemetryBuilder: telemetryBuilder},
+		telemetryBuilder:    telemetryBuilder,
 	}
 	for mappingMode := range NumMappingModes {
 		encoder, err := newEncoder(mappingMode)
@@ -84,6 +87,10 @@ func (e *elasticsearchExporter) Start(ctx context.Context, host component.Host) 
 func (e *elasticsearchExporter) Shutdown(ctx context.Context) error {
 	if err := e.bulkIndexers.shutdown(ctx); err != nil {
 		return fmt.Errorf("error shutting down bulk indexers: %w", err)
+	}
+	if e.telemetryBuilder != nil {
+		e.telemetryBuilder.Shutdown()
+		e.telemetryBuilder = nil
 	}
 	return nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41254 introduced additional telemetry for ES exporter bulk indexers, however, it missed shuting down the telemetry builder. The changes are not released yet so I have not added any changelog.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to  #38610 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A
<!--Please delete paragraphs that you did not use before submitting.-->
