### PR TITLE
[exporter/azureblobexporter] Add support for Entra Workload ID with AKS authentication

### DIFF
--- a/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
+++ b/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
+++ b/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: azureblobexporter
+component: exporter/azureblobexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support for Workload ID authentication to Azure Blob Exporter
@@ -15,7 +15,7 @@ issues: []
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Enable the use of workload identity authentication in AKS pods.
+subtext: Enable the use of workload identity authentication when running the exporter in an AKS pod.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
+++ b/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
@@ -10,7 +10,7 @@ component: exporter/azureblobexporter
 note: Add support for Workload ID authentication to Azure Blob Exporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [41285]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
+++ b/.chloggen/feature_azureblobexporter-add-workload-identity-auth.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component:
+component: azureblobexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: Add support for Workload ID authentication to Azure Blob Exporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: []
@@ -15,7 +15,7 @@ issues: []
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Enable the use of workload identity authentication in AKS pods.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/azureblobexporter/README.md
+++ b/exporter/azureblobexporter/README.md
@@ -19,11 +19,12 @@ The following settings are required:
 
 - url: Must be specified if auth type is not connection_string. If auth type is connection_string, it's optional or will be override by the auth.connection_string. Azure storage account endpoint. This setting might be replaced with `endpoint` for future. e.g. https://<account-name>.blob.core.windows.net/
 - auth (no default): Authentication method for exporter to ingest data.
-  - type (no default): Authentication type for expoter. supported values are: connection_string, service_principal, system_managed_identity, user_managed_identity and etc.
-  - tenand_id: Tenand Id for the client, only needed when type is service_principal.
-  - client_id: Client Id for the auth, only needed when type is service_principal and user_managed_identity.
+  - type (no default): Authentication type for expoter. supported values are: connection_string, service_principal, system_managed_identity, user_managed_identity and workload_identity.
+  - tenand_id: Tenand Id for the client, only needed when type is service_principal and workload_identity.
+  - client_id: Client Id for the auth, only needed when type is service_principal, user_managed_identity and workload_identity.
   - client_secret: Secret for the client, only needed when type is service_principal.
   - connection_string: Connection string to the endpoint. Only needed for connection_string auth type. Once provided, it'll **override** the `url` parameter to the storage account.
+  - federated_token_file: The path of the projected service account token file, only needed when type is workload_identity.
 
 
 The following settings can be optionally configured and have default values:

--- a/exporter/azureblobexporter/README.md
+++ b/exporter/azureblobexporter/README.md
@@ -19,7 +19,7 @@ The following settings are required:
 
 - url: Must be specified if auth type is not connection_string. If auth type is connection_string, it's optional or will be override by the auth.connection_string. Azure storage account endpoint. This setting might be replaced with `endpoint` for future. e.g. https://<account-name>.blob.core.windows.net/
 - auth (no default): Authentication method for exporter to ingest data.
-  - type (no default): Authentication type for expoter. supported values are: connection_string, service_principal, system_managed_identity, user_managed_identity and workload_identity.
+  - type (no default): Authentication type for exporter. supported values are: connection_string, service_principal, system_managed_identity, user_managed_identity and workload_identity.
   - tenand_id: Tenand Id for the client, only needed when type is service_principal and workload_identity.
   - client_id: Client Id for the auth, only needed when type is service_principal, user_managed_identity and workload_identity.
   - client_secret: Secret for the client, only needed when type is service_principal.

--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -51,6 +51,9 @@ type Authentication struct {
 
 	// ConnectionString to the endpoint.
 	ConnectionString string `mapstructure:"connection_string"`
+
+	// FederatedTokenFile is the path to the file containing the federated token. It's needed when type is workload_identity.
+	FederatedTokenFile string `mapstructure:"federated_token_file"`
 }
 
 type AuthType string
@@ -60,6 +63,7 @@ const (
 	SystemManagedIdentity AuthType = "system_managed_identity"
 	UserManagedIdentity   AuthType = "user_managed_identity"
 	ServicePrincipal      AuthType = "service_principal"
+	WorkloadIdentity      AuthType = "workload_identity"
 )
 
 // Config contains the main configuration options for the azure storage blob exporter
