### PR TITLE
[chore]: enable initClause rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,7 +123,6 @@ linters:
         - filepathJoin
         - hugeParam
         - importShadow
-        - initClause
         - methodExprCall
         - nestingReduce
         - nilValReturn

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -1104,7 +1104,8 @@ func Test_tracesamplerprocessor_HashSeedTraceState(t *testing.T) {
 				require.True(t, hasR)
 				require.True(t, threshold.ShouldSample(rnd))
 
-				if found++; find == found {
+				found++
+				if find == found {
 					break
 				}
 			}


### PR DESCRIPTION
#### Description

Enables and fixes [initClause](https://go-critic.com/overview.html#initclause) rule from go-critic

Related to #41202