### PR TITLE
[chore] add make generate and make gotidy to Makefile.Common

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -211,6 +211,15 @@ fmt: $(GOFUMPT) $(GOIMPORTS)
 	$(GOFUMPT) -l -w .
 	$(GOIMPORTS) -w -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
+.PHONY: generate
+generate: install-tools
+	PATH="$(TOOLS_BIN_DIR):$$PATH" $(GOCMD) generate ./...
+	$(MAKE) fmt
+
+.PHONY: gotidy
+gotidy: 
+	rm -rf go.sum && $(GOCMD) mod tidy -compat=1.23.0 && $(GOCMD) get toolchain@none
+
 .PHONY: lint
 lint: $(LINT) checklicense misspell
 	$(LINT) run


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Previously, `make generate` and `make gotidy` were only available at the root level, which required running them across all projects—often time-consuming. (Please correct me if there's a way to target a specific project; I may have missed it.)

To improve this, I've added both commands to `Makefile.Common` so they can now be run at the project level.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
