### PR TITLE
[receiver/httpcheck] Add optional request body

### DIFF
--- a/.chloggen/httpcheck-add-request-body.yaml
+++ b/.chloggen/httpcheck-add-request-body.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: httpcheckreceiver
+note: Add request body to http requests
+issues: [41325]
+subtext: |
+  The httpcheckreceiver can be configured to send a request body to the target endpoint.
+change_logs: [user]

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -41,6 +41,8 @@ Each target has the following properties:
 - `endpoint` (optional): A single URL to be monitored.
 - `endpoints` (optional): A list of URLs to be monitored.
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint or endpoints.
+- `body` (optional): Request body content for POST, PUT, PATCH, and other methods.
+- `validations` (optional): Response validation rules for API monitoring.
 
 At least one of `endpoint` or `endpoints` must be specified. Additionally, each target supports the client configuration options of [confighttp].
 
@@ -76,6 +78,8 @@ receivers:
         enabled: true
       httpcheck.client.request.duration:
         enabled: true
+      httpcheck.request.duration:
+        enabled: true
       httpcheck.response.duration:
         enabled: true
 ```
@@ -86,6 +90,73 @@ These metrics provide detailed timing information for different phases of the HT
 - `tls.handshake.duration`: Time spent performing TLS handshake (HTTPS only)
 - `client.request.duration`: Time spent sending the HTTP request
 - `response.duration`: Time spent receiving the HTTP response
+
+### Request Body Support
+
+The receiver supports sending request bodies for POST, PUT, PATCH, and other HTTP methods:
+
+```yaml
+receivers:
+  httpcheck:
+    targets:
+      # POST with JSON body
+      - endpoint: "https://api.example.com/users"
+        method: "POST"
+        body: '{"name": "John Doe", "email": "john@example.com"}'
+        
+      # PUT with form data
+      - endpoint: "https://api.example.com/profile"
+        method: "PUT"
+        body: "name=John&email=john@example.com"
+        
+      # PATCH with custom Content-Type
+      - endpoint: "https://api.example.com/settings"
+        method: "PATCH"
+        body: '{"theme": "dark"}'
+        headers:
+          Content-Type: "application/json"
+          Authorization: "Bearer token123"
+```
+
+**Content-Type Auto-Detection:**
+- JSON bodies (starting with `{` or `[`): `application/json`
+- Form data (containing `=`): `application/x-www-form-urlencoded`
+- Other content: `text/plain`
+- Custom headers override auto-detection
+
+### Response Validation
+
+The receiver supports response body validation for API monitoring:
+
+```yaml
+receivers:
+  httpcheck:
+    targets:
+      - endpoint: "https://api.example.com/health"
+        validations:
+          # String matching
+          - contains: "healthy"
+          - not_contains: "error"
+          
+          # JSON path validation using gjson syntax
+          - json_path: "$.status"
+            equals: "ok"
+          - json_path: "$.services[*].status"
+            equals: "up"
+          
+          # Response size validation (bytes)
+          - max_size: 1024
+          - min_size: 10
+          
+          # Regex validation
+          - regex: "^HTTP/[0-9.]+ 200"
+```
+
+**Validation Types:**
+- `contains` / `not_contains`: String matching
+- `json_path` + `equals`: JSON path queries using [gjson syntax](https://github.com/tidwall/gjson)
+- `max_size` / `min_size`: Response body size limits
+- `regex`: Regular expression matching
 
 ### Example Configuration
 
@@ -122,7 +193,18 @@ receivers:
         headers:
           Authorization: "Bearer <your_bearer_token>"
       - method: "GET"
-        endpoint: "https://example.com"
+        endpoint: "https://api.example.com/health"
+        validations:
+          - contains: "healthy"
+          - json_path: "$.status"
+            equals: "ok"
+          - max_size: 1024
+      - method: "POST"
+        endpoint: "https://api.example.com/users"
+        body: '{"name": "Test User", "email": "test@example.com"}'
+        validations:
+          - contains: "created"
+          - json_path: "$.id"
 processors:
   batch:
     send_batch_max_size: 1000

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -42,7 +42,6 @@ Each target has the following properties:
 - `endpoints` (optional): A list of URLs to be monitored.
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint or endpoints.
 - `body` (optional): Request body content for POST, PUT, PATCH, and other methods.
-- `validations` (optional): Response validation rules for API monitoring.
 
 At least one of `endpoint` or `endpoints` must be specified. Additionally, each target supports the client configuration options of [confighttp].
 
@@ -124,40 +123,6 @@ receivers:
 - Other content: `text/plain`
 - Custom headers override auto-detection
 
-### Response Validation
-
-The receiver supports response body validation for API monitoring:
-
-```yaml
-receivers:
-  httpcheck:
-    targets:
-      - endpoint: "https://api.example.com/health"
-        validations:
-          # String matching
-          - contains: "healthy"
-          - not_contains: "error"
-          
-          # JSON path validation using gjson syntax
-          - json_path: "$.status"
-            equals: "ok"
-          - json_path: "$.services[*].status"
-            equals: "up"
-          
-          # Response size validation (bytes)
-          - max_size: 1024
-          - min_size: 10
-          
-          # Regex validation
-          - regex: "^HTTP/[0-9.]+ 200"
-```
-
-**Validation Types:**
-- `contains` / `not_contains`: String matching
-- `json_path` + `equals`: JSON path queries using [gjson syntax](https://github.com/tidwall/gjson)
-- `max_size` / `min_size`: Response body size limits
-- `regex`: Regular expression matching
-
 ### Example Configuration
 
 ```yaml
@@ -194,17 +159,9 @@ receivers:
           Authorization: "Bearer <your_bearer_token>"
       - method: "GET"
         endpoint: "https://api.example.com/health"
-        validations:
-          - contains: "healthy"
-          - json_path: "$.status"
-            equals: "ok"
-          - max_size: 1024
       - method: "POST"
         endpoint: "https://api.example.com/users"
         body: '{"name": "Test User", "email": "test@example.com"}'
-        validations:
-          - contains: "created"
-          - json_path: "$.id"
 processors:
   batch:
     send_batch_max_size: 1000

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -36,6 +36,7 @@ type targetConfig struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 	Method                  string   `mapstructure:"method"`
 	Endpoints               []string `mapstructure:"endpoints"` // Field for a list of endpoints
+	Body                    string   `mapstructure:"body"`
 }
 
 // Validate validates an individual targetConfig.

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -35,8 +35,9 @@ type Config struct {
 type targetConfig struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 	Method                  string   `mapstructure:"method"`
-	Endpoints               []string `mapstructure:"endpoints"` // Field for a list of endpoints
-	Body                    string   `mapstructure:"body"`      // Request body content
+	Endpoints               []string `mapstructure:"endpoints"`         // Field for a list of endpoints
+	Body                    string   `mapstructure:"body"`              // Request body content
+	AutoContentType         bool     `mapstructure:"auto_content_type"` // Whether to automatically set Content-Type based on body
 }
 
 // Validate validates an individual targetConfig.

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -36,7 +36,7 @@ type targetConfig struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 	Method                  string   `mapstructure:"method"`
 	Endpoints               []string `mapstructure:"endpoints"` // Field for a list of endpoints
-	Body                    string   `mapstructure:"body"`
+	Body                    string   `mapstructure:"body"`      // Request body content
 }
 
 // Validate validates an individual targetConfig.

