### PR TITLE
fix: add missing TLS key_file to target allocator configs

### DIFF
--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -78,6 +78,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	assert.Equal(t, "http://localhost:8080", r0.TargetAllocator.Endpoint)
 	assert.Equal(t, 5*time.Second, r0.TargetAllocator.Timeout)
 	assert.Equal(t, "client.crt", r0.TargetAllocator.TLS.CertFile)
+	assert.Equal(t, "client.key", r0.TargetAllocator.TLS.KeyFile)
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)
 	assert.NotNil(t, r0.PrometheusConfig)

--- a/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
+++ b/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
@@ -4,6 +4,7 @@ prometheus:
     timeout: 5s
     tls:
       cert_file: "client.crt"
+      key_file: "client.key"
     interval: 30s
     collector_id: collector-1
 prometheus/withScrape:

--- a/receiver/prometheusreceiver/testdata/invalid-config-prometheus-target-allocator.yaml
+++ b/receiver/prometheusreceiver/testdata/invalid-config-prometheus-target-allocator.yaml
@@ -4,6 +4,7 @@ prometheus:
     timeout: 5s
     tls:
       cert_file: "client.crt"
+      key_file: "client.key"
     interval: 30s
     collector_id: collector-1
     http_scrape_config:


### PR DESCRIPTION
Updates test configurations to include both cert_file and key_file for TLS configs. 
(Needed for opentelemetry-collector PR [#13245](https://github.com/open-telemetry/opentelemetry-collector/pull/13245/))

cc: @jade-guiton-dd 