### PR TITLE
[receiver/webhookevent] Add new json splitter to webhookeventreceiver

### DIFF
--- a/.chloggen/webhook-json-splitter.yaml
+++ b/.chloggen/webhook-json-splitter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds configuration to split logs at JSON object boundaries.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39766]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -64,6 +64,21 @@ Three log records will be created from this example. The first two are JSON body
 
 This receiver does not attempt to marshal the body into a structured format as it is received so it cannot make a more intelligent determination about where the split records. 
 
+### Split logs at JSON boundary example
+
+If you don't have clear new-line splits between objects, the regex `}\s.{` will match the boundary between objects.
+`split_logs_at_json_boundary: true`
+
+```yaml
+{ "name": "francis", "city": "newyork", "multiple lines?": "you 
+know it!"}
+{ "name": "john", "city": "paris" }{ "name": "tim", "city": "london" }
+```
+
+This settings works when JSON objects have newlines in the middle of a string or multiple objects on a line.
+
+
+
 ### Configuration Example
 
 ```yaml

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -33,6 +33,7 @@ The following settings are optional:
     * `key` (required if `required_header` config option is set): Represents the key portion of the required header.
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
 * `split_logs_at_newline` (default: false): If true, the receiver will create a separate log record for each line in the request body.
+* `split_logs_at_json_boundary` (default: false): If true, the receiver will parse the request body to JSON and send each object as a log. Splitting on new line overrides json boundary so only enable one at a time.
 * `convert_headers_to_attributes` (optional): add all request headers (excluding `required_header` if also set) log attributes
 * `header_attribute_regex` (optional): add headers matching supplied regex as log attributes. Header attributes will be prefixed with `header.`
 
@@ -66,7 +67,7 @@ This receiver does not attempt to marshal the body into a structured format as i
 
 ### Split logs at JSON boundary example
 
-If you don't have clear new-line splits between objects, the regex `}\s.{` will match the boundary between objects.
+If you don't have clear new-line splits between objects, the receiver can use the JSON parser to handle separating the objects.
 `split_logs_at_json_boundary: true`
 
 ```yaml
@@ -76,8 +77,6 @@ know it!"}
 ```
 
 This settings works when JSON objects have newlines in the middle of a string or multiple objects on a line.
-
-
 
 ### Configuration Example
 

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	HealthPath                 string                   `mapstructure:"health_path"`                   // path for health check api. Default is /health_check
 	RequiredHeader             RequiredHeader           `mapstructure:"required_header"`               // optional setting to set a required header for all requests to have
 	SplitLogsAtNewLine         bool                     `mapstructure:"split_logs_at_newline"`         // optional setting to split logs into multiple log records
+	SplitLogsAtJSONBoundary    bool                     `mapstructure:"split_logs_at_json_boundary"`   // optional setting to split logs at JSON object boundaries
 	ConvertHeadersToAttributes bool                     `mapstructure:"convert_headers_to_attributes"` // optional to convert all headers to attributes
 	HeaderAttributeRegex       string                   `mapstructure:"header_attribute_regex"`        // optional to convert headers matching a regex to log attributes
 }
@@ -84,4 +85,8 @@ func (cfg *Config) Validate() error {
 	}
 
 	return errs
+}
+
+func (cfg *Config) ShouldSplitLogsAtJSONBoundary() bool {
+	return cfg.SplitLogsAtJSONBoundary
 }

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -76,6 +76,10 @@ func (cfg *Config) Validate() error {
 		errs = multierr.Append(errs, errRequiredHeader)
 	}
 
+	if cfg.SplitLogsAtNewLine && cfg.SplitLogsAtJSONBoundary {
+		errs = multierr.Append(errs, errors.New("split_logs_at_new_line and split_logs_at_json_boundary cannot be enabled at the same time"))
+	}
+
 	if cfg.HeaderAttributeRegex != "" {
 		_, err := regexp.Compile(cfg.HeaderAttributeRegex)
 		if err != nil {

--- a/receiver/webhookeventreceiver/factory.go
+++ b/receiver/webhookeventreceiver/factory.go
@@ -44,6 +44,7 @@ func createDefaultConfig() component.Config {
 		WriteTimeout:               defaultWriteTimeout,
 		ConvertHeadersToAttributes: false, // optional, off by default
 		SplitLogsAtNewLine:         false,
+		SplitLogsAtJSONBoundary:    false,
 	}
 }
 

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -54,7 +54,7 @@ func (er *eventReceiver) reqToLog(sc *bufio.Scanner,
 		if er.cfg.SplitLogsAtNewLine {
 			lines = strings.Split(sc.Text(), "\n")
 		} else if er.cfg.ShouldSplitLogsAtJSONBoundary() {
-			lines = splitJSONObjectsDecoder(sc.Text())
+			lines = splitJSONObjects(sc.Text())
 		}
 
 		for _, line := range lines {
@@ -98,32 +98,6 @@ func headerAttributeKey(header string) string {
 }
 
 func splitJSONObjects(data string) []string {
-	// Use regex to find boundaries between JSON objects
-	re := regexp.MustCompile(`}\s*{`)
-
-	// Find all matches
-	indices := re.FindAllStringIndex(data, -1)
-	if len(indices) == 0 {
-		return []string{data}
-	}
-
-	// Split the data at each boundary
-	var result []string
-	lastIdx := 0
-	for _, idx := range indices {
-		// Add the object up to the end of the closing brace
-		result = append(result, data[lastIdx:idx[0]+1])
-		// Start next object from the opening brace
-		lastIdx = idx[1] - 1
-	}
-	// Add the last object
-	result = append(result, data[lastIdx:])
-
-	return result
-}
-
-// splitJSONObjectsDecoder uses json.Decoder to properly parse concatenated JSON objects
-func splitJSONObjectsDecoder(data string) []string {
 	var result []string
 	decoder := json.NewDecoder(bytes.NewReader([]byte(data)))
 

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -6,15 +6,12 @@ package webhookeventreceiver
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -421,155 +418,5 @@ func processLogRecords(logs plog.Logs, fn func(lr plog.LogRecord)) {
 				fn(sl.LogRecords().At(k))
 			}
 		}
-	}
-}
-
-// TestSplitJSONObjectsComparison compares the performance and results of regex vs decoder approaches
-func TestSplitJSONObjectsComparison(t *testing.T) {
-	testCases := []struct {
-		name  string
-		input string
-		want  int // expected number of JSON objects
-	}{
-		{
-			name:  "single JSON object",
-			input: `{"name": "john", "age": 30}`,
-			want:  1,
-		},
-		{
-			name: "two JSON objects with newline",
-			input: `{"name": "john", "age": 30}
-{"name": "jane", "age": 25}`,
-			want: 2,
-		},
-		{
-			name:  "two JSON objects without space",
-			input: `{"name": "john", "age": 30}{"name": "jane", "age": 25}`,
-			want:  2,
-		},
-		{
-			name: "multiple JSON objects with spaces",
-			input: `{"name": "john", "age": 30}   {"name": "jane", "age": 25}
-			{"name": "bob", "city": "NYC"}`,
-			want: 3,
-		},
-		{
-			name: "nested JSON objects",
-			input: `{"user": {"name": "john", "address": {"city": "NYC"}}}
-{"user": {"name": "jane", "address": {"city": "LA"}}}`,
-			want: 2,
-		},
-		{
-			name:  "array of values",
-			input: `{"items": [1, 2, 3]}{"items": [4, 5, 6]}`,
-			want:  2,
-		},
-		{
-			name:  "mixed valid and invalid JSON",
-			input: `{"valid": true}not json{"another": "valid"}`,
-			want:  2, // regex will split all 3, decoder will only get valid JSON
-		},
-		{
-			name:  "empty input",
-			input: ``,
-			want:  1, // both return the original string as fallback
-		},
-		{
-			name:  "single invalid JSON",
-			input: `not a json object at all`,
-			want:  1, // both return the original string as fallback
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Time regex approach
-			start := time.Now()
-			regexResult := splitJSONObjects(tc.input)
-			regexDuration := time.Since(start)
-
-			// Time decoder approach
-			start = time.Now()
-			decoderResult := splitJSONObjectsDecoder(tc.input)
-			decoderDuration := time.Since(start)
-
-			t.Logf("Input: %q", tc.input)
-			t.Logf("Regex approach: %d objects in %v", len(regexResult), regexDuration)
-			t.Logf("Decoder approach: %d objects in %v", len(decoderResult), decoderDuration)
-
-			// Log the actual results for debugging
-			t.Logf("Regex results:")
-			for i, obj := range regexResult {
-				t.Logf("  [%d]: %q", i, obj)
-			}
-			t.Logf("Decoder results:")
-			for i, obj := range decoderResult {
-				t.Logf("  [%d]: %q", i, obj)
-			}
-
-			// Note: The two approaches may give different results for invalid JSON
-			// This is expected behavior - decoder is more strict
-			if tc.name != "mixed valid and invalid JSON" {
-				// For valid JSON cases, we expect similar counts
-				if len(regexResult) != len(decoderResult) {
-					t.Logf("Warning: Different result counts - regex: %d, decoder: %d",
-						len(regexResult), len(decoderResult))
-				}
-			}
-		})
-	}
-}
-
-// BenchmarkSplitJSONObjects benchmarks both approaches with various input sizes
-func BenchmarkSplitJSONObjects(b *testing.B) {
-	// Generate test data with different sizes
-	generateJSONObjects := func(count int) string {
-		var builder strings.Builder
-		for i := 0; i < count; i++ {
-			if i > 0 {
-				builder.WriteString("\n")
-			}
-			builder.WriteString(fmt.Sprintf(`{"id": %d, "name": "user%d", "timestamp": %d}`, i, i, time.Now().Unix()))
-		}
-		return builder.String()
-	}
-
-	testSizes := []int{1, 10, 100, 1000}
-
-	for _, size := range testSizes {
-		input := generateJSONObjects(size)
-
-		b.Run(fmt.Sprintf("Regex_%d_newlines", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = splitJSONObjects(input)
-			}
-		})
-
-		b.Run(fmt.Sprintf("Decoder_%d_newlines", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = splitJSONObjectsDecoder(input)
-			}
-		})
-	}
-
-	// Test with concatenated objects (no separators)
-	for _, size := range testSizes {
-		var builder strings.Builder
-		for i := 0; i < size; i++ {
-			builder.WriteString(fmt.Sprintf(`{"id": %d, "name": "user%d", "timestamp": %d}`, i, i, time.Now().Unix()))
-		}
-		input := builder.String()
-
-		b.Run(fmt.Sprintf("Regex_%d_single_line", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = splitJSONObjects(input)
-			}
-		})
-
-		b.Run(fmt.Sprintf("Decoder_%d_single_line", size), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = splitJSONObjectsDecoder(input)
-			}
-		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Note that this is restarting #39768 after a rebase.

Adds the ability to split webhook body contents at JSON boundaries so you don't have to worry about newline characters.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39766

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a test case to show newline vs json handling. 
<!--Describe the documentation added.-->
#### Documentation

Readme was updated with an additional example. 
<!--Please delete paragraphs that you did not use before submitting.-->
