### PR TITLE
docs(rabbitmqreceiver): fix indentation of metrics block in README

### DIFF
--- a/receiver/rabbitmqreceiver/README.md
+++ b/receiver/rabbitmqreceiver/README.md
@@ -46,7 +46,7 @@ receivers:
     username: otelu
     password: ${env:RABBITMQ_PASSWORD}
     collection_interval: 10s
-     metrics:  # Enable node metrics by explicitly setting them to true
+    metrics:  # Enable node metrics by explicitly setting them to true
       rabbitmq.node.disk_free:
         enabled: true
       rabbitmq.node.disk_free_limit:


### PR DESCRIPTION
#### Description

Fixes a documentation error in the rabbitmqreceiver README where the metrics: block was incorrectly indented with an extra space. This formatting issue caused YAML parsing failures when users copied the example config into their OpenTelemetry Collector setup.

#### Link to tracking issue

N/A – minor documentation fix not tied to an existing issue.

#### Testing

- [x] Visually verified the corrected indentation.
- [x] Tested the fixed YAML snippet in a local OpenTelemetry Collector config to ensure no parsing errors.

#### Documentation

- [x] Updated the example in receiver/rabbitmqreceiver/README.md to fix indentation and improve accuracy for users.
