### PR TITLE
[chore][extension/oidcauth] Add asweet-confluent as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -122,7 +122,7 @@ extension/observer/ecsobserver/                                  @open-telemetry
 extension/observer/hostobserver/                                 @open-telemetry/collector-contrib-approvers @MovieStoreGuy
 extension/observer/k8sobserver/                                  @open-telemetry/collector-contrib-approvers @dmitryax @ChrsMark
 extension/observer/kafkatopicsobserver/                          @open-telemetry/collector-contrib-approvers @MovieStoreGuy
-extension/oidcauthextension/                                     @open-telemetry/collector-contrib-approvers
+extension/oidcauthextension/                                     @open-telemetry/collector-contrib-approvers @asweet-confluent
 extension/opampcustommessages/                                   @open-telemetry/collector-contrib-approvers @evan-bradley
 extension/opampextension/                                        @open-telemetry/collector-contrib-approvers @portertech @evan-bradley @tigrannajaryan
 extension/pprofextension/                                        @open-telemetry/collector-contrib-approvers @MovieStoreGuy

--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -7,7 +7,7 @@
 | Distributions | [contrib], [k8s] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aextension%2Foidcauth%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aextension%2Foidcauth) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aextension%2Foidcauth%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aextension%2Foidcauth) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=extension_oidc)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=extension_oidc&displayType=list) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    |  \| Seeking more code owners! |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@asweet-confluent](https://www.github.com/asweet-confluent) \| Seeking more code owners! |
 | Emeritus      | [@jpkrohling](https://www.github.com/jpkrohling) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta

--- a/extension/oidcauthextension/metadata.yaml
+++ b/extension/oidcauthextension/metadata.yaml
@@ -7,6 +7,7 @@ status:
   distributions: [contrib, k8s]
   codeowners:
     seeking_new: true
+    active: [asweet-confluent]
     emeritus: [jpkrohling]
 
 tests:


### PR DESCRIPTION
#### Description

Adding myself as a code owner for the oidcauth extension.

https://cloud-native.slack.com/archives/C07CCCMRXBK/p1752511033862279?thread_ts=1752510941.246459&cid=C07CCCMRXBK