### PR TITLE
[chore]: enable evalOrder rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,7 +118,6 @@ linters:
         - deferInLoop
         - emptyFallthrough
         - equalFold
-        - evalOrder
         - exposedSyncMutex
         - filepathJoin
         - hugeParam

--- a/cmd/opampsupervisor/supervisor/persistence.go
+++ b/cmd/opampsupervisor/supervisor/persistence.go
@@ -119,5 +119,6 @@ func createNewPersistentState(file string, logger *zap.Logger) (*persistentState
 		logger:     logger,
 	}
 
-	return p, p.writeState()
+	err = p.writeState()
+	return p, err
 }

--- a/internal/rabbitmq/client.go
+++ b/internal/rabbitmq/client.go
@@ -94,7 +94,8 @@ func (c *client) DialConfig(config DialConfig) (Connection, error) {
 	ch.connLock.Lock()
 	defer ch.connLock.Unlock()
 
-	return ch, ch.connect()
+	err := ch.connect()
+	return ch, err
 }
 
 func (c *connectionHolder) ReconnectIfUnhealthy() error {


### PR DESCRIPTION
#### Description

Enables and fixes [evalOrder](https://go-critic.com/overview.html#evalorder) rule from go-critic

Related to #41202