### PR TITLE
[exporter/tinybird] implement metrics propagation

### DIFF
--- a/.chloggen/exporter-tinybird-metrics-implementation.yaml
+++ b/.chloggen/exporter-tinybird-metrics-implementation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tinybirdexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add metrics implementation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40475]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/tinybirdexporter/README.md
+++ b/exporter/tinybirdexporter/README.md
@@ -16,8 +16,14 @@ This is the initial version of the Tinybird Exporter that sends data to Tinybird
 ## Configuration
 - `endpoint`: Tinybird API endpoint
 - `token`: Tinybird API token
-- `metrics`
-  - `datasource` (default `metrics`): Name of the metrics datasource
+- `metrics_gauge`
+  - `datasource` (default `metrics_gauge`): Name of the gauge metrics datasource
+- `metrics_sum`
+  - `datasource` (default `metrics_sum`): Name of the sum metrics datasource
+- `metrics_histogram`
+  - `datasource` (default `metrics_histogram`): Name of the histogram metrics datasource
+- `metrics_exponential_histogram`
+  - `datasource` (default `metrics_exponential_histogram`): Name of the exponential histogram metrics datasource
 - `traces`
   - `datasource` (default `traces`): Name of the traces datasource
 - `logs`
@@ -29,8 +35,14 @@ exporters:
   tinybird:
     endpoint: https://api.us-east.aws.tinybird.co
     token: ${TINYBIRD_TOKEN}
-    metrics:
-      datasource: metrics
+    metrics_gauge:
+      datasource: "metrics_gauge"
+    metrics_sum:
+      datasource: "metrics_sum"
+    metrics_histogram:
+      datasource: "metrics_histogram"
+    metrics_exponential_histogram:
+      datasource: "metrics_exponential_histogram"
     logs:
       datasource: logs
     traces:

--- a/exporter/tinybirdexporter/README.md
+++ b/exporter/tinybirdexporter/README.md
@@ -16,14 +16,15 @@ This is the initial version of the Tinybird Exporter that sends data to Tinybird
 ## Configuration
 - `endpoint`: Tinybird API endpoint
 - `token`: Tinybird API token
-- `metrics_gauge`
-  - `datasource` (default `metrics_gauge`): Name of the gauge metrics datasource
-- `metrics_sum`
-  - `datasource` (default `metrics_sum`): Name of the sum metrics datasource
-- `metrics_histogram`
-  - `datasource` (default `metrics_histogram`): Name of the histogram metrics datasource
-- `metrics_exponential_histogram`
-  - `datasource` (default `metrics_exponential_histogram`): Name of the exponential histogram metrics datasource
+- `metrics`:
+  - `gauge`
+    - `datasource` (default `gauge`): Name of the gauge metrics datasource
+  - `sum`
+    - `datasource` (default `sum`): Name of the sum metrics datasource
+  - `histogram`
+    - `datasource` (default `histogram`): Name of the histogram metrics datasource
+  - `exponential_histogram`
+    - `datasource` (default `exponential_histogram`): Name of the exponential histogram metrics datasource
 - `traces`
   - `datasource` (default `traces`): Name of the traces datasource
 - `logs`
@@ -35,14 +36,15 @@ exporters:
   tinybird:
     endpoint: https://api.us-east.aws.tinybird.co
     token: ${TINYBIRD_TOKEN}
-    metrics_gauge:
-      datasource: "metrics_gauge"
-    metrics_sum:
-      datasource: "metrics_sum"
-    metrics_histogram:
-      datasource: "metrics_histogram"
-    metrics_exponential_histogram:
-      datasource: "metrics_exponential_histogram"
+    metrics:
+      gauge:
+        datasource: "metrics_gauge"
+      sum:
+        datasource: "metrics_sum"
+      histogram:
+        datasource: "metrics_histogram"
+      exponential_histogram:
+        datasource: "metrics_exponential_histogram"
     logs:
       datasource: logs
     traces:

