### PR TITLE
[chore]: enable ptrToRefParam rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,7 +132,6 @@ linters:
         - preferFprint
         - preferStringWriter
         - preferWriteByte
-        - ptrToRefParam
         - rangeValCopy
         - redundantSprint
         - regexpSimplify


### PR DESCRIPTION
#### Description

Enables and fixes [ptrToRefParam](https://go-critic.com/overview.html#ptrtorefparam) rule from go-critic

Related to #41202