### PR TITLE
[receiver/httpcheck] Remove unnecessary http.status_code attributes

### DIFF
--- a/.chloggen/httpcheck-remove-unnecessary-statuses.yaml
+++ b/.chloggen/httpcheck-remove-unnecessary-statuses.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: httpcheckreceiver
+note: Remove unnecessary status codes
+issues: [38564]
+subtext: |
+  The httpcheckreceiver now removes the http.status_code attribute from httpcheck.status metrics
+  when the metric value is 0, as per the feature request to avoid redundant status codes.
+change_logs: [user]

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -206,7 +206,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 						now,
 						int64(0),
 						h.cfg.Targets[targetIndex].Endpoint,
-						int64(statusCode),
+						int64(0), // Use 0 as status code when the class doesn't match
 						req.Method,
 						class,
 					)
@@ -217,7 +217,41 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 	}
 
 	wg.Wait()
-	return h.mb.Emit(), nil
+
+	// Emit metrics and post-process to remove http.status_code when value is 0
+	metrics := h.mb.Emit()
+	h.removeStatusCodeForZeroValues(metrics)
+
+	return metrics, nil
+}
+
+// removeStatusCodeForZeroValues removes the http.status_code attribute from httpcheck.status metrics
+func (h *httpcheckScraper) removeStatusCodeForZeroValues(metrics pmetric.Metrics) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		sms := rm.ScopeMetrics()
+		for j := 0; j < sms.Len(); j++ {
+			sm := sms.At(j)
+			ms := sm.Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				m := ms.At(k)
+				if m.Name() == "httpcheck.status" {
+					// Process sum data points
+					if m.Type() == pmetric.MetricTypeSum {
+						dps := m.Sum().DataPoints()
+						for l := 0; l < dps.Len(); l++ {
+							dp := dps.At(l)
+							// If the value is 0, remove the http.status_code attribute
+							if dp.IntValue() == 0 {
+								dp.Attributes().Remove("http.status_code")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 func newScraper(conf *Config, settings receiver.Settings) *httpcheckScraper {

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
@@ -25,9 +25,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 1xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -41,9 +38,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 2xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -57,9 +51,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 3xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -89,9 +80,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
@@ -39,9 +39,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 1xx
-                    - key: http.status_code
-                      value:
-                        intValue: "0"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -55,9 +52,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 2xx
-                    - key: http.status_code
-                      value:
-                        intValue: "0"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -71,9 +65,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 3xx
-                    - key: http.status_code
-                      value:
-                        intValue: "0"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -87,9 +78,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 4xx
-                    - key: http.status_code
-                      value:
-                        intValue: "0"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint
@@ -103,9 +91,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
-                    - key: http.status_code
-                      value:
-                        intValue: "0"
                     - key: http.url
                       value:
                         stringValue: http://invalid-endpoint

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -25,9 +25,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 1xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -57,9 +54,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 3xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -73,9 +67,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 4xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -89,9 +80,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
@@ -30,9 +30,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 1xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -46,9 +43,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 1xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -78,9 +72,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 2xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -94,9 +85,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 3xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -110,9 +98,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 3xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -126,9 +111,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 4xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -158,9 +140,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
-                    - key: http.status_code
-                      value:
-                        intValue: "200"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
@@ -174,9 +153,6 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
-                    - key: http.status_code
-                      value:
-                        intValue: "404"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a function call after the metrics are pulled by the auto-generated code and combs through the requests to remove all of the unnecessary status codes (where the value is zero). 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #38564 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Adds a unit test and replaces all the testdata/* files that had the errant status codes. 

