### PR TITLE
Revert "Add minimum token permissions for all github workflow files"

### DIFF
--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -5,17 +5,12 @@ on:
       - opened
       - ready_for_review
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
   add-owner:
-    permissions:
-      pull-requests: write # required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
     steps:

--- a/.github/workflows/auto-update-jmx-metrics-component.yml
+++ b/.github/workflows/auto-update-jmx-metrics-component.yml
@@ -6,9 +6,6 @@ on:
     - cron: '30 1 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   check-versions:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -725,8 +725,6 @@ jobs:
     # This job updates the "next release" milestone
     # to the latest released version and creates a new milestone
     # named "next release" in its place
-    permissions:
-      issues: write # required for managing milestones
     runs-on: ubuntu-24.04
     needs: [publish-stable]
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'

--- a/.github/workflows/check-lychee-config.yml
+++ b/.github/workflows/check-lychee-config.yml
@@ -8,9 +8,6 @@ on:
     paths:
       - '.github/lychee.toml'
 
-permissions:
-  contents: read
-
 jobs:
   check-lychee-config:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -4,14 +4,8 @@ on:
   schedule:
     - cron: "12 5 * * *" # arbitrary time not to DDOS GitHub
 
-permissions:
-  contents: read
-
 jobs:
   stale:
-    permissions:
-      issues: write # required for closing stale issues
-      pull-requests: write # required for closing stale pull requests
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -13,9 +13,6 @@ on:
       - "**/README.md"
   merge_group:
 
-permissions:
-  contents: read
-
 env:
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,9 +13,6 @@ on:
       - "**/README.md"
   merge_group:
 
-permissions:
-  contents: read
-
 env:
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -8,14 +8,8 @@ on:
       - ./.github/workflows/scripts/generate-component-labels.sh
     workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   generate-component-labels:
-    permissions:
-      issues: write # required for creating and managing issue labels
-      pull-requests: write # required for creating and managing PR labels
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:

--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -8,13 +8,8 @@ on:
     # run every tuesday at 1am UTC
     - cron: "0 1 * * 2"
 
-permissions:
-  contents: read
-
 jobs:
   get_issues:
-    permissions:
-      issues: write # required for creating weekly report issues
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:

--- a/.github/workflows/mark-issues-as-stale.yml
+++ b/.github/workflows/mark-issues-as-stale.yml
@@ -3,13 +3,8 @@ on:
   schedule:
     - cron: "27 3 * * 1-5" # Run at an arbitrary time on weekdays.
 
-permissions:
-  contents: read
-
 jobs:
   mark-issues-as-stale:
-    permissions:
-      issues: write # required for marking issues as stale
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:

--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -8,13 +8,8 @@ on:
     types:
       - closed
 
-permissions:
-  contents: read
-
 jobs:
   update-pr:
-    permissions:
-      pull-requests: write # required for adding milestone to PRs
     if: github.event.pull_request.merged
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,8 +12,6 @@ on:
       current-beta:
         required: true
         description: Current version (beta, like 0.69.1)
-permissions:
-  contents: read
 jobs:
   # Releasing opentelemetry-collector-contrib
   prepare-release:

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -11,9 +11,6 @@ on:
       - "**/README.md"
   merge_group:
 
-permissions:
-  contents: read
-
 # Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -4,8 +4,7 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   shellcheck:

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 env:
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.

--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -4,13 +4,8 @@ on:
   schedule:
     - cron: "27 8 * * 5" # Run at 08:27 UTC on Fridays.
 
-permissions:
-  contents: read
-
 jobs:
   update-otel:
-    permissions:
-      issues: write # required for creating failure issues
     runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#41011 to fix #41398

Relates to open-telemetry/sig-security/issues/148