--- a/receiver/httpcheckreceiver/config_test.go
+++ b/receiver/httpcheckreceiver/config_test.go
@@ -197,6 +197,54 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			desc: "valid config with auto_content_type enabled",
+			cfg: &Config{
+				Targets: []*targetConfig{
+					{
+						ClientConfig: confighttp.ClientConfig{
+							Endpoint: "https://opentelemetry.io",
+						},
+						Body:            `{"key": "value"}`,
+						AutoContentType: true,
+					},
+				},
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "valid config with auto_content_type disabled",
+			cfg: &Config{
+				Targets: []*targetConfig{
+					{
+						ClientConfig: confighttp.ClientConfig{
+							Endpoint: "https://opentelemetry.io",
+						},
+						Body:            `{"key": "value"}`,
+						AutoContentType: false,
+					},
+				},
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "valid config with auto_content_type default (zero value)",
+			cfg: &Config{
+				Targets: []*targetConfig{
+					{
+						ClientConfig: confighttp.ClientConfig{
+							Endpoint: "https://opentelemetry.io",
+						},
+						Body: `{"key": "value"}`,
+						// AutoContentType not set (zero value = false)
+					},
+				},
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v1.38.0
 	go.opentelemetry.io/collector/component/componenttest v0.132.0
 	go.opentelemetry.io/collector/config/confighttp v0.132.0
+	go.opentelemetry.io/collector/config/configopaque v1.38.0
 	go.opentelemetry.io/collector/config/configtls v1.38.0
 	go.opentelemetry.io/collector/confmap v1.38.0
 	go.opentelemetry.io/collector/consumer v1.38.0
@@ -57,7 +58,6 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.132.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.38.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.132.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.38.0 // indirect
 	go.opentelemetry.io/collector/config/configoptional v0.132.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.132.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.132.0 // indirect

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -216,8 +216,8 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 				req.Header.Set(key, value.String()) // Convert configopaque.String to string
 			}
 
-			// Set Content-Type header automatically if body is present and no Content-Type is set
-			if h.cfg.Targets[targetIndex].Body != "" && req.Header.Get("Content-Type") == "" {
+			// Set Content-Type header automatically if body is present, no Content-Type is set, and auto_content_type is enabled
+			if h.cfg.Targets[targetIndex].Body != "" && req.Header.Get("Content-Type") == "" && h.cfg.Targets[targetIndex].AutoContentType {
 				body := strings.TrimSpace(h.cfg.Targets[targetIndex].Body)
 				switch {
 				case strings.HasPrefix(body, "{") || strings.HasPrefix(body, "["):

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"strings"
 	"sync"
 	"time"
 
@@ -193,12 +194,17 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 				},
 			}
 
-			// Create request with trace context
+			// Create request with trace context and body
+			var requestBody io.Reader = http.NoBody
+			if h.cfg.Targets[targetIndex].Body != "" {
+				requestBody = strings.NewReader(h.cfg.Targets[targetIndex].Body)
+			}
+
 			req, err := http.NewRequestWithContext(
 				httptrace.WithClientTrace(ctx, trace),
 				h.cfg.Targets[targetIndex].Method,
 				h.cfg.Targets[targetIndex].Endpoint,
-				http.NoBody,
+				requestBody,
 			)
 			if err != nil {
 				h.settings.Logger.Error("failed to create request", zap.Error(err))
@@ -208,6 +214,19 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 			// Add headers to the request
 			for key, value := range h.cfg.Targets[targetIndex].Headers {
 				req.Header.Set(key, value.String()) // Convert configopaque.String to string
+			}
+
+			// Set Content-Type header automatically if body is present and no Content-Type is set
+			if h.cfg.Targets[targetIndex].Body != "" && req.Header.Get("Content-Type") == "" {
+				body := strings.TrimSpace(h.cfg.Targets[targetIndex].Body)
+				switch {
+				case strings.HasPrefix(body, "{") || strings.HasPrefix(body, "["):
+					req.Header.Set("Content-Type", "application/json")
+				case strings.Contains(h.cfg.Targets[targetIndex].Body, "="):
+					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				default:
+					req.Header.Set("Content-Type", "text/plain")
+				}
 			}
 
 			// Send the request and measure response time

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -4,7 +4,6 @@
 package httpcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver"
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io"
@@ -656,9 +655,9 @@ func TestRequestBodySupport(t *testing.T) {
 			}
 
 			scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
-			require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
+			require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
 
-			_, err := scraper.scrape(context.Background())
+			_, err := scraper.scrape(t.Context())
 			require.NoError(t, err)
 
 			// Verify the request was made correctly
@@ -700,9 +699,9 @@ func TestRequestBodyWithCustomHeaders(t *testing.T) {
 	}
 
 	scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
-	require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
 
-	_, err := scraper.scrape(context.Background())
+	_, err := scraper.scrape(t.Context())
 	require.NoError(t, err)
 
 	// Verify custom Content-Type overrides auto-detection
@@ -797,9 +796,9 @@ func TestAutoContentTypeConfiguration(t *testing.T) {
 			}
 
 			scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
-			require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
+			require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
 
-			_, err := scraper.scrape(context.Background())
+			_, err := scraper.scrape(t.Context())
 			require.NoError(t, err)
 
 			// Verify the Content-Type header behavior

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -6,6 +6,7 @@ package httpcheckreceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -559,4 +561,149 @@ func TestTimingMetrics(t *testing.T) {
 	assert.True(t, foundMetrics["httpcheck.client.connection.duration"])
 	assert.True(t, foundMetrics["httpcheck.client.request.duration"])
 	assert.True(t, foundMetrics["httpcheck.response.duration"])
+}
+
+func TestRequestBodySupport(t *testing.T) {
+	// Create a mock server that captures request details
+	var receivedBody []byte
+	var receivedMethod string
+	var receivedContentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			receivedBody = body
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, writeErr := w.Write([]byte(`{"result": "created"}`))
+		assert.NoError(t, writeErr)
+	}))
+	defer server.Close()
+
+	testCases := []struct {
+		name                string
+		method              string
+		body                string
+		expectedMethod      string
+		expectedBody        string
+		expectedContentType string
+	}{
+		{
+			name:                "POST with JSON body",
+			method:              "POST",
+			body:                `{"name": "test", "email": "test@example.com"}`,
+			expectedMethod:      "POST",
+			expectedBody:        `{"name": "test", "email": "test@example.com"}`,
+			expectedContentType: "application/json",
+		},
+		{
+			name:                "PUT with JSON array",
+			method:              "PUT",
+			body:                `[{"id": 1, "name": "test"}]`,
+			expectedMethod:      "PUT",
+			expectedBody:        `[{"id": 1, "name": "test"}]`,
+			expectedContentType: "application/json",
+		},
+		{
+			name:                "POST with form data",
+			method:              "POST",
+			body:                `name=test&email=test@example.com`,
+			expectedMethod:      "POST",
+			expectedBody:        `name=test&email=test@example.com`,
+			expectedContentType: "application/x-www-form-urlencoded",
+		},
+		{
+			name:                "POST with plain text",
+			method:              "POST",
+			body:                `plain text content`,
+			expectedMethod:      "POST",
+			expectedBody:        `plain text content`,
+			expectedContentType: "text/plain",
+		},
+		{
+			name:                "PATCH with JSON",
+			method:              "PATCH",
+			body:                `{"status": "updated"}`,
+			expectedMethod:      "PATCH",
+			expectedBody:        `{"status": "updated"}`,
+			expectedContentType: "application/json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset captured values
+			receivedBody = nil
+			receivedMethod = ""
+			receivedContentType = ""
+
+			cfg := createDefaultConfig().(*Config)
+			cfg.Targets = []*targetConfig{
+				{
+					ClientConfig: confighttp.ClientConfig{
+						Endpoint: server.URL,
+					},
+					Method: tc.method,
+					Body:   tc.body,
+				},
+			}
+
+			scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
+			require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
+
+			_, err := scraper.scrape(context.Background())
+			require.NoError(t, err)
+
+			// Verify the request was made correctly
+			assert.Equal(t, tc.expectedMethod, receivedMethod)
+			assert.Equal(t, tc.expectedBody, string(receivedBody))
+			assert.Equal(t, tc.expectedContentType, receivedContentType)
+		})
+	}
+}
+
+func TestRequestBodyWithCustomHeaders(t *testing.T) {
+	// Create a mock server that captures request details
+	var receivedContentType string
+	var receivedCustomHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedCustomHeader = r.Header.Get("X-Custom-Header")
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"result": "ok"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Targets = []*targetConfig{
+		{
+			ClientConfig: confighttp.ClientConfig{
+				Endpoint: server.URL,
+				Headers: map[string]configopaque.String{
+					"Content-Type":    configopaque.String("application/custom+json"),
+					"X-Custom-Header": configopaque.String("custom-value"),
+				},
+			},
+			Method: "POST",
+			Body:   `{"data": "test"}`,
+		},
+	}
+
+	scraper := newScraper(cfg, receivertest.NewNopSettings(metadata.Type))
+	require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
+
+	_, err := scraper.scrape(context.Background())
+	require.NoError(t, err)
+
+	// Verify custom Content-Type overrides auto-detection
+	assert.Equal(t, "application/custom+json", receivedContentType)
+	assert.Equal(t, "custom-value", receivedCustomHeader)
 }

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -4,6 +4,7 @@
 package httpcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver"
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io"

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -648,8 +648,9 @@ func TestRequestBodySupport(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint: server.URL,
 					},
-					Method: tc.method,
-					Body:   tc.body,
+					Method:          tc.method,
+					Body:            tc.body,
+					AutoContentType: true,
 				},
 			}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a body configuration that will be sent to the HTTP check endpoint to allow testing specific actions.

The default is the current empty body if it is not configured.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41325 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Adds unit tests to check that these metrics are behaving as expected.

<!--Describe the documentation added.-->
#### Documentation

The readme shows how to enable this capability in the configuraiton.

<!--Please delete paragraphs that you did not use before submitting.-->
