### PR TITLE
[chore]: enable httpNoBody rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,7 +123,6 @@ linters:
         - evalOrder
         - exposedSyncMutex
         - filepathJoin
-        - httpNoBody
         - hugeParam
         - importShadow
         - initClause

--- a/exporter/signalfxexporter/internal/apm/correlations/client.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client.go
@@ -279,7 +279,7 @@ func (cc *Client) makeRequest(r *request) {
 
 	switch r.operation {
 	case http.MethodGet:
-		req, err = http.NewRequest(r.operation, endpoint, nil)
+		req, err = http.NewRequest(r.operation, endpoint, http.NoBody)
 	case http.MethodPut:
 		// TODO: pool the reader
 		endpoint = fmt.Sprintf("%s/%s", endpoint, r.Type)
@@ -287,7 +287,7 @@ func (cc *Client) makeRequest(r *request) {
 		req.Header.Add("Content-Type", "text/plain")
 	case http.MethodDelete:
 		endpoint = fmt.Sprintf("%s/%s/%s", endpoint, r.Type, url.PathEscape(r.Value))
-		req, err = http.NewRequest(r.operation, endpoint, nil)
+		req, err = http.NewRequest(r.operation, endpoint, http.NoBody)
 	default:
 		err = errors.New("unknown operation")
 	}

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -637,7 +637,7 @@ func (c *client) start(ctx context.Context, host component.Host) (err error) {
 }
 
 func checkHecHealth(ctx context.Context, client *http.Client, healthCheckURL *url.URL) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheckURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheckURL.String(), http.NoBody)
 	if err != nil {
 		return consumererror.NewPermanent(err)
 	}

--- a/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
+++ b/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
@@ -47,7 +47,7 @@ func getSplunkSearchResults(user string, password string, baseURL string, jobID 
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	eventURL := fmt.Sprintf("%s/services/search/jobs/%s/events?output_mode=json", baseURL, jobID)
 	logger.Println("URL: " + eventURL)
-	reqEvents, err := http.NewRequest(http.MethodGet, eventURL, nil)
+	reqEvents, err := http.NewRequest(http.MethodGet, eventURL, http.NoBody)
 	if err != nil {
 		panic(err)
 	}
@@ -89,7 +89,7 @@ func checkSearchJobStatusCode(user string, password string, baseURL string, jobI
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	checkReqEvents, err := http.NewRequest(http.MethodGet, checkEventURL, nil)
+	checkReqEvents, err := http.NewRequest(http.MethodGet, checkEventURL, http.NoBody)
 	if err != nil {
 		panic(err)
 	}
@@ -173,7 +173,7 @@ func CheckMetricsFromSplunk(index string, metricName string) []any {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr, Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	req, err := http.NewRequest(http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		panic(err)
 	}

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -287,7 +287,7 @@ func TestFullOtelCollectorPayloadIntegration(t *testing.T) {
 	// Step 5: Simulate sending payload (in a real scenario, this would use serializer.SendEvents or similar)
 	// For this test, we simulate the HTTP request that would be made
 	client := &http.Client{Timeout: 5 * time.Second}
-	req, err := http.NewRequest(http.MethodPost, backendURL+"/api/v1/otel_collector", nil)
+	req, err := http.NewRequest(http.MethodPost, backendURL+"/api/v1/otel_collector", http.NoBody)
 	require.NoError(t, err)
 
 	req.Header.Set("Content-Type", "application/json")
@@ -662,7 +662,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 
 	// Step 6: Test HTTP endpoint functionality
 	// Test the handler directly since we're using port 0
-	req := httptest.NewRequest(http.MethodGet, serverConfig.Path, nil)
+	req := httptest.NewRequest(http.MethodGet, serverConfig.Path, http.NoBody)
 	recorder := httptest.NewRecorder()
 
 	server.HandleMetadata(recorder, req)
@@ -689,7 +689,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 	assert.Contains(t, err.Error(), "forwarder is not started")
 
 	// Test HandleMetadata with nil ResponseWriter (should not panic)
-	server.HandleMetadata(nil, httptest.NewRequest(http.MethodGet, serverConfig.Path, nil))
+	server.HandleMetadata(nil, httptest.NewRequest(http.MethodGet, serverConfig.Path, http.NoBody))
 }
 
 // TestHTTPServerConfigIntegration tests different HTTP server configurations
@@ -852,7 +852,7 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 
 			// Create test request
-			req := httptest.NewRequest(http.MethodGet, serverConfig.Path, nil)
+			req := httptest.NewRequest(http.MethodGet, serverConfig.Path, http.NoBody)
 			recorder := httptest.NewRecorder()
 
 			// Call HandleMetadata

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -281,7 +281,7 @@ func TestHandleMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, serializer := tt.setupTest()
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(http.MethodGet, "/metadata", nil)
+			r := httptest.NewRequest(http.MethodGet, "/metadata", http.NoBody)
 			r.Header.Set("Content-Type", "application/json")
 			srv := &Server{
 				logger:     logger,
@@ -369,7 +369,7 @@ func TestHandleMetadataConcurrency(t *testing.T) {
 		go func(index int) {
 			defer wg.Done()
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(http.MethodGet, "/metadata", nil)
+			r := httptest.NewRequest(http.MethodGet, "/metadata", http.NoBody)
 			r.Header.Set("Content-Type", "application/json")
 			responses[index] = w
 			srv.HandleMetadata(w, r)
@@ -746,7 +746,7 @@ func TestHandleMetadata_JSONMarshalError(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/metadata", nil)
+	r := httptest.NewRequest(http.MethodGet, "/metadata", http.NoBody)
 	r.Header.Set("Content-Type", "application/json")
 
 	srv.HandleMetadata(w, r)
@@ -830,7 +830,7 @@ func TestHandleMetadataErrorPaths(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodPost, "/metadata", nil) // Method doesn't matter
+		r := httptest.NewRequest(http.MethodPost, "/metadata", http.NoBody) // Method doesn't matter
 
 		srv.HandleMetadata(w, r)
 

--- a/extension/headerssetterextension/extension_test.go
+++ b/extension/headerssetterextension/extension_test.go
@@ -40,7 +40,7 @@ func TestRoundTripper(t *testing.T) {
 					Metadata: tt.metadata,
 				},
 			)
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "", nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "", http.NoBody)
 			assert.NoError(t, err)
 			assert.NotNil(t, req)
 

--- a/extension/jaegerremotesampling/internal/source/filesource/filesource.go
+++ b/extension/jaegerremotesampling/internal/source/filesource/filesource.go
@@ -109,7 +109,7 @@ func (h *samplingProvider) downloadSamplingStrategies(samplingURL string) ([]byt
 
 	ctx, cx := context.WithTimeout(context.Background(), time.Second)
 	defer cx()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, samplingURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, samplingURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("cannot construct HTTP request: %w", err)
 	}

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -310,7 +310,7 @@ func TestFailContactingOAuth(t *testing.T) {
 		Transport: roundTripper,
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "http://example.com/", nil)
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/", http.NoBody)
 	require.NoError(t, err)
 	_, err = client.Do(req)
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)

--- a/extension/opampextension/auth.go
+++ b/extension/opampextension/auth.go
@@ -61,7 +61,7 @@ func makeHeadersFunc(logger *zap.Logger, serverCfg *OpAMPServer, host component.
 		// This is a workaround while websocket authentication is being worked on.
 		// Currently, we are waiting on the auth module to be stabilized.
 		// See for more info: https://github.com/open-telemetry/opentelemetry-collector/issues/10864
-		dummyReq, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		dummyReq, err := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 		if err != nil {
 			logger.Error("Failed to create dummy request for authentication.", zap.Error(err))
 			return h

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -131,10 +131,10 @@ func TestGetCredsProviderFromWebIdentityConfig(t *testing.T) {
 }
 
 func TestCloneRequest(t *testing.T) {
-	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 
-	req2, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req2, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 	req2.Header.Add("Header1", "val1")
 

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -95,25 +95,25 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestInferServiceAndRegion(t *testing.T) {
-	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 
-	req2, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
+	req2, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", http.NoBody)
 	assert.NoError(t, err)
 
-	req3, err := http.NewRequest(http.MethodGet, "https://search-my-domain.us-east-1.es.amazonaws.com/_search?q=house", nil)
+	req3, err := http.NewRequest(http.MethodGet, "https://search-my-domain.us-east-1.es.amazonaws.com/_search?q=house", http.NoBody)
 	assert.NoError(t, err)
 
-	req4, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req4, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 
-	req5, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
+	req5, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", http.NoBody)
 	assert.NoError(t, err)
 
-	req6, err := http.NewRequest(http.MethodGet, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
+	req6, err := http.NewRequest(http.MethodGet, "https://logs.us-east-1.amazonaws.com/v1/logs", http.NoBody)
 	assert.NoError(t, err)
 
-	req7, err := http.NewRequest(http.MethodGet, "https://xray.us-east-1.amazonaws.com/v1/traces", nil)
+	req7, err := http.NewRequest(http.MethodGet, "https://xray.us-east-1.amazonaws.com/v1/traces", http.NoBody)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -192,13 +192,13 @@ func TestInferServiceAndRegion(t *testing.T) {
 }
 
 func TestHashPayload(t *testing.T) {
-	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 
 	req2, err := http.NewRequest(http.MethodGet, "https://example.com", bytes.NewReader([]byte("This is a test.")))
 	assert.NoError(t, err)
 
-	req3, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	req3, err := http.NewRequest(http.MethodGet, "https://example.com", http.NoBody)
 	assert.NoError(t, err)
 	req3.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("this will always fail") }
 

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -647,7 +647,7 @@ func (se *SumologicExtension) sendHeartbeatWithHTTPClient(ctx context.Context, h
 	if err != nil {
 		return fmt.Errorf("unable to parse heartbeat URL %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), http.NoBody)
 	if err != nil {
 		return fmt.Errorf("unable to create HTTP request %w", err)
 	}

--- a/internal/aws/ecsutil/client.go
+++ b/internal/aws/ecsutil/client.go
@@ -112,7 +112,7 @@ func (c *clientImpl) Get(path string) ([]byte, error) {
 
 func (c *clientImpl) buildReq(path string) (*http.Request, error) {
 	url := c.baseURL.String() + path
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -128,7 +128,7 @@ func TestHandlerNilBodyIsOk(t *testing.T) {
 
 	handler := srv.(*http.Server).Handler.ServeHTTP
 	req := httptest.NewRequest(http.MethodPost,
-		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", nil)
+		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", http.NoBody)
 	rec := httptest.NewRecorder()
 	handler(rec, req)
 

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -298,7 +298,7 @@ func (c *clientImpl) buildReq(p string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	req, err := http.NewRequest(http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metadataproviders/azure/metadata.go
+++ b/internal/metadataproviders/azure/metadata.go
@@ -66,7 +66,7 @@ func (p *azureProviderImpl) Metadata(ctx context.Context) (*ComputeMetadata, err
 		jsonFormat = "json"
 	)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.endpoint, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/metadataproviders/openshift/metadata.go
+++ b/internal/metadataproviders/openshift/metadata.go
@@ -45,7 +45,7 @@ type openshiftProvider struct {
 
 func (o *openshiftProvider) makeOCPRequest(ctx context.Context, endpoint, target string) (*http.Request, error) {
 	addr := fmt.Sprintf("%s/apis/config.openshift.io/v1/%s/%s/status", o.address, endpoint, target)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (o *openshiftProvider) Infrastructure(ctx context.Context) (*Infrastructure
 // K8SClusterVersion requests the ClusterVersion from the kubernetes api.
 func (o *openshiftProvider) K8SClusterVersion(ctx context.Context) (string, error) {
 	addr := fmt.Sprintf("%s/version", o.address)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, http.NoBody)
 	if err != nil {
 		return "", err
 	}

--- a/receiver/apachesparkreceiver/client.go
+++ b/receiver/apachesparkreceiver/client.go
@@ -166,7 +166,7 @@ func (c *apacheSparkClient) JobStats(appID string) ([]models.Job, error) {
 
 func (c *apacheSparkClient) buildReq(path string) (*http.Request, error) {
 	url := c.cfg.Endpoint + path
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils.go
@@ -96,7 +96,7 @@ func request(ctx context.Context, endpoint string, client doer) ([]byte, error) 
 }
 
 func clientGet(ctx context.Context, url string, client doer) (resp *http.Response, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/couchdbreceiver/client.go
+++ b/receiver/couchdbreceiver/client.go
@@ -95,7 +95,7 @@ func (c *couchDBClient) GetStats(nodeName string) (map[string]any, error) {
 
 func (c *couchDBClient) buildReq(path string) (*http.Request, error) {
 	url := c.cfg.Endpoint + path
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -207,7 +207,7 @@ func agentPayloadFromTraces(traces *pb.Traces) (agentPayload pb.AgentPayload) {
 
 func TestUpsertHeadersAttributes(t *testing.T) {
 	// Test case 1: Datadog-Meta-Tracer-Version is present in headers
-	req1, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req1, _ := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 	req1.Header.Set(header.TracerVersion, "1.2.3")
 	attrs1 := pcommon.NewMap()
 	upsertHeadersAttributes(req1, attrs1)
@@ -216,7 +216,7 @@ func TestUpsertHeadersAttributes(t *testing.T) {
 	assert.Equal(t, "Datadog-1.2.3", val.Str())
 
 	// Test case 2: Datadog-Meta-Lang is present in headers with ".NET"
-	req2, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req2, _ := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
 	req2.Header.Set(header.Lang, ".NET")
 	attrs2 := pcommon.NewMap()
 	upsertHeadersAttributes(req2, attrs2)

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -309,7 +309,7 @@ func TestDatadogInfoEndpoint(t *testing.T) {
 			req, err := http.NewRequest(
 				http.MethodPost,
 				fmt.Sprintf("http://%s/info", dd.(*datadogReceiver).address),
-				nil,
+				http.NoBody,
 			)
 			require.NoError(t, err, "Must not error when creating request")
 

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -221,7 +221,7 @@ func (c defaultElasticsearchClient) doRequest(ctx context.Context, path string) 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/expvarreceiver/scraper.go
+++ b/receiver/expvarreceiver/scraper.go
@@ -52,7 +52,7 @@ func (e *expVarScraper) start(ctx context.Context, host component.Host) error {
 
 func (e *expVarScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	emptyMetrics := pmetric.NewMetrics()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.cfg.Endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.cfg.Endpoint, http.NoBody)
 	if err != nil {
 		return emptyMetrics, err
 	}

--- a/receiver/githubreceiver/trace_receiver_test.go
+++ b/receiver/githubreceiver/trace_receiver_test.go
@@ -76,7 +76,7 @@ func TestHealthCheck(t *testing.T) {
 	}()
 
 	w := httptest.NewRecorder()
-	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", nil))
+	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", http.NoBody))
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)

--- a/receiver/gitlabreceiver/traces_receiver_test.go
+++ b/receiver/gitlabreceiver/traces_receiver_test.go
@@ -242,7 +242,7 @@ func TestHealthCheck(t *testing.T) {
 	}()
 
 	w := httptest.NewRecorder()
-	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", nil))
+	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", http.NoBody))
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)
@@ -350,7 +350,7 @@ func TestValidateReq(t *testing.T) {
 				cfg: cfg,
 			}
 
-			req := httptest.NewRequest(tt.method, "http://localhost", nil)
+			req := httptest.NewRequest(tt.method, "http://localhost", http.NoBody)
 			for k, v := range tt.headers {
 				req.Header.Set(k, v)
 			}

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -137,7 +137,7 @@ func (r *libhoneyReceiver) registerLogConsumer(tc consumer.Logs) {
 
 func (r *libhoneyReceiver) handleAuth(resp http.ResponseWriter, req *http.Request) {
 	authURL := fmt.Sprintf("%s/1/auth", r.cfg.AuthAPI)
-	authReq, err := http.NewRequest(http.MethodGet, authURL, nil)
+	authReq, err := http.NewRequest(http.MethodGet, authURL, http.NoBody)
 	if err != nil {
 		errJSON, _ := json.Marshal(`{"error": "failed to create auth request"}`)
 		writeResponse(resp, "json", http.StatusBadRequest, errJSON)

--- a/receiver/libhoneyreceiver/receiver_test.go
+++ b/receiver/libhoneyreceiver/receiver_test.go
@@ -231,7 +231,7 @@ func TestLibhoneyReceiver_AuthEndpoint(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			req := httptest.NewRequest(http.MethodGet, "/1/auth", nil)
+			req := httptest.NewRequest(http.MethodGet, "/1/auth", http.NoBody)
 			req.Header.Set("x-honeycomb-team", tt.apiKey)
 			w := httptest.NewRecorder()
 
@@ -288,7 +288,7 @@ func TestReadContentType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, "/test", nil)
+			req := httptest.NewRequest(tt.method, "/test", http.NoBody)
 			req.Header.Set("Content-Type", tt.contentType)
 			w := httptest.NewRecorder()
 

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -145,7 +145,7 @@ func (c *nsxClient) doRequest(ctx context.Context, path string) ([]byte, error) 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -209,7 +209,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 }
 
 func verifyCorsResp(t *testing.T, url string, origin string, wantStatus int, wantAllowed bool) {
-	req, err := http.NewRequest(http.MethodOptions, url, nil)
+	req, err := http.NewRequest(http.MethodOptions, url, http.NoBody)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
 	req.Header.Set("Origin", origin)
 	req.Header.Set("Access-Control-Request-Method", http.MethodPost)

--- a/receiver/podmanreceiver/libpod_client.go
+++ b/receiver/podmanreceiver/libpod_client.go
@@ -37,7 +37,7 @@ func newLibpodClient(logger *zap.Logger, cfg *Config) (PodmanClient, error) {
 }
 
 func (c *libpodClient) request(ctx context.Context, path string, params url.Values) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -196,7 +196,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest(http.MethodPut, "http://localhost", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost", http.NoBody),
 			assertResponse: func(t *testing.T, status int, body string) {
 				assert.Equal(t, http.StatusBadRequest, status)
 				assert.Equal(t, responseInvalidMethod, body)
@@ -220,7 +220,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_type",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Header.Set("Content-Type", "application/not-protobuf")
 				return req
 			}(),
@@ -232,7 +232,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -245,7 +245,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Header.Set("Content-Type", otlpContentHeader)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -258,7 +258,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "fail_to_read_body_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
@@ -271,7 +271,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "fail_to_read_body_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", otlpContentHeader)
 				return req
@@ -462,7 +462,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest(http.MethodPut, "http://localhost", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost", http.NoBody),
 			assertResponse: func(t *testing.T, status int, body string) {
 				assert.Equal(t, http.StatusBadRequest, status)
 				assert.Equal(t, responseInvalidMethod, body)
@@ -486,7 +486,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "incorrect_content_type",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Header.Set("Content-Type", "application/x-protobuf;format=otlp")
 				return req
 			}(),
@@ -498,7 +498,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -511,7 +511,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "fail_to_read_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", http.NoBody)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req

--- a/receiver/splunkenterprisereceiver/client.go
+++ b/receiver/splunkenterprisereceiver/client.go
@@ -124,7 +124,7 @@ func (c *splunkEntClient) createRequest(eptType string, sr *searchResponse) (req
 	path := fmt.Sprintf("/services/search/jobs/%s/results", *sr.Jobid)
 	url, _ := url.JoinPath(c.clients[eptType].endpoint.String(), path)
 
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (c *splunkEntClient) createAPIRequest(eptType string, apiEndpoint string) (
 		return nil, errNoClientFound
 	}
 
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/splunkenterprisereceiver/client_test.go
+++ b/receiver/splunkenterprisereceiver/client_test.go
@@ -121,7 +121,7 @@ func TestClientCreateRequest(t *testing.T) {
 				path := fmt.Sprintf("/services/search/jobs/%s/results", testJobID)
 				testEndpoint, _ := url.Parse("https://localhost:8089")
 				url, _ := url.JoinPath(testEndpoint.String(), path)
-				req, _ := http.NewRequest(method, url, nil)
+				req, _ := http.NewRequest(method, url, http.NoBody)
 				return req
 			}(),
 		},
@@ -169,7 +169,7 @@ func TestAPIRequestCreate(t *testing.T) {
 
 	// build the expected request
 	expectedURL := client.clients[typeIdx].endpoint.String() + "/test/endpoint"
-	expected, _ := http.NewRequest(http.MethodGet, expectedURL, nil)
+	expected, _ := http.NewRequest(http.MethodGet, expectedURL, http.NoBody)
 
 	require.Equal(t, expected.URL, req.URL)
 	require.Equal(t, expected.Method, req.Method)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -123,7 +123,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", http.NoBody),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusBadRequest, status)
@@ -151,7 +151,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", http.NoBody)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
 			}(),
@@ -914,7 +914,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", http.NoBody),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusBadRequest, status)
@@ -936,7 +936,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", http.NoBody)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
 			}(),
@@ -1146,7 +1146,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest(http.MethodPut, "http://localhost/ack", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/ack", http.NoBody),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{}
 			},
@@ -1159,7 +1159,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "no_channel_header",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", http.NoBody)
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1174,7 +1174,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "invalid_channel_header",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", http.NoBody)
 				req.Header.Set("X-Splunk-Request-Channel", "invalid-id")
 				return req
 			}(),
@@ -1190,7 +1190,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "empty_request_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", http.NoBody)
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1727,7 +1727,7 @@ func Test_splunkhecreceiver_handleHealthPath(t *testing.T) {
 		assert.NoError(t, rcv.Shutdown(context.Background()))
 	}()
 	w := httptest.NewRecorder()
-	rcv.handleHealthReq(w, httptest.NewRequest(http.MethodGet, "http://localhost/services/collector/health", nil))
+	rcv.handleHealthReq(w, httptest.NewRequest(http.MethodGet, "http://localhost/services/collector/health", http.NoBody))
 
 	resp := w.Result()
 	respBytes, err := io.ReadAll(resp.Body)
@@ -1971,7 +1971,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "correct_healthcheck",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health", http.NoBody)
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
@@ -1982,7 +1982,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "correct_healthcheck_v1",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health/1.0", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health/1.0", http.NoBody)
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
@@ -1993,7 +1993,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "incorrect_healthcheck_methods_v1",
 			req: func() *http.Request {
-				req := httptest.NewRequest(http.MethodPost, "http://localhost:0/services/collector/health/1.0", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost:0/services/collector/health/1.0", nil) //nolint:gocritic // use nil body on purpose
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {

--- a/receiver/webhookeventreceiver/receiver_test.go
+++ b/receiver/webhookeventreceiver/receiver_test.go
@@ -235,7 +235,7 @@ func TestFailedReq(t *testing.T) {
 		{
 			desc:   "Invalid method",
 			cfg:    *cfg,
-			req:    httptest.NewRequest(http.MethodGet, "http://localhost/events", nil),
+			req:    httptest.NewRequest(http.MethodGet, "http://localhost/events", http.NoBody),
 			status: http.StatusBadRequest,
 		},
 		{
@@ -310,7 +310,7 @@ func TestHealthCheck(t *testing.T) {
 	}()
 
 	w := httptest.NewRecorder()
-	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", nil), httprouter.ParamsFromContext(context.Background()))
+	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", http.NoBody), httprouter.ParamsFromContext(context.Background()))
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)


### PR DESCRIPTION
#### Description

Enables and fixes [httpNoBody](https://go-critic.com/overview.html#httpnobody) rule from go-critic

Related to #41202