### PR TITLE
[exporter/elasticsearch] Add latency metric to measure _bulk API calls

### DIFF
--- a/.chloggen/41389_esexporter_latency.yaml
+++ b/.chloggen/41389_esexporter_latency.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add telemetry for measuring latency to Elasticsearch bulk API"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41389]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Measure latency of Elasticsearch bulk API calls
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -452,7 +452,7 @@ func flushBulkIndexer(
 			}
 			attrSet := metric.WithAttributeSet(attribute.NewSet(
 				append([]attribute.KeyValue{
-					semconv.HTTPResponseStatusCode(bulkFailedErr.StatusCode()),
+					semconv.HTTPResponseStatusCode(code),
 					attribute.String("outcome", outcome),
 				}, defaultMetaAttrs...)...,
 			))
@@ -463,6 +463,7 @@ func flushBulkIndexer(
 			attrSet := metric.WithAttributeSet(attribute.NewSet(
 				append([]attribute.KeyValue{
 					attribute.String("outcome", "internal_server_error"),
+					semconv.HTTPResponseStatusCode(http.StatusInternalServerError),
 				}, defaultMetaAttrs...)...,
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -474,6 +474,7 @@ func flushBulkIndexer(
 		successAttrSet := metric.WithAttributeSet(attribute.NewSet(
 			append([]attribute.KeyValue{
 				attribute.String("outcome", "success"),
+				semconv.HTTPResponseStatusCode(http.StatusOK),
 			}, defaultMetaAttrs...)...,
 		))
 

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -415,7 +415,9 @@ func flushBulkIndexer(
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
+	startTime := time.Now()
 	stat, err := bi.Flush(ctx)
+	latency := time.Since(startTime).Seconds()
 	defaultMetaAttrs := getAttributesFromMetadataKeys(ctx, tMetaKeys)
 	defaultAttrsSet := attribute.NewSet(defaultMetaAttrs...)
 	if flushed := bi.BytesFlushed(); flushed > 0 {
@@ -436,6 +438,7 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
+			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
 		case errors.As(err, &bulkFailedErr):
 			var outcome string
 			code := bulkFailedErr.StatusCode()
@@ -455,6 +458,7 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
+			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
 		default:
 			attrSet := metric.WithAttributeSet(attribute.NewSet(
 				append([]attribute.KeyValue{
@@ -463,18 +467,18 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
+			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
 		}
 	} else {
 		// Record a successful completed bulk request
-		tb.ElasticsearchBulkRequestsCount.Add(
-			ctx,
-			int64(1),
-			metric.WithAttributeSet(attribute.NewSet(
-				append([]attribute.KeyValue{
-					attribute.String("outcome", "success"),
-				}, defaultMetaAttrs...)...,
-			)),
-		)
+		successAttrSet := metric.WithAttributeSet(attribute.NewSet(
+			append([]attribute.KeyValue{
+				attribute.String("outcome", "success"),
+			}, defaultMetaAttrs...)...,
+		))
+
+		tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), successAttrSet)
+		tb.ElasticsearchBulkLatency.Record(ctx, latency, successAttrSet)
 	}
 
 	var tooManyReqs, clientFailed, serverFailed int64

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -438,7 +438,7 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
-			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
+			tb.ElasticsearchBulkRequestsLatency.Record(ctx, latency, attrSet)
 		case errors.As(err, &bulkFailedErr):
 			var outcome string
 			code := bulkFailedErr.StatusCode()
@@ -458,7 +458,7 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
-			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
+			tb.ElasticsearchBulkRequestsLatency.Record(ctx, latency, attrSet)
 		default:
 			attrSet := metric.WithAttributeSet(attribute.NewSet(
 				append([]attribute.KeyValue{
@@ -467,7 +467,7 @@ func flushBulkIndexer(
 			))
 			tb.ElasticsearchDocsProcessed.Add(ctx, int64(itemsCount), attrSet)
 			tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), attrSet)
-			tb.ElasticsearchBulkLatency.Record(ctx, latency, attrSet)
+			tb.ElasticsearchBulkRequestsLatency.Record(ctx, latency, attrSet)
 		}
 	} else {
 		// Record a successful completed bulk request
@@ -479,7 +479,7 @@ func flushBulkIndexer(
 		))
 
 		tb.ElasticsearchBulkRequestsCount.Add(ctx, int64(1), successAttrSet)
-		tb.ElasticsearchBulkLatency.Record(ctx, latency, successAttrSet)
+		tb.ElasticsearchBulkRequestsLatency.Record(ctx, latency, successAttrSet)
 	}
 
 	var tooManyReqs, clientFailed, serverFailed int64

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -301,17 +301,20 @@ func TestAsyncBulkIndexer_flush_error(t *testing.T) {
 				Value: 1,
 				Attributes: attribute.NewSet(
 					attribute.String("outcome", "internal_server_error"),
+					semconv.HTTPResponseStatusCode(http.StatusInternalServerError),
 				),
 			},
 			wantESDocsProcessed: &metricdata.DataPoint[int64]{
 				Value: 1,
 				Attributes: attribute.NewSet(
 					attribute.String("outcome", "internal_server_error"),
+					semconv.HTTPResponseStatusCode(http.StatusInternalServerError),
 				),
 			},
 			wantESLatency: &metricdata.HistogramDataPoint[float64]{
 				Attributes: attribute.NewSet(
 					attribute.String("outcome", "internal_server_error"),
+					semconv.HTTPResponseStatusCode(http.StatusInternalServerError),
 				),
 			},
 		},

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -148,13 +148,12 @@ func TestAsyncBulkIndexer_flush(t *testing.T) {
 			metadatatest.AssertEqualElasticsearchFlushedBytes(t, ct, []metricdata.DataPoint[int64]{
 				{Value: 43}, // hard-coding the flush bytes since the input is fixed
 			}, metricdatatest.IgnoreTimestamp())
-			metadatatest.AssertEqualElasticsearchBulkLatency(t, ct, []metricdata.HistogramDataPoint[float64]{
+			metadatatest.AssertEqualElasticsearchBulkRequestsCount(t, ct, []metricdata.DataPoint[int64]{
 				{
 					Attributes: attribute.NewSet(
 						attribute.String("outcome", "success"),
 						semconv.HTTPResponseStatusCode(http.StatusOK),
 					),
-					Count: 1,
 				},
 			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 		})
@@ -454,7 +453,7 @@ func TestAsyncBulkIndexer_flush_error(t *testing.T) {
 				)
 			}
 			if tt.wantESLatency != nil {
-				metadatatest.AssertEqualElasticsearchBulkLatency(
+				metadatatest.AssertEqualElasticsearchBulkRequestsLatency(
 					t, ct,
 					[]metricdata.HistogramDataPoint[float64]{*tt.wantESLatency},
 					metricdatatest.IgnoreTimestamp(),

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -147,6 +147,14 @@ func TestAsyncBulkIndexer_flush(t *testing.T) {
 			metadatatest.AssertEqualElasticsearchFlushedBytes(t, ct, []metricdata.DataPoint[int64]{
 				{Value: 43}, // hard-coding the flush bytes since the input is fixed
 			}, metricdatatest.IgnoreTimestamp())
+			metadatatest.AssertEqualElasticsearchBulkLatency(t, ct, []metricdata.HistogramDataPoint[float64]{
+				{
+					Attributes: attribute.NewSet(
+						attribute.String("outcome", "success"),
+					),
+					Count: 1,
+				},
+			}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 		})
 	}
 }

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -127,6 +127,7 @@ func TestAsyncBulkIndexer_flush(t *testing.T) {
 					Value: 1,
 					Attributes: attribute.NewSet(
 						attribute.String("outcome", "success"),
+						semconv.HTTPResponseStatusCode(http.StatusOK),
 					),
 				},
 			}, metricdatatest.IgnoreTimestamp())
@@ -151,6 +152,7 @@ func TestAsyncBulkIndexer_flush(t *testing.T) {
 				{
 					Attributes: attribute.NewSet(
 						attribute.String("outcome", "success"),
+						semconv.HTTPResponseStatusCode(http.StatusOK),
 					),
 					Count: 1,
 				},

--- a/exporter/elasticsearchexporter/documentation.md
+++ b/exporter/elasticsearchexporter/documentation.md
@@ -19,7 +19,7 @@ Count of the completed bulk requests. [alpha]
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | outcome | The operation outcome. | Str: ``success``, ``failed_client``, ``failed_server``, ``timeout``, ``too_many``, ``failure_store``, ``internal_server_error`` |
-| http_status_code | HTTP status code. | Any Int |
+| http.response.status_code | HTTP status code. | Any Int |
 
 ### otelcol.elasticsearch.bulk_requests.latency
 
@@ -34,7 +34,7 @@ Latency of Elasticsearch bulk operations in seconds. [alpha]
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | outcome | The operation outcome. | Str: ``success``, ``failed_client``, ``failed_server``, ``timeout``, ``too_many``, ``failure_store``, ``internal_server_error`` |
-| http_status_code | HTTP status code. | Any Int |
+| http.response.status_code | HTTP status code. | Any Int |
 
 ### otelcol.elasticsearch.docs.processed
 
@@ -49,7 +49,7 @@ Count of documents flushed to Elasticsearch. [alpha]
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | outcome | The operation outcome. | Str: ``success``, ``failed_client``, ``failed_server``, ``timeout``, ``too_many``, ``failure_store``, ``internal_server_error`` |
-| http_status_code | HTTP status code. | Any Int |
+| http.response.status_code | HTTP status code. | Any Int |
 | failure_store | The status of the failure store. | Str: ``unknown``, ``not_enabled``, ``used``, ``failed`` |
 
 ### otelcol.elasticsearch.docs.received

--- a/exporter/elasticsearchexporter/documentation.md
+++ b/exporter/elasticsearchexporter/documentation.md
@@ -6,13 +6,13 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol.elasticsearch.bulk_latency
+### otelcol.elasticsearch.bulk_requests.count
 
-Latency of Elasticsearch bulk operations in seconds. [alpha]
+Count of the completed bulk requests. [alpha]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Histogram | Double |
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Sum | Int | true |
 
 #### Attributes
 
@@ -21,13 +21,13 @@ Latency of Elasticsearch bulk operations in seconds. [alpha]
 | outcome | The operation outcome. | Str: ``success``, ``failed_client``, ``failed_server``, ``timeout``, ``too_many``, ``failure_store``, ``internal_server_error`` |
 | http_status_code | HTTP status code. | Any Int |
 
-### otelcol.elasticsearch.bulk_requests.count
+### otelcol.elasticsearch.bulk_requests.latency
 
-Count of the completed bulk requests. [alpha]
+Latency of Elasticsearch bulk operations in seconds. [alpha]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| s | Histogram | Double |
 
 #### Attributes
 

--- a/exporter/elasticsearchexporter/documentation.md
+++ b/exporter/elasticsearchexporter/documentation.md
@@ -6,7 +6,7 @@
 
 The following telemetry is emitted by this component.
 
-### otelcol.elasticsearch.bulk.latency
+### otelcol.elasticsearch.bulk_latency
 
 Latency of Elasticsearch bulk operations in seconds. [alpha]
 

--- a/exporter/elasticsearchexporter/documentation.md
+++ b/exporter/elasticsearchexporter/documentation.md
@@ -6,6 +6,21 @@
 
 The following telemetry is emitted by this component.
 
+### otelcol.elasticsearch.bulk.latency
+
+Latency of Elasticsearch bulk operations in seconds. [alpha]
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| s | Histogram | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| outcome | The operation outcome. | Str: ``success``, ``failed_client``, ``failed_server``, ``timeout``, ``too_many``, ``failure_store``, ``internal_server_error`` |
+| http_status_code | HTTP status code. | Any Int |
+
 ### otelcol.elasticsearch.bulk_requests.count
 
 Count of the completed bulk requests. [alpha]

--- a/exporter/elasticsearchexporter/generated_package_test.go
+++ b/exporter/elasticsearchexporter/generated_package_test.go
@@ -3,9 +3,8 @@
 package elasticsearchexporter
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/elasticsearchexporter/generated_package_test.go
+++ b/exporter/elasticsearchexporter/generated_package_test.go
@@ -3,8 +3,9 @@
 package elasticsearchexporter
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
@@ -68,7 +68,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol.elasticsearch.bulk_latency",
 		metric.WithDescription("Latency of Elasticsearch bulk operations in seconds. [alpha]"),
 		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100}...),
+		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ElasticsearchBulkRequestsCount, err = builder.meter.Int64Counter(

--- a/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
@@ -26,8 +26,8 @@ type TelemetryBuilder struct {
 	meter                                 metric.Meter
 	mu                                    sync.Mutex
 	registrations                         []metric.Registration
-	ElasticsearchBulkLatency              metric.Float64Histogram
 	ElasticsearchBulkRequestsCount        metric.Int64Counter
+	ElasticsearchBulkRequestsLatency      metric.Float64Histogram
 	ElasticsearchDocsProcessed            metric.Int64Counter
 	ElasticsearchDocsReceived             metric.Int64Counter
 	ElasticsearchDocsRetried              metric.Int64Counter
@@ -64,17 +64,17 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	}
 	builder.meter = Meter(settings)
 	var err, errs error
-	builder.ElasticsearchBulkLatency, err = builder.meter.Float64Histogram(
-		"otelcol.elasticsearch.bulk_latency",
-		metric.WithDescription("Latency of Elasticsearch bulk operations in seconds. [alpha]"),
-		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}...),
-	)
-	errs = errors.Join(errs, err)
 	builder.ElasticsearchBulkRequestsCount, err = builder.meter.Int64Counter(
 		"otelcol.elasticsearch.bulk_requests.count",
 		metric.WithDescription("Count of the completed bulk requests. [alpha]"),
 		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ElasticsearchBulkRequestsLatency, err = builder.meter.Float64Histogram(
+		"otelcol.elasticsearch.bulk_requests.latency",
+		metric.WithDescription("Latency of Elasticsearch bulk operations in seconds. [alpha]"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ElasticsearchDocsProcessed, err = builder.meter.Int64Counter(

--- a/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/elasticsearchexporter/internal/metadata/generated_telemetry.go
@@ -65,7 +65,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.meter = Meter(settings)
 	var err, errs error
 	builder.ElasticsearchBulkLatency, err = builder.meter.Float64Histogram(
-		"otelcol.elasticsearch.bulk.latency",
+		"otelcol.elasticsearch.bulk_latency",
 		metric.WithDescription("Latency of Elasticsearch bulk operations in seconds. [alpha]"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries([]float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100}...),

--- a/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
@@ -21,21 +21,6 @@ func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
 	return set
 }
 
-func AssertEqualElasticsearchBulkLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol.elasticsearch.bulk_latency",
-		Description: "Latency of Elasticsearch bulk operations in seconds. [alpha]",
-		Unit:        "s",
-		Data: metricdata.Histogram[float64]{
-			Temporality: metricdata.CumulativeTemporality,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol.elasticsearch.bulk_latency")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
 func AssertEqualElasticsearchBulkRequestsCount(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol.elasticsearch.bulk_requests.count",
@@ -48,6 +33,21 @@ func AssertEqualElasticsearchBulkRequestsCount(t *testing.T, tt *componenttest.T
 		},
 	}
 	got, err := tt.GetMetric("otelcol.elasticsearch.bulk_requests.count")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualElasticsearchBulkRequestsLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.elasticsearch.bulk_requests.latency",
+		Description: "Latency of Elasticsearch bulk operations in seconds. [alpha]",
+		Unit:        "s",
+		Data: metricdata.Histogram[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.elasticsearch.bulk_requests.latency")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
@@ -23,7 +23,7 @@ func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
 
 func AssertEqualElasticsearchBulkLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
-		Name:        "otelcol.elasticsearch.bulk.latency",
+		Name:        "otelcol.elasticsearch.bulk_latency",
 		Description: "Latency of Elasticsearch bulk operations in seconds. [alpha]",
 		Unit:        "s",
 		Data: metricdata.Histogram[float64]{
@@ -31,7 +31,7 @@ func AssertEqualElasticsearchBulkLatency(t *testing.T, tt *componenttest.Telemet
 			DataPoints:  dps,
 		},
 	}
-	got, err := tt.GetMetric("otelcol.elasticsearch.bulk.latency")
+	got, err := tt.GetMetric("otelcol.elasticsearch.bulk_latency")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest.go
@@ -21,6 +21,21 @@ func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
 	return set
 }
 
+func AssertEqualElasticsearchBulkLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[float64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol.elasticsearch.bulk.latency",
+		Description: "Latency of Elasticsearch bulk operations in seconds. [alpha]",
+		Unit:        "s",
+		Data: metricdata.Histogram[float64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol.elasticsearch.bulk.latency")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualElasticsearchBulkRequestsCount(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol.elasticsearch.bulk_requests.count",

--- a/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -20,12 +20,16 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
+	tb.ElasticsearchBulkLatency.Record(context.Background(), 1)
 	tb.ElasticsearchBulkRequestsCount.Add(context.Background(), 1)
 	tb.ElasticsearchDocsProcessed.Add(context.Background(), 1)
 	tb.ElasticsearchDocsReceived.Add(context.Background(), 1)
 	tb.ElasticsearchDocsRetried.Add(context.Background(), 1)
 	tb.ElasticsearchFlushedBytes.Add(context.Background(), 1)
 	tb.ElasticsearchFlushedUncompressedBytes.Add(context.Background(), 1)
+	AssertEqualElasticsearchBulkLatency(t, testTel,
+		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualElasticsearchBulkRequestsCount(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())

--- a/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/elasticsearchexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -20,18 +20,18 @@ func TestSetupTelemetry(t *testing.T) {
 	tb, err := metadata.NewTelemetryBuilder(testTel.NewTelemetrySettings())
 	require.NoError(t, err)
 	defer tb.Shutdown()
-	tb.ElasticsearchBulkLatency.Record(context.Background(), 1)
 	tb.ElasticsearchBulkRequestsCount.Add(context.Background(), 1)
+	tb.ElasticsearchBulkRequestsLatency.Record(context.Background(), 1)
 	tb.ElasticsearchDocsProcessed.Add(context.Background(), 1)
 	tb.ElasticsearchDocsReceived.Add(context.Background(), 1)
 	tb.ElasticsearchDocsRetried.Add(context.Background(), 1)
 	tb.ElasticsearchFlushedBytes.Add(context.Background(), 1)
 	tb.ElasticsearchFlushedUncompressedBytes.Add(context.Background(), 1)
-	AssertEqualElasticsearchBulkLatency(t, testTel,
-		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
-		metricdatatest.IgnoreTimestamp())
 	AssertEqualElasticsearchBulkRequestsCount(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualElasticsearchBulkRequestsLatency(t, testTel,
+		[]metricdata.HistogramDataPoint[float64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualElasticsearchDocsProcessed(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -87,7 +87,7 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-    elasticsearch.bulk.latency:
+    elasticsearch.bulk_latency:
       prefix: otelcol.
       stability:
         level: alpha

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -87,6 +87,17 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    elasticsearch.bulk.latency:
+      prefix: otelcol.
+      stability:
+        level: alpha
+      enabled: true
+      description: Latency of Elasticsearch bulk operations in seconds.
+      unit: s
+      histogram:
+        value_type: double
+        bucket_boundaries: [0, 0.005, 0.010, 0.025, 0.050, 0.075, 0.100, 0.250, 0.500, 0.750, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100]
+      attributes: [outcome, http_status_code]
 
 tests:
   config:

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -96,7 +96,7 @@ telemetry:
       unit: s
       histogram:
         value_type: double
-        bucket_boundaries: [0, 0.005, 0.010, 0.025, 0.050, 0.075, 0.100, 0.250, 0.500, 0.750, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100]
+        bucket_boundaries: [0, 0.005, 0.010, 0.025, 0.050, 0.075, 0.100, 0.250, 0.500, 0.750, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
       attributes: [outcome, http_status_code]
 
 tests:

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -87,7 +87,7 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-    elasticsearch.bulk_latency:
+    elasticsearch.bulk_requests.latency:
       prefix: otelcol.
       stability:
         level: alpha

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -10,7 +10,7 @@ status:
     active: [JaredTan95, carsonip, lahsivjar]
 
 attributes:
-  http_status_code:
+  http.response.status_code:
     description: HTTP status code.
     type: int
   outcome:
@@ -34,7 +34,7 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-      attributes: [outcome, http_status_code]
+      attributes: [outcome, http.response.status_code]
     elasticsearch.docs.received:
       prefix: otelcol.
       stability:
@@ -55,7 +55,7 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
-      attributes: [outcome, http_status_code, failure_store]
+      attributes: [outcome, http.response.status_code, failure_store]
     elasticsearch.docs.retried:
       prefix: otelcol.
       stability:
@@ -97,7 +97,7 @@ telemetry:
       histogram:
         value_type: double
         bucket_boundaries: [0, 0.005, 0.010, 0.025, 0.050, 0.075, 0.100, 0.250, 0.500, 0.750, 1, 2.5, 5, 7.5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
-      attributes: [outcome, http_status_code]
+      attributes: [outcome, http.response.status_code]
 
 tests:
   config:


### PR DESCRIPTION
#### Description
+ Add additional telemetry to measure the latency of Elasticsearch bulk API calls. 
+ Fixed the incorrect status code attribute - `http.response.status_code`

#### Testing

Unit tests are added.

#### Documentation

Mdatagen docs are updated. 
