### PR TITLE
use the timestamp of the initial point as the start timestamp for future points

### DIFF
--- a/.chloggen/metricstarttime-fix.yaml
+++ b/.chloggen/metricstarttime-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix an issue where the start time wasn't properly set, but values were decreased.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41286]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster.go
@@ -114,6 +114,8 @@ func adjustMetricHistogram(referenceTsm, previousValueTsm *datapointstorage.Time
 			// First time we see this point. Skip it and use as a reference point for the next points.
 			referenceTsi.Histogram = pmetric.NewHistogramDataPoint()
 			minimalHistogramCopyTo(currentDist, referenceTsi.Histogram)
+			// Use the timestamp of the dropped point as the start timestamp for future points.
+			referenceTsi.Histogram.SetStartTimestamp(referenceTsi.Histogram.Timestamp())
 			previousTsi.Histogram = pmetric.NewHistogramDataPoint()
 			minimalHistogramCopyTo(currentDist, previousTsi.Histogram)
 			return true
@@ -127,7 +129,7 @@ func adjustMetricHistogram(referenceTsm, previousValueTsm *datapointstorage.Time
 
 		if datapointstorage.IsResetHistogram(currentDist, previousTsi.Histogram) {
 			// reset re-initialize everything and use the non adjusted points start time.
-			resetStartTimeStamp := pcommon.NewTimestampFromTime(pointStartTime.AsTime().Add(-1 * time.Millisecond))
+			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentDist.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentDist.SetStartTimestamp(resetStartTimeStamp)
 
 			// Update the reference value with the metric point.
@@ -166,6 +168,8 @@ func adjustMetricExponentialHistogram(referenceTsm, previousValueTsm *datapoints
 			// First time we see this point. Skip it and use as a reference point for the next points.
 			referenceTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
 			minimalExponentialHistogramCopyTo(currentDist, referenceTsi.ExponentialHistogram)
+			// Use the timestamp of the dropped point as the start timestamp for future points.
+			referenceTsi.ExponentialHistogram.SetStartTimestamp(referenceTsi.ExponentialHistogram.Timestamp())
 			previousTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
 			minimalExponentialHistogramCopyTo(currentDist, previousTsi.ExponentialHistogram)
 			return true
@@ -179,7 +183,7 @@ func adjustMetricExponentialHistogram(referenceTsm, previousValueTsm *datapoints
 
 		if datapointstorage.IsResetExponentialHistogram(currentDist, previousTsi.ExponentialHistogram) {
 			// reset re-initialize everything and use the non adjusted points start time.
-			resetStartTimeStamp := pcommon.NewTimestampFromTime(pointStartTime.AsTime().Add(-1 * time.Millisecond))
+			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentDist.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentDist.SetStartTimestamp(resetStartTimeStamp)
 
 			referenceTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
@@ -218,6 +222,8 @@ func adjustMetricSum(referenceTsm, previousValueTsm *datapointstorage.Timeseries
 			// First time we see this point. Skip it and use as a reference point for the next points.
 			referenceTsi.Number = pmetric.NewNumberDataPoint()
 			minimalSumCopyTo(currentSum, referenceTsi.Number)
+			// Use the timestamp of the dropped point as the start timestamp for future points.
+			referenceTsi.Number.SetStartTimestamp(referenceTsi.Number.Timestamp())
 			previousTsi.Number = pmetric.NewNumberDataPoint()
 			minimalSumCopyTo(currentSum, previousTsi.Number)
 			return true
@@ -231,7 +237,7 @@ func adjustMetricSum(referenceTsm, previousValueTsm *datapointstorage.Timeseries
 
 		if datapointstorage.IsResetSum(currentSum, previousTsi.Number) {
 			// reset re-initialize everything and use the non adjusted points start time.
-			resetStartTimeStamp := pcommon.NewTimestampFromTime(pointStartTime.AsTime().Add(-1 * time.Millisecond))
+			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentSum.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentSum.SetStartTimestamp(resetStartTimeStamp)
 
 			referenceTsi.Number = pmetric.NewNumberDataPoint()
@@ -261,6 +267,8 @@ func adjustMetricSummary(referenceTsm, previousValueTsm *datapointstorage.Timese
 			// First time we see this point. Skip it and use as a reference point for the next points.
 			referenceTsi.Summary = pmetric.NewSummaryDataPoint()
 			minimalSummaryCopyTo(currentSummary, referenceTsi.Summary)
+			// Use the timestamp of the dropped point as the start timestamp for future points.
+			referenceTsi.Summary.SetStartTimestamp(referenceTsi.Summary.Timestamp())
 			previousTsi.Summary = pmetric.NewSummaryDataPoint()
 			minimalSummaryCopyTo(currentSummary, previousTsi.Summary)
 			return true
@@ -274,7 +282,7 @@ func adjustMetricSummary(referenceTsm, previousValueTsm *datapointstorage.Timese
 
 		if datapointstorage.IsResetSummary(currentSummary, previousTsi.Summary) {
 			// reset re-initialize everything and use the non adjusted points start time.
-			resetStartTimeStamp := pcommon.NewTimestampFromTime(pointStartTime.AsTime().Add(-1 * time.Millisecond))
+			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentSummary.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentSummary.SetStartTimestamp(resetStartTimeStamp)
 
 			referenceTsi.Summary = pmetric.NewSummaryDataPoint()


### PR DESCRIPTION
#### Description

When start time adjustment code was taken from the Prometheus receiver, it still assumed that points had the start time set to the point's timestamp.  This assumption came out in two places:

1. The start timestamp of the initial "dropped" point was assumed to have already been set.
2. It assumed the start timestamp of the point was already set when computing resets.

#### Testing

Added unit tests, and tested end-to-end with the Prometheus receiver and the OTLP file exporter.


cc @ridwanmsharif 
