### PR TITLE
[chore] convert configgrpc.Keepalive params to configoptional

### DIFF
--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -614,10 +614,10 @@ func TestIntegrationSelfTracing(t *testing.T) {
 
 	testIntegrationTraces(ctx, t, params, func(_ *ExpConfig, rcfg *RecvConfig) {
 		rcfg.GRPC.Keepalive = configoptional.Some(configgrpc.KeepaliveServerConfig{
-			ServerParameters: &configgrpc.KeepaliveServerParameters{
+			ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 				MaxConnectionAge:      time.Second,
 				MaxConnectionAgeGrace: 5 * time.Second,
-			},
+			}),
 		})
 	}, func() GenFunc { return makeTestTraces }, consumerSuccess, multiStreamEnding)
 }

--- a/receiver/opencensusreceiver/config_test.go
+++ b/receiver/opencensusreceiver/config_test.go
@@ -53,17 +53,17 @@ func TestLoadConfig(t *testing.T) {
 					},
 					ReadBufferSize: 512 * 1024,
 					Keepalive: configoptional.Some(configgrpc.KeepaliveServerConfig{
-						ServerParameters: &configgrpc.KeepaliveServerParameters{
+						ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 							MaxConnectionIdle:     11 * time.Second,
 							MaxConnectionAge:      12 * time.Second,
 							MaxConnectionAgeGrace: 13 * time.Second,
 							Time:                  30 * time.Second,
 							Timeout:               5 * time.Second,
-						},
-						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+						}),
+						EnforcementPolicy: configoptional.Some(configgrpc.KeepaliveEnforcementPolicy{
 							MinTime:             10 * time.Second,
 							PermitWithoutStream: true,
-						},
+						}),
 					}),
 				},
 			},
@@ -81,9 +81,9 @@ func TestLoadConfig(t *testing.T) {
 					ReadBufferSize:       1024,
 					WriteBufferSize:      1024,
 					Keepalive: configoptional.Some(configgrpc.KeepaliveServerConfig{
-						ServerParameters: &configgrpc.KeepaliveServerParameters{
+						ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 							MaxConnectionIdle: 10 * time.Second,
-						},
+						}),
 					}),
 				},
 			},

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -136,13 +136,13 @@ func TestCreateMetrics(t *testing.T) {
 				ServerConfig: configgrpc.ServerConfig{
 					NetAddr: defaultNetAddr,
 					Keepalive: configoptional.Some(configgrpc.KeepaliveServerConfig{
-						ServerParameters: &configgrpc.KeepaliveServerParameters{
+						ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 							MaxConnectionAge: 60 * time.Second,
-						},
-						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+						}),
+						EnforcementPolicy: configoptional.Some(configgrpc.KeepaliveEnforcementPolicy{
 							MinTime:             30 * time.Second,
 							PermitWithoutStream: true,
-						},
+						}),
 					}),
 				},
 			},

--- a/receiver/otelarrowreceiver/config_test.go
+++ b/receiver/otelarrowreceiver/config_test.go
@@ -64,17 +64,17 @@ func TestUnmarshalConfig(t *testing.T) {
 					ReadBufferSize:       1024,
 					WriteBufferSize:      1024,
 					Keepalive: configoptional.Some(configgrpc.KeepaliveServerConfig{
-						ServerParameters: &configgrpc.KeepaliveServerParameters{
+						ServerParameters: configoptional.Some(configgrpc.KeepaliveServerParameters{
 							MaxConnectionIdle:     11 * time.Second,
 							MaxConnectionAge:      12 * time.Second,
 							MaxConnectionAgeGrace: 13 * time.Second,
 							Time:                  30 * time.Second,
 							Timeout:               5 * time.Second,
-						},
-						EnforcementPolicy: &configgrpc.KeepaliveEnforcementPolicy{
+						}),
+						EnforcementPolicy: configoptional.Some(configgrpc.KeepaliveEnforcementPolicy{
 							MinTime:             10 * time.Second,
 							PermitWithoutStream: true,
-						},
+						}),
 					}),
 				},
 				Arrow: ArrowConfig{

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -357,11 +357,13 @@ func TestOTelArrowShutdown(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.GRPC.Keepalive = configoptional.Some(configgrpc.KeepaliveServerConfig{
-				ServerParameters: &configgrpc.KeepaliveServerParameters{},
+				ServerParameters: configoptional.None[configgrpc.KeepaliveServerParameters](),
 			})
 			if !cooperative {
-				cfg.GRPC.Keepalive.Get().ServerParameters.MaxConnectionAge = time.Second
-				cfg.GRPC.Keepalive.Get().ServerParameters.MaxConnectionAgeGrace = 5 * time.Second
+				cfg.GRPC.Keepalive.Get().ServerParameters = configoptional.Some(configgrpc.KeepaliveServerParameters{
+					MaxConnectionAge:      time.Second,
+					MaxConnectionAgeGrace: 5 * time.Second,
+				})
 			}
 			cfg.GRPC.NetAddr.Endpoint = endpointGrpc
 			set := receivertest.NewNopSettings(componentmetadata.Type)
@@ -856,9 +858,7 @@ func TestOTelArrowHalfOpenShutdown(t *testing.T) {
 
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.GRPC.Keepalive = configoptional.Some(configgrpc.KeepaliveServerConfig{
-		ServerParameters: &configgrpc.KeepaliveServerParameters{},
-	})
+	cfg.GRPC.Keepalive = configoptional.None[configgrpc.KeepaliveServerConfig]()
 	// No keepalive parameters are set
 	cfg.GRPC.NetAddr.Endpoint = endpointGrpc
 	set := receivertest.NewNopSettings(componentmetadata.Type)


### PR DESCRIPTION
Signed-off-by: otelbot <197425009+otelbot@users.noreply.github.com><!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Convert tests/modules using `configgrpc.Keepalive` parameters to configoptional
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Required due to https://github.com/open-telemetry/opentelemetry-collector/pull/13364

<!--Describe what testing was performed and which tests were added.-->
#### Testing
existing unit/e2e/integration tests
<!--Describe the documentation added.-->
#### Documentation
none, no change to users or api in this repo
<!--Please delete paragraphs that you did not use before submitting.-->
