### PR TITLE
[chore] Only label issues and ping code owners for PRs that are ready to review

### DIFF
--- a/.github/workflows/add-codeowners-to-pr.yml
+++ b/.github/workflows/add-codeowners-to-pr.yml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - synchronize
+      - ready_for_review
 
 permissions: read-all
 
@@ -12,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' && github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 

--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -1,7 +1,9 @@
 name: 'Auto Assign'
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types:
+      - opened
+      - ready_for_review
 
 permissions:
   contents: read
@@ -15,7 +17,7 @@ jobs:
     permissions:
       pull-requests: write # required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     steps:
       - name: run
         uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e # v2.0.0

--- a/.github/workflows/ping-codeowners-prs.yml
+++ b/.github/workflows/ping-codeowners-prs.yml
@@ -1,7 +1,9 @@
 name: 'Ping code owners on PRs'
 on:
   pull_request_target:
-    types: [labeled]
+    types:
+      - labeled
+      - ready_for_review
 
 permissions: read-all
 
@@ -10,10 +12,10 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' && github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    
+
       - name: Run ping-codeowners-prs.sh
         run: ./.github/workflows/scripts/ping-codeowners-prs.sh
         env:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

A draft PR is by definition not yet ready for review, and may have further changes that add or remove pings (and we never remove labels and review requests).
So this changes the labels assignement and review requests to only happen for PRs that are ready to be reviewed.

See https://cloud-native.slack.com/archives/C07CCCMRXBK/p1752690459792339

Core equivalent: https://github.com/open-telemetry/opentelemetry-collector/pull/13410