@@ -103,6 +107,10 @@ func (c *Config) Validate() error {
 	case UserManagedIdentity:
 		if c.Auth.ClientID == "" {
 			return errors.New("client_id cannot be empty when auth type is user_managed_identity")
+		}
+	case WorkloadIdentity:
+		if c.Auth.TenantID == "" || c.Auth.ClientID == "" || c.Auth.FederatedTokenFile == "" {
+			return errors.New("tenant_id, client_id and federated_token_file cannot be empty when auth type is workload_identity")
 		}
 	}
 

--- a/exporter/azureblobexporter/config_test.go
+++ b/exporter/azureblobexporter/config_test.go
@@ -117,6 +117,37 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "wif"),
+			expected: &Config{
+				URL: "https://fakeaccount.blob.core.windows.net/",
+				Auth: &Authentication{
+					Type:               "workload_identity",
+					ClientID:           "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
+					TenantID:           "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
+					FederatedTokenFile: "/path/to/federated/token/file",
+				},
+				Container: &TelemetryConfig{
+					Metrics: "test",
+					Logs:    "test",
+					Traces:  "test",
+				},
+				BlobNameFormat: &BlobNameFormat{
+					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
+					LogsFormat:     "2006/01/02/logs_15_04_05.json",
+					TracesFormat:   "2006/01/02/traces_15_04_05.json",
+					SerialNumRange: 10000,
+					Params:         map[string]string{},
+				},
+				FormatType:    "json",
+				Encodings:     &Encodings{},
+				BackOffConfig: configretry.NewDefaultBackOffConfig(),
+				AppendBlob: &AppendBlob{
+					Enabled:   false,
+					Separator: "\n",
+				},
+			},
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "conn-string"),
 			expected: &Config{
 				Auth: &Authentication{
@@ -163,6 +194,10 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(metadata.Type, "err5"),
 			errorMessage: "unknown format type: custom",
+		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "err6"),
+			errorMessage: "tenant_id, client_id and federated_token_file cannot be empty when auth type is workload_identity",
 		},
 	}
 

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -143,6 +143,19 @@ func (e *azureBlobExporter) start(_ context.Context, host component.Host) error 
 		if err != nil {
 			return fmt.Errorf("failed to create client with user managed identity: %w", err)
 		}
+	case WorkloadIdentity:
+		cred, err := azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+			ClientID:      e.config.Auth.ClientID,
+			TenantID:      e.config.Auth.TenantID,
+			TokenFilePath: e.config.Auth.FederatedTokenFile,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create workload identity credential: %w", err)
+		}
+		azblobClient.client, err = azblob.NewClient(e.config.URL, cred, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create client with workload identity: %w", err)
+		}
 	default:
 		return fmt.Errorf("unsupported authentication type: %s", authType)
 	}

--- a/exporter/azureblobexporter/testdata/config.yaml
+++ b/exporter/azureblobexporter/testdata/config.yaml
@@ -36,6 +36,17 @@ azureblob/conn-string:
     metrics: "test"
     logs: "test"
     traces: "test"
+azureblob/wif:
+  url: "https://fakeaccount.blob.core.windows.net/"
+  auth:
+    type: "workload_identity"
+    client_id: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d"
+    tenant_id: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d"
+    federated_token_file: "/path/to/federated/token/file"
+  container:
+    metrics: "test"
+    logs: "test"
+    traces: "test"
 azureblob/err1:
   auth:
     type: "system_managed_identity"
@@ -57,3 +68,9 @@ azureblob/err5:
   auth:
     type: "system_managed_identity"
   format: "custom"
+azureblob/err6:
+  url: "https://fakeaccount.blob.core.windows.net/"
+  auth:
+    type: "workload_identity"
+    client_id: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d"
+    tenant_id: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds support for authenticating to Azure Storage using Entra Workload Identity when running exporter in Azure Kubernetes Service pod as the recommended way of passwordless authentication to Azure resources.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit test added.

<!--Describe the documentation added.-->
#### Documentation

Documentation updated to include Workload Identity Federation option.
<!--Please delete paragraphs that you did not use before submitting.-->
