### PR TITLE
[chore]: enable sqlQuery rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,7 +137,6 @@ linters:
         - redundantSprint
         - regexpSimplify
         - returnAfterHttpError
-        - sqlQuery
         - sloppyReassign
         - sprintfQuotedString
         - stringsCompare

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -163,7 +163,7 @@ func TestScrapeLogsFromContainer(t *testing.T) {
 	db, err := sql.Open("postgres", connStr)
 	assert.NoError(t, err)
 
-	_, err = db.Query("Select * from test2 where id = 67")
+	_, err = db.Exec("Select * from test2 where id = 67")
 	assert.NoError(t, err)
 	defer db.Close()
 
@@ -240,7 +240,7 @@ func TestScrapeLogsFromContainer(t *testing.T) {
 	}
 	assert.True(t, found, "Expected to find a log record with the query text from the first time top query")
 
-	_, err = db.Query("Select * from test2 where id = 67")
+	_, err = db.Exec("Select * from test2 where id = 67")
 	assert.NoError(t, err)
 
 	secondTimeTopQueryPLogs, err := ns.scrapeTopQuery(context.Background(), 30, 30, 30)

--- a/receiver/sqlserverreceiver/integration_test.go
+++ b/receiver/sqlserverreceiver/integration_test.go
@@ -195,7 +195,7 @@ func TestEventsScraper(t *testing.T) {
 					default:
 						queriesCount.Add(1)
 						// Simulate a long-running query
-						_, queryErr := db.Query(tc.clientQuery)
+						_, queryErr := db.Exec(tc.clientQuery)
 						if !finished.Load() {
 							// only check this condition if the test is not finished
 							assert.NoError(t, queryErr)


### PR DESCRIPTION
#### Description

Enables and fixes [sqlQuery](https://go-critic.com/overview.html#sqlquery) rule from go-critic

Related to #41202