--- a/exporter/tinybirdexporter/config.go
+++ b/exporter/tinybirdexporter/config.go
@@ -41,15 +41,19 @@ type Config struct {
 	QueueConfig  exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 
 	// Tinybird API token.
-	Token                       configopaque.String `mapstructure:"token"`
-	MetricsGauge                SignalConfig        `mapstructure:"metrics_gauge"`
-	MetricsSum                  SignalConfig        `mapstructure:"metrics_sum"`
-	MetricsHistogram            SignalConfig        `mapstructure:"metrics_histogram"`
-	MetricsExponentialHistogram SignalConfig        `mapstructure:"metrics_exponential_histogram"`
-	Traces                      SignalConfig        `mapstructure:"traces"`
-	Logs                        SignalConfig        `mapstructure:"logs"`
+	Token   configopaque.String `mapstructure:"token"`
+	Metrics metricSignalConfigs `mapstructure:"metrics"`
+	Traces  SignalConfig        `mapstructure:"traces"`
+	Logs    SignalConfig        `mapstructure:"logs"`
 	// Wait for data to be ingested before returning a response.
 	Wait bool `mapstructure:"wait"`
+}
+
+type metricSignalConfigs struct {
+	MetricsGauge                SignalConfig `mapstructure:"gauge"`
+	MetricsSum                  SignalConfig `mapstructure:"sum"`
+	MetricsHistogram            SignalConfig `mapstructure:"histogram"`
+	MetricsExponentialHistogram SignalConfig `mapstructure:"exponential_histogram"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/exporter/tinybirdexporter/config.go
+++ b/exporter/tinybirdexporter/config.go
@@ -41,10 +41,13 @@ type Config struct {
 	QueueConfig  exporterhelper.QueueBatchConfig `mapstructure:"sending_queue"`
 
 	// Tinybird API token.
-	Token   configopaque.String `mapstructure:"token"`
-	Metrics SignalConfig        `mapstructure:"metrics"`
-	Traces  SignalConfig        `mapstructure:"traces"`
-	Logs    SignalConfig        `mapstructure:"logs"`
+	Token                       configopaque.String `mapstructure:"token"`
+	MetricsGauge                SignalConfig        `mapstructure:"metrics_gauge"`
+	MetricsSum                  SignalConfig        `mapstructure:"metrics_sum"`
+	MetricsHistogram            SignalConfig        `mapstructure:"metrics_histogram"`
+	MetricsExponentialHistogram SignalConfig        `mapstructure:"metrics_exponential_histogram"`
+	Traces                      SignalConfig        `mapstructure:"traces"`
+	Logs                        SignalConfig        `mapstructure:"logs"`
 	// Wait for data to be ingested before returning a response.
 	Wait bool `mapstructure:"wait"`
 }

--- a/exporter/tinybirdexporter/config_test.go
+++ b/exporter/tinybirdexporter/config_test.go
@@ -39,12 +39,15 @@ func TestLoadConfig(t *testing.T) {
 					cfg.Endpoint = "https://api.tinybird.co"
 					return cfg
 				}(),
-				RetryConfig: configretry.NewDefaultBackOffConfig(),
-				QueueConfig: exporterhelper.NewDefaultQueueConfig(),
-				Token:       "test-token",
-				Metrics:     SignalConfig{Datasource: "metrics"},
-				Traces:      SignalConfig{Datasource: "traces"},
-				Logs:        SignalConfig{Datasource: "logs"},
+				RetryConfig:                 configretry.NewDefaultBackOffConfig(),
+				QueueConfig:                 exporterhelper.NewDefaultQueueConfig(),
+				Token:                       "test-token",
+				MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
+				MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
+				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
+				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+				Traces:                      SignalConfig{Datasource: "traces"},
+				Logs:                        SignalConfig{Datasource: "logs"},
 			},
 		},
 		{
@@ -67,17 +70,23 @@ func TestLoadConfig(t *testing.T) {
 					cfg.Enabled = false
 					return cfg
 				}(),
-				Token:   "test-token",
-				Metrics: SignalConfig{Datasource: "metrics"},
-				Traces:  SignalConfig{Datasource: "traces"},
-				Logs:    SignalConfig{Datasource: "logs"},
-				Wait:    true,
+				Token:                       "test-token",
+				MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
+				MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
+				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
+				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+				Traces:                      SignalConfig{Datasource: "traces"},
+				Logs:                        SignalConfig{Datasource: "logs"},
+				Wait:                        true,
 			},
 		},
 		{
 			id:      component.NewIDWithName(component.MustNewType(typeStr), "invalid_datasource"),
 			subName: "tinybird/invalid_datasource",
-			errorMessage: "metrics: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+			errorMessage: "metrics_gauge: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics_sum: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics_histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics_exponential_histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
 				"traces: invalid datasource \"traces-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
 				"logs: invalid datasource \"logs-with-dashes\": only letters, numbers, and underscores are allowed",
 		},

--- a/exporter/tinybirdexporter/config_test.go
+++ b/exporter/tinybirdexporter/config_test.go
@@ -39,15 +39,17 @@ func TestLoadConfig(t *testing.T) {
 					cfg.Endpoint = "https://api.tinybird.co"
 					return cfg
 				}(),
-				RetryConfig:                 configretry.NewDefaultBackOffConfig(),
-				QueueConfig:                 exporterhelper.NewDefaultQueueConfig(),
-				Token:                       "test-token",
-				MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
-				MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
-				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
-				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
-				Traces:                      SignalConfig{Datasource: "traces"},
-				Logs:                        SignalConfig{Datasource: "logs"},
+				RetryConfig: configretry.NewDefaultBackOffConfig(),
+				QueueConfig: exporterhelper.NewDefaultQueueConfig(),
+				Token:       "test-token",
+				Metrics: metricSignalConfigs{
+					MetricsGauge:                SignalConfig{Datasource: "gauge"},
+					MetricsSum:                  SignalConfig{Datasource: "sum"},
+					MetricsHistogram:            SignalConfig{Datasource: "histogram"},
+					MetricsExponentialHistogram: SignalConfig{Datasource: "exponential_histogram"},
+				},
+				Traces: SignalConfig{Datasource: "traces"},
+				Logs:   SignalConfig{Datasource: "logs"},
 			},
 		},
 		{
@@ -70,23 +72,25 @@ func TestLoadConfig(t *testing.T) {
 					cfg.Enabled = false
 					return cfg
 				}(),
-				Token:                       "test-token",
-				MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
-				MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
-				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
-				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
-				Traces:                      SignalConfig{Datasource: "traces"},
-				Logs:                        SignalConfig{Datasource: "logs"},
-				Wait:                        true,
+				Token: "test-token",
+				Metrics: metricSignalConfigs{
+					MetricsGauge:                SignalConfig{Datasource: "gauge"},
+					MetricsSum:                  SignalConfig{Datasource: "sum"},
+					MetricsHistogram:            SignalConfig{Datasource: "histogram"},
+					MetricsExponentialHistogram: SignalConfig{Datasource: "exponential_histogram"},
+				},
+				Traces: SignalConfig{Datasource: "traces"},
+				Logs:   SignalConfig{Datasource: "logs"},
+				Wait:   true,
 			},
 		},
 		{
 			id:      component.NewIDWithName(component.MustNewType(typeStr), "invalid_datasource"),
 			subName: "tinybird/invalid_datasource",
-			errorMessage: "metrics_gauge: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
-				"metrics_sum: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
-				"metrics_histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
-				"metrics_exponential_histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+			errorMessage: "metrics::gauge: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics::sum: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics::histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
+				"metrics::exponential_histogram: invalid datasource \"metrics-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
 				"traces: invalid datasource \"traces-with-dashes\": only letters, numbers, and underscores are allowed" + "\n" +
 				"logs: invalid datasource \"logs-with-dashes\": only letters, numbers, and underscores are allowed",
 		},

--- a/exporter/tinybirdexporter/exporter.go
+++ b/exporter/tinybirdexporter/exporter.go
@@ -74,8 +74,38 @@ func (e *tinybirdExporter) pushTraces(ctx context.Context, td ptrace.Traces) err
 	return nil
 }
 
-func (*tinybirdExporter) pushMetrics(context.Context, pmetric.Metrics) error {
-	return errors.New("this component is under development and metrics are not yet supported, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40475 to track development progress")
+func (e *tinybirdExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
+	sumBuffer := bytes.NewBuffer(nil)
+	sumEncoder := json.NewEncoder(sumBuffer)
+
+	gaugeBuffer := bytes.NewBuffer(nil)
+	gaugeEncoder := json.NewEncoder(gaugeBuffer)
+
+	histogramBuffer := bytes.NewBuffer(nil)
+	histogramEncoder := json.NewEncoder(histogramBuffer)
+
+	exponentialHistogramBuffer := bytes.NewBuffer(nil)
+	exponentialHistogramEncoder := json.NewEncoder(exponentialHistogramBuffer)
+
+	err := internal.ConvertMetrics(md, sumEncoder, gaugeEncoder, histogramEncoder, exponentialHistogramEncoder)
+	if err != nil {
+		return consumererror.NewPermanent(err)
+	}
+
+	// TODO: perform the exports in parallel to improve the operation latency
+	if sumBuffer.Len() > 0 {
+		err = errors.Join(err, e.export(ctx, e.config.MetricsSum.Datasource, sumBuffer))
+	}
+	if gaugeBuffer.Len() > 0 {
+		err = errors.Join(err, e.export(ctx, e.config.MetricsGauge.Datasource, gaugeBuffer))
+	}
+	if histogramBuffer.Len() > 0 {
+		err = errors.Join(err, e.export(ctx, e.config.MetricsHistogram.Datasource, histogramBuffer))
+	}
+	if exponentialHistogramBuffer.Len() > 0 {
+		err = errors.Join(err, e.export(ctx, e.config.MetricsExponentialHistogram.Datasource, exponentialHistogramBuffer))
+	}
+	return err
 }
 
 func (e *tinybirdExporter) pushLogs(ctx context.Context, ld plog.Logs) error {

--- a/exporter/tinybirdexporter/exporter.go
+++ b/exporter/tinybirdexporter/exporter.go
@@ -94,16 +94,16 @@ func (e *tinybirdExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) 
 
 	// TODO: perform the exports in parallel to improve the operation latency
 	if sumBuffer.Len() > 0 {
-		err = errors.Join(err, e.export(ctx, e.config.MetricsSum.Datasource, sumBuffer))
+		err = errors.Join(err, e.export(ctx, e.config.Metrics.MetricsSum.Datasource, sumBuffer))
 	}
 	if gaugeBuffer.Len() > 0 {
-		err = errors.Join(err, e.export(ctx, e.config.MetricsGauge.Datasource, gaugeBuffer))
+		err = errors.Join(err, e.export(ctx, e.config.Metrics.MetricsGauge.Datasource, gaugeBuffer))
 	}
 	if histogramBuffer.Len() > 0 {
-		err = errors.Join(err, e.export(ctx, e.config.MetricsHistogram.Datasource, histogramBuffer))
+		err = errors.Join(err, e.export(ctx, e.config.Metrics.MetricsHistogram.Datasource, histogramBuffer))
 	}
 	if exponentialHistogramBuffer.Len() > 0 {
-		err = errors.Join(err, e.export(ctx, e.config.MetricsExponentialHistogram.Datasource, exponentialHistogramBuffer))
+		err = errors.Join(err, e.export(ctx, e.config.Metrics.MetricsExponentialHistogram.Datasource, exponentialHistogramBuffer))
 	}
 	return err
 }

--- a/exporter/tinybirdexporter/exporter_test.go
+++ b/exporter/tinybirdexporter/exporter_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal/metadata"
@@ -33,11 +34,14 @@ func TestNewExporter(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: "http://localhost:8080",
 				},
-				Token:   "test-token",
-				Metrics: SignalConfig{Datasource: "metrics_test"},
-				Traces:  SignalConfig{Datasource: "traces_test"},
-				Logs:    SignalConfig{Datasource: "logs_test"},
-				Wait:    true,
+				Token:                       "test-token",
+				MetricsGauge:                SignalConfig{Datasource: "metrics_test"},
+				MetricsSum:                  SignalConfig{Datasource: "metrics_sum_test"},
+				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram_test"},
+				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram_test"},
+				Traces:                      SignalConfig{Datasource: "traces_test"},
+				Logs:                        SignalConfig{Datasource: "logs_test"},
+				Wait:                        true,
 			},
 		},
 	}
@@ -175,6 +179,291 @@ func TestExportTraces(t *testing.T) {
 			require.NoError(t, exp.start(context.Background(), componenttest.NewNopHost()))
 
 			err := exp.pushTraces(context.Background(), tt.args.traces)
+			if tt.want.err != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExportMetrics(t *testing.T) {
+	type args struct {
+		metrics pmetric.Metrics
+		config  Config
+	}
+	type want struct {
+		requestQuery   string
+		requestBody    string
+		responseStatus int
+		err            error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "export without metrics",
+			args: args{
+				metrics: func() pmetric.Metrics {
+					metrics := pmetric.NewMetrics()
+					rm := metrics.ResourceMetrics().AppendEmpty()
+					rm.ScopeMetrics().AppendEmpty()
+					return metrics
+				}(),
+				config: Config{
+					ClientConfig: confighttp.ClientConfig{},
+					Token:        "test-token",
+					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					Wait:         false,
+				},
+			},
+			want: want{
+				requestQuery:   "name=metrics_gauge",
+				requestBody:    "",
+				responseStatus: http.StatusOK,
+				err:            nil,
+			},
+		},
+		{
+			name: "export with gauge metric",
+			args: args{
+				metrics: func() pmetric.Metrics {
+					metrics := pmetric.NewMetrics()
+					rm := metrics.ResourceMetrics().AppendEmpty()
+					rm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := rm.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+
+					sm := rm.ScopeMetrics().AppendEmpty()
+					sm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scope := sm.Scope()
+					scope.SetName("test-scope")
+					scope.SetVersion("1.0.0")
+					scope.Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+
+					metric := sm.Metrics().AppendEmpty()
+					metric.SetName("test.gauge")
+					metric.SetDescription("Test gauge metric")
+					metric.SetUnit("bytes")
+					gauge := metric.SetEmptyGauge()
+					dp := gauge.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000)) // 2024-06-23T16:00:00Z
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))      // 2024-06-23T16:00:01Z
+					dp.SetDoubleValue(1024.5)
+					dp.Attributes().PutStr("host", "server-1")
+					dp.Attributes().PutStr("region", "us-west")
+
+					// Add exemplar
+					exemplar := dp.Exemplars().AppendEmpty()
+					exemplar.SetTimestamp(pcommon.Timestamp(1719158400500000000)) // 2024-06-23T16:00:00.5Z
+					exemplar.SetDoubleValue(1500.0)
+					exemplar.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+					exemplar.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+					exemplar.FilteredAttributes().PutStr("exemplar.type", "outlier")
+
+					return metrics
+				}(),
+				config: Config{
+					ClientConfig: confighttp.ClientConfig{},
+					Token:        "test-token",
+					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					Wait:         false,
+				},
+			},
+			want: want{
+				requestQuery:   "name=metrics_gauge",
+				requestBody:    `{"resource_schema_url":"https://opentelemetry.io/schemas/1.20.0","resource_attributes":{"service.name":"test-service","environment":"production"},"service_name":"test-service","scope_name":"test-scope","scope_version":"1.0.0","scope_schema_url":"https://opentelemetry.io/schemas/1.20.0","scope_attributes":{"telemetry.sdk.name":"opentelemetry"},"metric_name":"test.gauge","metric_description":"Test gauge metric","metric_unit":"bytes","metric_attributes":{"host":"server-1","region":"us-west"},"start_timestamp":"2024-06-23T16:00:00Z","timestamp":"2024-06-23T16:00:01Z","flags":0,"exemplars_filtered_attributes":[{"exemplar.type":"outlier"}],"exemplars_timestamp":["2024-06-23T16:00:00.5Z"],"exemplars_value":[1500],"exemplars_span_id":["0102030405060708"],"exemplars_trace_id":["0102030405060708090a0b0c0d0e0f10"],"value":1024.5}`,
+				responseStatus: http.StatusOK,
+				err:            nil,
+			},
+		},
+		{
+			name: "export with sum metric",
+			args: args{
+				metrics: func() pmetric.Metrics {
+					metrics := pmetric.NewMetrics()
+					rm := metrics.ResourceMetrics().AppendEmpty()
+					rm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := rm.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+
+					sm := rm.ScopeMetrics().AppendEmpty()
+					sm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scope := sm.Scope()
+					scope.SetName("test-scope")
+					scope.SetVersion("1.0.0")
+					scope.Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+
+					metric := sm.Metrics().AppendEmpty()
+					metric.SetName("test.sum")
+					metric.SetDescription("Test sum metric")
+					metric.SetUnit("requests")
+					sum := metric.SetEmptySum()
+					sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					sum.SetIsMonotonic(true)
+					dp := sum.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000)) // 2024-06-23T16:00:00Z
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))      // 2024-06-23T16:00:01Z
+					dp.SetIntValue(150)
+					dp.Attributes().PutStr("endpoint", "/api/users")
+					dp.Attributes().PutStr("method", "GET")
+
+					return metrics
+				}(),
+				config: Config{
+					ClientConfig: confighttp.ClientConfig{},
+					Token:        "test-token",
+					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					Wait:         false,
+				},
+			},
+			want: want{
+				requestQuery:   "name=metrics_sum",
+				requestBody:    `{"resource_schema_url":"https://opentelemetry.io/schemas/1.20.0","resource_attributes":{"service.name":"test-service","environment":"production"},"service_name":"test-service","scope_name":"test-scope","scope_version":"1.0.0","scope_schema_url":"https://opentelemetry.io/schemas/1.20.0","scope_attributes":{"telemetry.sdk.name":"opentelemetry"},"metric_name":"test.sum","metric_description":"Test sum metric","metric_unit":"requests","metric_attributes":{"endpoint":"/api/users","method":"GET"},"start_timestamp":"2024-06-23T16:00:00Z","timestamp":"2024-06-23T16:00:01Z","flags":0,"exemplars_filtered_attributes":[],"exemplars_timestamp":[],"exemplars_value":[],"exemplars_span_id":[],"exemplars_trace_id":[],"value":150,"aggregation_temporality":1,"is_monotonic":true}`,
+				responseStatus: http.StatusOK,
+				err:            nil,
+			},
+		},
+		{
+			name: "export with histogram metric",
+			args: args{
+				metrics: func() pmetric.Metrics {
+					metrics := pmetric.NewMetrics()
+					rm := metrics.ResourceMetrics().AppendEmpty()
+					rm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := rm.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+
+					sm := rm.ScopeMetrics().AppendEmpty()
+					sm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scope := sm.Scope()
+					scope.SetName("test-scope")
+					scope.SetVersion("1.0.0")
+					scope.Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+
+					metric := sm.Metrics().AppendEmpty()
+					metric.SetName("test.histogram")
+					metric.SetDescription("Test histogram metric")
+					metric.SetUnit("seconds")
+					histogram := metric.SetEmptyHistogram()
+					histogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					dp := histogram.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000)) // 2024-06-23T16:00:00Z
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))      // 2024-06-23T16:00:01Z
+					dp.SetCount(100)
+					dp.SetSum(50.5)
+					dp.SetMin(0.1)
+					dp.SetMax(2.0)
+					dp.BucketCounts().FromRaw([]uint64{10, 20, 30, 40})
+					dp.ExplicitBounds().FromRaw([]float64{0.5, 1.0, 1.5})
+					dp.Attributes().PutStr("operation", "database_query")
+					dp.Attributes().PutStr("table", "users")
+
+					return metrics
+				}(),
+				config: Config{
+					ClientConfig:     confighttp.ClientConfig{},
+					Token:            "test-token",
+					MetricsHistogram: SignalConfig{Datasource: "metrics_histogram"},
+					Wait:             false,
+				},
+			},
+			want: want{
+				requestQuery:   "name=metrics_histogram",
+				requestBody:    `{"resource_schema_url":"https://opentelemetry.io/schemas/1.20.0","resource_attributes":{"service.name":"test-service","environment":"production"},"service_name":"test-service","scope_name":"test-scope","scope_version":"1.0.0","scope_schema_url":"https://opentelemetry.io/schemas/1.20.0","scope_attributes":{"telemetry.sdk.name":"opentelemetry"},"metric_name":"test.histogram","metric_description":"Test histogram metric","metric_unit":"seconds","metric_attributes":{"operation":"database_query","table":"users"},"start_timestamp":"2024-06-23T16:00:00Z","timestamp":"2024-06-23T16:00:01Z","flags":0,"exemplars_filtered_attributes":[],"exemplars_timestamp":[],"exemplars_value":[],"exemplars_span_id":[],"exemplars_trace_id":[],"count":100,"sum":50.5,"bucket_counts":[10,20,30,40],"explicit_bounds":[0.5,1,1.5],"min":0.1,"max":2,"aggregation_temporality":1}`,
+				responseStatus: http.StatusOK,
+				err:            nil,
+			},
+		},
+		{
+			name: "export with exponential histogram metric",
+			args: args{
+				metrics: func() pmetric.Metrics {
+					metrics := pmetric.NewMetrics()
+					rm := metrics.ResourceMetrics().AppendEmpty()
+					rm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := rm.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+
+					sm := rm.ScopeMetrics().AppendEmpty()
+					sm.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scope := sm.Scope()
+					scope.SetName("test-scope")
+					scope.SetVersion("1.0.0")
+					scope.Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+
+					metric := sm.Metrics().AppendEmpty()
+					metric.SetName("test.exponential_histogram")
+					metric.SetDescription("Test exponential histogram metric")
+					metric.SetUnit("seconds")
+					expHistogram := metric.SetEmptyExponentialHistogram()
+					expHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					dp := expHistogram.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000)) // 2024-06-23T16:00:00Z
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))      // 2024-06-23T16:00:01Z
+					dp.SetCount(200)
+					dp.SetSum(75.25)
+					dp.SetMin(0.05)
+					dp.SetMax(5.0)
+					dp.SetScale(2)
+					dp.SetZeroCount(15)
+					dp.Positive().SetOffset(1)
+					dp.Positive().BucketCounts().FromRaw([]uint64{5, 10, 15, 20, 25})
+					dp.Negative().SetOffset(-2)
+					dp.Negative().BucketCounts().FromRaw([]uint64{3, 7, 12, 18})
+					dp.Attributes().PutStr("operation", "api_request")
+					dp.Attributes().PutStr("endpoint", "/api/data")
+
+					return metrics
+				}(),
+				config: Config{
+					ClientConfig:                confighttp.ClientConfig{},
+					Token:                       "test-token",
+					MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+					Wait:                        false,
+				},
+			},
+			want: want{
+				requestQuery:   "name=metrics_exponential_histogram",
+				requestBody:    `{"resource_schema_url":"https://opentelemetry.io/schemas/1.20.0","resource_attributes":{"service.name":"test-service","environment":"production"},"service_name":"test-service","scope_name":"test-scope","scope_version":"1.0.0","scope_schema_url":"https://opentelemetry.io/schemas/1.20.0","scope_attributes":{"telemetry.sdk.name":"opentelemetry"},"metric_name":"test.exponential_histogram","metric_description":"Test exponential histogram metric","metric_unit":"seconds","metric_attributes":{"operation":"api_request","endpoint":"/api/data"},"start_timestamp":"2024-06-23T16:00:00Z","timestamp":"2024-06-23T16:00:01Z","flags":0,"exemplars_filtered_attributes":[],"exemplars_timestamp":[],"exemplars_value":[],"exemplars_span_id":[],"exemplars_trace_id":[],"count":200,"sum":75.25,"scale":2,"zero_count":15,"positive_offset":1,"positive_bucket_counts":[5,10,15,20,25],"negative_offset":-2,"negative_bucket_counts":[3,7,12,18],"min":0.05,"max":5,"aggregation_temporality":1}`,
+				responseStatus: http.StatusOK,
+				err:            nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "POST", r.Method)
+				assert.Equal(t, "/v0/events", r.URL.Path)
+				assert.Equal(t, tt.want.requestQuery, r.URL.RawQuery)
+				assert.Equal(t, "application/x-ndjson", r.Header.Get("Content-Type"))
+				assert.Equal(t, "Bearer "+string(tt.args.config.Token), r.Header.Get("Authorization"))
+				gotBody, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				assert.JSONEq(t, tt.want.requestBody, string(gotBody))
+
+				w.WriteHeader(tt.want.responseStatus)
+			}))
+			defer server.Close()
+
+			tt.args.config.ClientConfig.Endpoint = server.URL
+
+			exp := newExporter(&tt.args.config, exportertest.NewNopSettings(metadata.Type))
+			require.NoError(t, exp.start(context.Background(), componenttest.NewNopHost()))
+
+			err := exp.pushMetrics(context.Background(), tt.args.metrics)
 			if tt.want.err != nil {
 				assert.Error(t, err)
 			} else {
@@ -351,10 +640,13 @@ func TestExportErrorHandling(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: server.URL,
 				},
-				Token:   "test-token",
-				Metrics: SignalConfig{Datasource: "metrics_test"},
-				Traces:  SignalConfig{Datasource: "traces_test"},
-				Logs:    SignalConfig{Datasource: "logs_test"},
+				Token:                       "test-token",
+				MetricsGauge:                SignalConfig{Datasource: "metrics_test"},
+				MetricsSum:                  SignalConfig{Datasource: "metrics_sum_test"},
+				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram_test"},
+				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram_test"},
+				Traces:                      SignalConfig{Datasource: "traces_test"},
+				Logs:                        SignalConfig{Datasource: "logs_test"},
 			}
 
 			exp := newExporter(config, exportertest.NewNopSettings(metadata.Type))

--- a/exporter/tinybirdexporter/exporter_test.go
+++ b/exporter/tinybirdexporter/exporter_test.go
@@ -34,14 +34,16 @@ func TestNewExporter(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: "http://localhost:8080",
 				},
-				Token:                       "test-token",
-				MetricsGauge:                SignalConfig{Datasource: "metrics_test"},
-				MetricsSum:                  SignalConfig{Datasource: "metrics_sum_test"},
-				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram_test"},
-				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram_test"},
-				Traces:                      SignalConfig{Datasource: "traces_test"},
-				Logs:                        SignalConfig{Datasource: "logs_test"},
-				Wait:                        true,
+				Token: "test-token",
+				Metrics: metricSignalConfigs{
+					MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
+					MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
+					MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
+					MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+				},
+				Traces: SignalConfig{Datasource: "traces_test"},
+				Logs:   SignalConfig{Datasource: "logs_test"},
+				Wait:   true,
 			},
 		},
 	}
@@ -216,9 +218,11 @@ func TestExportMetrics(t *testing.T) {
 				config: Config{
 					ClientConfig: confighttp.ClientConfig{},
 					Token:        "test-token",
-					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
-					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
-					Wait:         false,
+					Metrics: metricSignalConfigs{
+						MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+						MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					},
+					Wait: false,
 				},
 			},
 			want: want{
@@ -271,9 +275,11 @@ func TestExportMetrics(t *testing.T) {
 				config: Config{
 					ClientConfig: confighttp.ClientConfig{},
 					Token:        "test-token",
-					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
-					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
-					Wait:         false,
+					Metrics: metricSignalConfigs{
+						MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+						MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					},
+					Wait: false,
 				},
 			},
 			want: want{
@@ -320,9 +326,11 @@ func TestExportMetrics(t *testing.T) {
 				config: Config{
 					ClientConfig: confighttp.ClientConfig{},
 					Token:        "test-token",
-					MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
-					MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
-					Wait:         false,
+					Metrics: metricSignalConfigs{
+						MetricsGauge: SignalConfig{Datasource: "metrics_gauge"},
+						MetricsSum:   SignalConfig{Datasource: "metrics_sum"},
+					},
+					Wait: false,
 				},
 			},
 			want: want{
@@ -371,10 +379,12 @@ func TestExportMetrics(t *testing.T) {
 					return metrics
 				}(),
 				config: Config{
-					ClientConfig:     confighttp.ClientConfig{},
-					Token:            "test-token",
-					MetricsHistogram: SignalConfig{Datasource: "metrics_histogram"},
-					Wait:             false,
+					ClientConfig: confighttp.ClientConfig{},
+					Token:        "test-token",
+					Metrics: metricSignalConfigs{
+						MetricsHistogram: SignalConfig{Datasource: "metrics_histogram"},
+					},
+					Wait: false,
 				},
 			},
 			want: want{
@@ -427,10 +437,12 @@ func TestExportMetrics(t *testing.T) {
 					return metrics
 				}(),
 				config: Config{
-					ClientConfig:                confighttp.ClientConfig{},
-					Token:                       "test-token",
-					MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
-					Wait:                        false,
+					ClientConfig: confighttp.ClientConfig{},
+					Token:        "test-token",
+					Metrics: metricSignalConfigs{
+						MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+					},
+					Wait: false,
 				},
 			},
 			want: want{
@@ -640,13 +652,15 @@ func TestExportErrorHandling(t *testing.T) {
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: server.URL,
 				},
-				Token:                       "test-token",
-				MetricsGauge:                SignalConfig{Datasource: "metrics_test"},
-				MetricsSum:                  SignalConfig{Datasource: "metrics_sum_test"},
-				MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram_test"},
-				MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram_test"},
-				Traces:                      SignalConfig{Datasource: "traces_test"},
-				Logs:                        SignalConfig{Datasource: "logs_test"},
+				Token: "test-token",
+				Metrics: metricSignalConfigs{
+					MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
+					MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
+					MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
+					MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+				},
+				Traces: SignalConfig{Datasource: "traces_test"},
+				Logs:   SignalConfig{Datasource: "logs_test"},
 			}
 
 			exp := newExporter(config, exportertest.NewNopSettings(metadata.Type))

--- a/exporter/tinybirdexporter/factory.go
+++ b/exporter/tinybirdexporter/factory.go
@@ -43,17 +43,19 @@ func createDefaultConfig() component.Config {
 	clientConfig.WriteBufferSize = 512 * 1024
 
 	return &Config{
-		ClientConfig:                clientConfig,
-		RetryConfig:                 configretry.NewDefaultBackOffConfig(),
-		QueueConfig:                 exporterhelper.NewDefaultQueueConfig(),
-		Token:                       "",
-		MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
-		MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
-		MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
-		MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
-		Traces:                      SignalConfig{Datasource: "traces"},
-		Logs:                        SignalConfig{Datasource: "logs"},
-		Wait:                        false,
+		ClientConfig: clientConfig,
+		RetryConfig:  configretry.NewDefaultBackOffConfig(),
+		QueueConfig:  exporterhelper.NewDefaultQueueConfig(),
+		Token:        "",
+		Metrics: metricSignalConfigs{
+			MetricsGauge:                SignalConfig{Datasource: "gauge"},
+			MetricsSum:                  SignalConfig{Datasource: "sum"},
+			MetricsHistogram:            SignalConfig{Datasource: "histogram"},
+			MetricsExponentialHistogram: SignalConfig{Datasource: "exponential_histogram"},
+		},
+		Traces: SignalConfig{Datasource: "traces"},
+		Logs:   SignalConfig{Datasource: "logs"},
+		Wait:   false,
 	}
 }
 

--- a/exporter/tinybirdexporter/factory.go
+++ b/exporter/tinybirdexporter/factory.go
@@ -43,14 +43,17 @@ func createDefaultConfig() component.Config {
 	clientConfig.WriteBufferSize = 512 * 1024
 
 	return &Config{
-		ClientConfig: clientConfig,
-		RetryConfig:  configretry.NewDefaultBackOffConfig(),
-		QueueConfig:  exporterhelper.NewDefaultQueueConfig(),
-		Token:        "",
-		Metrics:      SignalConfig{Datasource: "metrics"},
-		Traces:       SignalConfig{Datasource: "traces"},
-		Logs:         SignalConfig{Datasource: "logs"},
-		Wait:         false,
+		ClientConfig:                clientConfig,
+		RetryConfig:                 configretry.NewDefaultBackOffConfig(),
+		QueueConfig:                 exporterhelper.NewDefaultQueueConfig(),
+		Token:                       "",
+		MetricsGauge:                SignalConfig{Datasource: "metrics_gauge"},
+		MetricsSum:                  SignalConfig{Datasource: "metrics_sum"},
+		MetricsHistogram:            SignalConfig{Datasource: "metrics_histogram"},
+		MetricsExponentialHistogram: SignalConfig{Datasource: "metrics_exponential_histogram"},
+		Traces:                      SignalConfig{Datasource: "traces"},
+		Logs:                        SignalConfig{Datasource: "logs"},
+		Wait:                        false,
 	}
 }
 

--- a/exporter/tinybirdexporter/generated_component_test.go
+++ b/exporter/tinybirdexporter/generated_component_test.go
@@ -73,6 +73,46 @@ func TestComponentLifecycle(t *testing.T) {
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
+		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), exportertest.NewNopSettings(typ), cfg)
+			require.NoError(t, err)
+			host := componenttest.NewNopHost()
+			err = c.Start(context.Background(), host)
+			require.NoError(t, err)
+			require.NotPanics(t, func() {
+				switch tt.name {
+				case "logs":
+					e, ok := c.(exporter.Logs)
+					require.True(t, ok)
+					logs := generateLifecycleTestLogs()
+					if !e.Capabilities().MutatesData {
+						logs.MarkReadOnly()
+					}
+					err = e.ConsumeLogs(context.Background(), logs)
+				case "metrics":
+					e, ok := c.(exporter.Metrics)
+					require.True(t, ok)
+					metrics := generateLifecycleTestMetrics()
+					if !e.Capabilities().MutatesData {
+						metrics.MarkReadOnly()
+					}
+					err = e.ConsumeMetrics(context.Background(), metrics)
+				case "traces":
+					e, ok := c.(exporter.Traces)
+					require.True(t, ok)
+					traces := generateLifecycleTestTraces()
+					if !e.Capabilities().MutatesData {
+						traces.MarkReadOnly()
+					}
+					err = e.ConsumeTraces(context.Background(), traces)
+				}
+			})
+
+			require.NoError(t, err)
+
+			err = c.Shutdown(context.Background())
+			require.NoError(t, err)
+		})
 	}
 }
 

--- a/exporter/tinybirdexporter/internal/metrics.go
+++ b/exporter/tinybirdexporter/internal/metrics.go
@@ -110,7 +110,7 @@ func covertValue(dp pmetric.NumberDataPoint) float64 {
 	return 0.0
 }
 
-func ConvertMetrics(md pmetric.Metrics, sumEncoder Encoder, gaugeEncoder Encoder, histogramEncoder Encoder, exponentialHistogramEncoder Encoder) error {
+func ConvertMetrics(md pmetric.Metrics, sumEncoder, gaugeEncoder, histogramEncoder, exponentialHistogramEncoder Encoder) error {
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
 		resource := rm.Resource()

--- a/exporter/tinybirdexporter/internal/metrics.go
+++ b/exporter/tinybirdexporter/internal/metrics.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal"
 
 import (

--- a/exporter/tinybirdexporter/internal/metrics.go
+++ b/exporter/tinybirdexporter/internal/metrics.go
@@ -1,0 +1,311 @@
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
+)
+
+type baseMetricSignal struct {
+	ResourceSchemaURL           string              `json:"resource_schema_url"`
+	ResourceAttributes          map[string]string   `json:"resource_attributes"`
+	ServiceName                 string              `json:"service_name"`
+	ScopeName                   string              `json:"scope_name"`
+	ScopeVersion                string              `json:"scope_version"`
+	ScopeSchemaURL              string              `json:"scope_schema_url"`
+	ScopeAttributes             map[string]string   `json:"scope_attributes"`
+	MetricName                  string              `json:"metric_name"`
+	MetricDescription           string              `json:"metric_description"`
+	MetricUnit                  string              `json:"metric_unit"`
+	MetricAttributes            map[string]string   `json:"metric_attributes"`
+	StartTimestamp              string              `json:"start_timestamp"`
+	Timestamp                   string              `json:"timestamp"`
+	Flags                       uint32              `json:"flags"`
+	ExemplarsFilteredAttributes []map[string]string `json:"exemplars_filtered_attributes"`
+	ExemplarsTimestamp          []string            `json:"exemplars_timestamp"`
+	ExemplarsValue              []float64           `json:"exemplars_value"`
+	ExemplarsSpanID             []string            `json:"exemplars_span_id"`
+	ExemplarsTraceID            []string            `json:"exemplars_trace_id"`
+}
+
+type sumMetricSignal struct {
+	baseMetricSignal
+	Value                  float64 `json:"value"`
+	AggregationTemporality int32   `json:"aggregation_temporality"`
+	IsMonotonic            bool    `json:"is_monotonic"`
+}
+
+type gaugeMetricSignal struct {
+	baseMetricSignal
+	Value float64 `json:"value"`
+}
+
+type histogramMetricSignal struct {
+	baseMetricSignal
+	Count                  uint64    `json:"count"`
+	Sum                    float64   `json:"sum"`
+	BucketCounts           []uint64  `json:"bucket_counts"`
+	ExplicitBounds         []float64 `json:"explicit_bounds"`
+	Min                    *float64  `json:"min,omitempty"`
+	Max                    *float64  `json:"max,omitempty"`
+	AggregationTemporality int32     `json:"aggregation_temporality"`
+}
+
+type exponentialHistogramMetricSignal struct {
+	baseMetricSignal
+	Count                  uint64   `json:"count"`
+	Sum                    float64  `json:"sum"`
+	Scale                  int32    `json:"scale"`
+	ZeroCount              uint64   `json:"zero_count"`
+	PositiveOffset         int32    `json:"positive_offset"`
+	PositiveBucketCounts   []uint64 `json:"positive_bucket_counts"`
+	NegativeOffset         int32    `json:"negative_offset"`
+	NegativeBucketCounts   []uint64 `json:"negative_bucket_counts"`
+	Min                    *float64 `json:"min,omitempty"`
+	Max                    *float64 `json:"max,omitempty"`
+	AggregationTemporality int32    `json:"aggregation_temporality"`
+}
+
+func convertExemplars(exemplars pmetric.ExemplarSlice) ([]map[string]string, []string, []float64, []string, []string) {
+	filteredAttributes := make([]map[string]string, exemplars.Len())
+	timestamps := make([]string, exemplars.Len())
+	values := make([]float64, exemplars.Len())
+	spanIDs := make([]string, exemplars.Len())
+	traceIDs := make([]string, exemplars.Len())
+	for i := 0; i < exemplars.Len(); i++ {
+		ex := exemplars.At(i)
+		filteredAttributes[i] = convertAttributes(ex.FilteredAttributes())
+		timestamps[i] = ex.Timestamp().AsTime().Format(time.RFC3339Nano)
+		var value float64
+		switch ex.ValueType() {
+		case pmetric.ExemplarValueTypeInt:
+			value = float64(ex.IntValue())
+		case pmetric.ExemplarValueTypeDouble:
+			value = ex.DoubleValue()
+		case pmetric.ExemplarValueTypeEmpty:
+			// Value is unset, use 0.0 as default
+			value = 0.0
+		}
+		values[i] = value
+		spanIDs[i] = traceutil.SpanIDToHexOrEmptyString(ex.SpanID())
+		traceIDs[i] = traceutil.TraceIDToHexOrEmptyString(ex.TraceID())
+	}
+	return filteredAttributes, timestamps, values, spanIDs, traceIDs
+}
+
+func covertValue(dp pmetric.NumberDataPoint) float64 {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		return float64(dp.IntValue())
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleValue()
+	case pmetric.NumberDataPointValueTypeEmpty:
+		return 0.0
+	}
+	return 0.0
+}
+
+func ConvertMetrics(md pmetric.Metrics, sumEncoder Encoder, gaugeEncoder Encoder, histogramEncoder Encoder, exponentialHistogramEncoder Encoder) error {
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		resource := rm.Resource()
+		schemaURL := rm.SchemaUrl()
+		resourceAttributesMap := resource.Attributes()
+		resourceAttributes := convertAttributes(resourceAttributesMap)
+		serviceName := getServiceName(resourceAttributesMap)
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			scopeSchemaURL := sm.SchemaUrl()
+			scope := sm.Scope()
+			scopeName := scope.Name()
+			scopeVersion := scope.Version()
+			scopeAttributes := convertAttributes(scope.Attributes())
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				metric := sm.Metrics().At(k)
+
+				switch metric.Type() {
+				case pmetric.MetricTypeSum:
+					sum := metric.Sum()
+					dps := sum.DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+
+						filteredAttrs, timestamps, values, spanIDs, traceIDs := convertExemplars(dp.Exemplars())
+
+						sumSignal := sumMetricSignal{
+							baseMetricSignal: baseMetricSignal{
+								ResourceSchemaURL:           schemaURL,
+								ResourceAttributes:          resourceAttributes,
+								ServiceName:                 serviceName,
+								ScopeName:                   scopeName,
+								ScopeVersion:                scopeVersion,
+								ScopeSchemaURL:              scopeSchemaURL,
+								ScopeAttributes:             scopeAttributes,
+								MetricName:                  metric.Name(),
+								MetricDescription:           metric.Description(),
+								MetricUnit:                  metric.Unit(),
+								MetricAttributes:            convertAttributes(dp.Attributes()),
+								StartTimestamp:              dp.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+								Timestamp:                   dp.Timestamp().AsTime().Format(time.RFC3339Nano),
+								Flags:                       uint32(dp.Flags()),
+								ExemplarsFilteredAttributes: filteredAttrs,
+								ExemplarsTimestamp:          timestamps,
+								ExemplarsValue:              values,
+								ExemplarsSpanID:             spanIDs,
+								ExemplarsTraceID:            traceIDs,
+							},
+							Value:                  covertValue(dp),
+							AggregationTemporality: int32(sum.AggregationTemporality()),
+							IsMonotonic:            sum.IsMonotonic(),
+						}
+						if err := sumEncoder.Encode(sumSignal); err != nil {
+							return err
+						}
+					}
+				case pmetric.MetricTypeGauge:
+					dps := metric.Gauge().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+
+						filteredAttrs, timestamps, values, spanIDs, traceIDs := convertExemplars(dp.Exemplars())
+						gaugeSignal := gaugeMetricSignal{
+							baseMetricSignal: baseMetricSignal{
+								ResourceSchemaURL:           schemaURL,
+								ResourceAttributes:          resourceAttributes,
+								ServiceName:                 serviceName,
+								ScopeName:                   scopeName,
+								ScopeVersion:                scopeVersion,
+								ScopeSchemaURL:              scopeSchemaURL,
+								ScopeAttributes:             scopeAttributes,
+								MetricName:                  metric.Name(),
+								MetricDescription:           metric.Description(),
+								MetricUnit:                  metric.Unit(),
+								MetricAttributes:            convertAttributes(dp.Attributes()),
+								StartTimestamp:              dp.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+								Timestamp:                   dp.Timestamp().AsTime().Format(time.RFC3339Nano),
+								Flags:                       uint32(dp.Flags()),
+								ExemplarsFilteredAttributes: filteredAttrs,
+								ExemplarsTimestamp:          timestamps,
+								ExemplarsValue:              values,
+								ExemplarsSpanID:             spanIDs,
+								ExemplarsTraceID:            traceIDs,
+							},
+							Value: covertValue(dp),
+						}
+						if err := gaugeEncoder.Encode(gaugeSignal); err != nil {
+							return err
+						}
+					}
+				case pmetric.MetricTypeHistogram:
+					hist := metric.Histogram()
+					dps := hist.DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+
+						var minVal, maxVal *float64
+						if dp.HasMin() {
+							localMin := dp.Min()
+							minVal = &localMin
+						}
+						if dp.HasMax() {
+							localMax := dp.Max()
+							maxVal = &localMax
+						}
+						filteredAttrs, timestamps, values, spanIDs, traceIDs := convertExemplars(dp.Exemplars())
+						histogramSignal := histogramMetricSignal{
+							baseMetricSignal: baseMetricSignal{
+								ResourceSchemaURL:           schemaURL,
+								ResourceAttributes:          resourceAttributes,
+								ServiceName:                 serviceName,
+								ScopeName:                   scopeName,
+								ScopeVersion:                scopeVersion,
+								ScopeSchemaURL:              scopeSchemaURL,
+								ScopeAttributes:             scopeAttributes,
+								MetricName:                  metric.Name(),
+								MetricDescription:           metric.Description(),
+								MetricUnit:                  metric.Unit(),
+								MetricAttributes:            convertAttributes(dp.Attributes()),
+								StartTimestamp:              dp.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+								Timestamp:                   dp.Timestamp().AsTime().Format(time.RFC3339Nano),
+								Flags:                       uint32(dp.Flags()),
+								ExemplarsFilteredAttributes: filteredAttrs,
+								ExemplarsTimestamp:          timestamps,
+								ExemplarsValue:              values,
+								ExemplarsSpanID:             spanIDs,
+								ExemplarsTraceID:            traceIDs,
+							},
+							Count:                  dp.Count(),
+							Sum:                    dp.Sum(),
+							BucketCounts:           dp.BucketCounts().AsRaw(),
+							ExplicitBounds:         dp.ExplicitBounds().AsRaw(),
+							Min:                    minVal,
+							Max:                    maxVal,
+							AggregationTemporality: int32(hist.AggregationTemporality()),
+						}
+						if err := histogramEncoder.Encode(histogramSignal); err != nil {
+							return err
+						}
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					ehist := metric.ExponentialHistogram()
+					dps := ehist.DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						dp := dps.At(l)
+
+						var minVal, maxVal *float64
+						if dp.HasMin() {
+							localMin := dp.Min()
+							minVal = &localMin
+						}
+						if dp.HasMax() {
+							localMax := dp.Max()
+							maxVal = &localMax
+						}
+						filteredAttrs, timestamps, values, spanIDs, traceIDs := convertExemplars(dp.Exemplars())
+						exponentialHistogramSignal := exponentialHistogramMetricSignal{
+							baseMetricSignal: baseMetricSignal{
+								ResourceSchemaURL:           schemaURL,
+								ResourceAttributes:          resourceAttributes,
+								ServiceName:                 serviceName,
+								ScopeName:                   scopeName,
+								ScopeVersion:                scopeVersion,
+								ScopeSchemaURL:              scopeSchemaURL,
+								ScopeAttributes:             scopeAttributes,
+								MetricName:                  metric.Name(),
+								MetricDescription:           metric.Description(),
+								MetricUnit:                  metric.Unit(),
+								MetricAttributes:            convertAttributes(dp.Attributes()),
+								StartTimestamp:              dp.StartTimestamp().AsTime().Format(time.RFC3339Nano),
+								Timestamp:                   dp.Timestamp().AsTime().Format(time.RFC3339Nano),
+								Flags:                       uint32(dp.Flags()),
+								ExemplarsFilteredAttributes: filteredAttrs,
+								ExemplarsTimestamp:          timestamps,
+								ExemplarsValue:              values,
+								ExemplarsSpanID:             spanIDs,
+								ExemplarsTraceID:            traceIDs,
+							},
+							Count:                  dp.Count(),
+							Sum:                    dp.Sum(),
+							Scale:                  dp.Scale(),
+							ZeroCount:              dp.ZeroCount(),
+							PositiveOffset:         dp.Positive().Offset(),
+							PositiveBucketCounts:   dp.Positive().BucketCounts().AsRaw(),
+							NegativeOffset:         dp.Negative().Offset(),
+							NegativeBucketCounts:   dp.Negative().BucketCounts().AsRaw(),
+							Min:                    minVal,
+							Max:                    maxVal,
+							AggregationTemporality: int32(ehist.AggregationTemporality()),
+						}
+						if err := exponentialHistogramEncoder.Encode(exponentialHistogramSignal); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/exporter/tinybirdexporter/internal/metrics_test.go
+++ b/exporter/tinybirdexporter/internal/metrics_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package internal
 
 import (

--- a/exporter/tinybirdexporter/internal/metrics_test.go
+++ b/exporter/tinybirdexporter/internal/metrics_test.go
@@ -1,0 +1,505 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type sumEncoderMock struct {
+	metrics []sumMetricSignal
+}
+
+func (e *sumEncoderMock) Encode(v any) error {
+	e.metrics = append(e.metrics, v.(sumMetricSignal))
+	return nil
+}
+
+type gaugeEncoderMock struct {
+	metrics []gaugeMetricSignal
+}
+
+func (e *gaugeEncoderMock) Encode(v any) error {
+	e.metrics = append(e.metrics, v.(gaugeMetricSignal))
+	return nil
+}
+
+type histogramEncoderMock struct {
+	metrics []histogramMetricSignal
+}
+
+func (e *histogramEncoderMock) Encode(v any) error {
+	e.metrics = append(e.metrics, v.(histogramMetricSignal))
+	return nil
+}
+
+type exponentialHistogramEncoderMock struct {
+	metrics []exponentialHistogramMetricSignal
+}
+
+func (e *exponentialHistogramEncoderMock) Encode(v any) error {
+	e.metrics = append(e.metrics, v.(exponentialHistogramMetricSignal))
+	return nil
+}
+
+func TestConvertMetrics(t *testing.T) {
+	type args struct {
+		md                          pmetric.Metrics
+		sumEncoder                  Encoder
+		gaugeEncoder                Encoder
+		histogramEncoder            Encoder
+		exponentialHistogramEncoder Encoder
+	}
+	tests := []struct {
+		name                     string
+		args                     args
+		wantSum                  []sumMetricSignal
+		wantGauge                []gaugeMetricSignal
+		wantHistogram            []histogramMetricSignal
+		wantExponentialHistogram []exponentialHistogramMetricSignal
+		wantErr                  bool
+	}{
+		{
+			name: "empty metrics",
+			args: args{
+				md:                          pmetric.NewMetrics(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum:                  []sumMetricSignal{},
+			wantGauge:                []gaugeMetricSignal{},
+			wantHistogram:            []histogramMetricSignal{},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{},
+		},
+		{
+			name: "sum metric without attributes",
+			args: args{
+				md: func() pmetric.Metrics {
+					md := pmetric.NewMetrics()
+					resourceMetrics := md.ResourceMetrics().AppendEmpty()
+					resourceMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+					scopeMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics.Scope().SetName("test-scope")
+					scopeMetrics.Scope().SetVersion("1.0.0")
+					metric := scopeMetrics.Metrics().AppendEmpty()
+					metric.SetName("test.sum")
+					metric.SetDescription("Test sum metric")
+					metric.SetUnit("count")
+					sum := metric.SetEmptySum()
+					sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+					sum.SetIsMonotonic(true)
+					dp := sum.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					dp.SetDoubleValue(42.5)
+					return md
+				}(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum: []sumMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL:           "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes:          map[string]string{},
+						ServiceName:                 "",
+						ScopeName:                   "test-scope",
+						ScopeVersion:                "1.0.0",
+						ScopeSchemaURL:              "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes:             map[string]string{},
+						MetricName:                  "test.sum",
+						MetricDescription:           "Test sum metric",
+						MetricUnit:                  "count",
+						MetricAttributes:            map[string]string{},
+						StartTimestamp:              "2024-06-23T16:00:00Z",
+						Timestamp:                   "2024-06-23T16:00:01Z",
+						Flags:                       0,
+						ExemplarsFilteredAttributes: []map[string]string{},
+						ExemplarsTimestamp:          []string{},
+						ExemplarsValue:              []float64{},
+						ExemplarsSpanID:             []string{},
+						ExemplarsTraceID:            []string{},
+					},
+					Value:                  42.5,
+					AggregationTemporality: 2, // Cumulative
+					IsMonotonic:            true,
+				},
+			},
+			wantGauge:                []gaugeMetricSignal{},
+			wantHistogram:            []histogramMetricSignal{},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{},
+		},
+		{
+			name: "gauge metric with attributes",
+			args: args{
+				md: func() pmetric.Metrics {
+					md := pmetric.NewMetrics()
+					resourceMetrics := md.ResourceMetrics().AppendEmpty()
+					resourceMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceMetrics.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					resource.Attributes().PutStr("environment", "production")
+					scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+					scopeMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics.Scope().SetName("test-scope")
+					scopeMetrics.Scope().SetVersion("1.0.0")
+					scopeMetrics.Scope().Attributes().PutStr("telemetry.sdk.name", "opentelemetry")
+					metric := scopeMetrics.Metrics().AppendEmpty()
+					metric.SetName("test.gauge")
+					metric.SetDescription("Test gauge metric")
+					metric.SetUnit("bytes")
+					gauge := metric.SetEmptyGauge()
+					dp := gauge.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					dp.SetIntValue(1024)
+					dp.Attributes().PutStr("host", "server-1")
+					dp.Attributes().PutStr("region", "us-west")
+					return md
+				}(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum: []sumMetricSignal{},
+			wantGauge: []gaugeMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes: map[string]string{
+							"service.name": "test-service",
+							"environment":  "production",
+						},
+						ServiceName:    "test-service",
+						ScopeName:      "test-scope",
+						ScopeVersion:   "1.0.0",
+						ScopeSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes: map[string]string{
+							"telemetry.sdk.name": "opentelemetry",
+						},
+						MetricName:        "test.gauge",
+						MetricDescription: "Test gauge metric",
+						MetricUnit:        "bytes",
+						MetricAttributes: map[string]string{
+							"host":   "server-1",
+							"region": "us-west",
+						},
+						StartTimestamp:              "2024-06-23T16:00:00Z",
+						Timestamp:                   "2024-06-23T16:00:01Z",
+						Flags:                       0,
+						ExemplarsFilteredAttributes: []map[string]string{},
+						ExemplarsTimestamp:          []string{},
+						ExemplarsValue:              []float64{},
+						ExemplarsSpanID:             []string{},
+						ExemplarsTraceID:            []string{},
+					},
+					Value: 1024.0,
+				},
+			},
+			wantHistogram:            []histogramMetricSignal{},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{},
+		},
+		{
+			name: "histogram metric with exemplars",
+			args: args{
+				md: func() pmetric.Metrics {
+					md := pmetric.NewMetrics()
+					resourceMetrics := md.ResourceMetrics().AppendEmpty()
+					resourceMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceMetrics.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+					scopeMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics.Scope().SetName("test-scope")
+					scopeMetrics.Scope().SetVersion("1.0.0")
+					metric := scopeMetrics.Metrics().AppendEmpty()
+					metric.SetName("test.histogram")
+					metric.SetDescription("Test histogram metric")
+					metric.SetUnit("seconds")
+					histogram := metric.SetEmptyHistogram()
+					histogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					dp := histogram.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					dp.SetCount(100)
+					dp.SetSum(50.5)
+					dp.BucketCounts().FromRaw([]uint64{10, 20, 30, 40})
+					dp.ExplicitBounds().FromRaw([]float64{0.5, 1.0, 1.5})
+
+					// Add exemplar
+					exemplar := dp.Exemplars().AppendEmpty()
+					exemplar.SetTimestamp(pcommon.Timestamp(1719158400500000000))
+					exemplar.SetDoubleValue(1.2)
+					exemplar.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+					exemplar.SetSpanID(pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+					exemplar.FilteredAttributes().PutStr("exemplar.type", "outlier")
+
+					return md
+				}(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum:   []sumMetricSignal{},
+			wantGauge: []gaugeMetricSignal{},
+			wantHistogram: []histogramMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes: map[string]string{
+							"service.name": "test-service",
+						},
+						ServiceName:       "test-service",
+						ScopeName:         "test-scope",
+						ScopeVersion:      "1.0.0",
+						ScopeSchemaURL:    "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes:   map[string]string{},
+						MetricName:        "test.histogram",
+						MetricDescription: "Test histogram metric",
+						MetricUnit:        "seconds",
+						MetricAttributes:  map[string]string{},
+						StartTimestamp:    "2024-06-23T16:00:00Z",
+						Timestamp:         "2024-06-23T16:00:01Z",
+						Flags:             0,
+						ExemplarsFilteredAttributes: []map[string]string{
+							{
+								"exemplar.type": "outlier",
+							},
+						},
+						ExemplarsTimestamp: []string{"2024-06-23T16:00:00.5Z"},
+						ExemplarsValue:     []float64{1.2},
+						ExemplarsSpanID:    []string{"0102030405060708"},
+						ExemplarsTraceID:   []string{"0102030405060708090a0b0c0d0e0f10"},
+					},
+					Count:                  100,
+					Sum:                    50.5,
+					BucketCounts:           []uint64{10, 20, 30, 40},
+					ExplicitBounds:         []float64{0.5, 1.0, 1.5},
+					Min:                    nil,
+					Max:                    nil,
+					AggregationTemporality: 1, // Delta
+				},
+			},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{},
+		},
+		{
+			name: "exponential histogram metric",
+			args: args{
+				md: func() pmetric.Metrics {
+					md := pmetric.NewMetrics()
+					resourceMetrics := md.ResourceMetrics().AppendEmpty()
+					resourceMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceMetrics.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+					scopeMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics.Scope().SetName("test-scope")
+					scopeMetrics.Scope().SetVersion("1.0.0")
+					metric := scopeMetrics.Metrics().AppendEmpty()
+					metric.SetName("test.exponential_histogram")
+					metric.SetDescription("Test exponential histogram metric")
+					metric.SetUnit("bytes")
+					ehistogram := metric.SetEmptyExponentialHistogram()
+					ehistogram.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+					dp := ehistogram.DataPoints().AppendEmpty()
+					dp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					dp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					dp.SetCount(200)
+					dp.SetSum(100.0)
+					dp.SetScale(2)
+					dp.SetZeroCount(50)
+					dp.Positive().SetOffset(1)
+					dp.Positive().BucketCounts().FromRaw([]uint64{10, 20, 30})
+					dp.Negative().SetOffset(-1)
+					dp.Negative().BucketCounts().FromRaw([]uint64{5, 15, 25})
+					dp.SetMin(0.1)
+					dp.SetMax(10.0)
+					return md
+				}(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum:       []sumMetricSignal{},
+			wantGauge:     []gaugeMetricSignal{},
+			wantHistogram: []histogramMetricSignal{},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL: "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes: map[string]string{
+							"service.name": "test-service",
+						},
+						ServiceName:                 "test-service",
+						ScopeName:                   "test-scope",
+						ScopeVersion:                "1.0.0",
+						ScopeSchemaURL:              "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes:             map[string]string{},
+						MetricName:                  "test.exponential_histogram",
+						MetricDescription:           "Test exponential histogram metric",
+						MetricUnit:                  "bytes",
+						MetricAttributes:            map[string]string{},
+						StartTimestamp:              "2024-06-23T16:00:00Z",
+						Timestamp:                   "2024-06-23T16:00:01Z",
+						Flags:                       0,
+						ExemplarsFilteredAttributes: []map[string]string{},
+						ExemplarsTimestamp:          []string{},
+						ExemplarsValue:              []float64{},
+						ExemplarsSpanID:             []string{},
+						ExemplarsTraceID:            []string{},
+					},
+					Count:                  200,
+					Sum:                    100.0,
+					Scale:                  2,
+					ZeroCount:              50,
+					PositiveOffset:         1,
+					PositiveBucketCounts:   []uint64{10, 20, 30},
+					NegativeOffset:         -1,
+					NegativeBucketCounts:   []uint64{5, 15, 25},
+					Min:                    &[]float64{0.1}[0],
+					Max:                    &[]float64{10.0}[0],
+					AggregationTemporality: 2, // Cumulative
+				},
+			},
+		},
+		{
+			name: "mixed metric types",
+			args: args{
+				md: func() pmetric.Metrics {
+					md := pmetric.NewMetrics()
+					resourceMetrics := md.ResourceMetrics().AppendEmpty()
+					resourceMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					resource := resourceMetrics.Resource()
+					resource.Attributes().PutStr("service.name", "test-service")
+					scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
+					scopeMetrics.SetSchemaUrl("https://opentelemetry.io/schemas/1.20.0")
+					scopeMetrics.Scope().SetName("test-scope")
+					scopeMetrics.Scope().SetVersion("1.0.0")
+
+					// Sum metric
+					sumMetric := scopeMetrics.Metrics().AppendEmpty()
+					sumMetric.SetName("test.sum")
+					sumMetric.SetDescription("Test sum metric")
+					sumMetric.SetUnit("count")
+					sum := sumMetric.SetEmptySum()
+					sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+					sum.SetIsMonotonic(true)
+					sumDp := sum.DataPoints().AppendEmpty()
+					sumDp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					sumDp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					sumDp.SetIntValue(100)
+
+					// Gauge metric
+					gaugeMetric := scopeMetrics.Metrics().AppendEmpty()
+					gaugeMetric.SetName("test.gauge")
+					gaugeMetric.SetDescription("Test gauge metric")
+					gaugeMetric.SetUnit("bytes")
+					gauge := gaugeMetric.SetEmptyGauge()
+					gaugeDp := gauge.DataPoints().AppendEmpty()
+					gaugeDp.SetStartTimestamp(pcommon.Timestamp(1719158400000000000))
+					gaugeDp.SetTimestamp(pcommon.Timestamp(1719158401000000000))
+					gaugeDp.SetDoubleValue(2048.5)
+
+					return md
+				}(),
+				sumEncoder:                  &sumEncoderMock{metrics: []sumMetricSignal{}},
+				gaugeEncoder:                &gaugeEncoderMock{metrics: []gaugeMetricSignal{}},
+				histogramEncoder:            &histogramEncoderMock{metrics: []histogramMetricSignal{}},
+				exponentialHistogramEncoder: &exponentialHistogramEncoderMock{metrics: []exponentialHistogramMetricSignal{}},
+			},
+			wantSum: []sumMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL:           "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes:          map[string]string{"service.name": "test-service"},
+						ServiceName:                 "test-service",
+						ScopeName:                   "test-scope",
+						ScopeVersion:                "1.0.0",
+						ScopeSchemaURL:              "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes:             map[string]string{},
+						MetricName:                  "test.sum",
+						MetricDescription:           "Test sum metric",
+						MetricUnit:                  "count",
+						MetricAttributes:            map[string]string{},
+						StartTimestamp:              "2024-06-23T16:00:00Z",
+						Timestamp:                   "2024-06-23T16:00:01Z",
+						Flags:                       0,
+						ExemplarsFilteredAttributes: []map[string]string{},
+						ExemplarsTimestamp:          []string{},
+						ExemplarsValue:              []float64{},
+						ExemplarsSpanID:             []string{},
+						ExemplarsTraceID:            []string{},
+					},
+					Value:                  100.0,
+					AggregationTemporality: 2, // Cumulative
+					IsMonotonic:            true,
+				},
+			},
+			wantGauge: []gaugeMetricSignal{
+				{
+					baseMetricSignal: baseMetricSignal{
+						ResourceSchemaURL:           "https://opentelemetry.io/schemas/1.20.0",
+						ResourceAttributes:          map[string]string{"service.name": "test-service"},
+						ServiceName:                 "test-service",
+						ScopeName:                   "test-scope",
+						ScopeVersion:                "1.0.0",
+						ScopeSchemaURL:              "https://opentelemetry.io/schemas/1.20.0",
+						ScopeAttributes:             map[string]string{},
+						MetricName:                  "test.gauge",
+						MetricDescription:           "Test gauge metric",
+						MetricUnit:                  "bytes",
+						MetricAttributes:            map[string]string{},
+						StartTimestamp:              "2024-06-23T16:00:00Z",
+						Timestamp:                   "2024-06-23T16:00:01Z",
+						Flags:                       0,
+						ExemplarsFilteredAttributes: []map[string]string{},
+						ExemplarsTimestamp:          []string{},
+						ExemplarsValue:              []float64{},
+						ExemplarsSpanID:             []string{},
+						ExemplarsTraceID:            []string{},
+					},
+					Value: 2048.5,
+				},
+			},
+			wantHistogram:            []histogramMetricSignal{},
+			wantExponentialHistogram: []exponentialHistogramMetricSignal{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ConvertMetrics(tt.args.md, tt.args.sumEncoder, tt.args.gaugeEncoder, tt.args.histogramEncoder, tt.args.exponentialHistogramEncoder); (err != nil) != tt.wantErr {
+				t.Errorf("ConvertMetrics() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Check sum metrics
+			if !reflect.DeepEqual(tt.args.sumEncoder.(*sumEncoderMock).metrics, tt.wantSum) {
+				t.Errorf("ConvertMetrics() sum metrics = %v, want %v", tt.args.sumEncoder.(*sumEncoderMock).metrics, tt.wantSum)
+			}
+
+			// Check gauge metrics
+			if !reflect.DeepEqual(tt.args.gaugeEncoder.(*gaugeEncoderMock).metrics, tt.wantGauge) {
+				t.Errorf("ConvertMetrics() gauge metrics = %v, want %v", tt.args.gaugeEncoder.(*gaugeEncoderMock).metrics, tt.wantGauge)
+			}
+
+			// Check histogram metrics
+			if !reflect.DeepEqual(tt.args.histogramEncoder.(*histogramEncoderMock).metrics, tt.wantHistogram) {
+				t.Errorf("ConvertMetrics() histogram metrics = %v, want %v", tt.args.histogramEncoder.(*histogramEncoderMock).metrics, tt.wantHistogram)
+			}
+
+			// Check exponential histogram metrics
+			if !reflect.DeepEqual(tt.args.exponentialHistogramEncoder.(*exponentialHistogramEncoderMock).metrics, tt.wantExponentialHistogram) {
+				t.Errorf("ConvertMetrics() exponential histogram metrics = %v, want %v", tt.args.exponentialHistogramEncoder.(*exponentialHistogramEncoderMock).metrics, tt.wantExponentialHistogram)
+			}
+		})
+	}
+}

--- a/exporter/tinybirdexporter/metadata.yaml
+++ b/exporter/tinybirdexporter/metadata.yaml
@@ -12,7 +12,9 @@ tests:
   config:
     endpoint: "http://localhost:1234"
     token: "test-token"
-    metrics::datasource: "metrics"
+    metrics_gauge::datasource: "metrics_gauge"
+    metrics_sum::datasource: "metrics_sum"
+    metrics_histogram::datasource: "metrics_histogram"
+    metrics_exponential_histogram::datasource: "metrics_exponential_histogram"
     traces::datasource: "traces"
     logs::datasource: "logs"
-  skip_lifecycle: true

--- a/exporter/tinybirdexporter/metadata.yaml
+++ b/exporter/tinybirdexporter/metadata.yaml
@@ -12,9 +12,14 @@ tests:
   config:
     endpoint: "http://localhost:1234"
     token: "test-token"
-    metrics_gauge::datasource: "metrics_gauge"
-    metrics_sum::datasource: "metrics_sum"
-    metrics_histogram::datasource: "metrics_histogram"
-    metrics_exponential_histogram::datasource: "metrics_exponential_histogram"
+    metrics:
+      gauge:
+        datasource: "metrics_gauge"
+      sum:
+        datasource: "metrics_sum"
+      histogram:
+        datasource: "metrics_histogram"
+      exponential_histogram:
+        datasource: "metrics_exponential_histogram"
     traces::datasource: "traces"
     logs::datasource: "logs"

--- a/exporter/tinybirdexporter/testdata/config.yaml
+++ b/exporter/tinybirdexporter/testdata/config.yaml
@@ -10,7 +10,10 @@ tinybird/full:
   sending_queue:
     enabled: false
   token: "test-token"
-  metrics::datasource: "metrics"
+  metrics_gauge::datasource: "metrics_gauge"
+  metrics_sum::datasource: "metrics_sum"
+  metrics_histogram::datasource: "metrics_histogram"
+  metrics_exponential_histogram::datasource: "metrics_exponential_histogram"
   traces::datasource: "traces"
   logs::datasource: "logs"
   wait: true
@@ -18,7 +21,10 @@ tinybird/full:
 tinybird/invalid_datasource:
   endpoint: "https://api.tinybird.co"
   token: "test-token"
-  metrics::datasource: "metrics-with-dashes"
+  metrics_gauge::datasource: "metrics-with-dashes"
+  metrics_sum::datasource: "metrics-with-dashes"
+  metrics_histogram::datasource: "metrics-with-dashes"
+  metrics_exponential_histogram::datasource: "metrics-with-dashes"
   traces::datasource: "traces-with-dashes"
   logs::datasource: "logs-with-dashes"
 

--- a/exporter/tinybirdexporter/testdata/config.yaml
+++ b/exporter/tinybirdexporter/testdata/config.yaml
@@ -10,10 +10,15 @@ tinybird/full:
   sending_queue:
     enabled: false
   token: "test-token"
-  metrics_gauge::datasource: "metrics_gauge"
-  metrics_sum::datasource: "metrics_sum"
-  metrics_histogram::datasource: "metrics_histogram"
-  metrics_exponential_histogram::datasource: "metrics_exponential_histogram"
+  metrics:
+    gauge:
+      datasource: "gauge"
+    sum:
+      datasource: "sum"
+    histogram:
+      datasource: "histogram"
+    exponential_histogram:
+      datasource: "exponential_histogram"
   traces::datasource: "traces"
   logs::datasource: "logs"
   wait: true
@@ -21,10 +26,15 @@ tinybird/full:
 tinybird/invalid_datasource:
   endpoint: "https://api.tinybird.co"
   token: "test-token"
-  metrics_gauge::datasource: "metrics-with-dashes"
-  metrics_sum::datasource: "metrics-with-dashes"
-  metrics_histogram::datasource: "metrics-with-dashes"
-  metrics_exponential_histogram::datasource: "metrics-with-dashes"
+  metrics:
+    gauge:
+      datasource: "metrics-with-dashes"
+    sum:
+      datasource: "metrics-with-dashes"
+    histogram:
+      datasource: "metrics-with-dashes"
+    exponential_histogram:
+      datasource: "metrics-with-dashes"
   traces::datasource: "traces-with-dashes"
   logs::datasource: "logs-with-dashes"
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Implement metrics propagation for the new Tinybird Exporter. The exporter iterates over the pmetric data, extracts the required fields (service name, attributes, spanID, etc.), generates an NDJSON, and performs a request to the Tinybird [EventsAPI](https://www.tinybird.co/docs/forward/get-data-in/events-api) with all the data.

It's the same implementation done in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/40993 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41248, but this time focused on metrics. The only difference is that instead of just having a `SignalConfig` for `Metrics`, it has one for each type of metric (`MetricsGauge`, `MetricsSum`, `MetricsHistogram`, and `MetricsExponentialHistogram`). The reason is that each type of metric is stored in a different datasource in Tinybird (each has different schema). This is based on the clickhouseexporter.

Now that the three signals have been implemented, the component lifecycle tests have been re-enabled

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40475

<!--Describe the documentation added.-->
#### Documentation
- Modified the exporter README to add the per metric configuration

<!--Please delete paragraphs that you did not use before submitting.-->
