### PR TITLE
[chore]: enable preferStringWriter and preferFprint rules from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,8 +129,6 @@ linters:
         - nilValReturn
         - paramTypeCombine
         - preferDecodeRune
-        - preferFprint
-        - preferStringWriter
         - preferWriteByte
         - ptrToRefParam
         - rangeValCopy

--- a/exporter/elasticsearchexporter/integrationtest/collector.go
+++ b/exporter/elasticsearchexporter/integrationtest/collector.go
@@ -176,7 +176,7 @@ func (c *recreatableOtelCol) Start(_ testbed.StartParams) error {
 		return err
 	}
 
-	if _, err = confFile.Write([]byte(c.configStr)); err != nil {
+	if _, err = confFile.WriteString(c.configStr); err != nil {
 		os.Remove(confFile.Name())
 		return err
 	}

--- a/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
+++ b/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
@@ -98,7 +98,7 @@ func (h *OTelDataPointHasher) UpdateResource(resource pcommon.Resource) {
 
 func (h *OTelDataPointHasher) UpdateScope(scope pcommon.InstrumentationScope) {
 	hasher := xxhash.New()
-	_, _ = hasher.Write([]byte(scope.Name()))
+	_, _ = hasher.WriteString(scope.Name())
 	// There is special handling to merge geo attributes during serialization,
 	// but we can hash them as if they are separate now.
 	mapHashSortedExcludeReservedAttrs(hasher, scope.Attributes(), elasticsearch.MappingHintsAttrKey)
@@ -115,7 +115,7 @@ func (h *OTelDataPointHasher) UpdateDataPoint(dp datapoints.DataPoint) {
 	binary.LittleEndian.PutUint64(timestampBuf, uint64(dp.StartTimestamp()))
 	_, _ = hasher.Write(timestampBuf)
 
-	_, _ = hasher.Write([]byte(dp.Metric().Unit()))
+	_, _ = hasher.WriteString(dp.Metric().Unit())
 
 	// There is special handling to merge geo attributes during serialization,
 	// but we can hash them as if they are separate now.

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/metrics.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/metrics.go
@@ -94,7 +94,7 @@ func serializeDataPoints(v *json.Visitor, dataPoints []datapoints.DataPoint, val
 	sort.Strings(metricNames)
 	hasher := xxhash.New()
 	for _, name := range metricNames {
-		_, _ = hasher.Write([]byte(name))
+		_, _ = hasher.WriteString(name)
 	}
 	// workaround for https://github.com/elastic/elasticsearch/issues/99123
 	// should use a string field to benefit from run-length encoding

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/benchmark_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/benchmark_test.go
@@ -28,7 +28,7 @@ func newLogFileContent(b *testing.B, nLogs int) io.Reader {
 	for i := 0; i < nLogs; i++ {
 		buf.Write(data)
 		if i != nLogs-1 {
-			buf.Write([]byte("\n"))
+			buf.WriteString("\n")
 		}
 	}
 

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -260,7 +260,7 @@ func TestOIDCFailedToLoadIssuerCAFromPathInvalidContent(t *testing.T) {
 	file, err := os.CreateTemp(os.TempDir(), "cert")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
-	_, err = file.Write([]byte("foobar"))
+	_, err = file.WriteString("foobar")
 	require.NoError(t, err)
 
 	config := &Config{

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -291,7 +291,7 @@ func TestRotatedOutOfPatternMoveCreate(t *testing.T) {
 	require.NoError(t, os.Rename(originalFileName, originalFileName+".old"))
 
 	newFile := filetest.OpenFile(t, originalFileName)
-	_, err := newFile.Write([]byte("testlog4\ntestlog5\n"))
+	_, err := newFile.WriteString("testlog4\ntestlog5\n")
 	require.NoError(t, err)
 
 	// poll again
@@ -350,7 +350,7 @@ func TestRotatedOutOfPatternCopyTruncate(t *testing.T) {
 	_, err = originalFile.Seek(0, 0)
 	require.NoError(t, err)
 	require.NoError(t, originalFile.Truncate(0))
-	_, err = originalFile.Write([]byte("testlog4\ntestlog5\n"))
+	_, err = originalFile.WriteString("testlog4\ntestlog5\n")
 	require.NoError(t, err)
 
 	// poll again

--- a/receiver/jmxreceiver/internal/subprocess/integration_test.go
+++ b/receiver/jmxreceiver/internal/subprocess/integration_test.go
@@ -45,7 +45,7 @@ func (suite *SubprocessIntegrationSuite) SetupSuite() {
 	scriptFile, err := os.CreateTemp(t.TempDir(), "subproc")
 	require.NoError(t, err)
 
-	_, err = scriptFile.Write([]byte(scriptContents))
+	_, err = scriptFile.WriteString(scriptContents)
 	require.NoError(t, err)
 	require.NoError(t, scriptFile.Chmod(0o700))
 	scriptFile.Close()

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -69,7 +69,7 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) er
 		return fmt.Errorf("failed to get tmp file for jmxreceiver config: %w", err)
 	}
 
-	if _, err = tmpFile.Write([]byte(javaConfig)); err != nil {
+	if _, err = tmpFile.WriteString(javaConfig); err != nil {
 		return fmt.Errorf("failed to write config file for jmxreceiver config: %w", err)
 	}
 

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -130,7 +130,7 @@ service:
 	confFile, err := os.CreateTemp(os.TempDir(), "conf-")
 	require.NoError(t, err)
 	defer os.Remove(confFile.Name())
-	_, err = confFile.Write([]byte(cfg))
+	_, err = confFile.WriteString(cfg)
 	require.NoError(t, err)
 	// 4. Run the OpenTelemetry Collector.
 	receivers, err := otelcol.MakeFactoryMap[receiver.Factory](prometheusreceiver.NewFactory())

--- a/testbed/correctnesstests/metrics/results.go
+++ b/testbed/correctnesstests/metrics/results.go
@@ -5,7 +5,6 @@ package metrics // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -51,7 +50,7 @@ func (r *results) Add(_ string, rslt any) {
 }
 
 func (r *results) writeString(s string) {
-	_, _ = io.WriteString(r.resultsFile, s)
+	_, _ = r.resultsFile.WriteString(s)
 }
 
 func (r *results) Save() {

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -54,7 +54,7 @@ func (ipp *inProcessCollector) Start(_ StartParams) error {
 		return err
 	}
 
-	if _, err = confFile.Write([]byte(ipp.configStr)); err != nil {
+	if _, err = confFile.WriteString(ipp.configStr); err != nil {
 		os.Remove(confFile.Name())
 		return err
 	}

--- a/testbed/testbed/results.go
+++ b/testbed/testbed/results.go
@@ -6,7 +6,6 @@ package testbed // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -82,17 +81,19 @@ func (r *PerformanceResults) Init(resultsDir string) {
 	}
 
 	// Write the header
-	_, _ = io.WriteString(r.resultsFile,
-		"# Test PerformanceResults\n"+
-			fmt.Sprintf("Started: %s\n\n", time.Now().Format(time.RFC1123Z))+
-			"Test                                    |Result|Duration|CPU Avg%|CPU Max%|CPU Limit|RAM Avg MiB|RAM Max MiB|RAM Limit MiB|Sent Items|Received Items|\n"+
-			"----------------------------------------|------|-------:|-------:|-------:|--------:|----------:|----------:|------------:|---------:|-------------:|\n")
+	_, _ = fmt.Fprintf(r.resultsFile, `# Test PerformanceResults
+Started: %s
+
+Test                                    |Result|Duration|CPU Avg%%|CPU Max%%|CPU Limit|RAM Avg MiB|RAM Max MiB|RAM Limit MiB|Sent Items|Received Items|
+----------------------------------------|------|-------:|-------:|-------:|--------:|----------:|----------:|------------:|---------:|-------------:|
+`, time.Now().Format(time.RFC1123Z))
 }
 
 // Save the total results and close the file.
 func (r *PerformanceResults) Save() {
-	_, _ = io.WriteString(r.resultsFile,
-		fmt.Sprintf("\nTotal duration: %.0fs\n", r.totalDuration.Seconds()))
+	_, _ = fmt.Fprintf(r.resultsFile,
+		"\nTotal duration: %.0fs\n",
+		r.totalDuration.Seconds())
 	r.resultsFile.Close()
 	r.saveBenchmarks()
 }
@@ -104,21 +105,20 @@ func (r *PerformanceResults) Add(_ string, result any) {
 		return
 	}
 
-	_, _ = io.WriteString(r.resultsFile,
-		fmt.Sprintf("%-40s|%-6s|%7.0fs|%8.1f|%8.1f|%8.1f|%11d|%11d|%11d|%10d|%14d|%s\n",
-			testResult.testName,
-			testResult.result,
-			testResult.duration.Seconds(),
-			testResult.cpuPercentageAvg,
-			testResult.cpuPercentageMax,
-			testResult.cpuPercentageLimit,
-			testResult.ramMibAvg,
-			testResult.ramMibMax,
-			testResult.ramMibLimit,
-			testResult.sentSpanCount,
-			testResult.receivedSpanCount,
-			testResult.errorCause,
-		),
+	_, _ = fmt.Fprintf(r.resultsFile,
+		"%-40s|%-6s|%7.0fs|%8.1f|%8.1f|%8.1f|%11d|%11d|%11d|%10d|%14d|%s\n",
+		testResult.testName,
+		testResult.result,
+		testResult.duration.Seconds(),
+		testResult.cpuPercentageAvg,
+		testResult.cpuPercentageMax,
+		testResult.cpuPercentageLimit,
+		testResult.ramMibAvg,
+		testResult.ramMibMax,
+		testResult.ramMibLimit,
+		testResult.sentSpanCount,
+		testResult.receivedSpanCount,
+		testResult.errorCause,
 	)
 	r.totalDuration += testResult.duration
 
@@ -234,11 +234,12 @@ func (r *CorrectnessResults) Init(resultsDir string) {
 	}
 
 	// Write the header
-	_, _ = io.WriteString(r.resultsFile,
-		"# Test Results\n"+
-			fmt.Sprintf("Started: %s\n\n", time.Now().Format(time.RFC1123Z))+
-			"Test                                    |Result|Duration|Sent Items|Received Items|Failure Count|Failures\n"+
-			"----------------------------------------|------|-------:|---------:|-------------:|------------:|--------\n")
+	_, _ = fmt.Fprintf(r.resultsFile, `# Test Results
+Started: %s
+
+Test                                    |Result|Duration|Sent Items|Received Items|Failure Count|Failures
+----------------------------------------|------|-------:|---------:|-------------:|------------:|--------
+`, time.Now().Format(time.RFC1123Z))
 }
 
 func (r *CorrectnessResults) Add(_ string, result any) {
@@ -252,16 +253,14 @@ func (r *CorrectnessResults) Add(_ string, result any) {
 		failuresStr = fmt.Sprintf("%s%s,%#v!=%#v,count=%d; ", failuresStr, af.fieldPath, af.expectedValue,
 			af.actualValue, af.sumCount)
 	}
-	_, _ = io.WriteString(r.resultsFile,
-		fmt.Sprintf("%-40s|%-6s|%7.0fs|%10d|%14d|%13d|%s\n",
-			testResult.testName,
-			testResult.result,
-			testResult.duration.Seconds(),
-			testResult.sentSpanCount,
-			testResult.receivedSpanCount,
-			testResult.traceAssertionFailureCount,
-			failuresStr,
-		),
+	_, _ = fmt.Fprintf(r.resultsFile, "%-40s|%-6s|%7.0fs|%10d|%14d|%13d|%s\n",
+		testResult.testName,
+		testResult.result,
+		testResult.duration.Seconds(),
+		testResult.sentSpanCount,
+		testResult.receivedSpanCount,
+		testResult.traceAssertionFailureCount,
+		failuresStr,
 	)
 	r.perTestResults = append(r.perTestResults, testResult)
 	r.totalAssertionFailures += testResult.traceAssertionFailureCount
@@ -269,10 +268,8 @@ func (r *CorrectnessResults) Add(_ string, result any) {
 }
 
 func (r *CorrectnessResults) Save() {
-	_, _ = io.WriteString(r.resultsFile,
-		fmt.Sprintf("\nTotal assertion failures: %d\n", r.totalAssertionFailures))
-	_, _ = io.WriteString(r.resultsFile,
-		fmt.Sprintf("\nTotal duration: %.0fs\n", r.totalDuration.Seconds()))
+	_, _ = fmt.Fprintf(r.resultsFile, "\nTotal assertion failures: %d\n", r.totalAssertionFailures)
+	_, _ = fmt.Fprintf(r.resultsFile, "\nTotal duration: %.0fs\n", r.totalDuration.Seconds())
 	r.resultsFile.Close()
 }
 


### PR DESCRIPTION
#### Description

Enables and fixes [preferStringWriter](https://go-critic.com/overview.html#preferstringwriter) and [preferFprint](https://go-critic.com/overview.html#preferfprint) rules from go-critic

Related to #41202