### PR TITLE
[exporter/bmchelix] enhance metric name disambiguation using attributes

### DIFF
--- a/.chloggen/bmchelixexporter_enhance_metric_name_disambiguation_with_attributes.yaml
+++ b/.chloggen/bmchelixexporter_enhance_metric_name_disambiguation_with_attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement 
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bmchelixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enhance metric name disambiguation using attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41303]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -38,6 +38,7 @@ func NewMetricsProducer(logger *zap.Logger) *MetricsProducer {
 		logger: logger,
 	}
 }
+
 // coreAttributes are label keys that should be ignored when building metric name suffixes.
 var coreAttributes = map[string]struct{}{
 	"source":                 {},
@@ -83,7 +84,7 @@ func (mp *MetricsProducer) ProduceHelixPayload(metrics pmetric.Metrics) ([]BMCHe
 					mp.logger.Warn("Failed to create Helix metrics", zap.Error(err))
 					continue
 				}
-				
+
 				// Grow the helixMetrics slice for the new metrics
 				helixMetrics = slices.Grow(helixMetrics, len(newMetrics))
 

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -153,19 +153,19 @@ func generateMockMetrics(setMetricType func(metric pmetric.Metric) pmetric.Numbe
 func TestEnrichMetricNamesWithAttributes(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name           string
-		inputMetrics   []BMCHelixOMMetric
-		expectedNames  []string
+		name          string
+		inputMetrics  []BMCHelixOMMetric
+		expectedNames []string
 	}{
 		{
 			name: "Single metric without varying attributes",
 			inputMetrics: []BMCHelixOMMetric{
 				{
 					Labels: map[string]string{
-						"entityId":    "host:cpu:core0",
-						"metricName":  "system.cpu.time",
-						"cpu.mode":       "idle",
-						"cpu.logical_number":         "0",
+						"entityId":           "host:cpu:core0",
+						"metricName":         "system.cpu.time",
+						"cpu.mode":           "idle",
+						"cpu.logical_number": "0",
 					},
 				},
 			},
@@ -178,14 +178,14 @@ func TestEnrichMetricNamesWithAttributes(t *testing.T) {
 					Labels: map[string]string{
 						"entityId":   "host:cpu:core0",
 						"metricName": "system.cpu.time",
-						"cpu.mode":      "idle",
+						"cpu.mode":   "idle",
 					},
 				},
 				{
 					Labels: map[string]string{
 						"entityId":   "host:cpu:core0",
 						"metricName": "system.cpu.time",
-						"cpu.mode":      "user",
+						"cpu.mode":   "user",
 					},
 				},
 			},
@@ -199,20 +199,20 @@ func TestEnrichMetricNamesWithAttributes(t *testing.T) {
 			inputMetrics: []BMCHelixOMMetric{
 				{
 					Labels: map[string]string{
-						"entityId":   "host:cpu:core0",
-						"metricName": "system.cpu.time",
-						"cpu.mode":      "system",
-						"cpu.mode.code": "0",
-						"cpu.logical_number":        "0",
+						"entityId":           "host:cpu:core0",
+						"metricName":         "system.cpu.time",
+						"cpu.mode":           "system",
+						"cpu.mode.code":      "0",
+						"cpu.logical_number": "0",
 					},
 				},
 				{
 					Labels: map[string]string{
-						"entityId":   "host:cpu:core0",
-						"metricName": "system.cpu.time",
-						"cpu.mode":      "user",
-						"cpu.mode.code": "1",
-						"cpu.logical_number":        "0",
+						"entityId":           "host:cpu:core0",
+						"metricName":         "system.cpu.time",
+						"cpu.mode":           "user",
+						"cpu.mode.code":      "1",
+						"cpu.logical_number": "0",
 					},
 				},
 			},


### PR DESCRIPTION
This pull request enhances the `bmchelixexporter` component by improving metric name disambiguation using attributes. Key changes include adding a mechanism to enrich metric names with identifying attributes, ensuring compatibility with BMC Helix Operations Management, and introducing tests to validate the new functionality.

### Enhancements to Metric Name Disambiguation:
* Added a new function, `enrichMetricNamesWithAttributes`, to append distinguishing attributes to metric names when attributes have more than one distinct value across metrics with the same `entityId` and `metricName`. This ensures unique and meaningful metric names in the BMC Helix Operations Management payload. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`)
* Introduced a `coreAttributes` map to specify attributes that should be ignored when building metric name suffixes. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`)

### Compatibility Improvements:
* Updated the `updateEntityInformation` method to sanitize `entityName` by trimming and removing colons for compatibility with BMC Helix Operations Management. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`)

### Testing:
* Added a new test, `TestEnrichMetricNamesWithAttributes`, to validate the behavior of the `enrichMetricNamesWithAttributes` function under various scenarios, ensuring robustness. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go`)

### Documentation:
* Created a changelog entry to document the enhancement for release notes. (`.chloggen/bmchelixexporter_enhance_metric_name_disambiguation_with_attributes.yaml`)

#### Link to tracking issue
Fixes #41303
