### PR TITLE
[chore]: enable extra-rules from gofumpt and paramTypeCombine from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@ formatters:
         - standard
         - default
         - prefix(github.com/open-telemetry/opentelemetry-collector-contrib)
+    gofumpt:
+      # Choose whether to use the extra rules.
+      extra-rules: true
 
 issues:
   # Maximum issues count per one linter.
@@ -127,7 +130,6 @@ linters:
         - hugeParam
         - importShadow
         - nestingReduce
-        - paramTypeCombine
         - ptrToRefParam
         - rangeValCopy
         - returnAfterHttpError

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -208,7 +208,7 @@ checklinks:
 
 .PHONY: fmt
 fmt: $(GOFUMPT) $(GOIMPORTS)
-	$(GOFUMPT) -l -w .
+	$(GOFUMPT) -l -w -extra .
 	$(GOIMPORTS) -w -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
 .PHONY: generate

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -30,10 +30,6 @@ import (
 	"text/template"
 	"time"
 
-	"go.opentelemetry.io/collector/pdata/ptrace"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
-
 	"github.com/google/uuid"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
@@ -45,6 +41,7 @@ import (
 	"github.com/open-telemetry/opamp-go/server/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -53,6 +50,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
 // getTestModes returns the test modes for the supervisor tests.
@@ -100,7 +98,7 @@ func (tl testLogger) Errorf(_ context.Context, format string, args ...any) {
 }
 
 func defaultConnectingHandler(connectionCallbacks types.ConnectionCallbacks) func(request *http.Request) types.ConnectionResponse {
-	return func(_ *http.Request) types.ConnectionResponse {
+	return func(*http.Request) types.ConnectionResponse {
 		return types.ConnectionResponse{
 			Accept:              true,
 			ConnectionCallbacks: connectionCallbacks,
@@ -333,7 +331,7 @@ func TestSupervisorStartsCollectorWithLocalConfigOnly(t *testing.T) {
 		t.Run(mode.name, func(t *testing.T) {
 			connected := atomic.Bool{}
 			server := newOpAMPServer(t, defaultConnectingHandler, types.ConnectionCallbacks{
-				OnConnected: func(_ context.Context, _ types.Connection) {
+				OnConnected: func(context.Context, types.Connection) {
 					connected.Store(true)
 				},
 			})
@@ -1420,10 +1418,10 @@ func TestSupervisorOpAMPConnectionSettings(t *testing.T) {
 		t,
 		defaultConnectingHandler,
 		types.ConnectionCallbacks{
-			OnConnected: func(_ context.Context, _ types.Connection) {
+			OnConnected: func(context.Context, types.Connection) {
 				connectedToNewServer.Store(true)
 			},
-			OnMessage: func(_ context.Context, _ types.Connection, _ *protobufs.AgentToServer) *protobufs.ServerToAgent {
+			OnMessage: func(context.Context, types.Connection, *protobufs.AgentToServer) *protobufs.ServerToAgent {
 				return &protobufs.ServerToAgent{}
 			},
 		})

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -50,7 +50,7 @@ func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.Conn
 	}
 }
 
-func (fs flattenedSettings) OnConnected(_ context.Context, _ serverTypes.Connection) {}
+func (fs flattenedSettings) OnConnected(context.Context, serverTypes.Connection) {}
 
 func (fs flattenedSettings) OnMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	if fs.onMessage != nil {

--- a/cmd/opampsupervisor/supervisor/server_test.go
+++ b/cmd/opampsupervisor/supervisor/server_test.go
@@ -28,7 +28,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 	t.Run("accept connection", func(t *testing.T) {
 		onConnectingFuncCalled := false
 		fs := flattenedSettings{
-			onConnecting: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
+			onConnecting: func(*http.Request) (shouldConnect bool, rejectStatusCode int) {
 				onConnectingFuncCalled = true
 				return true, 0
 			},
@@ -43,7 +43,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 	t.Run("do not accept connection", func(t *testing.T) {
 		onConnectingFuncCalled := false
 		fs := flattenedSettings{
-			onConnecting: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
+			onConnecting: func(*http.Request) (shouldConnect bool, rejectStatusCode int) {
 				onConnectingFuncCalled = true
 				return false, 500
 			},
@@ -60,7 +60,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 func Test_flattenedSettings_OnMessage(t *testing.T) {
 	onMessageFuncCalled := false
 	fs := flattenedSettings{
-		onMessage: func(_ serverTypes.Connection, _ *protobufs.AgentToServer) *protobufs.ServerToAgent {
+		onMessage: func(serverTypes.Connection, *protobufs.AgentToServer) *protobufs.ServerToAgent {
 			onMessageFuncCalled = true
 			return &protobufs.ServerToAgent{}
 		},
@@ -75,7 +75,7 @@ func Test_flattenedSettings_OnMessage(t *testing.T) {
 func Test_flattenedSettings_OnConnectionClose(t *testing.T) {
 	onConnectionCloseFuncCalled := false
 	fs := flattenedSettings{
-		onConnectionClose: func(_ serverTypes.Connection) {
+		onConnectionClose: func(serverTypes.Connection) {
 			onConnectionCloseFuncCalled = true
 		},
 	}

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -571,7 +571,7 @@ service:
 				)
 				return nil
 			},
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				return nil
 			},
 		}
@@ -672,7 +672,7 @@ service:
 				)
 				return errors.New("unexpected error")
 			},
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				return nil
 			},
 		}
@@ -740,7 +740,7 @@ service:
 				assert.NotEmpty(t, rcs.ErrorMessage)
 				return nil
 			},
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				return nil
 			},
 		}
@@ -829,7 +829,7 @@ service:
 
 		remoteConfigStatusUpdated := false
 		mc := &mockOpAMPClient{
-			setRemoteConfigStatusFunc: func(_ *protobufs.RemoteConfigStatus) error {
+			setRemoteConfigStatusFunc: func(*protobufs.RemoteConfigStatus) error {
 				remoteConfigStatusUpdated = true
 				return nil
 			},
@@ -942,7 +942,7 @@ service:
 				)
 				return nil
 			},
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				return nil
 			},
 		}
@@ -1087,7 +1087,7 @@ func Test_handleAgentOpAMPMessage(t *testing.T) {
 	t.Run("EffectiveConfig - Effective config from agent is stored in OpAmpClient", func(t *testing.T) {
 		updatedClientEffectiveConfig := false
 		mc := &mockOpAMPClient{
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				updatedClientEffectiveConfig = true
 				return nil
 			},
@@ -1126,7 +1126,7 @@ func Test_handleAgentOpAMPMessage(t *testing.T) {
 	t.Run("EffectiveConfig - Effective config from agent is stored in OpAmpClient; client returns error", func(t *testing.T) {
 		updatedClientEffectiveConfig := false
 		mc := &mockOpAMPClient{
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				updatedClientEffectiveConfig = true
 				return errors.New("unexpected error")
 			},
@@ -1165,7 +1165,7 @@ func Test_handleAgentOpAMPMessage(t *testing.T) {
 	t.Run("EffectiveConfig - Effective config message contains an empty config", func(t *testing.T) {
 		updatedClientEffectiveConfig := false
 		mc := &mockOpAMPClient{
-			updateEffectiveConfigFunc: func(_ context.Context) error {
+			updateEffectiveConfigFunc: func(context.Context) error {
 				updatedClientEffectiveConfig = true
 				return nil
 			},
@@ -1201,7 +1201,7 @@ func Test_handleAgentOpAMPMessage(t *testing.T) {
 	t.Run("ComponentHealth - Component health from agent is set in OpAmpClient", func(t *testing.T) {
 		healthSet := false
 		mc := &mockOpAMPClient{
-			setHealthFunc: func(_ *protobufs.ComponentHealth) {
+			setHealthFunc: func(*protobufs.ComponentHealth) {
 				healthSet = true
 			},
 		}
@@ -1367,11 +1367,11 @@ type mockOpAMPClient struct {
 	setHealthFunc             func(health *protobufs.ComponentHealth)
 }
 
-func (mockOpAMPClient) Start(_ context.Context, _ types.StartSettings) error {
+func (mockOpAMPClient) Start(context.Context, types.StartSettings) error {
 	return nil
 }
 
-func (mockOpAMPClient) Stop(_ context.Context) error {
+func (mockOpAMPClient) Stop(context.Context) error {
 	return nil
 }
 
@@ -1397,11 +1397,11 @@ func (m mockOpAMPClient) SetRemoteConfigStatus(rcs *protobufs.RemoteConfigStatus
 	return m.setRemoteConfigStatusFunc(rcs)
 }
 
-func (mockOpAMPClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error {
+func (mockOpAMPClient) SetPackageStatuses(*protobufs.PackageStatuses) error {
 	return nil
 }
 
-func (mockOpAMPClient) RequestConnectionSettings(_ *protobufs.ConnectionSettingsRequest) error {
+func (mockOpAMPClient) RequestConnectionSettings(*protobufs.ConnectionSettingsRequest) error {
 	return nil
 }
 
@@ -1422,11 +1422,11 @@ func (m mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (me
 	return msgChan, nil
 }
 
-func (m mockOpAMPClient) SetAvailableComponents(_ *protobufs.AvailableComponents) (err error) {
+func (m mockOpAMPClient) SetAvailableComponents(*protobufs.AvailableComponents) (err error) {
 	return nil
 }
 
-func (m mockOpAMPClient) SetFlags(_ protobufs.AgentToServerFlags) {}
+func (m mockOpAMPClient) SetFlags(protobufs.AgentToServerFlags) {}
 
 type mockConn struct {
 	sendFunc func(ctx context.Context, message *protobufs.ServerToAgent) error

--- a/cmd/telemetrygen/config.go
+++ b/cmd/telemetrygen/config.go
@@ -34,7 +34,7 @@ var tracesCmd = &cobra.Command{
 	Use:     "traces",
 	Short:   "Simulates a client generating traces. (Stability level: alpha)",
 	Example: "telemetrygen traces",
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		return traces.Start(tracesCfg)
 	},
 }
@@ -44,7 +44,7 @@ var metricsCmd = &cobra.Command{
 	Use:     "metrics",
 	Short:   "Simulates a client generating metrics. (Stability level: development)",
 	Example: "telemetrygen metrics",
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		return metrics.Start(metricsCfg)
 	},
 }
@@ -54,7 +54,7 @@ var logsCmd = &cobra.Command{
 	Use:     "logs",
 	Short:   "Simulates a client generating metrics. (Stability level: development)",
 	Example: "telemetrygen logs",
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(*cobra.Command, []string) error {
 		return logs.Start(logsCfg)
 	},
 }

--- a/cmd/telemetrygen/pkg/logs/worker_test.go
+++ b/cmd/telemetrygen/pkg/logs/worker_test.go
@@ -33,11 +33,11 @@ func (m *mockExporter) Export(_ context.Context, records []sdklog.Record) error 
 	return nil
 }
 
-func (m *mockExporter) Shutdown(_ context.Context) error {
+func (m *mockExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func (m *mockExporter) ForceFlush(_ context.Context) error {
+func (m *mockExporter) ForceFlush(context.Context) error {
 	return nil
 }
 

--- a/cmd/telemetrygen/pkg/metrics/worker_test.go
+++ b/cmd/telemetrygen/pkg/metrics/worker_test.go
@@ -33,11 +33,11 @@ type mockExporter struct {
 	rms []*metricdata.ResourceMetrics
 }
 
-func (m *mockExporter) Temporality(_ sdkmetric.InstrumentKind) metricdata.Temporality {
+func (m *mockExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
 	return metricdata.DeltaTemporality
 }
 
-func (m *mockExporter) Aggregation(_ sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+func (m *mockExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
 	return sdkmetric.AggregationDefault{}
 }
 
@@ -46,11 +46,11 @@ func (m *mockExporter) Export(_ context.Context, metrics *metricdata.ResourceMet
 	return nil
 }
 
-func (m *mockExporter) ForceFlush(_ context.Context) error {
+func (m *mockExporter) ForceFlush(context.Context) error {
 	return nil
 }
 
-func (m *mockExporter) Shutdown(_ context.Context) error {
+func (m *mockExporter) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/confmap/provider/s3provider/provider.go
+++ b/confmap/provider/s3provider/provider.go
@@ -52,7 +52,7 @@ func NewFactory() confmap.ProviderFactory {
 	return confmap.NewProviderFactory(newWithSettings)
 }
 
-func newWithSettings(_ confmap.ProviderSettings) confmap.Provider {
+func newWithSettings(confmap.ProviderSettings) confmap.Provider {
 	return &provider{client: nil}
 }
 

--- a/confmap/provider/secretsmanagerprovider/provider_test.go
+++ b/confmap/provider/secretsmanagerprovider/provider_test.go
@@ -21,8 +21,8 @@ type testSecretManagerClient struct {
 }
 
 // Implement GetSecretValue()
-func (client *testSecretManagerClient) GetSecretValue(_ context.Context, _ *secretsmanager.GetSecretValueInput,
-	_ ...func(*secretsmanager.Options),
+func (client *testSecretManagerClient) GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput,
+	...func(*secretsmanager.Options),
 ) (*secretsmanager.GetSecretValueOutput, error) {
 	return &secretsmanager.GetSecretValueOutput{SecretString: &client.secretValue}, nil
 }

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -133,7 +133,7 @@ func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfi
 }
 
 // Start implements the component.Component interface.
-func (c *traceToMetricConnector) Start(_ context.Context, _ component.Host) error {
+func (c *traceToMetricConnector) Start(context.Context, component.Host) error {
 	c.logger.Info("Starting datadogconnector")
 	c.agent.Start()
 	go c.run()
@@ -163,7 +163,7 @@ func (c *traceToMetricConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (c *traceToMetricConnector) addToCache(containerID string, key string) {
+func (c *traceToMetricConnector) addToCache(containerID, key string) {
 	if tags, ok := c.containerTagCache.Get(containerID); ok {
 		tagList := tags.(*sync.Map)
 		tagList.Store(key, struct{}{})

--- a/connector/datadogconnector/connector_native.go
+++ b/connector/datadogconnector/connector_native.go
@@ -100,7 +100,7 @@ func newTraceToMetricConnectorNative(set component.TelemetrySettings, cfg compon
 }
 
 // Start implements the component.Component interface.
-func (c *traceToMetricConnectorNative) Start(_ context.Context, _ component.Host) error {
+func (c *traceToMetricConnectorNative) Start(context.Context, component.Host) error {
 	c.logger.Info("Starting datadogconnector")
 	c.concentrator.Start()
 	c.wg.Add(1)

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -163,7 +163,7 @@ func TestContainerTags(t *testing.T) {
 	// check if the container tags are added to the cache
 	assert.Len(t, connector.containerTagCache.Items(), 1)
 	count := 0
-	connector.containerTagCache.Items()["my-container-id"].Object.(*sync.Map).Range(func(_, _ any) bool {
+	connector.containerTagCache.Items()["my-container-id"].Object.(*sync.Map).Range(func(any, any) bool {
 		count++
 		return true
 	})

--- a/connector/datadogconnector/traces_connector.go
+++ b/connector/datadogconnector/traces_connector.go
@@ -26,12 +26,12 @@ func newTraceToTraceConnector(logger *zap.Logger, nextConsumer consumer.Traces) 
 }
 
 // Start implements the component interface.
-func (c *traceToTraceConnector) Start(_ context.Context, _ component.Host) error {
+func (c *traceToTraceConnector) Start(context.Context, component.Host) error {
 	return nil
 }
 
 // Shutdown implements the component interface.
-func (c *traceToTraceConnector) Shutdown(_ context.Context) error {
+func (c *traceToTraceConnector) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/connector/exceptionsconnector/connector.go
+++ b/connector/exceptionsconnector/connector.go
@@ -44,7 +44,7 @@ func newDimensions(cfgDims []Dimension) []pdatautil.Dimension {
 //
 // The ok flag indicates if a dimension value was fetched in order to differentiate
 // an empty string value from a state where no value was found.
-func getDimensionValue(d pdatautil.Dimension, spanAttrs pcommon.Map, eventAttrs pcommon.Map, resourceAttr pcommon.Map) (v pcommon.Value, ok bool) {
+func getDimensionValue(d pdatautil.Dimension, spanAttrs, eventAttrs, resourceAttr pcommon.Map) (v pcommon.Value, ok bool) {
 	// The more specific span attribute should take precedence.
 	if attr, exists := spanAttrs.Get(d.Name); exists {
 		return attr, true

--- a/connector/exceptionsconnector/connector_metrics.go
+++ b/connector/exceptionsconnector/connector_metrics.go
@@ -176,7 +176,7 @@ func (c *metricsConnector) addExemplar(exc *exception, traceID pcommon.TraceID, 
 	e.SetDoubleValue(float64(exc.count))
 }
 
-func buildDimensionKVs(dimensions []pdatautil.Dimension, serviceName string, span ptrace.Span, eventAttrs pcommon.Map, resourceAttrs pcommon.Map) pcommon.Map {
+func buildDimensionKVs(dimensions []pdatautil.Dimension, serviceName string, span ptrace.Span, eventAttrs, resourceAttrs pcommon.Map) pcommon.Map {
 	dims := pcommon.NewMap()
 	dims.EnsureCapacity(3 + len(dimensions))
 	dims.PutStr(serviceNameKey, serviceName)
@@ -196,7 +196,7 @@ func buildDimensionKVs(dimensions []pdatautil.Dimension, serviceName string, spa
 // or resource attributes. If the dimension exists in both, the span's attributes, being the most specific, takes precedence.
 //
 // The metric key is a simple concatenation of dimension values, delimited by a null character.
-func buildKey(dest *bytes.Buffer, serviceName string, span ptrace.Span, optionalDims []pdatautil.Dimension, eventAttrs pcommon.Map, resourceAttrs pcommon.Map) {
+func buildKey(dest *bytes.Buffer, serviceName string, span ptrace.Span, optionalDims []pdatautil.Dimension, eventAttrs, resourceAttrs pcommon.Map) {
 	concatDimensionValue(dest, serviceName, false)
 	concatDimensionValue(dest, span.Name(), true)
 	concatDimensionValue(dest, traceutil.SpanKindStr(span.Kind()), true)

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -154,7 +154,7 @@ func verifyConsumeMetricsInputCumulative(tb testing.TB, input pmetric.Metrics) b
 	return verifyConsumeMetricsInput(tb, input, 1)
 }
 
-func verifyBadMetricsOkay(_ testing.TB, _ pmetric.Metrics) bool {
+func verifyBadMetricsOkay(testing.TB, pmetric.Metrics) bool {
 	return true // Validating no exception
 }
 

--- a/connector/failoverconnector/logs.go
+++ b/connector/failoverconnector/logs.go
@@ -87,7 +87,7 @@ func (f *logsFailover) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	return f.failover.Consume(ctx, ld)
 }
 
-func (f *logsFailover) Shutdown(_ context.Context) error {
+func (f *logsFailover) Shutdown(context.Context) error {
 	if f.failover != nil {
 		f.failover.Shutdown()
 	}

--- a/connector/failoverconnector/metrics.go
+++ b/connector/failoverconnector/metrics.go
@@ -87,7 +87,7 @@ func (f *metricsFailover) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 	return f.failover.Consume(ctx, md)
 }
 
-func (f *metricsFailover) Shutdown(_ context.Context) error {
+func (f *metricsFailover) Shutdown(context.Context) error {
 	if f.failover != nil {
 		f.failover.Shutdown()
 	}

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -88,7 +88,7 @@ func (f *tracesFailover) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 	return f.failover.Consume(ctx, td)
 }
 
-func (f *tracesFailover) Shutdown(_ context.Context) error {
+func (f *tracesFailover) Shutdown(context.Context) error {
 	if f.failover != nil {
 		f.failover.Shutdown()
 	}

--- a/connector/routingconnector/internal/common/functions.go
+++ b/connector/routingconnector/internal/common/functions.go
@@ -10,7 +10,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func createRouteFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+func createRouteFunction[K any](ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[K], error) {
 	return func(context.Context, K) (any, error) {
 		return true, nil
 	}, nil

--- a/connector/routingconnector/internal/pmetricutil/metrics_test.go
+++ b/connector/routingconnector/internal/pmetricutil/metrics_test.go
@@ -92,7 +92,7 @@ func TestMoveMetricsWithContextIf(t *testing.T) {
 	}{
 		{
 			name: "move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewGauges("AB", "CD", "EF", "GH"),
@@ -102,7 +102,7 @@ func TestMoveMetricsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewGauges("AB", "CD", "EF", "GH"),
@@ -275,7 +275,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		// gauge
 		{
 			name: "gauge/move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewGauges("AB", "CD", "EF", "GH"),
@@ -285,7 +285,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "gauge/move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewGauges("AB", "CD", "EF", "GH"),
@@ -520,7 +520,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		// sum
 		{
 			name: "sum/move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewSums("AB", "CD", "EF", "GH", false, pmetric.AggregationTemporalityUnspecified),
@@ -530,7 +530,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "sum/move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewSums("AB", "CD", "EF", "GH", false, pmetric.AggregationTemporalityUnspecified),
@@ -540,7 +540,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "sum/move_all_aggregation_temporality_and_is_monotonic_are_preserved",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewSums("AB", "CD", "EF", "GH", true, pmetric.AggregationTemporalityCumulative),
@@ -775,7 +775,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		// histogram
 		{
 			name: "histogram/move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityUnspecified),
@@ -785,7 +785,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "histogram/move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityUnspecified),
@@ -795,7 +795,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "histogram/move_all_aggregation_temporality_preserved",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityCumulative),
@@ -1030,7 +1030,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		// exponential_histogram
 		{
 			name: "exponential_histogram/move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewExponentialHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityUnspecified),
@@ -1040,7 +1040,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "exponential_histogram/move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewExponentialHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityUnspecified),
@@ -1050,7 +1050,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "exponential_histogram/move_all_aggregation_temporality_preserved",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewExponentialHistograms("AB", "CD", "EF", "GH", pmetric.AggregationTemporalityCumulative),
@@ -1285,7 +1285,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		// summary
 		{
 			name: "summary/move_none",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return false
 			},
 			from:       pmetricutiltest.NewSummaries("AB", "CD", "EF", "GH"),
@@ -1295,7 +1295,7 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		},
 		{
 			name: "summary/move_all",
-			moveIf: func(_ pmetric.ResourceMetrics, _ pmetric.ScopeMetrics, _ pmetric.Metric, _ any) bool {
+			moveIf: func(pmetric.ResourceMetrics, pmetric.ScopeMetrics, pmetric.Metric, any) bool {
 				return true
 			},
 			from:       pmetricutiltest.NewSummaries("AB", "CD", "EF", "GH"),

--- a/connector/routingconnector/internal/ptraceutil/traces_test.go
+++ b/connector/routingconnector/internal/ptraceutil/traces_test.go
@@ -92,7 +92,7 @@ func TestMoveSpansWithContextIf(t *testing.T) {
 	}{
 		{
 			name: "move_none",
-			moveIf: func(_ ptrace.ResourceSpans, _ ptrace.ScopeSpans, _ ptrace.Span) bool {
+			moveIf: func(ptrace.ResourceSpans, ptrace.ScopeSpans, ptrace.Span) bool {
 				return false
 			},
 			from:       ptraceutiltest.NewTraces("AB", "CD", "EF", "GH"),
@@ -102,7 +102,7 @@ func TestMoveSpansWithContextIf(t *testing.T) {
 		},
 		{
 			name: "move_all",
-			moveIf: func(_ ptrace.ResourceSpans, _ ptrace.ScopeSpans, _ ptrace.Span) bool {
+			moveIf: func(ptrace.ResourceSpans, ptrace.ScopeSpans, ptrace.Span) bool {
 				return true
 			},
 			from:       ptraceutiltest.NewTraces("AB", "CD", "EF", "GH"),

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -151,7 +151,7 @@ func newConnector(set component.TelemetrySettings, config component.Config, next
 	}, nil
 }
 
-func (p *serviceGraphConnector) Start(_ context.Context, _ component.Host) error {
+func (p *serviceGraphConnector) Start(context.Context, component.Host) error {
 	p.store = store.NewStore(p.config.Store.TTL, p.config.Store.MaxItems, p.onComplete, p.onExpire)
 
 	go p.metricFlushLoop(*p.config.MetricsFlushInterval)
@@ -199,7 +199,7 @@ func (p *serviceGraphConnector) flushMetrics(ctx context.Context) error {
 	return p.metricsConsumer.ConsumeMetrics(ctx, md)
 }
 
-func (p *serviceGraphConnector) Shutdown(_ context.Context) error {
+func (p *serviceGraphConnector) Shutdown(context.Context) error {
 	p.logger.Info("Shutting down servicegraphconnector")
 	close(p.shutdownCh)
 	return nil
@@ -319,7 +319,7 @@ func (p *serviceGraphConnector) aggregateMetrics(ctx context.Context, td ptrace.
 	return nil
 }
 
-func (p *serviceGraphConnector) upsertDimensions(kind string, m map[string]string, resourceAttr pcommon.Map, spanAttr pcommon.Map) {
+func (p *serviceGraphConnector) upsertDimensions(kind string, m map[string]string, resourceAttr, spanAttr pcommon.Map) {
 	for _, dim := range p.config.Dimensions {
 		if v, ok := pdatautil.GetAttributeValue(dim, resourceAttr, spanAttr); ok {
 			m[kind+"_"+dim] = v

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -458,7 +458,7 @@ func TestUpdateDurationMetrics(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.caseStr, func(_ *testing.T) {
+		t.Run(tc.caseStr, func(*testing.T) {
 			p.updateDurationMetrics(metricKey, tc.duration, tc.duration)
 		})
 	}

--- a/connector/servicegraphconnector/internal/store/store_test.go
+++ b/connector/servicegraphconnector/internal/store/store_test.go
@@ -162,10 +162,10 @@ func TestStoreConcurrency(t *testing.T) {
 	close(end)
 }
 
-func noopCallback(_ *Edge) {}
+func noopCallback(*Edge) {}
 
 func countingCallback(counter *int) func(*Edge) {
-	return func(_ *Edge) {
+	return func(*Edge) {
 		*counter++
 	}
 }

--- a/connector/signaltometricsconnector/internal/customottl/adjustedcount.go
+++ b/connector/signaltometricsconnector/internal/customottl/adjustedcount.go
@@ -16,7 +16,7 @@ func NewAdjustedCountFactory() ottl.Factory[ottlspan.TransformContext] {
 	return ottl.NewFactory("AdjustedCount", nil, createAdjustedCountFunction)
 }
 
-func createAdjustedCountFunction(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[ottlspan.TransformContext], error) {
+func createAdjustedCountFunction(ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[ottlspan.TransformContext], error) {
 	return adjustedCount()
 }
 

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -597,7 +597,7 @@ func (p *connectorImp) buildKey(serviceName string, span ptrace.Span, optionalDi
 }
 
 // buildMetricName builds the namespace prefix for the metric name.
-func buildMetricName(namespace string, name string) string {
+func buildMetricName(namespace, name string) string {
 	if namespace != "" {
 		return namespace + "." + name
 	}

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -126,7 +126,7 @@ func verifyConsumeMetricsInputCumulative(tb testing.TB, input pmetric.Metrics) b
 	return verifyConsumeMetricsInput(tb, input, pmetric.AggregationTemporalityCumulative, 1)
 }
 
-func verifyBadMetricsOkay(_ testing.TB, _ pmetric.Metrics) bool {
+func verifyBadMetricsOkay(testing.TB, pmetric.Metrics) bool {
 	return true // Validating no exception
 }
 
@@ -1680,11 +1680,11 @@ func assertDataPointsHaveExactlyOneExemplarForTrace(t *testing.T, metrics pmetri
 func TestTimestampsForUninterruptedStream(t *testing.T) {
 	tests := []struct {
 		temporality      string
-		verifyTimestamps func(startTime1 pcommon.Timestamp, timestamp1 pcommon.Timestamp, startTime2 pcommon.Timestamp, timestamp2 pcommon.Timestamp)
+		verifyTimestamps func(startTime1, timestamp1, startTime2, timestamp2 pcommon.Timestamp)
 	}{
 		{
 			temporality: cumulative,
-			verifyTimestamps: func(startTime1 pcommon.Timestamp, timestamp1 pcommon.Timestamp, startTime2 pcommon.Timestamp, timestamp2 pcommon.Timestamp) {
+			verifyTimestamps: func(startTime1, timestamp1, startTime2, timestamp2 pcommon.Timestamp) {
 				// (T1, T2), (T1, T3) ...
 				assert.Greater(t, timestamp1, startTime1)
 				assert.Equal(t, startTime1, startTime2)
@@ -1693,7 +1693,7 @@ func TestTimestampsForUninterruptedStream(t *testing.T) {
 		},
 		{
 			temporality: delta,
-			verifyTimestamps: func(startTime1 pcommon.Timestamp, timestamp1 pcommon.Timestamp, startTime2 pcommon.Timestamp, timestamp2 pcommon.Timestamp) {
+			verifyTimestamps: func(startTime1, timestamp1, startTime2, timestamp2 pcommon.Timestamp) {
 				// (T1, T2), (T2, T3) ...
 				assert.Greater(t, timestamp1, startTime1)
 				assert.Equal(t, timestamp1, startTime2)
@@ -1750,7 +1750,7 @@ func TestTimestampsForUninterruptedStream(t *testing.T) {
 	}
 }
 
-func verifyAndCollectCommonTimestamps(t *testing.T, m pmetric.Metrics) (start pcommon.Timestamp, timestamp pcommon.Timestamp) {
+func verifyAndCollectCommonTimestamps(t *testing.T, m pmetric.Metrics) (start, timestamp pcommon.Timestamp) {
 	// Go through all data points and collect the start timestamp and timestamp. They should be the same value for each data point
 	for i := 0; i < m.ResourceMetrics().Len(); i++ {
 		rm := m.ResourceMetrics().At(i)

--- a/exporter/awscloudwatchlogsexporter/util.go
+++ b/exporter/awscloudwatchlogsexporter/util.go
@@ -68,7 +68,7 @@ func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string
 	return s, true
 }
 
-func replace(s, pattern string, value string, logger *zap.Logger) (string, bool) {
+func replace(s, pattern, value string, logger *zap.Logger) (string, bool) {
 	if value == "" {
 		logger.Debug("Empty resource attribute value found for pattern " + pattern)
 		return strings.ReplaceAll(s, pattern, "undefined"), false

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -306,7 +306,7 @@ func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(idx int, 
 	return datapoints, true
 }
 
-func collectDatapointsWithPositiveBuckets(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex int, currentPositiveIndex int) (int, int) {
+func collectDatapointsWithPositiveBuckets(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex, currentPositiveIndex int) (int, int) {
 	if split.isFull() || currentPositiveIndex < 0 {
 		return currentBucketIndex, currentPositiveIndex
 	}
@@ -347,7 +347,7 @@ func collectDatapointsWithPositiveBuckets(split *dataPointSplit, metric pmetric.
 	return currentBucketIndex, currentPositiveIndex
 }
 
-func collectDatapointsWithZeroBucket(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex int, currentZeroIndex int) (int, int) {
+func collectDatapointsWithZeroBucket(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex, currentZeroIndex int) (int, int) {
 	if metric.ZeroCount() > 0 && !split.isFull() && currentZeroIndex == 0 {
 		split.appendMetricData(0, metric.ZeroCount())
 
@@ -365,7 +365,7 @@ func collectDatapointsWithZeroBucket(split *dataPointSplit, metric pmetric.Expon
 	return currentBucketIndex, currentZeroIndex
 }
 
-func collectDatapointsWithNegativeBuckets(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex int, currentNegativeIndex int) (int, int) {
+func collectDatapointsWithNegativeBuckets(split *dataPointSplit, metric pmetric.ExponentialHistogramDataPoint, currentBucketIndex, currentNegativeIndex int) (int, int) {
 	// According to metrics spec, the value in histogram is expected to be non-negative.
 	// https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram
 	// However, the negative support is defined in metrics data model.

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -49,7 +49,7 @@ func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string
 	return s, true
 }
 
-func replace(s, pattern string, value string, logger *zap.Logger) (string, bool) {
+func replace(s, pattern, value string, logger *zap.Logger) (string, bool) {
 	if value == "" {
 		logger.Debug("Empty resource attribute value found for pattern " + pattern)
 		return strings.ReplaceAll(s, pattern, "undefined"), false

--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -188,7 +188,7 @@ func makeCause(span ptrace.Span, attributes map[string]pcommon.Value, resource p
 	return isError, isFault, isThrottle, filtered, cause
 }
 
-func parseException(exceptionType string, message string, stacktrace string, isRemote bool, language string) []awsxray.Exception {
+func parseException(exceptionType, message, stacktrace string, isRemote bool, language string) []awsxray.Exception {
 	exceptions := make([]awsxray.Exception, 0, 1)
 	segmentID := newSegmentID()
 	exceptions = append(exceptions, awsxray.Exception{

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -36,16 +36,16 @@ type azureBlobExporter struct {
 }
 
 type azblobClient interface {
-	UploadStream(ctx context.Context, containerName string, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error)
+	UploadStream(ctx context.Context, containerName, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error)
 	URL() string
-	AppendBlock(ctx context.Context, containerName string, blobName string, data []byte, o *appendblob.AppendBlockOptions) error
+	AppendBlock(ctx context.Context, containerName, blobName string, data []byte, o *appendblob.AppendBlockOptions) error
 }
 
 type azblobClientImpl struct {
 	client *azblob.Client
 }
 
-func (c *azblobClientImpl) UploadStream(ctx context.Context, containerName string, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
+func (c *azblobClientImpl) UploadStream(ctx context.Context, containerName, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
 	return c.client.UploadStream(ctx, containerName, blobName, body, o)
 }
 
@@ -53,7 +53,7 @@ func (c *azblobClientImpl) URL() string {
 	return c.client.URL()
 }
 
-func (c *azblobClientImpl) AppendBlock(ctx context.Context, containerName string, blobName string, data []byte, o *appendblob.AppendBlockOptions) error {
+func (c *azblobClientImpl) AppendBlock(ctx context.Context, containerName, blobName string, data []byte, o *appendblob.AppendBlockOptions) error {
 	containerClient := c.client.ServiceClient().NewContainerClient(containerName)
 	appendBlobClient := containerClient.NewAppendBlobClient(blobName)
 

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -179,7 +179,7 @@ func TestGenerateBlobNameSerialNumBefore(t *testing.T) {
 
 	ae := newAzureBlobExporter(c, zaptest.NewLogger(t), pipeline.SignalMetrics)
 
-	assertFormat := func(blobName string, format string) {
+	assertFormat := func(blobName, format string) {
 		ext := filepath.Ext(format)
 		formatWithoutExt := strings.TrimSuffix(format, ext)
 		assert.True(t, strings.HasPrefix(blobName, formatWithoutExt))
@@ -218,12 +218,12 @@ func (_m *mockAzBlobClient) URL() string {
 	return _m.url
 }
 
-func (_m *mockAzBlobClient) UploadStream(ctx context.Context, containerName string, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
+func (_m *mockAzBlobClient) UploadStream(ctx context.Context, containerName, blobName string, body io.Reader, o *azblob.UploadStreamOptions) (azblob.UploadStreamResponse, error) {
 	args := _m.Called(ctx, containerName, blobName, body, o)
 	return args.Get(0).(azblob.UploadStreamResponse), args.Error(1)
 }
 
-func (_m *mockAzBlobClient) AppendBlock(ctx context.Context, containerName string, blobName string, data []byte, o *appendblob.AppendBlockOptions) error {
+func (_m *mockAzBlobClient) AppendBlock(ctx context.Context, containerName, blobName string, data []byte, o *appendblob.AppendBlockOptions) error {
 	args := _m.Called(ctx, containerName, blobName, data, o)
 	return args.Error(0)
 }

--- a/exporter/azuredataexplorerexporter/adx_exporter.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter.go
@@ -213,7 +213,7 @@ func createKcsb(config *Config, version string) *azkustodata.ConnectionStringBui
 }
 
 // Depending on the table, create separate ingestors
-func createManagedStreamingIngestor(config *Config, version string, tablename string) (*azkustoingest.Managed, error) {
+func createManagedStreamingIngestor(config *Config, version, tablename string) (*azkustoingest.Managed, error) {
 	kcsb := createKcsb(config, version)
 	ingestopts := []azkustoingest.Option{
 		azkustoingest.WithDefaultDatabase(config.Database),
@@ -224,7 +224,7 @@ func createManagedStreamingIngestor(config *Config, version string, tablename st
 }
 
 // A queued ingestor in case that is provided as the config option
-func createQueuedIngestor(config *Config, version string, tablename string) (*azkustoingest.Ingestion, error) {
+func createQueuedIngestor(config *Config, version, tablename string) (*azkustoingest.Ingestion, error) {
 	kcsb := createKcsb(config, version)
 	ingestopts := []azkustoingest.Option{
 		azkustoingest.WithDefaultDatabase(config.Database),

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
@@ -61,7 +61,7 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 	if h := resourceAttrs[hostkey]; h != nil {
 		host = h.(string)
 	}
-	createMetric := func(times time.Time, attr pcommon.Map, value func() float64, name string, desc string, mt pmetric.MetricType) *adxMetric {
+	createMetric := func(times time.Time, attr pcommon.Map, value func() float64, name, desc string, mt pmetric.MetricType) *adxMetric {
 		clonedScopedAttributes := copyMap(cloneMap(scopeattrs), attr.AsRaw())
 		if isEmpty(name) {
 			name = md.Name()
@@ -255,7 +255,7 @@ func rawMetricsToAdxMetrics(_ context.Context, metrics pmetric.Metrics, logger *
 	return transformedAdxMetrics
 }
 
-func copyMap(toAttrib map[string]any, fromAttrib map[string]any) map[string]any {
+func copyMap(toAttrib, fromAttrib map[string]any) map[string]any {
 	for k, v := range fromAttrib {
 		toAttrib[k] = v
 	}

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -753,7 +753,7 @@ func setAttributeValueAsProperty(
 	}
 }
 
-func prefixIfNecessary(s string, prefix string) string {
+func prefixIfNecessary(s, prefix string) string {
 	if strings.HasPrefix(s, prefix) {
 		return s
 	}

--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -311,7 +311,7 @@ type carbonServer struct {
 	expectedContainsValue string
 }
 
-func newCarbonServer(t *testing.T, addr string, expectedContainsValue string) *carbonServer {
+func newCarbonServer(t *testing.T, addr, expectedContainsValue string) *carbonServer {
 	laddr, err := net.ResolveTCPAddr("tcp", addr)
 	require.NoError(t, err)
 	ln, err := net.ListenTCP("tcp", laddr)

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -169,7 +169,7 @@ func convertEvents(events ptrace.SpanEventSlice) (times []time.Time, names []str
 	return
 }
 
-func convertLinks(links ptrace.SpanLinkSlice) (traceIDs []string, spanIDs []string, states []string, attrs []column.IterableOrderedMap) {
+func convertLinks(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states []string, attrs []column.IterableOrderedMap) {
 	for i := 0; i < links.Len(); i++ {
 		link := links.At(i)
 		traceIDs = append(traceIDs, traceutil.TraceIDToHexOrEmptyString(link.TraceID()))

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -170,7 +170,7 @@ func (e *tracesJSONExporter) pushTraceData(ctx context.Context, td ptrace.Traces
 	return nil
 }
 
-func convertEventsJSON(events ptrace.SpanEventSlice) (times []time.Time, names []string, attrs []string, err error) {
+func convertEventsJSON(events ptrace.SpanEventSlice) (times []time.Time, names, attrs []string, err error) {
 	for i := 0; i < events.Len(); i++ {
 		event := events.At(i)
 		times = append(times, event.Timestamp().AsTime())
@@ -186,7 +186,7 @@ func convertEventsJSON(events ptrace.SpanEventSlice) (times []time.Time, names [
 	return
 }
 
-func convertLinksJSON(links ptrace.SpanLinkSlice) (traceIDs []string, spanIDs []string, states []string, attrs []string, err error) {
+func convertLinksJSON(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states, attrs []string, err error) {
 	for i := 0; i < links.Len(); i++ {
 		link := links.At(i)
 		traceIDs = append(traceIDs, link.TraceID().String())

--- a/exporter/clickhouseexporter/internal/metrics/exponential_histogram_metrics.go
+++ b/exporter/clickhouseexporter/internal/metrics/exponential_histogram_metrics.go
@@ -111,7 +111,7 @@ func (e *expHistogramMetrics) insert(ctx context.Context, db driver.Conn) error 
 	return nil
 }
 
-func (e *expHistogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (e *expHistogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error {
 	expHistogram, ok := metrics.(pmetric.ExponentialHistogram)
 	if !ok {
 		return errors.New("metrics param is not type of ExponentialHistogram")

--- a/exporter/clickhouseexporter/internal/metrics/gauge_metrics.go
+++ b/exporter/clickhouseexporter/internal/metrics/gauge_metrics.go
@@ -100,7 +100,7 @@ func (g *gaugeMetrics) insert(ctx context.Context, db driver.Conn) error {
 	return nil
 }
 
-func (g *gaugeMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (g *gaugeMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error {
 	gauge, ok := metrics.(pmetric.Gauge)
 	if !ok {
 		return errors.New("metrics param is not type of Gauge")

--- a/exporter/clickhouseexporter/internal/metrics/histogram_metrics.go
+++ b/exporter/clickhouseexporter/internal/metrics/histogram_metrics.go
@@ -106,7 +106,7 @@ func (h *histogramMetrics) insert(ctx context.Context, db driver.Conn) error {
 	return nil
 }
 
-func (h *histogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (h *histogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error {
 	histogram, ok := metrics.(pmetric.Histogram)
 	if !ok {
 		return errors.New("metrics param is not type of Histogram")

--- a/exporter/clickhouseexporter/internal/metrics/metrics_model.go
+++ b/exporter/clickhouseexporter/internal/metrics/metrics_model.go
@@ -43,7 +43,7 @@ type MetricTypeConfig struct {
 // any type of metrics need implement it.
 type MetricsModel interface {
 	// Add used to bind MetricsMetaData to a specific metric then put them into a slice
-	Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error
+	Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error
 	// insert is used to insert metric data to clickhouse
 	insert(ctx context.Context, db driver.Conn) error
 }

--- a/exporter/clickhouseexporter/internal/metrics/sum_metrics.go
+++ b/exporter/clickhouseexporter/internal/metrics/sum_metrics.go
@@ -102,7 +102,7 @@ func (s *sumMetrics) insert(ctx context.Context, db driver.Conn) error {
 	return nil
 }
 
-func (s *sumMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (s *sumMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error {
 	sum, ok := metrics.(pmetric.Sum)
 	if !ok {
 		return errors.New("metrics param is not type of Sum")

--- a/exporter/clickhouseexporter/internal/metrics/summary_metrics.go
+++ b/exporter/clickhouseexporter/internal/metrics/summary_metrics.go
@@ -99,7 +99,7 @@ func (s *summaryMetrics) insert(ctx context.Context, db driver.Conn) error {
 	return nil
 }
 
-func (s *summaryMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (s *summaryMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name, description, unit string) error {
 	summary, ok := metrics.(pmetric.Summary)
 	if !ok {
 		return errors.New("metrics param is not type of Summary")

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -227,7 +227,7 @@ func checkAndCastConfig(c component.Config, logger *zap.Logger) *datadogconfig.C
 	return cfg
 }
 
-func (f *factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, statsIn <-chan []byte, statsWriter *writer.DatadogStatsWriter, tracerVersion string, agentVersion string, logger *zap.Logger) {
+func (f *factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, statsIn <-chan []byte, statsWriter *writer.DatadogStatsWriter, tracerVersion, agentVersion string, logger *zap.Logger) {
 	for i := 0; i < runtime.NumCPU(); i++ {
 		wg.Add(1)
 		go func() {

--- a/exporter/datadogexporter/internal/metrics/series.go
+++ b/exporter/datadogexporter/internal/metrics/series.go
@@ -53,7 +53,7 @@ func NewCount(name string, ts uint64, value float64, tags []string) datadogV2.Me
 }
 
 // DefaultMetrics creates built-in metrics to report that an exporter is running
-func DefaultMetrics(exporterType string, hostname string, timestamp uint64, tags []string) []datadogV2.MetricSeries {
+func DefaultMetrics(exporterType, hostname string, timestamp uint64, tags []string) []datadogV2.MetricSeries {
 	metrics := []datadogV2.MetricSeries{
 		NewGauge(fmt.Sprintf("otel.datadog_exporter.%s.running", exporterType), timestamp, 1.0, tags),
 	}

--- a/exporter/datadogexporter/internal/metrics/series_deprecated.go
+++ b/exporter/datadogexporter/internal/metrics/series_deprecated.go
@@ -55,7 +55,7 @@ func NewZorkianCount(name string, ts uint64, value float64, tags []string) zorki
 }
 
 // DefaultZorkianMetrics creates built-in metrics to report that an exporter is running
-func DefaultZorkianMetrics(exporterType string, hostname string, timestamp uint64, buildInfo component.BuildInfo) []zorkian.Metric {
+func DefaultZorkianMetrics(exporterType, hostname string, timestamp uint64, buildInfo component.BuildInfo) []zorkian.Metric {
 	var tags []string
 
 	if buildInfo.Version != "" {

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -155,7 +155,7 @@ func (exp *traceExporter) consumeTraces(
 	return nil
 }
 
-func (exp *traceExporter) exportUsageMetrics(ctx context.Context, hosts map[string]struct{}, tags map[string]struct{}) {
+func (exp *traceExporter) exportUsageMetrics(ctx context.Context, hosts, tags map[string]struct{}) {
 	now := pcommon.NewTimestampFromTime(time.Now())
 	buildTags := metrics.TagsFromBuildInfo(exp.params.BuildInfo)
 	var err error

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -567,11 +567,11 @@ func TestResRelatedAttributesInSpanAttributes_ReceiveResourceSpansV2Enabled(t *t
 	assert.Empty(t, span.Meta["version"])
 }
 
-func simpleTraces(rattrs map[string]any, sattrs map[string]any, kind ptrace.SpanKind) ptrace.Traces {
+func simpleTraces(rattrs, sattrs map[string]any, kind ptrace.SpanKind) ptrace.Traces {
 	return genTraces([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4}, rattrs, sattrs, kind)
 }
 
-func genTraces(traceID pcommon.TraceID, rattrs map[string]any, sattrs map[string]any, kind ptrace.SpanKind) ptrace.Traces {
+func genTraces(traceID pcommon.TraceID, rattrs, sattrs map[string]any, kind ptrace.SpanKind) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	rspans := traces.ResourceSpans().AppendEmpty()
 	span := rspans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()

--- a/exporter/datasetexporter/datasetexporter.go
+++ b/exporter/datasetexporter/datasetexporter.go
@@ -80,7 +80,7 @@ func sendBatch(events []*add_events.EventBundle, client *client.DataSetClient) e
 	return client.AddEvents(events)
 }
 
-func buildKey(prefix string, separator string, key string, depth int) string {
+func buildKey(prefix, separator, key string, depth int) string {
 	res := prefix
 	if depth > 0 && prefix != "" {
 		res += separator
@@ -89,21 +89,21 @@ func buildKey(prefix string, separator string, key string, depth int) string {
 	return res
 }
 
-func updateWithPrefixedValuesMap(target map[string]any, prefix string, separator string, suffix string, source map[string]any, depth int) {
+func updateWithPrefixedValuesMap(target map[string]any, prefix, separator, suffix string, source map[string]any, depth int) {
 	for k, v := range source {
 		key := buildKey(prefix, separator, k, depth)
 		updateWithPrefixedValues(target, key, separator, suffix, v, depth+1)
 	}
 }
 
-func updateWithPrefixedValuesArray(target map[string]any, prefix string, separator string, suffix string, source []any, depth int) {
+func updateWithPrefixedValuesArray(target map[string]any, prefix, separator, suffix string, source []any, depth int) {
 	for i, v := range source {
 		key := buildKey(prefix, separator, strconv.FormatInt(int64(i), 10), depth)
 		updateWithPrefixedValues(target, key, separator, suffix, v, depth+1)
 	}
 }
 
-func updateWithPrefixedValues(target map[string]any, prefix string, separator string, suffix string, source any, depth int) {
+func updateWithPrefixedValues(target map[string]any, prefix, separator, suffix string, source any, depth int) {
 	setValue := func() {
 		for {
 			// now the last value wins

--- a/exporter/datasetexporter/traces_exporter.go
+++ b/exporter/datasetexporter/traces_exporter.go
@@ -100,7 +100,7 @@ const (
 	Process = ResourceType("process")
 )
 
-func updateResource(attrs map[string]any, resource map[string]any) {
+func updateResource(attrs, resource map[string]any) {
 	// first detect, whether there is key service.name
 	// if it's there, we are done
 	name, found := resource["service.name"]

--- a/exporter/dorisexporter/exporter_common.go
+++ b/exporter/dorisexporter/exporter_common.go
@@ -73,7 +73,7 @@ func (r *streamLoadResponse) duplication() bool {
 	return r.Status == "Label Already Exists"
 }
 
-func streamLoadURL(address string, db string, table string) string {
+func streamLoadURL(address, db, table string) string {
 	return address + "/api/" + db + "/" + table + "/_stream_load"
 }
 

--- a/exporter/elasticsearchexporter/attribute.go
+++ b/exporter/elasticsearchexporter/attribute.go
@@ -15,7 +15,7 @@ const (
 	defaultDataStreamTypeProfiles = "profiles"
 )
 
-func getFromAttributes(name string, defaultValue string, attributeMaps ...pcommon.Map) (string, bool) {
+func getFromAttributes(name, defaultValue string, attributeMaps ...pcommon.Map) (string, bool) {
 	for _, attributeMap := range attributeMaps {
 		if value, exists := attributeMap.Get(name); exists {
 			return value.AsString(), true

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -40,7 +40,7 @@ type bulkIndexer interface {
 
 type bulkIndexerSession interface {
 	// Add adds a document to the bulk indexing session.
-	Add(ctx context.Context, index string, docID string, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error
+	Add(ctx context.Context, index, docID, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error
 
 	// End must be called on the session object once it is no longer
 	// needed, in order to release any associated resources.
@@ -166,7 +166,7 @@ type syncBulkIndexerSession struct {
 }
 
 // Add adds an item to the sync bulk indexer session.
-func (s *syncBulkIndexerSession) Add(ctx context.Context, index string, docID string, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error {
+func (s *syncBulkIndexerSession) Add(ctx context.Context, index, docID, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error {
 	doc := docappender.BulkIndexerItem{
 		Index:            index,
 		Body:             document,
@@ -313,7 +313,7 @@ func (a *asyncBulkIndexer) Close(ctx context.Context) error {
 // Add adds an item to the async bulk indexer session.
 //
 // Adding an item after a call to Close() will panic.
-func (s asyncBulkIndexerSession) Add(ctx context.Context, index string, docID string, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error {
+func (s asyncBulkIndexerSession) Add(ctx context.Context, index, docID, pipeline string, document io.WriterTo, dynamicTemplates map[string]string, action string) error {
 	item := docappender.BulkIndexerItem{
 		Index:            index,
 		Body:             document,

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -143,7 +143,7 @@ func (doc *Document) Add(key string, v Value) {
 }
 
 // AddString adds a string to the document.
-func (doc *Document) AddString(key string, v string) {
+func (doc *Document) AddString(key, v string) {
 	if v != "" {
 		doc.Add(key, StringValue(v))
 	}
@@ -586,7 +586,7 @@ func appendAttributeFields(fields []field, path string, am pcommon.Map) []field 
 	return fields
 }
 
-func appendAttributeValue(fields []field, path string, key string, attr pcommon.Value) []field {
+func appendAttributeValue(fields []field, path, key string, attr pcommon.Value) []field {
 	if attr.Type() == pcommon.ValueTypeEmpty {
 		return fields
 	}

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/profile_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/profile_test.go
@@ -177,7 +177,7 @@ func TestSerializeProfile(t *testing.T) {
 			buf := []*bytes.Buffer{}
 			ser, err := New()
 			require.NoError(t, err)
-			err = ser.SerializeProfile(dic, resource.Resource(), scope.Scope(), profile, func(b *bytes.Buffer, _ string, _ string) error {
+			err = ser.SerializeProfile(dic, resource.Resource(), scope.Scope(), profile, func(b *bytes.Buffer, _, _ string) error {
 				buf = append(buf, b)
 				return nil
 			})
@@ -222,7 +222,7 @@ func BenchmarkSerializeProfile(b *testing.B) {
 	resource := profiles.ResourceProfiles().At(0)
 	scope := resource.ScopeProfiles().At(0)
 	profile := scope.Profiles().At(0)
-	pushData := func(_ *bytes.Buffer, _ string, _ string) error {
+	pushData := func(_ *bytes.Buffer, _, _ string) error {
 		return nil
 	}
 

--- a/exporter/kafkaexporter/internal/kafkaclient/headers.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/headers.go
@@ -38,7 +38,7 @@ func metadataToHeaders[H any](ctx context.Context, keys []string,
 // Usage example (Sarama):
 //
 //	setMessageHeaders(ctx, allMessages, keys, makeHeader, getHeaders, setHeaders)
-func setMessageHeaders[M any, H any](ctx context.Context,
+func setMessageHeaders[M, H any](ctx context.Context,
 	messages []M,
 	metadataKeys []string,
 	makeHeader func(key string, value []byte) H,
@@ -54,7 +54,7 @@ func setMessageHeaders[M any, H any](ctx context.Context,
 }
 
 // setHeaders sets or appends headers on each message in messages using the provided get/set functions.
-func setHeaders[M any, H any](messages []M, headers []H,
+func setHeaders[M, H any](messages []M, headers []H,
 	getHeaders func(M) []H,
 	setHeaders func(M, []H),
 ) {

--- a/exporter/kineticaexporter/metrics_exporter.go
+++ b/exporter/kineticaexporter/metrics_exporter.go
@@ -1354,7 +1354,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 }
 
 // Utility functions
-func (e *kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID string, key string, vtPair valueTypePair) (*gaugeResourceAttribute, error) {
+func (e *kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID, key string, vtPair valueTypePair) (*gaugeResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1367,7 +1367,7 @@ func (e *kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID string,
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID string, datapointID string, key string, vtPair valueTypePair) (*gaugeDatapointAttribute, error) {
+func (e *kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID, datapointID, key string, vtPair valueTypePair) (*gaugeDatapointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1380,7 +1380,7 @@ func (e *kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID string
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID string, key string, scopeName string, scopeVersion string, vtPair valueTypePair) (*gaugeScopeAttribute, error) {
+func (e *kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*gaugeScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1393,7 +1393,7 @@ func (e *kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID string, ke
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSumDatapointAttributeValue(sumID string, datapointID string, key string, vtPair valueTypePair) (*sumDataPointAttribute, error) {
+func (e *kineticaMetricsExporter) newSumDatapointAttributeValue(sumID, datapointID, key string, vtPair valueTypePair) (*sumDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1406,7 +1406,7 @@ func (e *kineticaMetricsExporter) newSumDatapointAttributeValue(sumID string, da
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newSumResourceAttributeValue(sumID string, key string, vtPair valueTypePair) (*sumResourceAttribute, error) {
+func (e *kineticaMetricsExporter) newSumResourceAttributeValue(sumID, key string, vtPair valueTypePair) (*sumResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1419,7 +1419,7 @@ func (e *kineticaMetricsExporter) newSumResourceAttributeValue(sumID string, key
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newSumScopeAttributeValue(sumID string, key string, scopeName string, scopeVersion string, vtPair valueTypePair) (*sumScopeAttribute, error) {
+func (e *kineticaMetricsExporter) newSumScopeAttributeValue(sumID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*sumScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1432,7 +1432,7 @@ func (e *kineticaMetricsExporter) newSumScopeAttributeValue(sumID string, key st
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID string, sumDatapointID string, sumDatapointExemplarID string, key string, vtPair valueTypePair) (*sumDataPointExemplarAttribute, error) {
+func (e *kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID, sumDatapointID, sumDatapointExemplarID, key string, vtPair valueTypePair) (*sumDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1445,7 +1445,7 @@ func (e *kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID st
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttributeValue(histogramID string, histogramDatapointID string, histogramDatapointExemplarID string, key string, vtPair valueTypePair) (*exponentialHistogramDataPointExemplarAttribute, error) {
+func (e *kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttributeValue(histogramID, histogramDatapointID, histogramDatapointExemplarID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1458,7 +1458,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttrib
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue(histogramID string, datapointID string, key string, vtPair valueTypePair) (*exponentialHistogramDataPointAttribute, error) {
+func (e *kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1471,7 +1471,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(histogramID string, datapointID string, exemplarID string, key string, vtPair valueTypePair) (*histogramDataPointExemplarAttribute, error) {
+func (e *kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(histogramID, datapointID, exemplarID, key string, vtPair valueTypePair) (*histogramDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1484,7 +1484,7 @@ func (e *kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(hi
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeID string, gaugeDatapointID string, gaugeDatapointExemplarID string, key string, vtPair valueTypePair) (*gaugeDataPointExemplarAttribute, error) {
+func (e *kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeID, gaugeDatapointID, gaugeDatapointExemplarID, key string, vtPair valueTypePair) (*gaugeDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1497,7 +1497,7 @@ func (e *kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeI
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID string, key string, vtPair valueTypePair) (*histogramResourceAttribute, error) {
+func (e *kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*histogramResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1510,7 +1510,7 @@ func (e *kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID string, key string, scopeName string, scopeVersion string, vtPair valueTypePair) (*histogramScopeAttribute, error) {
+func (e *kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*histogramScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1523,7 +1523,7 @@ func (e *kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID st
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(histogramID string, key string, vtPair valueTypePair) (*exponentialHistogramResourceAttribute, error) {
+func (e *kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*exponentialHistogramResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1536,7 +1536,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(histogramID string, key string, scopeName string, scopeVersion string, vtPair valueTypePair) (*exponentialHistogramScopeAttribute, error) {
+func (e *kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*exponentialHistogramScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1549,7 +1549,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(his
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID string, key string, vtPair valueTypePair) (*summaryResourceAttribute, error) {
+func (e *kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID, key string, vtPair valueTypePair) (*summaryResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1562,7 +1562,7 @@ func (e *kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID str
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID string, key string, scopeName string, scopeVersion string, vtPair valueTypePair) (*summaryScopeAttribute, error) {
+func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*summaryScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1575,7 +1575,7 @@ func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID string
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID string, summaryDatapointID string, key string, vtPair valueTypePair) (*SummaryDataPointAttribute, error) {
+func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID, summaryDatapointID, key string, vtPair valueTypePair) (*SummaryDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1588,7 +1588,7 @@ func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID st
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramDatapointAttributeValue(histogramID string, datapointID string, key string, vtPair valueTypePair) (*histogramDataPointAttribute, error) {
+func (e *kineticaMetricsExporter) newHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*histogramDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -65,7 +65,7 @@ func (h *hashRing) findEndpoint(pos position) string {
 }
 
 // bsearch is a binary search-like algorithm, returning the closest "next" item instead of an exact match
-func bsearch(pos position, left []ringItem, right []ringItem) ringItem {
+func bsearch(pos position, left, right []ringItem) ringItem {
 	// if it's the last item of the left side, return it
 	if left[len(left)-1].pos == pos {
 		return left[len(left)-1]

--- a/exporter/loadbalancingexporter/helpers.go
+++ b/exporter/loadbalancingexporter/helpers.go
@@ -8,7 +8,7 @@ import (
 )
 
 // mergeTraces concatenates two ptrace.Traces into a single ptrace.Traces.
-func mergeTraces(t1 ptrace.Traces, t2 ptrace.Traces) ptrace.Traces {
+func mergeTraces(t1, t2 ptrace.Traces) ptrace.Traces {
 	t2.ResourceSpans().MoveAndAppendTo(t1.ResourceSpans())
 	return t1
 }

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -186,7 +186,7 @@ func loadMetricsMap(t *testing.T, path string) map[string]pmetric.Metrics {
 	return expectedOutput
 }
 
-func compareMetricsMaps(t *testing.T, expected map[string]pmetric.Metrics, actual map[string]pmetric.Metrics) {
+func compareMetricsMaps(t *testing.T, expected, actual map[string]pmetric.Metrics) {
 	expectedKeys := make([]string, 0, len(expected))
 	for key := range expected {
 		expectedKeys = append(expectedKeys, key)
@@ -832,7 +832,7 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 	require.Positive(t, counter2.Load())
 }
 
-func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpCount int) pmetric.Metrics {
+func randomMetrics(t require.TestingT, rmCount, smCount, mCount, dpCount int) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 
 	timeStamp := pcommon.Timestamp(rand.IntN(256))
@@ -884,7 +884,7 @@ func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpC
 	return md
 }
 
-func benchConsumeMetrics(b *testing.B, routingKey string, endpointsCount int, rmCount int, smCount int, mCount int, dpCount int) {
+func benchConsumeMetrics(b *testing.B, routingKey string, endpointsCount, rmCount, smCount, mCount, dpCount int) {
 	ts, tb := getTelemetryAssets(b)
 
 	sink := new(consumertest.MetricsSink)

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -726,7 +726,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	waitWG.Wait()
 }
 
-func benchConsumeTraces(b *testing.B, endpointsCount int, tracesCount int) {
+func benchConsumeTraces(b *testing.B, endpointsCount, tracesCount int) {
 	ts, tb := getTelemetryAssets(b)
 	sink := new(consumertest.TracesSink)
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {

--- a/exporter/opensearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/opensearchexporter/internal/objmodel/objmodel.go
@@ -123,7 +123,7 @@ func (doc *Document) Add(key string, v Value) {
 }
 
 // AddString adds a string to the document.
-func (doc *Document) AddString(key string, v string) {
+func (doc *Document) AddString(key, v string) {
 	if v != "" {
 		doc.Add(key, StringValue(v))
 	}
@@ -499,7 +499,7 @@ func appendAttributeFields(fields []field, path string, am pcommon.Map) []field 
 	return fields
 }
 
-func appendAttributeValue(fields []field, path string, key string, attr pcommon.Value) []field {
+func appendAttributeValue(fields []field, path, key string, attr pcommon.Value) []field {
 	if attr.Type() == pcommon.ValueTypeEmpty {
 		return fields
 	}

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -26,7 +26,7 @@ type traceBulkIndexer struct {
 	bulkIndexer opensearchutil.BulkIndexer
 }
 
-func newTraceBulkIndexer(dataset string, namespace string, bulkAction string, model mappingModel) *traceBulkIndexer {
+func newTraceBulkIndexer(dataset, namespace, bulkAction string, model mappingModel) *traceBulkIndexer {
 	return &traceBulkIndexer{dataset, namespace, bulkAction, model, nil, nil}
 }
 

--- a/exporter/otelarrowexporter/metadata.go
+++ b/exporter/otelarrowexporter/metadata.go
@@ -100,7 +100,7 @@ func (e *metadataExporter) start(_ context.Context, host component.Host) (err er
 
 func (e *metadataExporter) shutdown(ctx context.Context) error {
 	var err error
-	e.exporters.Range(func(_ any, value any) bool {
+	e.exporters.Range(func(_, value any) bool {
 		be := value.(exp)
 		err = multierr.Append(err, be.shutdown(ctx))
 		return true

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -38,7 +38,7 @@ type accumulator interface {
 	Accumulate(resourceMetrics pmetric.ResourceMetrics) (processed int)
 	// Collect returns a slice with relevant aggregated metrics and their resource attributes.
 	// The number or metrics and attributes returned will be the same.
-	Collect() (metrics []pmetric.Metric, resourceAttrs []pcommon.Map, scopeNames []string, scopeVersions []string, scopeSchemaURLs []string, scopeAttributes []pcommon.Map)
+	Collect() (metrics []pmetric.Metric, resourceAttrs []pcommon.Map, scopeNames, scopeVersions, scopeSchemaURLs []string, scopeAttributes []pcommon.Map)
 }
 
 // LastValueAccumulator keeps last value for accumulated metrics
@@ -78,7 +78,7 @@ func (a *lastValueAccumulator) Accumulate(rm pmetric.ResourceMetrics) (n int) {
 	return
 }
 
-func (a *lastValueAccumulator) addMetric(metric pmetric.Metric, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, resourceAttrs pcommon.Map, now time.Time) int {
+func (a *lastValueAccumulator) addMetric(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) int {
 	a.logger.Debug(fmt.Sprintf("accumulating metric: %s", metric.Name()))
 
 	switch metric.Type() {
@@ -100,7 +100,7 @@ func (a *lastValueAccumulator) addMetric(metric pmetric.Metric, scopeName string
 	return 0
 }
 
-func (a *lastValueAccumulator) accumulateSummary(metric pmetric.Metric, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, resourceAttrs pcommon.Map, now time.Time) (n int) {
+func (a *lastValueAccumulator) accumulateSummary(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	dps := metric.Summary().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		ip := dps.At(i)
@@ -129,7 +129,7 @@ func (a *lastValueAccumulator) accumulateSummary(metric pmetric.Metric, scopeNam
 	return n
 }
 
-func (a *lastValueAccumulator) accumulateGauge(metric pmetric.Metric, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, resourceAttrs pcommon.Map, now time.Time) (n int) {
+func (a *lastValueAccumulator) accumulateGauge(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	dps := metric.Gauge().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		ip := dps.At(i)
@@ -163,7 +163,7 @@ func (a *lastValueAccumulator) accumulateGauge(metric pmetric.Metric, scopeName 
 	return
 }
 
-func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, resourceAttrs pcommon.Map, now time.Time) (n int) {
+func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	doubleSum := metric.Sum()
 
 	// Drop metrics with unspecified aggregations
@@ -224,7 +224,7 @@ func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, scopeName st
 	return
 }
 
-func (a *lastValueAccumulator) accumulateHistogram(metric pmetric.Metric, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, resourceAttrs pcommon.Map, now time.Time) (n int) {
+func (a *lastValueAccumulator) accumulateHistogram(metric pmetric.Metric, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes, resourceAttrs pcommon.Map, now time.Time) (n int) {
 	histogram := metric.Histogram()
 	a.logger.Debug("Accumulate histogram.....")
 	dps := histogram.DataPoints()
@@ -325,7 +325,7 @@ func (a *lastValueAccumulator) Collect() ([]pmetric.Metric, []pcommon.Map, []str
 	return metrics, resourceAttrs, scopeNames, scopeVersions, scopeSchemaURLs, scopeAttributes
 }
 
-func timeseriesSignature(scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map, metric pmetric.Metric, attributes pcommon.Map, resourceAttrs pcommon.Map) string {
+func timeseriesSignature(scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map, metric pmetric.Metric, attributes, resourceAttrs pcommon.Map) string {
 	var b strings.Builder
 	b.WriteString("*" + metric.Name())
 	b.WriteString(metric.Type().String())

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -377,7 +377,7 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 }
 
 func TestAccumulateDeltaToCumulativeHistogram(t *testing.T) {
-	appendDeltaHistogram := func(startTs time.Time, ts time.Time, count uint64, sum float64, counts []uint64, bounds []float64, metrics pmetric.MetricSlice) {
+	appendDeltaHistogram := func(startTs, ts time.Time, count uint64, sum float64, counts []uint64, bounds []float64, metrics pmetric.MetricSlice) {
 		metric := metrics.AppendEmpty()
 		metric.SetName("test_metric")
 		metric.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -108,7 +108,7 @@ func (c *collector) processMetrics(rm pmetric.ResourceMetrics) (n int) {
 
 var errUnknownMetricType = errors.New("unknown metric type")
 
-func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
 		return c.convertGauge(metric, resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
@@ -123,7 +123,7 @@ func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.M
 	return nil, errUnknownMetricType
 }
 
-func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricType, attributes pcommon.Map, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (*prometheus.Desc, []string, error) {
+func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricType, attributes, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (*prometheus.Desc, []string, error) {
 	name := c.metricNamer.Build(prom.TranslatorMetricFromOtelMetric(metric))
 	help, err := c.validateMetrics(name, metric.Description(), mType)
 	if err != nil {
@@ -162,7 +162,7 @@ func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricTy
 	return prometheus.NewDesc(name, help, keys, c.constLabels), values, nil
 }
 
-func (c *collector) convertGauge(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+func (c *collector) convertGauge(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
 	ip := metric.Gauge().DataPoints().At(0)
 
 	desc, attributes, err := c.getMetricMetadata(metric, dto.MetricType_GAUGE.Enum(), ip.Attributes(), resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
@@ -193,7 +193,7 @@ func (c *collector) convertGauge(metric pmetric.Metric, resourceAttrs pcommon.Ma
 	return m, nil
 }
 
-func (c *collector) convertSum(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+func (c *collector) convertSum(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
 	ip := metric.Sum().DataPoints().At(0)
 
 	metricType := prometheus.GaugeValue
@@ -244,7 +244,7 @@ func (c *collector) convertSum(metric pmetric.Metric, resourceAttrs pcommon.Map,
 	return m, nil
 }
 
-func (c *collector) convertSummary(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+func (c *collector) convertSummary(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
 	// TODO: In the off chance that we have multiple points
 	// within the same metric, how should we handle them?
 	point := metric.Summary().DataPoints().At(0)
@@ -276,7 +276,7 @@ func (c *collector) convertSummary(metric pmetric.Metric, resourceAttrs pcommon.
 	return m, nil
 }
 
-func (c *collector) convertDoubleHistogram(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName string, scopeVersion string, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+func (c *collector) convertDoubleHistogram(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
 	ip := metric.Histogram().DataPoints().At(0)
 	desc, attributes, err := c.getMetricMetadata(metric, dto.MetricType_HISTOGRAM.Enum(), ip.Attributes(), resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
 	if err != nil {

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -453,7 +453,7 @@ func Test_PushMetrics(t *testing.T) {
 
 	staleNaNSumBatch := getMetricsFromMetricList(staleNaNMetrics[staleNaNSum])
 
-	checkFunc := func(t *testing.T, r *http.Request, expected int, isStaleMarker bool, enableSendingRW2 bool) {
+	checkFunc := func(t *testing.T, r *http.Request, expected int, isStaleMarker, enableSendingRW2 bool) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
@@ -489,7 +489,7 @@ func Test_PushMetrics(t *testing.T) {
 	tests := []struct {
 		name                       string
 		metrics                    pmetric.Metrics
-		reqTestFunc                func(t *testing.T, r *http.Request, expected int, isStaleMarker bool, enableSendingRW2 bool)
+		reqTestFunc                func(t *testing.T, r *http.Request, expected int, isStaleMarker, enableSendingRW2 bool)
 		expectedTimeSeries         int
 		httpResponseCode           int
 		returnErr                  bool

--- a/exporter/prometheusremotewriteexporter/exporter_v2.go
+++ b/exporter/prometheusremotewriteexporter/exporter_v2.go
@@ -107,7 +107,7 @@ func (prwe *prwExporter) handleExportV2(ctx context.Context, symbolsTable writev
 	return prwe.exportV2(ctx, requests)
 }
 
-func (prwe *prwExporter) handleHeader(ctx context.Context, resp *http.Response, headerName string, metricType string, recordFunc func(context.Context, int64)) {
+func (prwe *prwExporter) handleHeader(ctx context.Context, resp *http.Response, headerName, metricType string, recordFunc func(context.Context, int64)) {
 	headerValue := resp.Header.Get(headerName)
 	if headerValue == "" {
 		prwe.settings.Logger.Warn(

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -152,7 +152,7 @@ func getPromLabels(lbs ...string) []prompb.Label {
 	return pbLbs.Labels
 }
 
-func getLabel(name string, value string) prompb.Label {
+func getLabel(name, value string) prompb.Label {
 	return prompb.Label{
 		Name:  name,
 		Value: value,
@@ -401,7 +401,7 @@ func getSummaryMetric(name string, attributes pcommon.Map, ts uint64, sum float6
 	return metric
 }
 
-func getQuantiles(bounds []float64, values []float64) pmetric.SummaryDataPointValueAtQuantileSlice {
+func getQuantiles(bounds, values []float64) pmetric.SummaryDataPointValueAtQuantileSlice {
 	quantiles := pmetric.NewSummaryDataPointValueAtQuantileSlice()
 	quantiles.EnsureCapacity(len(bounds))
 

--- a/exporter/rabbitmqexporter/integration_test.go
+++ b/exporter/rabbitmqexporter/integration_test.go
@@ -114,7 +114,7 @@ func TestExportWithNetworkIssueRecovery(t *testing.T) {
 	}
 }
 
-func startRabbitMQContainer(t *testing.T, image string, port string) testcontainers.Container {
+func startRabbitMQContainer(t *testing.T, image, port string) testcontainers.Container {
 	container, err := testcontainers.GenericContainer(
 		context.Background(),
 		testcontainers.GenericContainerRequest{
@@ -142,7 +142,7 @@ func startRabbitMQContainer(t *testing.T, image string, port string) testcontain
 	return container
 }
 
-func setupQueueConsumer(t *testing.T, queueName string, endpoint string) (*amqp.Connection, *amqp.Channel, <-chan amqp.Delivery) {
+func setupQueueConsumer(t *testing.T, queueName, endpoint string) (*amqp.Connection, *amqp.Channel, <-chan amqp.Delivery) {
 	connection, err := amqp.DialConfig(endpoint, amqp.Config{
 		SASL: []amqp.Authentication{
 			&amqp.PlainAuth{

--- a/exporter/rabbitmqexporter/rabbitmq_exporter.go
+++ b/exporter/rabbitmqexporter/rabbitmq_exporter.go
@@ -33,7 +33,7 @@ type (
 	tlsFactory       = func(context.Context) (*tls.Config, error)
 )
 
-func newRabbitmqExporter(cfg *Config, set component.TelemetrySettings, publisherFactory publisherFactory, tlsFactory tlsFactory, routingKey string, connectionName string) *rabbitmqExporter {
+func newRabbitmqExporter(cfg *Config, set component.TelemetrySettings, publisherFactory publisherFactory, tlsFactory tlsFactory, routingKey, connectionName string) *rabbitmqExporter {
 	exporter := &rabbitmqExporter{
 		config:           cfg,
 		settings:         set,

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -294,7 +294,7 @@ func convertToSentrySpan(span ptrace.Span, library pcommon.InstrumentationScope,
 //
 // See https://github.com/open-telemetry/opentelemetry-specification/tree/5b78ee1/specification/trace/semantic_conventions
 // for more details about the semantic conventions.
-func generateSpanDescriptors(name string, attrs pcommon.Map, spanKind ptrace.SpanKind) (op string, description string) {
+func generateSpanDescriptors(name string, attrs pcommon.Map, spanKind ptrace.SpanKind) (op, description string) {
 	var opBuilder strings.Builder
 	var dBuilder strings.Builder
 

--- a/exporter/signalfxexporter/internal/apm/correlations/client.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client.go
@@ -44,7 +44,7 @@ var _ error = (*ErrMaxEntries)(nil)
 type CorrelationClient interface {
 	Correlate(*Correlation, CorrelateCB)
 	Delete(*Correlation, SuccessfulDeleteCB)
-	Get(dimName string, dimValue string, cb SuccessfulGetCB)
+	Get(dimName, dimValue string, cb SuccessfulGetCB)
 	Start()
 	Shutdown()
 }
@@ -237,7 +237,7 @@ func (cc *Client) Delete(cor *Correlation, callback SuccessfulDeleteCB) {
 type SuccessfulGetCB func(map[string][]string)
 
 // Get
-func (cc *Client) Get(dimName string, dimValue string, callback SuccessfulGetCB) {
+func (cc *Client) Get(dimName, dimValue string, callback SuccessfulGetCB) {
 	err := cc.putRequestOnChan(&request{
 		Correlation: &Correlation{
 			DimName:  dimName,

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -50,7 +50,7 @@ loop:
 	return cors
 }
 
-func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Value, forcedRespPayload *atomic.Value) http.HandlerFunc {
+func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode, forcedRespPayload *atomic.Value) http.HandlerFunc {
 	forcedRespCode.Store(200)
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -87,7 +87,7 @@ type correlationTestClient struct {
 
 func (c *correlationTestClient) Start()    { /*no-op*/ }
 func (c *correlationTestClient) Shutdown() { /*no-op*/ }
-func (c *correlationTestClient) Get(_ string, dimValue string, cb correlations.SuccessfulGetCB) {
+func (c *correlationTestClient) Get(_, dimValue string, cb correlations.SuccessfulGetCB) {
 	atomic.AddInt64(&c.getCounter, 1)
 	go func() {
 		cb(c.getPayload[dimValue])

--- a/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
@@ -72,7 +72,7 @@ func getLinuxVersion(ctx context.Context) (string, error) {
 	return "", errors.New("unable to find linux version")
 }
 
-func getStringFromFile(pattern string, path string) (string, error) {
+func getStringFromFile(pattern, path string) (string, error) {
 	var err error
 	var file []byte
 	reg := regexp.MustCompile(pattern)

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -120,7 +120,7 @@ func (c *MetricsConverter) translateAndFilter(dps []*sfxpb.DataPoint) []*sfxpb.D
 	return dps
 }
 
-func filterKeyChars(str string, nonAlphanumericDimChars string) string {
+func filterKeyChars(str, nonAlphanumericDimChars string) string {
 	filterMap := func(r rune) rune {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune(nonAlphanumericDimChars, r) {
 			return r

--- a/exporter/signalfxexporter/internal/translation/delta_translator.go
+++ b/exporter/signalfxexporter/internal/translation/delta_translator.go
@@ -75,7 +75,7 @@ func (t *deltaTranslator) shutdown() {
 	}
 }
 
-func doubleDeltaPt(currPt *sfxpb.DataPoint, prevPt *sfxpb.DataPoint, deltaMetricName string) *sfxpb.DataPoint {
+func doubleDeltaPt(currPt, prevPt *sfxpb.DataPoint, deltaMetricName string) *sfxpb.DataPoint {
 	delta := *currPt.Value.DoubleValue - *prevPt.Value.DoubleValue
 	if delta < 0 {
 		// assume a reset, emit the current value
@@ -86,7 +86,7 @@ func doubleDeltaPt(currPt *sfxpb.DataPoint, prevPt *sfxpb.DataPoint, deltaMetric
 	return deltaPt
 }
 
-func intDeltaPt(currPt *sfxpb.DataPoint, prevPt *sfxpb.DataPoint, deltaMetricName string) *sfxpb.DataPoint {
+func intDeltaPt(currPt, prevPt *sfxpb.DataPoint, deltaMetricName string) *sfxpb.DataPoint {
 	delta := *currPt.Value.IntValue - *prevPt.Value.IntValue
 	if delta < 0 {
 		// assume a reset, emit the current value

--- a/exporter/signalfxexporter/internal/translation/dpfilters/filterset.go
+++ b/exporter/signalfxexporter/internal/translation/dpfilters/filterset.go
@@ -30,7 +30,7 @@ func (fs *FilterSet) Matches(dp *sfxpb.DataPoint) bool {
 	return false
 }
 
-func NewFilterSet(excludes []MetricFilter, includes []MetricFilter) (*FilterSet, error) {
+func NewFilterSet(excludes, includes []MetricFilter) (*FilterSet, error) {
 	excludeSet, err := getDataPointFilters(excludes)
 	if err != nil {
 		return nil, err

--- a/exporter/signalfxexporter/internal/translation/translator.go
+++ b/exporter/signalfxexporter/internal/translation/translator.go
@@ -573,7 +573,7 @@ func calcNewMetricInputPairs(processedDataPoints []*sfxpb.DataPoint, tr Rule) []
 	return out
 }
 
-func dimensionsEqual(d1 []*sfxpb.Dimension, d2 []*sfxpb.Dimension) bool {
+func dimensionsEqual(d1, d2 []*sfxpb.Dimension) bool {
 	if d1 == nil && d2 == nil {
 		return true
 	}

--- a/exporter/signalfxexporter/internal/translation/translator_test.go
+++ b/exporter/signalfxexporter/internal/translation/translator_test.go
@@ -1890,7 +1890,7 @@ func TestTranslateDataPoints(t *testing.T) {
 	}
 }
 
-func assertEqualPoints(t *testing.T, got []*sfxpb.DataPoint, want []*sfxpb.DataPoint, action Action) {
+func assertEqualPoints(t *testing.T, got, want []*sfxpb.DataPoint, action Action) {
 	// Sort metrics to handle not deterministic order from aggregation
 	if action == ActionAggregateMetric {
 		sort.Sort(byContent(want))
@@ -2990,7 +2990,7 @@ func doubleMD(secondsDelta int64, valueDelta float64) pmetric.Metrics {
 	return wrapMetric(md)
 }
 
-func intMD(secondsDelta int64, valueDelta int64) pmetric.Metrics {
+func intMD(secondsDelta, valueDelta int64) pmetric.Metrics {
 	md := baseMD()
 	ms := md.SetEmptySum()
 	intTS("cpu0", "user", secondsDelta, 100, valueDelta, ms.DataPoints().AppendEmpty())
@@ -3003,7 +3003,7 @@ func intMD(secondsDelta int64, valueDelta int64) pmetric.Metrics {
 	return wrapMetric(md)
 }
 
-func intMDAfterReset(secondsDelta int64, valueDelta int64) pmetric.Metrics {
+func intMDAfterReset(secondsDelta, valueDelta int64) pmetric.Metrics {
 	md := baseMD()
 	ms := md.SetEmptySum()
 	intTS("cpu0", "user", secondsDelta, 0, valueDelta, ms.DataPoints().AppendEmpty())
@@ -3023,7 +3023,7 @@ func baseMD() pmetric.Metric {
 	return out
 }
 
-func dblTS(lbl0 string, lbl1 string, secondsDelta int64, v float64, valueDelta float64, out pmetric.NumberDataPoint) {
+func dblTS(lbl0, lbl1 string, secondsDelta int64, v, valueDelta float64, out pmetric.NumberDataPoint) {
 	out.Attributes().PutStr("cpu", lbl0)
 	out.Attributes().PutStr("state", lbl1)
 	const startTime = 1600000000
@@ -3031,7 +3031,7 @@ func dblTS(lbl0 string, lbl1 string, secondsDelta int64, v float64, valueDelta f
 	out.SetDoubleValue(v + valueDelta)
 }
 
-func intTS(lbl0 string, lbl1 string, secondsDelta int64, v int64, valueDelta int64, out pmetric.NumberDataPoint) {
+func intTS(lbl0, lbl1 string, secondsDelta, v, valueDelta int64, out pmetric.NumberDataPoint) {
 	out.Attributes().PutStr("cpu", lbl0)
 	out.Attributes().PutStr("state", lbl1)
 	const startTime = 1600000000

--- a/exporter/splunkhecexporter/batchperscope.go
+++ b/exporter/splunkhecexporter/batchperscope.go
@@ -106,7 +106,7 @@ func (rb *perScopeBatcher) ConsumeLogs(ctx context.Context, logs plog.Logs) erro
 	return err
 }
 
-func copyResourceLogs(src plog.ResourceLogs, dest plog.ResourceLogs, isProfiling bool) {
+func copyResourceLogs(src, dest plog.ResourceLogs, isProfiling bool) {
 	src.Resource().CopyTo(dest.Resource())
 	for j := 0; j < src.ScopeLogs().Len(); j++ {
 		sl := src.ScopeLogs().At(j)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -101,7 +101,7 @@ func createMetricsData(resourcesNum, dataPointsNum int) pmetric.Metrics {
 	return metrics
 }
 
-func createTraceData(resourcesNum int, spansNum int) ptrace.Traces {
+func createTraceData(resourcesNum, spansNum int) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 
@@ -129,11 +129,11 @@ func createTraceData(resourcesNum int, spansNum int) ptrace.Traces {
 	return traces
 }
 
-func createLogData(numResources int, numLibraries int, numRecords int) plog.Logs {
+func createLogData(numResources, numLibraries, numRecords int) plog.Logs {
 	return createLogDataWithCustomLibraries(numResources, make([]string, numLibraries), repeat(numRecords, numLibraries))
 }
 
-func repeat(what int, times int) []int {
+func repeat(what, times int) []int {
 	result := make([]int, times)
 	for i := range result {
 		result[i] = what
@@ -1801,7 +1801,7 @@ func Benchmark_pushLogData_compressed_100_200_5M(b *testing.B) {
 	benchPushLogData(b, 100, 200, 5*1024*1024, true)
 }
 
-func benchPushLogData(b *testing.B, numResources int, numRecords int, bufSize uint, compressionEnabled bool) {
+func benchPushLogData(b *testing.B, numResources, numRecords int, bufSize uint, compressionEnabled bool) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
 	config.MaxContentLengthLogs = bufSize
 	config.DisableCompression = !compressionEnabled
@@ -1950,7 +1950,7 @@ func Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric(b *testing.B) {
 	benchPushMetricData(b, 100, 200, 5*1024*1024, true, true)
 }
 
-func benchPushMetricData(b *testing.B, numResources int, numRecords int, bufSize uint, compressionEnabled bool, useMultiMetricFormat bool) {
+func benchPushMetricData(b *testing.B, numResources, numRecords int, bufSize uint, compressionEnabled, useMultiMetricFormat bool) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
 	config.MaxContentLengthMetrics = bufSize
 	config.DisableCompression = !compressionEnabled

--- a/exporter/splunkhecexporter/integration_test.go
+++ b/exporter/splunkhecexporter/integration_test.go
@@ -172,7 +172,7 @@ func prepareLogs() plog.Logs {
 	return logs
 }
 
-func prepareLogsNonDefaultParams(index string, source string, sourcetype string, event string) plog.Logs {
+func prepareLogsNonDefaultParams(index, source, sourcetype, event string) plog.Logs {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -200,7 +200,7 @@ func prepareMetricsData(metricName string) pmetric.Metrics {
 	return metricData
 }
 
-func prepareTracesData(index string, source string, sourcetype string) ptrace.Traces {
+func prepareTracesData(index, source, sourcetype string) ptrace.Traces {
 	ts := pcommon.Timestamp(0)
 
 	traces := ptrace.NewTraces()

--- a/exporter/splunkhecexporter/internal/integrationtestutils/config_helper.go
+++ b/exporter/splunkhecexporter/internal/integrationtestutils/config_helper.go
@@ -68,7 +68,7 @@ func GetConfigVariable(key string) string {
 	}
 }
 
-func SetConfigVariable(key string, value string) {
+func SetConfigVariable(key, value string) {
 	// Read YAML file
 	fileData, err := os.ReadFile(configFilePath)
 	if err != nil {

--- a/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
+++ b/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-func CheckEventsFromSplunk(searchQuery string, startTime string, endTimeOptional ...string) []any {
+func CheckEventsFromSplunk(searchQuery, startTime string, endTimeOptional ...string) []any {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	logger.Println("-->> Splunk Search: checking events in Splunk --")
 	user := GetConfigVariable("USER")
@@ -43,7 +43,7 @@ func CheckEventsFromSplunk(searchQuery string, startTime string, endTimeOptional
 	return results
 }
 
-func getSplunkSearchResults(user string, password string, baseURL string, jobID string) []any {
+func getSplunkSearchResults(user, password, baseURL, jobID string) []any {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	eventURL := fmt.Sprintf("%s/services/search/jobs/%s/events?output_mode=json", baseURL, jobID)
 	logger.Println("URL: " + eventURL)
@@ -81,7 +81,7 @@ func getSplunkSearchResults(user string, password string, baseURL string, jobID 
 	return results
 }
 
-func checkSearchJobStatusCode(user string, password string, baseURL string, jobID string) any {
+func checkSearchJobStatusCode(user, password, baseURL, jobID string) any {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	checkEventURL := baseURL + "/services/search/jobs/" + jobID + "?output_mode=json"
 	logger.Println("URL: " + checkEventURL)
@@ -116,7 +116,7 @@ func checkSearchJobStatusCode(user string, password string, baseURL string, jobI
 	return isDone
 }
 
-func postSearchRequest(user string, password string, baseURL string, searchQuery string, startTime string, endTime string) string {
+func postSearchRequest(user, password, baseURL, searchQuery, startTime, endTime string) string {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	searchURL := fmt.Sprintf("%s/services/search/jobs?output_mode=json", baseURL)
 	query := "search " + searchQuery
@@ -159,7 +159,7 @@ func postSearchRequest(user string, password string, baseURL string, searchQuery
 	return jsonResponse["sid"].(string)
 }
 
-func CheckMetricsFromSplunk(index string, metricName string) []any {
+func CheckMetricsFromSplunk(index, metricName string) []any {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	logger.Println("-->> Splunk Search: checking metrics in Splunk --")
 	baseURL := "https://" + GetConfigVariable("HOST") + ":" + GetConfigVariable("MANAGEMENT_PORT")
@@ -196,7 +196,7 @@ func CheckMetricsFromSplunk(index string, metricName string) []any {
 	return events
 }
 
-func CreateAnIndexInSplunk(index string, indexType string) {
+func CreateAnIndexInSplunk(index, indexType string) {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	user := GetConfigVariable("USER")
 	password := GetConfigVariable("PASSWORD")

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -219,7 +219,7 @@ func mapMetricToSplunkEvent(res pcommon.Resource, m pmetric.Metric, config *Conf
 	}
 }
 
-func createEvent(timestamp pcommon.Timestamp, host string, source string, sourceType string, index string, fields map[string]any) *splunk.Event {
+func createEvent(timestamp pcommon.Timestamp, host, source, sourceType, index string, fields map[string]any) *splunk.Event {
 	return &splunk.Event{
 		Time:       timestampToSecondsWithMillisecondPrecision(timestamp),
 		Host:       host,

--- a/exporter/sumologicexporter/prometheus_formatter.go
+++ b/exporter/sumologicexporter/prometheus_formatter.go
@@ -43,7 +43,7 @@ func newPrometheusFormatter() prometheusFormatter {
 }
 
 // PrometheusLabels returns all attributes as sanitized prometheus labels string
-func (f *prometheusFormatter) tags2String(attr pcommon.Map, labels pcommon.Map) prometheusTags {
+func (f *prometheusFormatter) tags2String(attr, labels pcommon.Map) prometheusTags {
 	attrsPlusLabelsLen := attr.Len() + labels.Len()
 	if attrsPlusLabelsLen == 0 {
 		return ""
@@ -234,7 +234,7 @@ func (f *prometheusFormatter) bucketMetric(name string) string {
 }
 
 // mergeAttributes gets two pcommon.Maps and returns new which contains values from both of them
-func (f *prometheusFormatter) mergeAttributes(attributes pcommon.Map, additionalAttributes pcommon.Map) pcommon.Map {
+func (f *prometheusFormatter) mergeAttributes(attributes, additionalAttributes pcommon.Map) pcommon.Map {
 	mergedAttributes := pcommon.NewMap()
 	mergedAttributes.EnsureCapacity(attributes.Len() + additionalAttributes.Len())
 

--- a/exporter/syslogexporter/formatter.go
+++ b/exporter/syslogexporter/formatter.go
@@ -20,7 +20,7 @@ type formatter interface {
 
 // getAttributeValueOrDefault returns the value of the requested log record's attribute as a string.
 // If the attribute was not found, it returns the provided default value.
-func getAttributeValueOrDefault(logRecord plog.LogRecord, attributeName string, defaultValue string) string {
+func getAttributeValueOrDefault(logRecord plog.LogRecord, attributeName, defaultValue string) string {
 	value := defaultValue
 	if attributeValue, found := logRecord.Attributes().Get(attributeName); found {
 		value = attributeValue.AsString()

--- a/exporter/tinybirdexporter/internal/traces.go
+++ b/exporter/tinybirdexporter/internal/traces.go
@@ -43,7 +43,7 @@ type traceSignal struct {
 	LinksAttributes  []map[string]string `json:"links_attributes"`
 }
 
-func convertEvents(events ptrace.SpanEventSlice) (timestamps []string, names []string, attributes []map[string]string) {
+func convertEvents(events ptrace.SpanEventSlice) (timestamps, names []string, attributes []map[string]string) {
 	timestamps = make([]string, events.Len())
 	names = make([]string, events.Len())
 	attributes = make([]map[string]string, events.Len())
@@ -56,7 +56,7 @@ func convertEvents(events ptrace.SpanEventSlice) (timestamps []string, names []s
 	return timestamps, names, attributes
 }
 
-func convertLinks(links ptrace.SpanLinkSlice) (traceIDs []string, spanIDs []string, states []string, attrs []map[string]string) {
+func convertLinks(links ptrace.SpanLinkSlice) (traceIDs, spanIDs, states []string, attrs []map[string]string) {
 	traceIDs = make([]string, links.Len())
 	spanIDs = make([]string, links.Len())
 	states = make([]string, links.Len())

--- a/extension/ackextension/inmemory.go
+++ b/extension/ackextension/inmemory.go
@@ -66,12 +66,12 @@ func (as *ackPartition) computeAcks(ackIDs []uint64) map[uint64]bool {
 }
 
 // Start of inMemoryAckExtension does nothing and returns nil
-func (i *inMemoryAckExtension) Start(_ context.Context, _ component.Host) error {
+func (i *inMemoryAckExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
 // Shutdown of inMemoryAckExtension does nothing and returns nil
-func (i *inMemoryAckExtension) Shutdown(_ context.Context) error {
+func (i *inMemoryAckExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/asapauthextension/extension_test.go
+++ b/extension/asapauthextension/extension_test.go
@@ -30,7 +30,7 @@ var _ http.RoundTripper = (*mockRoundTripper)(nil)
 // mockKeyFetcher implements asap.KeyFetcher, eliminating the need to contact a key server.
 type mockKeyFetcher struct{}
 
-func (k *mockKeyFetcher) Fetch(_ string) (any, error) {
+func (k *mockKeyFetcher) Fetch(string) (any, error) {
 	return asap.NewPublicKey([]byte(publicKey))
 }
 

--- a/extension/azureauthextension/extension.go
+++ b/extension/azureauthextension/extension.go
@@ -118,11 +118,11 @@ func getCertificateAndKey(filename string) (*x509.Certificate, crypto.PrivateKey
 	return certs[0], privateKey, nil
 }
 
-func (a *authenticator) Start(_ context.Context, _ component.Host) error {
+func (a *authenticator) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (a *authenticator) Shutdown(_ context.Context) error {
+func (a *authenticator) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/azureauthextension/extension_test.go
+++ b/extension/azureauthextension/extension_test.go
@@ -209,7 +209,7 @@ type mockTokenCredential struct {
 
 var _ azcore.TokenCredential = (*mockTokenCredential)(nil)
 
-func (m *mockTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+func (m *mockTokenCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	args := m.Called()
 	return args.Get(0).(azcore.AccessToken), args.Error(1)
 }

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
@@ -112,7 +112,7 @@ func (r *errorReader) Read(_ []byte) (int, error) {
 	return 0, r.err
 }
 
-func readLogFile(t *testing.T, dir string, file string) io.Reader {
+func readLogFile(t *testing.T, dir, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
 	return bytes.NewReader(data)

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler_test.go
@@ -98,7 +98,7 @@ func compressToGZIPReader(t *testing.T, buf []byte) io.Reader {
 
 // readAndCompressLogFile reads the data inside it, compresses it
 // and returns a GZIP reader for it.
-func readAndCompressLogFile(t *testing.T, dir string, file string) io.Reader {
+func readAndCompressLogFile(t *testing.T, dir, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
 	return compressToGZIPReader(t, data)

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler_test.go
@@ -36,7 +36,7 @@ func compressToGZIPReader(t *testing.T, buf []byte) io.Reader {
 
 // readAndCompressLogFile reads the data inside it, compresses it
 // and returns a GZIP reader for it.
-func readAndCompressLogFile(t *testing.T, dir string, file string) io.Reader {
+func readAndCompressLogFile(t *testing.T, dir, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
 	return compressToGZIPReader(t, data)

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
@@ -160,7 +160,7 @@ func (w *wafLogUnmarshaler) addWAFLog(log wafLog, record plog.LogRecord) error {
 		record.Attributes().PutInt(string(conventions.HTTPResponseStatusCodeKey), *log.ResponseCodeSent)
 	}
 
-	putStr := func(name string, value string) {
+	putStr := func(name, value string) {
 		if value != "" {
 			record.Attributes().PutStr(name, value)
 		}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler_test.go
@@ -36,7 +36,7 @@ func compressToGZIPReader(t *testing.T, buf []byte) io.Reader {
 
 // readAndCompressLogFile reads the data inside it, compacts the JSON
 // struct, compresses it and returns a GZIP reader for it.
-func readAndCompressLogFile(t *testing.T, dir string, file string) io.Reader {
+func readAndCompressLogFile(t *testing.T, dir, file string) io.Reader {
 	data, err := os.ReadFile(filepath.Join(dir, file))
 	require.NoError(t, err)
 	compacted := bytes.NewBuffer([]byte{})

--- a/extension/httpforwarderextension/extension.go
+++ b/extension/httpforwarderextension/extension.go
@@ -113,7 +113,7 @@ func (h *httpForwarder) forwardRequest(writer http.ResponseWriter, request *http
 	}
 }
 
-func addViaHeader(header http.Header, protocol string, host string) {
+func addViaHeader(header http.Header, protocol, host string) {
 	header.Add("Via", fmt.Sprintf("%s %s", protocol, host))
 }
 

--- a/extension/observer/ecsobserver/internal/ecsmock/service.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service.go
@@ -317,7 +317,7 @@ func GenTasks(arnPrefix string, count int, modifier func(i int, task *ecstypes.T
 
 // GenTaskDefinitions returns tasks with TaskArn set to arnPrefix+offset+version, where offset is [0, count).
 // e.g. foo0:1, foo1:1 the `:` is following the task family version syntax.
-func GenTaskDefinitions(arnPrefix string, count int, version int, modifier func(i int, def *ecstypes.TaskDefinition)) []*ecstypes.TaskDefinition {
+func GenTaskDefinitions(arnPrefix string, count, version int, modifier func(i int, def *ecstypes.TaskDefinition)) []*ecstypes.TaskDefinition {
 	var defs []*ecstypes.TaskDefinition
 	for i := 0; i < count; i++ {
 		d := &ecstypes.TaskDefinition{

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -223,7 +223,7 @@ func newTestTaskFetcher(t *testing.T, ecsClient ecsClient, ec2Client ec2Client, 
 		Region:      "not used",
 		ecsOverride: ecsClient,
 		ec2Override: ec2Client,
-		serviceNameFilter: func(_ string) bool {
+		serviceNameFilter: func(string) bool {
 			return true
 		},
 	}

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -97,7 +97,7 @@ func (s *serviceMatcher) matchTargets(t *taskAnnotated, c ecstypes.ContainerDefi
 func serviceConfigsToFilter(cfgs []ServiceConfig) (serviceNameFilter, error) {
 	// If no service config, don't describe any services
 	if len(cfgs) == 0 {
-		return func(_ string) bool {
+		return func(string) bool {
 			return false
 		}, nil
 	}

--- a/extension/observer/k8sobserver/ingress_endpoint.go
+++ b/extension/observer/k8sobserver/ingress_endpoint.go
@@ -63,7 +63,7 @@ func getTLSHosts(i *v1.Ingress) []string {
 }
 
 // matchesHostPattern returns true if the host matches the host pattern or wildcard pattern.
-func matchesHostPattern(pattern string, host string) bool {
+func matchesHostPattern(pattern, host string) bool {
 	// if host match the pattern (host pattern).
 	if pattern == host {
 		return true

--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -177,7 +177,7 @@ func (e *oidcExtension) setProviderConfig(ctx context.Context, config *Config) e
 	return err
 }
 
-func getSubjectFromClaims(claims map[string]any, usernameClaim string, fallback string) (string, error) {
+func getSubjectFromClaims(claims map[string]any, usernameClaim, fallback string) (string, error) {
 	if usernameClaim != "" {
 		username, found := claims[usernameClaim]
 		if !found {

--- a/extension/sigv4authextension/signingroundtripper.go
+++ b/extension/sigv4authextension/signingroundtripper.go
@@ -110,7 +110,7 @@ func hashPayload(req *http.Request) (string, error) {
 // inferServiceAndRegion attempts to infer a service
 // and a region from an http.request, and returns either an empty
 // string for both or a valid value for both.
-func (si *signingRoundTripper) inferServiceAndRegion(r *http.Request) (service string, region string) {
+func (si *signingRoundTripper) inferServiceAndRegion(r *http.Request) (service, region string) {
 	service = si.service
 	region = si.region
 

--- a/extension/storage/dbstorage/client.go
+++ b/extension/storage/dbstorage/client.go
@@ -3,8 +3,6 @@
 
 package dbstorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage"
 
-// goimports and gci has unresolvable conflict here, so we have to disable one of them
-//nolint:gci
 import (
 	"context"
 	"database/sql"
@@ -12,13 +10,10 @@ import (
 	"strconv"
 	"strings"
 
-	// Postgres driver
-	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/jackc/pgx/v5/stdlib" // Postgres driver
 	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.uber.org/zap"
-
-	// SQLite driver
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // SQLite driver
 )
 
 type dbStorageClient struct {
@@ -27,7 +22,7 @@ type dbStorageClient struct {
 	dialect *dbDialect
 }
 
-func newClient(ctx context.Context, logger *zap.Logger, db *sql.DB, driverName string, tableName string) (*dbStorageClient, error) {
+func newClient(ctx context.Context, logger *zap.Logger, db *sql.DB, driverName, tableName string) (*dbStorageClient, error) {
 	dialect := newDBDialect(driverName, tableName)
 
 	// Create storage table if not exists
@@ -297,7 +292,7 @@ func canAggregate(ops ...*storage.Operation) (storage.OpType, bool) {
 // By default, when `groupSize = 0` will generate N monotonic placeholders, i.e. "$1, $2, ... $n"
 // If `groupSize > 0` - will generate placeholders groups with size = `groupSize`,
 // i.e for `groupSize = 2` - "($1, $2), ($3, $4), ... ($n*groupSize-1, $n*groupSize)"
-func generatePlaceholders(n int, groupSize int) string {
+func generatePlaceholders(n, groupSize int) string {
 	if n <= 0 {
 		return ""
 	}

--- a/extension/storage/dbstorage/client_queries.go
+++ b/extension/storage/dbstorage/client_queries.go
@@ -115,7 +115,7 @@ func (d *dbDialect) Close() error {
 }
 
 // newDBDialect creates a new DB dialect which is just a set of DB-specific queries/prepared statements
-func newDBDialect(driverName string, tableName string) *dbDialect {
+func newDBDialect(driverName, tableName string) *dbDialect {
 	queries := getDialectQueries(driverName)
 
 	var aggSize int

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -297,7 +297,7 @@ func (c *fileStorageClient) shouldCompact() bool {
 	return true
 }
 
-func (c *fileStorageClient) getDbSize() (totalSizeResult int64, dataSizeResult int64, errResult error) {
+func (c *fileStorageClient) getDbSize() (totalSizeResult, dataSizeResult int64, errResult error) {
 	var totalSize int64
 
 	err := c.db.View(func(tx *bbolt.Tx) error {
@@ -315,7 +315,7 @@ func (c *fileStorageClient) getDbSize() (totalSizeResult int64, dataSizeResult i
 
 // moveFileWithFallback is the equivalent of os.Rename, except it falls back to
 // a non-atomic Truncate and Copy if the arguments are on different filesystems
-func moveFileWithFallback(src string, dest string) error {
+func moveFileWithFallback(src, dest string) error {
 	var err error
 	if err = os.Rename(src, dest); err == nil {
 		return nil

--- a/extension/storage/storagetest/client.go
+++ b/extension/storage/storagetest/client.go
@@ -45,7 +45,7 @@ func NewInMemoryClient(kind component.Kind, id component.ID, name string) *TestC
 // NewFileBackedClient creates a storage.Client that will load previous
 // storage contents upon creation and save storage contents when closed.
 // It also has metadata which may be used to validate test expectations.
-func NewFileBackedClient(kind component.Kind, id component.ID, name string, storageDir string) *TestClient {
+func NewFileBackedClient(kind component.Kind, id component.ID, name, storageDir string) *TestClient {
 	client := NewInMemoryClient(kind, id, name)
 
 	client.storageFile = filepath.Join(storageDir, fmt.Sprintf("%s_%s_%s_%s", kind, id.Type(), id.Name(), name))

--- a/extension/storage/storagetest/extension.go
+++ b/extension/storage/storagetest/extension.go
@@ -36,7 +36,7 @@ func NewInMemoryStorageExtension(name string) *TestStorage {
 }
 
 // NewFileBackedStorageExtension creates a TestStorage extension
-func NewFileBackedStorageExtension(name string, storageDir string) *TestStorage {
+func NewFileBackedStorageExtension(name, storageDir string) *TestStorage {
 	return &TestStorage{
 		ID:         NewStorageID(name),
 		storageDir: storageDir,

--- a/extension/sumologicextension/credentials/encrypt.go
+++ b/extension/sumologicextension/credentials/encrypt.go
@@ -65,8 +65,8 @@ func HashKeyToEncryptionKeyWith(hasher Hasher, key string) ([]byte, error) {
 }
 
 // encrypt encrypts provided byte slice with AES using the encryption key.
-func encrypt(data []byte, encryptionKey []byte) ([]byte, error) {
-	f := func(_ Hasher, data []byte, encryptionKey []byte) ([]byte, error) {
+func encrypt(data, encryptionKey []byte) ([]byte, error) {
+	f := func(_ Hasher, data, encryptionKey []byte) ([]byte, error) {
 		block, err := aes.NewCipher(encryptionKey)
 		if err != nil {
 			return nil, err
@@ -92,8 +92,8 @@ func encrypt(data []byte, encryptionKey []byte) ([]byte, error) {
 }
 
 // decrypt decrypts provided byte slice with AES using the encryptionKey.
-func decrypt(data []byte, encryptionKey []byte) ([]byte, error) {
-	f := func(_ Hasher, data []byte, encryptionKey []byte) ([]byte, error) {
+func decrypt(data, encryptionKey []byte) ([]byte, error) {
+	f := func(_ Hasher, data, encryptionKey []byte) ([]byte, error) {
 		block, err := aes.NewCipher(encryptionKey)
 		if err != nil {
 			return nil, fmt.Errorf("unable tocreate new aes cipher: %w", err)

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -1068,7 +1068,7 @@ func (rt roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func addCollectorCredentials(req *http.Request, collectorCredentialID string, collectorCredentialKey string) {
+func addCollectorCredentials(req *http.Request, collectorCredentialID, collectorCredentialKey string) {
 	token := base64.StdEncoding.EncodeToString(
 		[]byte(collectorCredentialID + ":" + collectorCredentialKey),
 	)

--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -20,7 +20,7 @@ import (
 )
 
 // newHTTPClient returns new HTTP client instance with provided configuration.
-func newHTTPClient(logger *zap.Logger, maxIdle int, requestTimeout int, noVerify bool,
+func newHTTPClient(logger *zap.Logger, maxIdle, requestTimeout int, noVerify bool,
 	proxyAddress string,
 ) (*http.Client, error) {
 	logger.Debug("Using proxy address: ",

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -138,12 +138,12 @@ func getPrefixByMetricType(mType string) string {
 
 // MetricName returns the metric name based on metric type and measurement name
 // For example, a type "node" and a measurement "cpu_utilization" gives "node_cpu_utilization"
-func MetricName(mType string, measurement string) string {
+func MetricName(mType, measurement string) string {
 	return getPrefixByMetricType(mType) + measurement
 }
 
 // RemovePrefix removes the prefix (e.g. "node_", "pod_") from the metric name
-func RemovePrefix(mType string, metricName string) string {
+func RemovePrefix(mType, metricName string) string {
 	prefix := getPrefixByMetricType(mType)
 	return strings.Replace(metricName, prefix, "", 1)
 }
@@ -206,7 +206,7 @@ func ConvertToOTLPMetrics(fields map[string]any, tags map[string]string, logger 
 	return md
 }
 
-func intGauge(ilm pmetric.ScopeMetrics, metricName string, unit string, value int64, ts pcommon.Timestamp) {
+func intGauge(ilm pmetric.ScopeMetrics, metricName, unit string, value int64, ts pcommon.Timestamp) {
 	metric := initMetric(ilm, metricName, unit)
 
 	intGauge := metric.SetEmptyGauge()
@@ -217,7 +217,7 @@ func intGauge(ilm pmetric.ScopeMetrics, metricName string, unit string, value in
 	dataPoint.SetTimestamp(ts)
 }
 
-func doubleGauge(ilm pmetric.ScopeMetrics, metricName string, unit string, value float64, ts pcommon.Timestamp) {
+func doubleGauge(ilm pmetric.ScopeMetrics, metricName, unit string, value float64, ts pcommon.Timestamp) {
 	metric := initMetric(ilm, metricName, unit)
 
 	doubleGauge := metric.SetEmptyGauge()

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -70,7 +70,7 @@ func newCloudWatchLogClient(svc cloudWatchClient, logRetention int32, tags map[s
 	return logClient
 }
 
-func newCollectorUserAgent(buildInfo component.BuildInfo, logGroupName string, componentName string, opts ...ClientOption) string {
+func newCollectorUserAgent(buildInfo component.BuildInfo, logGroupName, componentName string, opts ...ClientOption) string {
 	// Loop through each option
 	option := &cwLogClientConfig{
 		userAgentExtras: []string{},

--- a/internal/aws/proxy/conn.go
+++ b/internal/aws/proxy/conn.go
@@ -42,7 +42,7 @@ const (
 	stsAwsCnPartitionIDSuffix = ".amazonaws.com.cn" // AWS China partition.
 )
 
-var newAWSSession = func(roleArn string, region string, log *zap.Logger) (*session.Session, error) {
+var newAWSSession = func(roleArn, region string, log *zap.Logger) (*session.Session, error) {
 	sts := &stsCalls{log: log, getSTSCredsFromRegionEndpoint: getSTSCredsFromRegionEndpoint}
 
 	if roleArn == "" {
@@ -206,7 +206,7 @@ type stsCalls struct {
 
 // getCreds gets STS credentials first from the regional endpoint, then from the primary
 // region in the respective AWS partition if the regional endpoint is disabled.
-func (s *stsCalls) getCreds(region string, roleArn string) (*credentials.Credentials, error) {
+func (s *stsCalls) getCreds(region, roleArn string) (*credentials.Credentials, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func (s *stsCalls) getCreds(region string, roleArn string) (*credentials.Credent
 // getSTSCredsFromRegionEndpoint fetches STS credentials for provided roleARN from regional endpoint.
 // AWS STS recommends that you provide both the Region and endpoint when you make calls to a Regional endpoint.
 // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code
-var getSTSCredsFromRegionEndpoint = func(log *zap.Logger, sess *session.Session, region string, roleArn string) *credentials.Credentials {
+var getSTSCredsFromRegionEndpoint = func(log *zap.Logger, sess *session.Session, region, roleArn string) *credentials.Credentials {
 	regionalEndpoint := getSTSRegionalEndpoint(region)
 	// if regionalEndpoint is "", the STS endpoint is Global endpoint for classic regions except ap-east-1 - (HKG)
 	// for other opt-in regions, region value will create STS regional endpoint.
@@ -247,7 +247,7 @@ var getSTSCredsFromRegionEndpoint = func(log *zap.Logger, sess *session.Session,
 
 // getSTSCredsFromPrimaryRegionEndpoint fetches STS credentials for provided roleARN from primary region endpoint in the
 // respective partition.
-func (s *stsCalls) getSTSCredsFromPrimaryRegionEndpoint(sess *session.Session, roleArn string, region string) (*credentials.Credentials, error) {
+func (s *stsCalls) getSTSCredsFromPrimaryRegionEndpoint(sess *session.Session, roleArn, region string) (*credentials.Credentials, error) {
 	partitionID := getPartition(region)
 	switch partitionID {
 	case endpoints.AwsPartitionID:

--- a/internal/aws/proxy/conn_test.go
+++ b/internal/aws/proxy/conn_test.go
@@ -33,7 +33,7 @@ func (m *mock) getEC2Region(_ *session.Session) (string, error) {
 	return ec2Region, nil
 }
 
-func (m *mock) newAWSSession(_ string, _ string, _ *zap.Logger) (*session.Session, error) {
+func (m *mock) newAWSSession(string, string, *zap.Logger) (*session.Session, error) {
 	return m.sn, nil
 }
 
@@ -43,7 +43,7 @@ func logSetup() (*zap.Logger, *observer.ObservedLogs) {
 }
 
 func setupMock(sess *session.Session) (f1 func(s *session.Session) (string, error),
-	f2 func(roleArn string, region string, logger *zap.Logger) (*session.Session, error),
+	f2 func(roleArn, region string, logger *zap.Logger) (*session.Session, error),
 ) {
 	f1 = getEC2Region
 	f2 = newAWSSession
@@ -55,7 +55,7 @@ func setupMock(sess *session.Session) (f1 func(s *session.Session) (string, erro
 
 func tearDownMock(
 	f1 func(s *session.Session) (string, error),
-	f2 func(roleArn string, region string, logger *zap.Logger) (*session.Session, error),
+	f2 func(roleArn, region string, logger *zap.Logger) (*session.Session, error),
 ) {
 	getEC2Region = f1
 	newAWSSession = f2

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -189,7 +189,7 @@ func TestCantGetAWSConfigSession(t *testing.T) {
 	}()
 
 	expectedErr := errors.New("expected newAWSSessionError")
-	newAWSSession = func(_ string, _ string, _ *zap.Logger) (*session.Session, error) {
+	newAWSSession = func(string, string, *zap.Logger) (*session.Session, error) {
 		return nil, expectedErr
 	}
 	_, err := NewServer(cfg, logger)

--- a/internal/common/ttlmap/ttl_map.go
+++ b/internal/common/ttlmap/ttl_map.go
@@ -21,7 +21,7 @@ type TTLMap struct {
 // TTLMap to begin periodic sweeps which check for expiration and evict entries
 // as needed.
 // done is the channel that will be used to signal to the timer to stop its work.
-func New(sweepIntervalSeconds int64, maxAgeSeconds int64, done chan struct{}) *TTLMap {
+func New(sweepIntervalSeconds, maxAgeSeconds int64, done chan struct{}) *TTLMap {
 	return &TTLMap{
 		sweepInterval: sweepIntervalSeconds,
 		md:            newTTLMapData(maxAgeSeconds),

--- a/internal/coreinternal/attraction/type_converter.go
+++ b/internal/coreinternal/attraction/type_converter.go
@@ -16,7 +16,7 @@ const (
 	doubleConversionTarget = "double"
 )
 
-func convertValue(logger *zap.Logger, key string, to string, v pcommon.Value) {
+func convertValue(logger *zap.Logger, key, to string, v pcommon.Value) {
 	switch to {
 	case stringConversionTarget:
 		switch v.Type() {

--- a/internal/coreinternal/goldendataset/metrics_gen.go
+++ b/internal/coreinternal/goldendataset/metrics_gen.go
@@ -204,7 +204,7 @@ func populatePtAttributes(cfg MetricsCfg, lm pcommon.Map) {
 	}
 }
 
-func getTimestamp(startTime uint64, stepSize uint64, i int) pcommon.Timestamp {
+func getTimestamp(startTime, stepSize uint64, i int) pcommon.Timestamp {
 	return pcommon.Timestamp(startTime + (stepSize * uint64(i+1)))
 }
 

--- a/internal/coreinternal/goldendataset/traces_generator.go
+++ b/internal/coreinternal/goldendataset/traces_generator.go
@@ -17,7 +17,7 @@ import (
 // parameters defined in the parameters file specified by the tracePairsFile parameter. The pairs to generate
 // spans for for defined in the file specified by the spanPairsFile parameter.
 // The slice of ResourceSpans are returned. If an err is returned, the slice elements will be nil.
-func GenerateTraces(tracePairsFile string, spanPairsFile string) ([]ptrace.Traces, error) {
+func GenerateTraces(tracePairsFile, spanPairsFile string) ([]ptrace.Traces, error) {
 	random := (*randReader)(rand.New(rand.NewPCG(42, 0)))
 	pairsData, err := loadPictOutputFile(tracePairsFile)
 	if err != nil {

--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -28,7 +28,7 @@ func DiffMetrics(diffs []*MetricDiff, expected, actual pmetric.Metrics) []*Metri
 	return append(diffs, diffMetricData(expected, actual)...)
 }
 
-func diffRMSlices(sent []pmetric.ResourceMetrics, recd []pmetric.ResourceMetrics) []*MetricDiff {
+func diffRMSlices(sent, recd []pmetric.ResourceMetrics) []*MetricDiff {
 	var diffs []*MetricDiff
 	if len(sent) != len(recd) {
 		return []*MetricDiff{{
@@ -45,7 +45,7 @@ func diffRMSlices(sent []pmetric.ResourceMetrics, recd []pmetric.ResourceMetrics
 	return diffs
 }
 
-func diffRMs(diffs []*MetricDiff, expected pmetric.ResourceMetrics, actual pmetric.ResourceMetrics) []*MetricDiff {
+func diffRMs(diffs []*MetricDiff, expected, actual pmetric.ResourceMetrics) []*MetricDiff {
 	diffs = diffResource(diffs, expected.Resource(), actual.Resource())
 	diffs = diffILMSlice(
 		diffs,
@@ -79,7 +79,7 @@ func diffILM(
 	return diffMetrics(diffs, expected.Metrics(), actual.Metrics())
 }
 
-func diffMetrics(diffs []*MetricDiff, expected pmetric.MetricSlice, actual pmetric.MetricSlice) []*MetricDiff {
+func diffMetrics(diffs []*MetricDiff, expected, actual pmetric.MetricSlice) []*MetricDiff {
 	var mismatch bool
 	diffs, mismatch = diffValues(diffs, actual.Len(), expected.Len(), "MetricSlice len")
 	if mismatch {
@@ -104,7 +104,7 @@ func toSlice(s pmetric.ResourceMetricsSlice) (out []pmetric.ResourceMetrics) {
 	return out
 }
 
-func DiffMetric(diffs []*MetricDiff, expected pmetric.Metric, actual pmetric.Metric) []*MetricDiff {
+func DiffMetric(diffs []*MetricDiff, expected, actual pmetric.Metric) []*MetricDiff {
 	var mismatch bool
 	diffs, mismatch = diffMetricDescriptor(diffs, expected, actual)
 	if mismatch {
@@ -282,11 +282,11 @@ func diffExemplars(
 	return diffs
 }
 
-func diffResource(diffs []*MetricDiff, expected pcommon.Resource, actual pcommon.Resource) []*MetricDiff {
+func diffResource(diffs []*MetricDiff, expected, actual pcommon.Resource) []*MetricDiff {
 	return diffResourceAttrs(diffs, expected.Attributes(), actual.Attributes())
 }
 
-func diffResourceAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.Map) []*MetricDiff {
+func diffResourceAttrs(diffs []*MetricDiff, expected, actual pcommon.Map) []*MetricDiff {
 	if !reflect.DeepEqual(expected, actual) {
 		diffs = append(diffs, &MetricDiff{
 			ExpectedValue: attrMapToString(expected),
@@ -297,7 +297,7 @@ func diffResourceAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon
 	return diffs
 }
 
-func diffMetricAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.Map) []*MetricDiff {
+func diffMetricAttrs(diffs []*MetricDiff, expected, actual pcommon.Map) []*MetricDiff {
 	if !reflect.DeepEqual(expected, actual) {
 		diffs = append(diffs, &MetricDiff{
 			ExpectedValue: attrMapToString(expected),
@@ -308,7 +308,7 @@ func diffMetricAttrs(diffs []*MetricDiff, expected pcommon.Map, actual pcommon.M
 	return diffs
 }
 
-func diff(diffs []*MetricDiff, expected any, actual any, msg string) []*MetricDiff {
+func diff(diffs []*MetricDiff, expected, actual any, msg string) []*MetricDiff {
 	out, _ := diffValues(diffs, expected, actual, msg)
 	return out
 }

--- a/internal/coreinternal/parseutils/csv.go
+++ b/internal/coreinternal/parseutils/csv.go
@@ -70,7 +70,7 @@ func ReadCSVRow(row string, delimiter rune, lazyQuotes bool) ([]string, error) {
 }
 
 // MapCSVHeaders creates a map of headers[i] -> fields[i].
-func MapCSVHeaders(headers []string, fields []string) (map[string]any, error) {
+func MapCSVHeaders(headers, fields []string) (map[string]any, error) {
 	if len(fields) != len(headers) {
 		return nil, fmt.Errorf("wrong number of fields: expected %d, found %d", len(headers), len(fields))
 	}

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -262,7 +262,7 @@ func (ci *ContainerInfo) MappedPort(t *testing.T, port string) string {
 	return ci.MappedPortForNamedContainer(t, "", port)
 }
 
-func (ci *ContainerInfo) MappedPortForNamedContainer(t *testing.T, containerName string, port string) string {
+func (ci *ContainerInfo) MappedPortForNamedContainer(t *testing.T, containerName, port string) string {
 	c := ci.container(t, containerName)
 	p, err := c.MappedPort(context.Background(), nat.Port(port))
 	require.NoErrorf(t, err, "get port %q for container %q: %v", port, containerName, err)

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -41,7 +41,7 @@ func ParseLocalizedStrptime(layout string, value any, location *time.Location, l
 	return ParseLocalizedGotime(goLayout, value, location, language)
 }
 
-func GetLocation(location *string, layout *string) (*time.Location, error) {
+func GetLocation(location, layout *string) (*time.Location, error) {
 	if location != nil && *location != "" {
 		// If location is specified, it must be in the local timezone database
 		loc, err := time.LoadLocation(*location)

--- a/internal/datadog/clientutil/api.go
+++ b/internal/datadog/clientutil/api.go
@@ -70,7 +70,7 @@ func GetRequestContext(ctx context.Context, apiKey string) context.Context {
 
 // CreateZorkianClient creates a new Zorkian Datadog client
 // Deprecated: CreateZorkianClient returns a Zorkian Datadog client and Zorkian is deprecated. Use CreateAPIClient instead.
-func CreateZorkianClient(apiKey string, endpoint string) *zorkian.Client {
+func CreateZorkianClient(apiKey, endpoint string) *zorkian.Client {
 	client := zorkian.NewClient(apiKey, "")
 	client.SetBaseUrl(endpoint)
 

--- a/internal/exp/metrics/metrics.go
+++ b/internal/exp/metrics/metrics.go
@@ -23,7 +23,7 @@ import (
 //	Merge(cleanedMetrics, mdB)
 //
 // That said, this will do a large amount of memory copying
-func Merge(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics {
+func Merge(mdA, mdB pmetric.Metrics) pmetric.Metrics {
 outer:
 	for i := 0; i < mdB.ResourceMetrics().Len(); i++ {
 		rmB := mdB.ResourceMetrics().At(i)
@@ -48,7 +48,7 @@ outer:
 	return mdA
 }
 
-func mergeResourceMetrics(resourceID identity.Resource, rmA pmetric.ResourceMetrics, rmB pmetric.ResourceMetrics) pmetric.ResourceMetrics {
+func mergeResourceMetrics(resourceID identity.Resource, rmA, rmB pmetric.ResourceMetrics) pmetric.ResourceMetrics {
 outer:
 	for i := 0; i < rmB.ScopeMetrics().Len(); i++ {
 		smB := rmB.ScopeMetrics().At(i)
@@ -73,7 +73,7 @@ outer:
 	return rmA
 }
 
-func mergeScopeMetrics(scopeID identity.Scope, smA pmetric.ScopeMetrics, smB pmetric.ScopeMetrics) pmetric.ScopeMetrics {
+func mergeScopeMetrics(scopeID identity.Scope, smA, smB pmetric.ScopeMetrics) pmetric.ScopeMetrics {
 outer:
 	for i := 0; i < smB.Metrics().Len(); i++ {
 		mB := smB.Metrics().At(i)
@@ -111,7 +111,7 @@ outer:
 	return smA
 }
 
-func mergeDataPoints[DPS dataPointSlice[DP], DP dataPoint[DP]](dataPointsA DPS, dataPointsB DPS) DPS {
+func mergeDataPoints[DPS dataPointSlice[DP], DP dataPoint[DP]](dataPointsA, dataPointsB DPS) DPS {
 	// Append all the datapoints from B to A
 	for i := 0; i < dataPointsB.Len(); i++ {
 		dpB := dataPointsB.At(i)

--- a/internal/exp/metrics/metrics_test.go
+++ b/internal/exp/metrics/metrics_test.go
@@ -49,7 +49,7 @@ func TestMergeMetrics(t *testing.T) {
 	}
 }
 
-func naiveMerge(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics {
+func naiveMerge(mdA, mdB pmetric.Metrics) pmetric.Metrics {
 	for i := 0; i < mdB.ResourceMetrics().Len(); i++ {
 		rm := mdB.ResourceMetrics().At(i)
 
@@ -63,7 +63,7 @@ func naiveMerge(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics {
 func BenchmarkMergeManyIntoSingle(b *testing.B) {
 	benchmarks := []struct {
 		name      string
-		mergeFunc func(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics
+		mergeFunc func(mdA, mdB pmetric.Metrics) pmetric.Metrics
 	}{
 		{
 			name:      "Naive",
@@ -97,7 +97,7 @@ func BenchmarkMergeManyIntoSingle(b *testing.B) {
 func BenchmarkMergeManyIntoMany(b *testing.B) {
 	benchmarks := []struct {
 		name      string
-		mergeFunc func(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics
+		mergeFunc func(mdA, mdB pmetric.Metrics) pmetric.Metrics
 	}{
 		{
 			name:      "Naive",

--- a/internal/filter/filtermetric/filtermetric.go
+++ b/internal/filter/filtermetric/filtermetric.go
@@ -22,7 +22,7 @@ var UseOTTLBridge = featuregate.GlobalRegistry().MustRegister(
 // NewSkipExpr creates a BoolExpr that on evaluation returns true if a metric should NOT be processed or kept.
 // The logic determining if a metric should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
-func NewSkipExpr(include *filterconfig.MetricMatchProperties, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
+func NewSkipExpr(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
 	if UseOTTLBridge.IsEnabled() {
 		return filterottl.NewMetricSkipExprBridge(include, exclude)
 	}

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -305,7 +305,7 @@ func createBasicConditions(template string, input []string) []string {
 	return conditions
 }
 
-func createLibraryConditions(nameTemplate string, versionTemplate string, libraries []filterconfig.InstrumentationLibrary) ([]string, []string) {
+func createLibraryConditions(nameTemplate, versionTemplate string, libraries []filterconfig.InstrumentationLibrary) ([]string, []string) {
 	var scopeNameConditions []string
 	var scopeVersionConditions []string
 	for _, scope := range libraries {
@@ -348,7 +348,7 @@ func createSeverityNumberConditions(severityNumberProperties *filterconfig.LogSe
 	return &severityNumberCondition
 }
 
-func NewMetricSkipExprBridge(include *filterconfig.MetricMatchProperties, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
+func NewMetricSkipExprBridge(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
 	statements := make([]string, 0, 2)
 	if include != nil {
 		statement, err := createMetricStatement(*include)

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -80,7 +80,7 @@ func createHasAttributeOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Ar
 	return hasAttributeOnDatapoint(args.Key, args.ExpectedVal)
 }
 
-func hasAttributeOnDatapoint(key string, expectedVal string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func hasAttributeOnDatapoint(key, expectedVal string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
 	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
 		return checkDataPoints(tCtx, key, &expectedVal)
 	}, nil

--- a/internal/gopsutilenv/gopsutilenv_linux.go
+++ b/internal/gopsutilenv/gopsutilenv_linux.go
@@ -69,7 +69,7 @@ func SetGlobalRootPath(rootPath string) {
 // copied from gopsutil:
 // GetEnvWithContext retrieves the environment variable key. If it does not exist it returns the default.
 // The context may optionally contain a map superseding os.EnvKey.
-func GetEnvWithContext(ctx context.Context, key string, dfault string, combineWith ...string) string {
+func GetEnvWithContext(ctx context.Context, key, dfault string, combineWith ...string) string {
 	var value string
 	if env, ok := ctx.Value(common.EnvKey).(common.EnvMap); ok {
 		value = env[common.EnvKeyType(key)]

--- a/internal/gopsutilenv/gopsutilenv_others.go
+++ b/internal/gopsutilenv/gopsutilenv_others.go
@@ -23,7 +23,7 @@ func SetGoPsutilEnvVars(_ string) common.EnvMap {
 	return common.EnvMap{}
 }
 
-func GetEnvWithContext(_ context.Context, _ string, dfault string, _ ...string) string {
+func GetEnvWithContext(_ context.Context, _, dfault string, _ ...string) string {
 	return dfault
 }
 

--- a/internal/metadataproviders/aws/eks/metadata_test.go
+++ b/internal/metadataproviders/aws/eks/metadata_test.go
@@ -85,7 +85,7 @@ func TestGetK8sInstanceMetadata(t *testing.T) {
 	}
 }
 
-func setupNodeProviderID(client *fake.Clientset, provideID string, nodeName string) error {
+func setupNodeProviderID(client *fake.Clientset, provideID, nodeName string) error {
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,

--- a/internal/metadataproviders/kubeadm/metadata.go
+++ b/internal/metadataproviders/kubeadm/metadata.go
@@ -32,7 +32,7 @@ type kubeadmProvider struct {
 	cache               LocalCache
 }
 
-func NewProvider(configMapName string, kubeSystemNamespace string, apiConf k8sconfig.APIConfig) (Provider, error) {
+func NewProvider(configMapName, kubeSystemNamespace string, apiConf k8sconfig.APIConfig) (Provider, error) {
 	k8sAPIClient, err := k8sconfig.MakeClient(apiConf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create K8s API client: %w", err)

--- a/internal/otelarrow/admission2/boundedqueue_test.go
+++ b/internal/otelarrow/admission2/boundedqueue_test.go
@@ -279,7 +279,7 @@ func (bq bqTest) verifyPoint(t *testing.T, m metricdata.Metrics) int64 {
 	return -1
 }
 
-func (bq bqTest) verifyMetrics(t *testing.T) (inflight int64, waiting int64) {
+func (bq bqTest) verifyMetrics(t *testing.T) (inflight, waiting int64) {
 	inflight = -1
 	waiting = -1
 

--- a/internal/sqlquery/metrics.go
+++ b/internal/sqlquery/metrics.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
 
-func rowToMetric(row StringMap, cfg MetricCfg, dest pmetric.Metric, startTime pcommon.Timestamp, ts pcommon.Timestamp, scrapeCfg scraperhelper.ControllerConfig) error {
+func rowToMetric(row StringMap, cfg MetricCfg, dest pmetric.Metric, startTime, ts pcommon.Timestamp, scrapeCfg scraperhelper.ControllerConfig) error {
 	dest.SetName(cfg.MetricName)
 	dest.SetDescription(cfg.Description)
 	dest.SetUnit(cfg.Unit)
@@ -66,7 +66,7 @@ func rowToMetric(row StringMap, cfg MetricCfg, dest pmetric.Metric, startTime pc
 	return errors.Join(errs...)
 }
 
-func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, startTime pcommon.Timestamp, ts pcommon.Timestamp, scrapeCfg scraperhelper.ControllerConfig) {
+func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, startTime, ts pcommon.Timestamp, scrapeCfg scraperhelper.ControllerConfig) {
 	dp.SetTimestamp(ts)
 
 	// Cumulative sum should have a start time set to the beginning of the data points cumulation

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -82,7 +82,7 @@ func valueFor(x any) value {
 }
 
 // comparison is a test helper that constructs a comparison object using valueFor
-func comparisonHelper(left any, right any, op string) *comparison {
+func comparisonHelper(left, right any, op string) *comparison {
 	return &comparison{
 		Left:  valueFor(left),
 		Right: valueFor(right),
@@ -216,13 +216,13 @@ func Test_newConditionEvaluator_invalid(t *testing.T) {
 }
 
 func True() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return true, nil
 	}, nil
 }
 
 func False() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return false, nil
 	}, nil
 }

--- a/pkg/ottl/compare.go
+++ b/pkg/ottl/compare.go
@@ -17,25 +17,25 @@ import (
 type ValueComparator interface {
 	// Equal compares two values for equality, returning true if they are equals
 	// according to the OTTL comparison rules.
-	Equal(a any, b any) bool
+	Equal(a, b any) bool
 	// NotEqual compares two values for equality, returning true if they are different
 	// according to the OTTL comparison rules.
-	NotEqual(a any, b any) bool
+	NotEqual(a, b any) bool
 	// Less compares two values, returning true if the first value is less than the second
 	// value, using the OTTL comparison rules.
-	Less(a any, b any) bool
+	Less(a, b any) bool
 	// LessEqual compares two values, returning true if the first value is less or equal
 	// to the second value, using the OTTL comparison rules.
-	LessEqual(a any, b any) bool
+	LessEqual(a, b any) bool
 	// Greater compares two values, returning true if the first value is greater than the
 	// second value, using the OTTL comparison rules.
-	Greater(a any, b any) bool
+	Greater(a, b any) bool
 	// GreaterEqual compares two values, returning true if the first value is greater or
 	// equal to the second value, using the OTTL comparison rules.
-	GreaterEqual(a any, b any) bool
+	GreaterEqual(a, b any) bool
 	// compare is a private method that compares two values using the grammar compareOp,
 	// it also restricts custom implementations outside of this package.
-	compare(a any, b any, op compareOp) bool
+	compare(a, b any, op compareOp) bool
 }
 
 // ottlValueComparator is the default implementation of the ValueComparator
@@ -53,7 +53,7 @@ func (p *ottlValueComparator) invalidComparison(op compareOp) bool {
 
 // comparePrimitives implements a generic comparison helper for all Ordered types (derived from Float, Int, or string).
 // According to benchmarks, it's faster than explicit comparison functions for these types.
-func comparePrimitives[T constraints.Ordered](a T, b T, op compareOp) bool {
+func comparePrimitives[T constraints.Ordered](a, b T, op compareOp) bool {
 	switch op {
 	case eq:
 		return a == b
@@ -72,7 +72,7 @@ func comparePrimitives[T constraints.Ordered](a T, b T, op compareOp) bool {
 	}
 }
 
-func (p *ottlValueComparator) compareBools(a bool, b bool, op compareOp) bool {
+func (p *ottlValueComparator) compareBools(a, b bool, op compareOp) bool {
 	switch op {
 	case eq:
 		return a == b
@@ -91,7 +91,7 @@ func (p *ottlValueComparator) compareBools(a bool, b bool, op compareOp) bool {
 	}
 }
 
-func (p *ottlValueComparator) compareBytes(a []byte, b []byte, op compareOp) bool {
+func (p *ottlValueComparator) compareBytes(a, b []byte, op compareOp) bool {
 	switch op {
 	case eq:
 		return bytes.Equal(a, b)
@@ -287,7 +287,7 @@ func (p *ottlValueComparator) comparePSlice(a pcommon.Slice, b any, op compareOp
 
 // a and b are the return values from a Getter; we try to compare them
 // according to the given operator.
-func (p *ottlValueComparator) compare(a any, b any, op compareOp) bool {
+func (p *ottlValueComparator) compare(a, b any, op compareOp) bool {
 	// nils are equal to each other and never equal to anything else,
 	// so if they're both nil, report equality.
 	if a == nil && b == nil {
@@ -338,27 +338,27 @@ func (p *ottlValueComparator) compare(a any, b any, op compareOp) bool {
 	}
 }
 
-func (p *ottlValueComparator) Equal(a any, b any) bool {
+func (p *ottlValueComparator) Equal(a, b any) bool {
 	return p.compare(a, b, eq)
 }
 
-func (p *ottlValueComparator) NotEqual(a any, b any) bool {
+func (p *ottlValueComparator) NotEqual(a, b any) bool {
 	return p.compare(a, b, ne)
 }
 
-func (p *ottlValueComparator) Less(a any, b any) bool {
+func (p *ottlValueComparator) Less(a, b any) bool {
 	return p.compare(a, b, lt)
 }
 
-func (p *ottlValueComparator) LessEqual(a any, b any) bool {
+func (p *ottlValueComparator) LessEqual(a, b any) bool {
 	return p.compare(a, b, lte)
 }
 
-func (p *ottlValueComparator) Greater(a any, b any) bool {
+func (p *ottlValueComparator) Greater(a, b any) bool {
 	return p.compare(a, b, gt)
 }
 
-func (p *ottlValueComparator) GreaterEqual(a any, b any) bool {
+func (p *ottlValueComparator) GreaterEqual(a, b any) bool {
 	return p.compare(a, b, gte)
 }
 

--- a/pkg/ottl/compare_test.go
+++ b/pkg/ottl/compare_test.go
@@ -299,7 +299,7 @@ func BenchmarkCompareLTNil(b *testing.B) {
 
 // this is only used for benchmarking, and is a rough equivalent of the original compare function
 // before adding lt, lte, gte, and gt.
-func compareEq(a any, b any, op compareOp) bool {
+func compareEq(a, b any, op compareOp) bool {
 	switch op {
 	case eq:
 		return a == b

--- a/pkg/ottl/contexts/internal/ctxutil/map_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map_test.go
@@ -20,10 +20,10 @@ import (
 
 func Test_GetMapValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -152,10 +152,10 @@ func Test_GetMapValue_NilKey(t *testing.T) {
 
 func Test_SetMapValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -396,7 +396,7 @@ func Test_GetMap(t *testing.T) {
 
 func Test_GetMapKeyName(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/ctxutil/slice_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/slice_test.go
@@ -34,10 +34,10 @@ func Test_GetSliceValue_Valid(t *testing.T) {
 
 func Test_GetSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -121,10 +121,10 @@ func Test_SetSliceValue_Valid(t *testing.T) {
 
 func Test_SetSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -211,10 +211,10 @@ func Test_GetCommonTypedSliceValue_Valid(t *testing.T) {
 
 func Test_GetCommonTypedSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -298,10 +298,10 @@ func Test_SetCommonTypedSliceValue_Valid(t *testing.T) {
 
 func Test_SetCommonTypedSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -475,10 +475,10 @@ func Test_GetCommonIntSliceValue_Valid(t *testing.T) {
 
 func Test_GetCommonIntSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}
@@ -568,10 +568,10 @@ func Test_SetCommonIntSliceValue_Valid(t *testing.T) {
 
 func Test_SetCommonIntSliceValue_Invalid(t *testing.T) {
 	getSetter := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			return nil
 		},
 	}

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 func hello() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return "world", nil
 	}, nil
 }
 
 func pmap() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		m := pcommon.NewMap()
 		m.PutEmptyMap("foo").PutStr("bar", "pass")
 		return m, nil
@@ -32,7 +32,7 @@ func pmap() (ExprFunc[any], error) {
 }
 
 func basicMap() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return map[string]any{
 			"foo": map[string]any{
 				"bar": "pass",
@@ -42,7 +42,7 @@ func basicMap() (ExprFunc[any], error) {
 }
 
 func pslice() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		s := pcommon.NewSlice()
 		s.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("pass")
 		return s, nil
@@ -50,7 +50,7 @@ func pslice() (ExprFunc[any], error) {
 }
 
 func basicSlice() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]any{
 				"pass",
@@ -60,7 +60,7 @@ func basicSlice() (ExprFunc[any], error) {
 }
 
 func basicSliceString() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]string{
 				"pass",
@@ -70,7 +70,7 @@ func basicSliceString() (ExprFunc[any], error) {
 }
 
 func basicSliceBool() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]bool{
 				true,
@@ -80,7 +80,7 @@ func basicSliceBool() (ExprFunc[any], error) {
 }
 
 func basicSliceInteger() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]int64{
 				1,
@@ -90,7 +90,7 @@ func basicSliceInteger() (ExprFunc[any], error) {
 }
 
 func basicSliceFloat() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]float64{
 				1,
@@ -100,7 +100,7 @@ func basicSliceFloat() (ExprFunc[any], error) {
 }
 
 func basicSliceByte() (ExprFunc[any], error) {
-	return func(_ context.Context, _ any) (any, error) {
+	return func(context.Context, any) (any, error) {
 		return []any{
 			[]byte{
 				byte('p'),
@@ -904,7 +904,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -914,7 +914,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "ValueTypeString type",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueStr("str"), nil
 				},
 			},
@@ -924,7 +924,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -934,7 +934,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -995,7 +995,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function getter",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -1006,7 +1006,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function getter nil",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1018,7 +1018,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function arg mismatch",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1030,7 +1030,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "Cannot create function",
 			getter: StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1063,7 +1063,7 @@ func Test_FunctionGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardStringGetter_WrappedError(t *testing.T) {
 	getter := StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1084,7 +1084,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -1094,7 +1094,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "bool type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1104,7 +1104,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1114,7 +1114,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1124,7 +1124,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "byte[] type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte{0}, nil
 				},
 			},
@@ -1134,7 +1134,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.map type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("test", "passed")
 					return m, nil
@@ -1146,7 +1146,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.slice type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewSlice()
 					v := s.AppendEmpty()
 					v.SetStr("test")
@@ -1159,7 +1159,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1170,7 +1170,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1180,7 +1180,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return make(chan int), nil
 				},
 			},
@@ -1210,7 +1210,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardStringLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardStringLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1231,7 +1231,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1241,7 +1241,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "ValueTypeFloat type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueDouble(1.1), nil
 				},
 			},
@@ -1251,7 +1251,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1261,7 +1261,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardFloatGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1287,7 +1287,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardFloatGetter_WrappedError(t *testing.T) {
 	getter := StandardFloatGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1308,7 +1308,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1.0", nil
 				},
 			},
@@ -1318,7 +1318,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1328,7 +1328,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1338,7 +1338,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 bool true",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1348,7 +1348,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 bool false",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return false, nil
 				},
 			},
@@ -1358,7 +1358,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1369,7 +1369,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type float",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueDouble(float64(1.1))
 					return v, nil
 				},
@@ -1380,7 +1380,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueStr("1.1")
 					return v, nil
 				},
@@ -1391,7 +1391,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool true",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1402,7 +1402,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool false",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(false)
 					return v, nil
 				},
@@ -1413,7 +1413,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1423,7 +1423,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -1433,7 +1433,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.Value type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1464,7 +1464,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardFloatLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardFloatLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1485,7 +1485,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardIntGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1495,7 +1495,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "ValueTypeInt type",
 			getter: StandardIntGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueInt(1), nil
 				},
 			},
@@ -1505,7 +1505,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardIntGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1515,7 +1515,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardIntGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1541,7 +1541,7 @@ func Test_StandardIntGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardIntGetter_WrappedError(t *testing.T) {
 	getter := StandardIntGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1562,7 +1562,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1", nil
 				},
 			},
@@ -1572,7 +1572,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1582,7 +1582,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1592,7 +1592,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool true",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1602,7 +1602,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool false",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return false, nil
 				},
 			},
@@ -1612,7 +1612,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1623,7 +1623,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type float",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueDouble(float64(1.9))
 					return v, nil
 				},
@@ -1634,7 +1634,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueStr("1")
 					return v, nil
 				},
@@ -1645,7 +1645,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool true",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1656,7 +1656,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool false",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(false)
 					return v, nil
 				},
@@ -1667,7 +1667,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1677,7 +1677,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -1687,7 +1687,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.Value type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1718,7 +1718,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardIntLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardIntLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1739,7 +1739,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1", nil
 				},
 			},
@@ -1749,7 +1749,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "byte type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte{49}, nil
 				},
 			},
@@ -1759,7 +1759,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(12), nil
 				},
 			},
@@ -1769,7 +1769,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1779,7 +1779,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool true",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1789,7 +1789,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool false",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return false, nil
 				},
 			},
@@ -1799,7 +1799,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1810,7 +1810,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type float",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueDouble(float64(1.9))
 					return v, nil
 				},
@@ -1821,7 +1821,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueStr("1")
 					return v, nil
 				},
@@ -1832,7 +1832,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bytes",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBytes()
 					v.SetEmptyBytes().Append(byte(12))
 					return v, nil
@@ -1844,7 +1844,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool true",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1855,7 +1855,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool false",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(false)
 					return v, nil
 				},
@@ -1866,7 +1866,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1876,7 +1876,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]string{}, nil
 				},
 			},
@@ -1886,7 +1886,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.Value type",
 			getter: StandardByteSliceLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1917,7 +1917,7 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardByteSliceLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardByteSliceLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1938,7 +1938,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "primitive bool type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1948,7 +1948,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "ValueTypeBool type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueBool(true), nil
 				},
 			},
@@ -1958,7 +1958,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1, nil
 				},
 			},
@@ -1968,7 +1968,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardBoolGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1994,7 +1994,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardBoolGetter_WrappedError(t *testing.T) {
 	getter := StandardBoolGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -2015,7 +2015,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "string type true",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "true", nil
 				},
 			},
@@ -2025,7 +2025,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "string type false",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "false", nil
 				},
 			},
@@ -2035,7 +2035,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "int type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 0, nil
 				},
 			},
@@ -2045,7 +2045,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return float64(0.0), nil
 				},
 			},
@@ -2055,7 +2055,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueInt(int64(0))
 					return v, nil
 				},
@@ -2066,7 +2066,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueStr("false")
 					return v, nil
 				},
@@ -2077,7 +2077,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -2088,7 +2088,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type double",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueDouble(float64(0.0))
 					return v, nil
 				},
@@ -2099,7 +2099,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -2109,7 +2109,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -2119,7 +2119,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.value type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -2150,7 +2150,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardBoolLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardBoolLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -2171,7 +2171,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "pcommon.slice type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewSlice(), nil
 				},
 			},
@@ -2181,7 +2181,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]any type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{}, nil
 				},
 			},
@@ -2191,7 +2191,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]string type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{}, nil
 				},
 			},
@@ -2201,7 +2201,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]int type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []int{}, nil
 				},
 			},
@@ -2211,7 +2211,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]int16 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []int32{}, nil
 				},
 			},
@@ -2221,7 +2221,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]int32 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []int32{}, nil
 				},
 			},
@@ -2231,7 +2231,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]int64 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []int64{}, nil
 				},
 			},
@@ -2241,7 +2241,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]uint type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []uint{}, nil
 				},
 			},
@@ -2251,7 +2251,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]uint16 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []uint16{}, nil
 				},
 			},
@@ -2261,7 +2261,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]uint32 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []uint32{}, nil
 				},
 			},
@@ -2271,7 +2271,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]uint64 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []uint64{}, nil
 				},
 			},
@@ -2281,7 +2281,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]float32 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []float32{}, nil
 				},
 			},
@@ -2291,7 +2291,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "[]float64 type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []float64{}, nil
 				},
 			},
@@ -2301,7 +2301,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "ValueTypeSlice type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueSlice(), nil
 				},
 			},
@@ -2311,7 +2311,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -2321,7 +2321,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -2346,7 +2346,7 @@ func Test_StandardPSliceGetter(t *testing.T) {
 
 func Test_StandardPSliceGetter_WrappedError(t *testing.T) {
 	getter := StandardPSliceGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -2367,7 +2367,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "pcommon.map type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewMap(), nil
 				},
 			},
@@ -2377,7 +2377,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "map[string]any type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return make(map[string]any), nil
 				},
 			},
@@ -2387,7 +2387,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "ValueTypeMap type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueMap(), nil
 				},
 			},
@@ -2397,7 +2397,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -2407,7 +2407,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -2433,7 +2433,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardPMapGetter_WrappedError(t *testing.T) {
 	getter := StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -2463,7 +2463,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "complex duration",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h1m1s")
 				},
 			},
@@ -2473,7 +2473,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "simple duration",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100ns")
 				},
 			},
@@ -2483,7 +2483,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "complex duation values less than 1 seconc",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("10ms66us7000ns")
 				},
 			},
@@ -2493,7 +2493,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "invalid duration units",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("70ps")
 				},
 			},
@@ -2503,7 +2503,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "wrong type - int",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1, nil
 				},
 			},
@@ -2513,7 +2513,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -2538,7 +2538,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardDurationGetter_WrappedError(t *testing.T) {
 	getter := StandardDurationGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -2559,7 +2559,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "2023 time",
 			getter: StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 8, 17, 1, 1, 1, 1, time.UTC), nil
 				},
 			},
@@ -2569,7 +2569,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "before 2000 time",
 			getter: StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1999, 12, 1, 10, 59, 58, 57, time.UTC), nil
 				},
 			},
@@ -2579,7 +2579,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "wrong type - duration",
 			getter: StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("70ns")
 				},
 			},
@@ -2589,7 +2589,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "wrong type - bool",
 			getter: StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -2599,7 +2599,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -2627,7 +2627,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 //nolint:errorlint
 func Test_StandardTimeGetter_WrappedError(t *testing.T) {
 	getter := StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return nil, TypeError("")
 		},
 	}

--- a/pkg/ottl/math.go
+++ b/pkg/ottl/math.go
@@ -162,7 +162,7 @@ func performOpDuration(x time.Duration, y any, op mathOp) (any, error) {
 	return nil, errors.New("only addition and subtraction supported for time.Time and time.Duration")
 }
 
-func performOp[N int64 | float64](x N, y N, op mathOp) (N, error) {
+func performOp[N int64 | float64](x, y N, op mathOp) (N, error) {
 	switch op {
 	case add:
 		return x + y, nil

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -62,7 +62,7 @@ func threePointOne[K any]() (ExprFunc[K], error) {
 	}, nil
 }
 
-func testTime[K any](time string, format string) (ExprFunc[K], error) {
+func testTime[K any](time, format string) (ExprFunc[K], error) {
 	loc, err := timeutils.GetLocation(nil, &format)
 	if err != nil {
 		return nil, err

--- a/pkg/ottl/ottlfuncs/func_append_test.go
+++ b/pkg/ottl/ottlfuncs/func_append_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Test_Append(t *testing.T) {
-	setter := func(_ context.Context, res any, val any) error {
+	setter := func(_ context.Context, res, val any) error {
 		rSlice := res.(pcommon.Slice)
 		vSlice := val.(pcommon.Slice)
 		assert.NoError(t, rSlice.FromRaw(vSlice.AsRaw()))
@@ -26,13 +26,13 @@ func Test_Append(t *testing.T) {
 	var nilSliceOptional ottl.Optional[[]ottl.Getter[any]]
 
 	singleGetter := ottl.NewTestingOptional[ottl.Getter[any]](ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "a", nil
 		},
 	})
 
 	singleIntGetter := ottl.NewTestingOptional[ottl.Getter[any]](ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 66, nil
 		},
 	})
@@ -40,12 +40,12 @@ func Test_Append(t *testing.T) {
 	multiGetter := ottl.NewTestingOptional[[]ottl.Getter[any]](
 		[]ottl.Getter[any]{
 			ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "a", nil
 				},
 			},
 			ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "b", nil
 				},
 			},
@@ -62,7 +62,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: non existing target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 				Setter: setter,
@@ -76,7 +76,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: non existing target - non string value",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 				Setter: setter,
@@ -90,7 +90,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: standard []string target - empty",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{}, nil
 				},
 				Setter: setter,
@@ -104,7 +104,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: standard []string target - empty",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{}, nil
 				},
 				Setter: setter,
@@ -120,7 +120,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: standard []string target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{"5", "6"}, nil
 				},
 				Setter: setter,
@@ -136,7 +136,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: standard []string target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{"5", "6"}, nil
 				},
 				Setter: setter,
@@ -154,7 +154,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: Slice target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					ps := pcommon.NewSlice()
 					if err := ps.FromRaw([]any{"5", "6"}); err != nil {
 						return nil, err
@@ -174,7 +174,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: Slice target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					ps := pcommon.NewSlice()
 					if err := ps.FromRaw([]any{"5", "6"}); err != nil {
 						return nil, err
@@ -196,7 +196,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: Slice target of string values in pcommon.value",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					ps := pcommon.NewSlice()
 					ps.AppendEmpty().SetStr("5")
 					ps.AppendEmpty().SetStr("6")
@@ -215,7 +215,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: Slice target of string values in pcommon.value",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					ps := pcommon.NewSlice()
 					ps.AppendEmpty().SetStr("5")
 					ps.AppendEmpty().SetStr("6")
@@ -236,7 +236,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: []any target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{5, 6}, nil
 				},
 				Setter: setter,
@@ -252,7 +252,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: []any target",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{5, 6}, nil
 				},
 				Setter: setter,
@@ -270,7 +270,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: pcommon.Value - string",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := "5"
 					return v, nil
 				},
@@ -286,7 +286,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: pcommon.Value - string",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := "5"
 					return v, nil
 				},
@@ -304,7 +304,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: pcommon.Value - slice",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueSlice()
 					if err := v.FromRaw([]any{"5", "6"}); err != nil {
 						return nil, err
@@ -324,7 +324,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: pcommon.Value - slice",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueSlice()
 					if err := v.FromRaw([]any{"5", "6"}); err != nil {
 						return nil, err
@@ -346,7 +346,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: scalar target string",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "5", nil
 				},
 				Setter: setter,
@@ -361,7 +361,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: scalar target string",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "5", nil
 				},
 				Setter: setter,
@@ -378,7 +378,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: scalar target any",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 5, nil
 				},
 				Setter: setter,
@@ -393,7 +393,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Slice: scalar target any",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 5, nil
 				},
 				Setter: setter,
@@ -410,7 +410,7 @@ func Test_Append(t *testing.T) {
 		{
 			"Single: scalar target any append int",
 			&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 5, nil
 				},
 				Setter: setter,
@@ -446,7 +446,7 @@ func TestTargetType(t *testing.T) {
 	expectedSlice := pcommon.NewValueSlice()
 	assert.NoError(t, expectedSlice.Slice().FromRaw([]any{"a"}))
 	singleIntGetter := ottl.NewTestingOptional[ottl.Getter[any]](ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return expectedInt, nil
 		},
 	})
@@ -619,10 +619,10 @@ func TestTargetType(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			target := &ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tc.TargetValue, nil
 				},
-				Setter: func(_ context.Context, res any, val any) error {
+				Setter: func(_ context.Context, res, val any) error {
 					rSlice := res.(pcommon.Slice)
 					vSlice := val.(pcommon.Slice)
 					assert.NoError(t, rSlice.FromRaw(vSlice.AsRaw()))
@@ -657,7 +657,7 @@ func Test_ArgumentsArePresent(t *testing.T) {
 	var nilOptional ottl.Optional[ottl.Getter[any]]
 	var nilSliceOptional ottl.Optional[[]ottl.Getter[any]]
 	singleGetter := ottl.NewTestingOptional[ottl.Getter[any]](ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "val", nil
 		},
 	})
@@ -665,12 +665,12 @@ func Test_ArgumentsArePresent(t *testing.T) {
 	multiGetter := ottl.NewTestingOptional[[]ottl.Getter[any]](
 		[]ottl.Getter[any]{
 			ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "val1", nil
 				},
 			},
 			ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "val2", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -24,12 +24,12 @@ func Test_concat(t *testing.T) {
 			name: "concat strings",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "world", nil
 					},
 				},
@@ -41,17 +41,17 @@ func Test_concat(t *testing.T) {
 			name: "nil",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "world", nil
 					},
 				},
@@ -63,12 +63,12 @@ func Test_concat(t *testing.T) {
 			name: "integers",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return int64(1), nil
 					},
 				},
@@ -80,12 +80,12 @@ func Test_concat(t *testing.T) {
 			name: "floats",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return 3.14159, nil
 					},
 				},
@@ -97,12 +97,12 @@ func Test_concat(t *testing.T) {
 			name: "booleans",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return true, nil
 					},
 				},
@@ -114,7 +114,7 @@ func Test_concat(t *testing.T) {
 			name: "byte slices",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}, nil
 					},
 				},
@@ -126,14 +126,14 @@ func Test_concat(t *testing.T) {
 			name: "pcommon.Slice",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						s := pcommon.NewSlice()
 						_ = s.FromRaw([]any{1, 2})
 						return s, nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						s := pcommon.NewSlice()
 						_ = s.FromRaw([]any{3, 4})
 						return s, nil
@@ -147,14 +147,14 @@ func Test_concat(t *testing.T) {
 			name: "maps",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						m := pcommon.NewMap()
 						m.PutStr("a", "b")
 						return m, nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						m := pcommon.NewMap()
 						m.PutStr("c", "d")
 						return m, nil
@@ -168,17 +168,17 @@ func Test_concat(t *testing.T) {
 			name: "empty string values",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
@@ -190,7 +190,7 @@ func Test_concat(t *testing.T) {
 			name: "single argument",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "hello", nil
 					},
 				},
@@ -229,7 +229,7 @@ func Test_concat(t *testing.T) {
 
 func Test_concat_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return make(chan int), nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_contains_value_test.go
+++ b/pkg/ottl/ottlfuncs/func_contains_value_test.go
@@ -23,12 +23,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "find item in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{"hello", "world"}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "hello", nil
 				},
 			},
@@ -37,12 +37,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "not find item in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{"hello", "world"}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "unknown", nil
 				},
 			},
@@ -51,12 +51,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "find integers in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{0, 1}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -65,12 +65,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "find floats in taget",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{0, 3.14159}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 3.14159, nil
 				},
 			},
@@ -79,12 +79,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "find booleans in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{true, false}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -93,14 +93,14 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "find pcommon.Slice in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewSlice()
 					_ = s.FromRaw([]any{1, 2})
 					return s, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -109,14 +109,14 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "not find pcommon.Slice in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewSlice()
 					_ = s.FromRaw([]any{1, 2})
 					return s, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(4), nil
 				},
 			},
@@ -125,14 +125,14 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "not find pcommon.Slice in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewSlice()
 					_ = s.FromRaw([]any{1, 2})
 					return s, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(4), nil
 				},
 			},
@@ -141,14 +141,14 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "not find pcommon.Value in target",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewSlice()
 					_ = s.FromRaw([]any{1, 4})
 					return s, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueInt(4), nil
 				},
 			},
@@ -157,12 +157,12 @@ func Test_ContainsValue(t *testing.T) {
 		{
 			name: "Target is []string",
 			target: ottl.StandardPSliceGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{"test1", "test2"}, nil
 				},
 			},
 			item: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pcommon.NewValueStr("test1").AsRaw(), nil
 				},
 			},
@@ -181,12 +181,12 @@ func Test_ContainsValue(t *testing.T) {
 
 func Test_ContainsValue_Error(t *testing.T) {
 	target := &ottl.StandardPSliceGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return make(chan int), nil
 		},
 	}
 	item := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "test", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_convert_attributes_to_elements_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_attributes_to_elements_xml_test.go
@@ -81,7 +81,7 @@ func Test_ConvertAttributesToElementsXML(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			args := &ConvertAttributesToElementsXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return tt.document, nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_convert_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_case_test.go
@@ -24,7 +24,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake simple convert",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simpleString", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake noop already snake case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -44,7 +44,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake multiple uppercase",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "CPUUtilizationMetric", nil
 				},
 			},
@@ -54,7 +54,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -64,7 +64,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -75,7 +75,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "camel simple convert",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -85,7 +85,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake noop already snake case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "SimpleString", nil
 				},
 			},
@@ -95,7 +95,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -105,7 +105,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -116,7 +116,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple", nil
 				},
 			},
@@ -126,7 +126,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -136,7 +136,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -147,7 +147,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "SIMPLE", nil
 				},
 			},
@@ -157,7 +157,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -167,7 +167,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -195,7 +195,7 @@ func Test_convertCaseError(t *testing.T) {
 		{
 			name: "error bad case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simpleString", nil
 				},
 			},
@@ -221,7 +221,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -231,7 +231,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml.go
+++ b/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml.go
@@ -45,7 +45,7 @@ func createConvertTextToElementsXMLFunction[K any](_ ottl.FunctionContext, oArgs
 }
 
 // convertTextToElementsXML returns a string that is a result of wrapping any extraneous text nodes with a dedicated element.
-func convertTextToElementsXML[K any](target ottl.StringGetter[K], xPath string, elementName string) ottl.ExprFunc[K] {
+func convertTextToElementsXML[K any](target ottl.StringGetter[K], xPath, elementName string) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (any, error) {
 		var doc *xmlquery.Node
 		if targetVal, err := target.Get(ctx, tCtx); err != nil {

--- a/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_text_to_elements_xml_test.go
@@ -81,7 +81,7 @@ func Test_ConvertTextToElementsXML(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			args := &ConvertTextToElementsXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return tt.document, nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_day_test.go
+++ b/pkg/ottl/ottlfuncs/func_day_test.go
@@ -22,7 +22,7 @@ func Test_Day(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Day(t *testing.T) {
 
 func Test_Day_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -121,7 +121,7 @@ func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 
 func Test_deleteMatchingKeys_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardPMapGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (pcommon.Map, error) {
+		Getter: func(context.Context, any) (pcommon.Map, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return pcommon.Map{}, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_duration_test.go
+++ b/pkg/ottl/ottlfuncs/func_duration_test.go
@@ -23,7 +23,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "100 milliseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "100ms", nil
 				},
 			},
@@ -32,7 +32,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "234 microseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "234us", nil
 				},
 			},
@@ -41,7 +41,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "777 nanoseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "777ns", nil
 				},
 			},
@@ -50,7 +50,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "one second",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1s", nil
 				},
 			},
@@ -59,7 +59,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "two hundred second",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "200s", nil
 				},
 			},
@@ -68,7 +68,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "three minutes",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "3m", nil
 				},
 			},
@@ -77,7 +77,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "45 minutes",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "45m", nil
 				},
 			},
@@ -86,7 +86,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "7 mins, 12 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "7m12s", nil
 				},
 			},
@@ -95,7 +95,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "4 hours",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "4h", nil
 				},
 			},
@@ -104,7 +104,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 23 mins, 59 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "5h23m59s", nil
 				},
 			},
@@ -113,7 +113,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 59 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "5h59s", nil
 				},
 			},
@@ -122,7 +122,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 23 mins",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "5h23m", nil
 				},
 			},
@@ -131,7 +131,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "2 mins, 1 sec, 64 microsecs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2m1s64us", nil
 				},
 			},
@@ -140,7 +140,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "59 hours, 1 min, 78 millisecs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "59h1m78ms", nil
 				},
 			},
@@ -167,7 +167,7 @@ func Test_DurationError(t *testing.T) {
 		{
 			name: "empty duration",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -176,7 +176,7 @@ func Test_DurationError(t *testing.T) {
 		{
 			name: "empty duration",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "one second", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
@@ -104,7 +104,7 @@ func Test_extractGrokPatterns_patterns(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			nco := ottl.NewTestingOptional(tt.namedCapturesOnly)
 			target := &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tt.targetString, nil
 				},
 			}
@@ -144,7 +144,7 @@ func Test_extractGrokPatterns_validation(t *testing.T) {
 		{
 			name: "bad regex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -155,7 +155,7 @@ func Test_extractGrokPatterns_validation(t *testing.T) {
 		{
 			name: "no named capture group",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -166,7 +166,7 @@ func Test_extractGrokPatterns_validation(t *testing.T) {
 		{
 			name: "custom pattern name invalid",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "http://user:password@example.com:80/path?query=string", nil
 				},
 			},
@@ -204,7 +204,7 @@ func Test_extractGrokPatterns_bad_input(t *testing.T) {
 		{
 			name: "regex - target is non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 123, nil
 				},
 			},
@@ -213,7 +213,7 @@ func Test_extractGrokPatterns_bad_input(t *testing.T) {
 		{
 			name: "regex - target is nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -222,7 +222,7 @@ func Test_extractGrokPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -231,7 +231,7 @@ func Test_extractGrokPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 123, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_extractPatterns(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return `a=b c=d`, nil
 		},
 	}
@@ -75,7 +75,7 @@ func Test_extractPatterns_validation(t *testing.T) {
 		{
 			name: "bad regex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -84,7 +84,7 @@ func Test_extractPatterns_validation(t *testing.T) {
 		{
 			name: "no named capture group",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -109,7 +109,7 @@ func Test_extractPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 123, nil
 				},
 			},
@@ -118,7 +118,7 @@ func Test_extractPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -344,10 +344,10 @@ func Test_flatten(t *testing.T) {
 
 			setterWasCalled := false
 			target := ottl.StandardPMapGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (pcommon.Map, error) {
+				Getter: func(context.Context, any) (pcommon.Map, error) {
 					return m, nil
 				},
-				Setter: func(_ context.Context, _ any, val any) error {
+				Setter: func(_ context.Context, _, val any) error {
 					setterWasCalled = true
 					if v, ok := val.(pcommon.Map); ok {
 						v.CopyTo(m)
@@ -506,10 +506,10 @@ func Test_flatten_undeterministic(t *testing.T) {
 
 			setterWasCalled := false
 			target := ottl.StandardPMapGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (pcommon.Map, error) {
+				Getter: func(context.Context, any) (pcommon.Map, error) {
 					return m, nil
 				},
-				Setter: func(_ context.Context, _ any, val any) error {
+				Setter: func(_ context.Context, _, val any) error {
 					setterWasCalled = true
 					if v, ok := val.(pcommon.Map); ok {
 						v.CopyTo(m)
@@ -552,7 +552,7 @@ func Test_flatten_bad_depth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			target := &ottl.StandardPMapGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (pcommon.Map, error) {
+				Getter: func(context.Context, any) (pcommon.Map, error) {
 					return pcommon.NewMap(), nil
 				},
 			}

--- a/pkg/ottl/ottlfuncs/func_format_test.go
+++ b/pkg/ottl/ottlfuncs/func_format_test.go
@@ -36,7 +36,7 @@ func Test_Format(t *testing.T) {
 			name:         "padded int",
 			formatString: "test-%04d",
 			formatArgs: []ottl.Getter[any]{
-				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+				getterFunc[any](func(context.Context, any) (any, error) {
 					return 2, nil
 				}),
 			},
@@ -46,10 +46,10 @@ func Test_Format(t *testing.T) {
 			name:         "multiple-args",
 			formatString: "test-%04d-%4s",
 			formatArgs: []ottl.Getter[any]{
-				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+				getterFunc[any](func(context.Context, any) (any, error) {
 					return 2, nil
 				}),
-				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+				getterFunc[any](func(context.Context, any) (any, error) {
 					return "te", nil
 				}),
 			},
@@ -68,7 +68,7 @@ func Test_Format(t *testing.T) {
 }
 
 func TestFormat_error(t *testing.T) {
-	target := getterFunc[any](func(_ context.Context, _ any) (any, error) {
+	target := getterFunc[any](func(context.Context, any) (any, error) {
 		return nil, errors.New("failed to get")
 	})
 

--- a/pkg/ottl/ottlfuncs/func_formattime_test.go
+++ b/pkg/ottl/ottlfuncs/func_formattime_test.go
@@ -31,7 +31,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "invalid time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "something", nil
 				},
 			},
@@ -41,7 +41,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "simple short form",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 4, 12, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -51,7 +51,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "simple short form with short year and slashes",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2011, 11, 11, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -61,7 +61,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "month day year",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 2, 4, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -71,7 +71,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "simple long form",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1993, 7, 31, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -81,7 +81,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "date with FormatTime",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 3, 14, 17, 0o2, 59, 0, time.Local), nil
 				},
 			},
@@ -91,7 +91,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "day of the week long form",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 5, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -101,7 +101,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "short weekday, short month, long format",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 5, 20, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -111,7 +111,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "short months",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 2, 15, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -121,7 +121,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "simple short form with time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 5, 26, 12, 34, 56, 0, time.Local), nil
 				},
 			},
@@ -131,7 +131,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2012, 11, 0o1, 22, 8, 41, 0, time.Local), nil
 				},
 			},
@@ -141,7 +141,7 @@ func Test_FormatTime(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format before 2000",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1986, 10, 0o1, 0o0, 17, 33, 0o0, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_get_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_get_xml_test.go
@@ -99,7 +99,7 @@ func Test_GetXML(t *testing.T) {
 				ottl.FunctionContext{},
 				&GetXMLArguments[any]{
 					Target: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.document, nil
 						},
 					},

--- a/pkg/ottl/ottlfuncs/func_has_prefix_test.go
+++ b/pkg/ottl/ottlfuncs/func_has_prefix_test.go
@@ -47,7 +47,7 @@ func Test_HasPrefix(t *testing.T) {
 				ottl.FunctionContext{},
 				&HasPrefixArguments[any]{
 					Target: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.target, nil
 						},
 					},
@@ -63,7 +63,7 @@ func Test_HasPrefix(t *testing.T) {
 
 func Test_HasPrefix_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return true, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_has_suffix_test.go
+++ b/pkg/ottl/ottlfuncs/func_has_suffix_test.go
@@ -47,7 +47,7 @@ func Test_HasSuffix(t *testing.T) {
 				ottl.FunctionContext{},
 				&HasSuffixArguments[any]{
 					Target: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.target, nil
 						},
 					},
@@ -63,7 +63,7 @@ func Test_HasSuffix(t *testing.T) {
 
 func Test_HasSuffix_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return true, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_hex_test.go
+++ b/pkg/ottl/ottlfuncs/func_hex_test.go
@@ -27,7 +27,7 @@ func TestHex(t *testing.T) {
 			name: "int64",
 			args: args{
 				target: &ottl.StandardByteSliceLikeGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return int64(12), nil
 					},
 				},
@@ -40,7 +40,7 @@ func TestHex(t *testing.T) {
 			name: "nil",
 			args: args{
 				target: &ottl.StandardByteSliceLikeGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, nil
 					},
 				},
@@ -54,7 +54,7 @@ func TestHex(t *testing.T) {
 			name: "error",
 			args: args{
 				target: &ottl.StandardByteSliceLikeGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return map[string]string{"hi": "hi"}, nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_hour_test.go
+++ b/pkg/ottl/ottlfuncs/func_hour_test.go
@@ -22,7 +22,7 @@ func Test_Hour(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Hour(t *testing.T) {
 
 func Test_Hour_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_hours_test.go
+++ b/pkg/ottl/ottlfuncs/func_hours_test.go
@@ -22,7 +22,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "100 hours",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "1 min",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100m")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "234 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("234ms")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_insert_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_insert_xml_test.go
@@ -122,13 +122,13 @@ func Test_InsertXML(t *testing.T) {
 				ottl.FunctionContext{},
 				&InsertXMLArguments[any]{
 					Target: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.document, nil
 						},
 					},
 					XPath: tt.xPath,
 					SubDocument: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.subdoc, nil
 						},
 					},
@@ -178,7 +178,7 @@ func TestCreateInsertXMLFunc(t *testing.T) {
 	exprFunc, err = factory.CreateFunction(
 		fCtx, &InsertXMLArguments[any]{
 			Target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "<a/>", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -24,7 +24,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match true",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "hello world", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match false",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "goodbye world", nil
 				},
 			},
@@ -44,7 +44,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match complex",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "-12.001", nil
 				},
 			},
@@ -54,7 +54,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target bool",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return true, nil
 				},
 			},
@@ -64,7 +64,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target int",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target float",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -84,7 +84,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target pcommon.Value",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					v := pcommon.NewValueEmpty()
 					v.SetStr("test")
 					return v, nil
@@ -96,7 +96,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "nil target",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -117,7 +117,7 @@ func Test_isMatch(t *testing.T) {
 
 func Test_isMatch_validation(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "anything", nil
 		},
 	}
@@ -127,7 +127,7 @@ func Test_isMatch_validation(t *testing.T) {
 
 func Test_isMatch_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return make(chan int), nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keys_test.go
@@ -39,7 +39,7 @@ func Test_keys(t *testing.T) {
 			err := m.FromRaw(tt.target)
 			assert.NoError(t, err)
 			target := ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return m, nil
 				},
 			}

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -284,7 +284,7 @@ func Test_Len(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc := computeLen[any](&ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tt.value, nil
 				},
 			})

--- a/pkg/ottl/ottlfuncs/func_merge_maps_test.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps_test.go
@@ -174,7 +174,7 @@ func Test_MergeMaps_bad_target(t *testing.T) {
 
 func Test_MergeMaps_bad_input(t *testing.T) {
 	input := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 1, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_microseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_microseconds_test.go
@@ -22,7 +22,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "100 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100us")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "1000 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "50 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("50m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_milliseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_milliseconds_test.go
@@ -22,7 +22,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "100 Milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100ms")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "1000 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "47 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("47m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_minute_test.go
+++ b/pkg/ottl/ottlfuncs/func_minute_test.go
@@ -22,7 +22,7 @@ func Test_Minute(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Minute(t *testing.T) {
 
 func Test_Minute_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_minutes_test.go
+++ b/pkg/ottl/ottlfuncs/func_minutes_test.go
@@ -22,7 +22,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "100 minutes",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100m")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "234 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("234ms")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_month_test.go
+++ b/pkg/ottl/ottlfuncs/func_month_test.go
@@ -22,7 +22,7 @@ func Test_Month(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Month(t *testing.T) {
 
 func Test_Month_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_murmur3_hash128_test.go
+++ b/pkg/ottl/ottlfuncs/func_murmur3_hash128_test.go
@@ -73,7 +73,7 @@ func Test_CreateMurmur3Hash128Func(t *testing.T) {
 	exprFunc, err = factory.CreateFunction(
 		fCtx, &Murmur3Hash128Arguments[any]{
 			Target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Hello World", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_murmur3_hash_test.go
+++ b/pkg/ottl/ottlfuncs/func_murmur3_hash_test.go
@@ -73,7 +73,7 @@ func Test_CreateMurmur3HashFunc(t *testing.T) {
 	exprFunc, err = factory.CreateFunction(
 		fCtx, &Murmur3HashArguments[any]{
 			Target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Hello World", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_nanosecond_test.go
+++ b/pkg/ottl/ottlfuncs/func_nanosecond_test.go
@@ -22,7 +22,7 @@ func Test_Nanosecond(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 197382465, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Nanosecond(t *testing.T) {
 
 func Test_Nanosecond_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_nanoseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_nanoseconds_test.go
@@ -22,7 +22,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "100 nanoseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100ns")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "23 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("23m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_parse_csv_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_csv_test.go
@@ -28,12 +28,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse comma separated values",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -48,12 +48,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in first field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1\nnewline,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -68,12 +68,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in middle field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2\nnewline,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -88,12 +88,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in last field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3\nnewline", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -108,12 +108,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in multiple fields",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1\nnewline1,val2\nnewline2,val3\nnewline3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -128,12 +128,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with leading newline",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "\nval1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -148,12 +148,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with trailing newline",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3\n", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -168,12 +168,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline at end of field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1\n,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -188,12 +188,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse comma separated values with explicit mode",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -209,12 +209,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse tab separated values",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1\tval2\tval3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1\tcol2\tcol3", nil
 					},
 				},
@@ -230,12 +230,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Header delimiter is different from row delimiter",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1\tval2\tval3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1 col2 col3", nil
 					},
 				},
@@ -252,12 +252,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid target (strict mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -268,12 +268,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid header (strict mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
@@ -289,12 +289,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to header/row column mismatch",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2,val3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -305,12 +305,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to header/row column mismatch",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2,val3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -321,12 +321,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Empty header string (strict)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
@@ -337,12 +337,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to empty row",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -353,12 +353,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails for row with bare quotes",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2,v"al3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -371,12 +371,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse lazyQuotes with quote in row",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2,v"al3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -392,12 +392,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse lazyQuotes invalid csv",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,"val2,"val3,val4"`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3,col4", nil
 					},
 				},
@@ -410,12 +410,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse quotes invalid csv",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,"val2,"val3,val4"`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3,col4", nil
 					},
 				},
@@ -432,12 +432,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid target (ignoreQuotes mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -449,12 +449,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid header (ignoreQuotes mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1,val2`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
@@ -466,12 +466,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Empty header string (ignoreQuotes)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `val1`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", nil
 					},
 				},
@@ -484,12 +484,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Delimiter is greater than one character",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -501,12 +501,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "HeaderDelimiter is greater than one character",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -518,12 +518,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Bad mode",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_parse_int_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_int_test.go
@@ -25,7 +25,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "string in base 10",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "string in base 2",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "01010101", nil
 				},
 			},
@@ -53,7 +53,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "an out of range string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return fmt.Sprintf("%d", uint64(math.MaxUint64)), nil
 				},
 			},
@@ -68,7 +68,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "string in base 16",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "AF", nil
 				},
 			},
@@ -82,7 +82,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "string in base 16 with 0x prefix",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "0XAF", nil
 				},
 			},
@@ -96,7 +96,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "not a number string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "test", nil
 				},
 			},
@@ -111,7 +111,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -126,7 +126,7 @@ func Test_ParseInt(t *testing.T) {
 		{
 			name: "negative base value",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "12345", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -24,7 +24,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle string",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":"string value"}`, nil
 				},
 			},
@@ -35,7 +35,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle bool",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":true}`, nil
 				},
 			},
@@ -46,7 +46,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle int",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":1}`, nil
 				},
 			},
@@ -57,7 +57,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle float",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":1.1}`, nil
 				},
 			},
@@ -68,7 +68,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle nil",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":null}`, nil
 				},
 			},
@@ -79,7 +79,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle array",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":["string","value"]}`, nil
 				},
 			},
@@ -92,7 +92,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle top level array",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `["string","value"]`, nil
 				},
 			},
@@ -104,7 +104,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle top level array of objects",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `[{"test":"value"},{"test":"value"}]`, nil
 				},
 			},
@@ -116,7 +116,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle nested object",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test":{"nested":"true"}}`, nil
 				},
 			},
@@ -128,7 +128,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "updates existing",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"existing":"pass"}`, nil
 				},
 			},
@@ -139,7 +139,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "complex",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `{"test1":{"nested":"true"},"test2":"string","test3":1,"test4":1.1,"test5":[[1], [2, 3],[]],"test6":null}`, nil
 				},
 			},
@@ -190,7 +190,7 @@ func Test_ParseJSON(t *testing.T) {
 
 func Test_ParseJSON_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -251,7 +251,7 @@ func BenchmarkParseJSON(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := parseJSON(ottl.StandardStringGetter[any]{
-			Getter: func(_ context.Context, _ any) (any, error) {
+			Getter: func(context.Context, any) (any, error) {
 				return benchData, nil
 			},
 		})(ctx, nil)

--- a/pkg/ottl/ottlfuncs/func_parse_key_value.go
+++ b/pkg/ottl/ottlfuncs/func_parse_key_value.go
@@ -34,7 +34,7 @@ func createParseKeyValueFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argum
 	return parseKeyValue[K](args.Target, args.Delimiter, args.PairDelimiter)
 }
 
-func parseKeyValue[K any](target ottl.StringGetter[K], d ottl.Optional[string], p ottl.Optional[string]) (ottl.ExprFunc[K], error) {
+func parseKeyValue[K any](target ottl.StringGetter[K], d, p ottl.Optional[string]) (ottl.ExprFunc[K], error) {
 	delimiter := "="
 	if !d.IsEmpty() {
 		if d.Get() == "" {

--- a/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
@@ -24,7 +24,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "simple",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "name=ottl func=key_value", nil
 				},
 			},
@@ -38,7 +38,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "large",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `name=ottl age=1 job="software engineering" location="grand rapids michigan" src="10.3.3.76" dst=172.217.0.10 protocol=udp sport=57112 port=443 translated_src_ip=96.63.176.3 translated_port=57112`, nil
 				},
 			},
@@ -61,7 +61,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "embedded double quotes in single quoted value",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `a=b c='this is a "co ol" value'`, nil
 				},
 			},
@@ -75,7 +75,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "double quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `requestClientApplication="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0"`, nil
 				},
 			},
@@ -88,7 +88,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "single quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "requestClientApplication='Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0'", nil
 				},
 			},
@@ -101,7 +101,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "double quotes strip leading & trailing spaces",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `name="   ottl " func="  key_ value"`, nil
 				},
 			},
@@ -115,7 +115,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "! delimiter && whitespace pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "   name!ottl     func!key_value hello!world  ", nil
 				},
 			},
@@ -130,7 +130,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "!! delimiter && whitespace pair delimiter with newlines",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `   
 name!!ottl     
 func!!key_value                      hello!!world  `, nil
@@ -147,7 +147,7 @@ func!!key_value                      hello!!world  `, nil
 		{
 			name: "!! delimiter && newline pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `name!!ottl     
 func!!      key_value another!!pair
 hello!!world  `, nil
@@ -164,7 +164,7 @@ hello!!world  `, nil
 		{
 			name: "quoted value contains delimiter and pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `name="ottl="_func="=key_value"`, nil
 				},
 			},
@@ -178,7 +178,7 @@ hello!!world  `, nil
 		{
 			name: "complicated delimiters",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `k1@*v1_!_k2@**v2_!__k3@@*v3__`, nil
 				},
 			},
@@ -193,7 +193,7 @@ hello!!world  `, nil
 		{
 			name: "leading and trailing pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "   k1=v1   k2==v2       k3=v3= ", nil
 				},
 			},
@@ -208,7 +208,7 @@ hello!!world  `, nil
 		{
 			name: "embedded double quotes end single quoted value",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return `a=b c='this is a "co ol"'`, nil
 				},
 			},
@@ -222,7 +222,7 @@ hello!!world  `, nil
 		{
 			name: "more quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "a=b c=d'='", nil
 				},
 			},
@@ -237,7 +237,7 @@ hello!!world  `, nil
 		{
 			name: "long pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "a=b c=d", nil
 				},
 			},
@@ -276,7 +276,7 @@ hello!!world  `, nil
 
 func Test_parseKeyValue_equal_delimiters(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "", nil
 		},
 	}
@@ -292,7 +292,7 @@ func Test_parseKeyValue_equal_delimiters(t *testing.T) {
 
 func Test_parseKeyValue_bad_target(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -306,7 +306,7 @@ func Test_parseKeyValue_bad_target(t *testing.T) {
 
 func Test_parseKeyValue_empty_target(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "", nil
 		},
 	}
@@ -320,7 +320,7 @@ func Test_parseKeyValue_empty_target(t *testing.T) {
 
 func Test_parseKeyValue_bad_split(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "name=ottl!hello_world", nil
 		},
 	}
@@ -334,7 +334,7 @@ func Test_parseKeyValue_bad_split(t *testing.T) {
 
 func Test_parseKeyValue_mismatch_quotes(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return `k1=v1 k2='v2"`, nil
 		},
 	}
@@ -346,7 +346,7 @@ func Test_parseKeyValue_mismatch_quotes(t *testing.T) {
 
 func Test_parseKeyValue_bad_delimiter(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "a=b c=d", nil
 		},
 	}
@@ -361,7 +361,7 @@ func Test_parseKeyValue_bad_delimiter(t *testing.T) {
 
 func Test_parseKeyValue_empty_delimiters(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "a=b c=d", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_parse_simplified_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_simplified_xml_test.go
@@ -245,7 +245,7 @@ func Test_ParseSimplifiedXML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			target := ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tt.document, nil
 				},
 			}

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -27,7 +27,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Text values in nested elements",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>", nil
 					},
 				},
@@ -63,7 +63,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Formatted example",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `
 						<Log>
 						  <User>
@@ -107,7 +107,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Multiple tags with the same name",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`, nil
 					},
 				},
@@ -135,7 +135,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Multiple lines of content",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log>
 						This record has multiple lines of
 						<User id="0001"/>
@@ -161,7 +161,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Attribute only element",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws" />`, nil
 					},
 				},
@@ -179,7 +179,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Ignores XML declaration",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<?xml version="1.0" encoding="UTF-8" ?><Log>Log content</Log>`, nil
 					},
 				},
@@ -193,7 +193,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Ignores comments",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log>This has a comment <!-- This is comment text --></Log>`, nil
 					},
 				},
@@ -207,7 +207,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Ignores processing instructions",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log><?xml-stylesheet type="text/xsl" href="style.xsl"?>Log content</Log>`, nil
 					},
 				},
@@ -221,7 +221,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Ignores directives",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log><!ELEMENT xi:fallback ANY>Log content</Log>`, nil
 					},
 				},
@@ -235,7 +235,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Missing closing element",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log id="1">`, nil
 					},
 				},
@@ -246,7 +246,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Missing nested closing element",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log><Text></Log>`, nil
 					},
 				},
@@ -257,7 +257,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Multiple XML elements in payload (trailing bytes)",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return `<Log></Log><Log></Log>`, nil
 					},
 				},
@@ -268,7 +268,7 @@ func Test_ParseXML(t *testing.T) {
 			name: "Error getting target",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return "", errors.New("failed to get string")
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_remove_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_remove_xml_test.go
@@ -105,7 +105,7 @@ func Test_RemoveXML(t *testing.T) {
 				ottl.FunctionContext{},
 				&RemoveXMLArguments[any]{
 					Target: ottl.StandardStringGetter[any]{
-						Getter: func(_ context.Context, _ any) (any, error) {
+						Getter: func(context.Context, any) (any, error) {
 							return tt.document, nil
 						},
 					},
@@ -151,7 +151,7 @@ func TestCreateRemoveXMLFunc(t *testing.T) {
 
 func invalidXMLGetter() ottl.StandardStringGetter[any] {
 	return ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return `<a>>>>>>>`, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -42,7 +42,7 @@ func createReplaceAllPatternsFunction[K any](_ ottl.FunctionContext, oArgs ottl.
 	return replaceAllPatterns(args.Target, args.Mode, args.RegexPattern, args.Replacement, args.Function, args.ReplacementFormat)
 }
 
-func replaceAllPatterns[K any](target ottl.PMapGetSetter[K], mode string, regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
+func replaceAllPatterns[K any](target ottl.PMapGetSetter[K], mode, regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_all_patterns is not a valid pattern: %w", err)

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -605,7 +605,7 @@ func Test_replaceAllPatterns_bad_function_result(t *testing.T) {
 			}
 			return pcommon.Map{}, errors.New("expected pcommon.Map")
 		},
-		Setter: func(_ context.Context, tCtx any, m any) error {
+		Setter: func(_ context.Context, tCtx, m any) error {
 			if v, ok := tCtx.(pcommon.Map); ok {
 				if v2, ok2 := m.(pcommon.Map); ok2 {
 					v.CopyTo(v2)
@@ -643,7 +643,7 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 			assert.Nil(t, tCtx)
 			return pcommon.NewMap(), nil
 		},
-		Setter: func(_ context.Context, tCtx any, m any) error {
+		Setter: func(_ context.Context, tCtx, m any) error {
 			if v, ok := tCtx.(pcommon.Map); ok {
 				if v2, ok2 := m.(pcommon.Map); ok2 {
 					v.CopyTo(v2)

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -118,7 +118,7 @@ func Test_replaceMatch_bad_input(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -147,7 +147,7 @@ func Test_replaceMatch_bad_function_input(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -175,7 +175,7 @@ func Test_replaceMatch_bad_function_result(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -208,7 +208,7 @@ func Test_replaceMatch_get_nil(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -64,7 +64,7 @@ func applyReplaceFormat[K any](ctx context.Context, tCtx K, replacementFormat ot
 	return replacementVal, nil
 }
 
-func applyOptReplaceFunction[K any](ctx context.Context, tCtx K, compiledPattern *regexp.Regexp, fn ottl.Optional[ottl.FunctionGetter[K]], originalValStr string, replacementVal string, replacementFormat ottl.Optional[ottl.StringGetter[K]]) (string, error) {
+func applyOptReplaceFunction[K any](ctx context.Context, tCtx K, compiledPattern *regexp.Regexp, fn ottl.Optional[ottl.FunctionGetter[K]], originalValStr, replacementVal string, replacementFormat ottl.Optional[ottl.StringGetter[K]]) (string, error) {
 	var updatedString string
 	updatedString = originalValStr
 	submatches := compiledPattern.FindAllStringSubmatchIndex(updatedString, -1)

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -255,7 +255,7 @@ func Test_replacePattern_bad_input(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -283,7 +283,7 @@ func Test_replacePattern_bad_function_input(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -311,7 +311,7 @@ func Test_replacePattern_bad_function_result(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -344,7 +344,7 @@ func Test_replacePattern_get_nil(t *testing.T) {
 		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -367,11 +367,11 @@ func Test_replacePattern_get_nil(t *testing.T) {
 
 func Test_replacePatterns_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
 		},
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},

--- a/pkg/ottl/ottlfuncs/func_second_test.go
+++ b/pkg/ottl/ottlfuncs/func_second_test.go
@@ -22,7 +22,7 @@ func Test_Second(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Second(t *testing.T) {
 
 func Test_Second_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_seconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_seconds_test.go
@@ -22,7 +22,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "100 seconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100s")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "11 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("11m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "50 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("11us")
 				},
 			},
@@ -58,7 +58,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_set_test.go
+++ b/pkg/ottl/ottlfuncs/func_set_test.go
@@ -74,7 +74,7 @@ func Test_set(t *testing.T) {
 
 func Test_set_get_nil(t *testing.T) {
 	setter := &ottl.StandardGetSetter[any]{
-		Setter: func(_ context.Context, _ any, _ any) error {
+		Setter: func(context.Context, any, any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},

--- a/pkg/ottl/ottlfuncs/func_slice_to_map_test.go
+++ b/pkg/ottl/ottlfuncs/func_slice_to_map_test.go
@@ -283,7 +283,7 @@ func Test_SliceToMap(t *testing.T) {
 			}
 			associateFunc, err := sliceToMapFunction[any](ottl.FunctionContext{}, &SliceToMapArguments[any]{
 				Target: &ottl.StandardGetSetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
+					Getter: func(context.Context, any) (any, error) {
 						return tt.value(), nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_sort_test.go
+++ b/pkg/ottl/ottlfuncs/func_sort_test.go
@@ -28,7 +28,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "int slice",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{9, 6, 3})
 					return s, nil
@@ -40,7 +40,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "int slice desc",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{3, 6, 9})
 					return s, nil
@@ -52,7 +52,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "string slice",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{"i", "am", "awesome", "slice"})
 					return s, nil
@@ -64,7 +64,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "double slice",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{1.5, 10.2, 2.3, 0.5})
 					return s, nil
@@ -76,7 +76,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "empty slice",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					return s, nil
 				},
@@ -87,7 +87,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "bool slice compares as string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{true, false, true, false})
 					return s, nil
@@ -99,7 +99,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "mixed types slice compares as string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{1, "two", 3.33, false})
 					return s, nil
@@ -111,7 +111,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "double and string slice compares as string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{1.5, "10.2", 2.3, 0.5})
 					return s, nil
@@ -123,7 +123,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "mixed numeric types slice compares as double",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{0, 2, 3.33, 0})
 					return s, nil
@@ -135,7 +135,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "mixed numeric types slice compares as double desc",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					s := pcommon.NewValueSlice().SetEmptySlice()
 					_ = s.FromRaw([]any{3.14, 2, 3.33, 0})
 					return s, nil
@@ -147,7 +147,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]any compares as string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{1, "two", 3.33, false}, nil
 				},
 			},
@@ -157,7 +157,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []string{"A", "a", "aa"}, nil
 				},
 			},
@@ -167,7 +167,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]bool compares as string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []bool{true, false}, nil
 				},
 			},
@@ -177,7 +177,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]int64",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []int64{6, 3, 9}, nil
 				},
 			},
@@ -187,7 +187,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]float64",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []float64{1.5, 10.2, 2.3, 0.5}, nil
 				},
 			},
@@ -197,7 +197,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "pcommon.Value is a slice",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					pv := pcommon.NewValueEmpty()
 					s := pv.SetEmptySlice()
 					_ = s.FromRaw([]any{"a", "slice", "a"})
@@ -210,7 +210,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "pcommon.Value is empty",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					pv := pcommon.NewValueEmpty()
 					return pv, nil
 				},
@@ -222,7 +222,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "unsupported ValueTypeMap",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return pMap, nil
 				},
 			},
@@ -233,7 +233,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "unsupported bytes",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []byte("still fine"), nil
 				},
 			},
@@ -244,7 +244,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "unsupported string",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "no change", nil
 				},
 			},
@@ -255,7 +255,7 @@ func Test_Sort(t *testing.T) {
 		{
 			name: "[]any with a map",
 			getter: ottl.StandardGetSetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return []any{map[string]string{"some": "invalid kv"}}, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -22,7 +22,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "A|B|C", nil
 				},
 			},
@@ -32,7 +32,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty delimiter",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "A|B|C", nil
 				},
 			},
@@ -52,7 +52,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string and empty delimiter",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -72,7 +72,7 @@ func Test_split(t *testing.T) {
 
 func Test_Split_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 1, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_substring.go
+++ b/pkg/ottl/ottlfuncs/func_substring.go
@@ -31,7 +31,7 @@ func createSubstringFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments
 	return substring(args.Target, args.Start, args.Length), nil
 }
 
-func substring[K any](target ottl.StringGetter[K], startGetter ottl.IntGetter[K], lengthGetter ottl.IntGetter[K]) ottl.ExprFunc[K] {
+func substring[K any](target ottl.StringGetter[K], startGetter, lengthGetter ottl.IntGetter[K]) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (any, error) {
 		start, err := startGetter.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -23,7 +23,7 @@ func Test_substring(t *testing.T) {
 		{
 			name: "substring",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_substring(t *testing.T) {
 		{
 			name: "substring with result of total string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -79,7 +79,7 @@ func Test_substring_validation(t *testing.T) {
 		{
 			name: "substring with result of empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -97,7 +97,7 @@ func Test_substring_validation(t *testing.T) {
 		{
 			name: "substring with invalid start index",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -133,7 +133,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -151,7 +151,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring with invalid length index",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -169,7 +169,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 123456789, nil
 				},
 			},
@@ -187,7 +187,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring nil string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_time.go
+++ b/pkg/ottl/ottlfuncs/func_time.go
@@ -33,7 +33,7 @@ func createTimeFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ot
 	return Time(args.Time, args.Format, args.Location, args.Locale)
 }
 
-func Time[K any](inputTime ottl.StringGetter[K], format string, location ottl.Optional[string], locale ottl.Optional[string]) (ottl.ExprFunc[K], error) {
+func Time[K any](inputTime ottl.StringGetter[K], format string, location, locale ottl.Optional[string]) (ottl.ExprFunc[K], error) {
 	if format == "" {
 		return nil, errors.New("format cannot be nil")
 	}

--- a/pkg/ottl/ottlfuncs/func_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_time_test.go
@@ -29,7 +29,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple short form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-04-12", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple short form with short year and slashes",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "month day year",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "02/04/2023", nil
 				},
 			},
@@ -59,7 +59,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "July 31, 1993", nil
 				},
 			},
@@ -69,7 +69,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "date with timestamp",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Mar 14 2023 17:02:59", nil
 				},
 			},
@@ -79,7 +79,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "day of the week long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Monday, May 01, 2023", nil
 				},
 			},
@@ -89,7 +89,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short weekday, short month, long format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Sat, May 20, 2023", nil
 				},
 			},
@@ -99,7 +99,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short months",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Feb 15, 2023", nil
 				},
 			},
@@ -109,7 +109,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "timestamp with time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56 HST", nil
 				},
 			},
@@ -119,7 +119,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short date with timestamp without time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26T12:34:56 GMT", nil
 				},
 			},
@@ -129,7 +129,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2012-11-01T22:08:41+0000 EST", nil
 				},
 			},
@@ -139,7 +139,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format before 2000",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1986-10-01T00:17:33 MST", nil
 				},
 			},
@@ -149,7 +149,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "no location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2022/01/01", nil
 				},
 			},
@@ -159,7 +159,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "with location - America",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -170,7 +170,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "with location - Asia",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -181,7 +181,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format before 2000, ignore default location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1986-10-01T00:17:33 MST", nil
 				},
 			},
@@ -192,7 +192,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "with locale",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Febrero 25 lunes, 2002, 02:03:04 p.m.", nil
 				},
 			},
@@ -203,7 +203,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "with locale - date only",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "mercoledì set 4 2024", nil
 				},
 			},
@@ -214,7 +214,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "with locale and location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Febrero 25 lunes, 2002, 02:03:04 p.m.", nil
 				},
 			},
@@ -253,7 +253,7 @@ func Test_TimeError(t *testing.T) {
 		{
 			name: "invalid short format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -263,7 +263,7 @@ func Test_TimeError(t *testing.T) {
 		{
 			name: "invalid RFC3339 with no time",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -295,7 +295,7 @@ func Test_TimeFormatError(t *testing.T) {
 		{
 			name: "invalid short with no format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -305,7 +305,7 @@ func Test_TimeFormatError(t *testing.T) {
 		{
 			name: "with unknown location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -316,7 +316,7 @@ func Test_TimeFormatError(t *testing.T) {
 		{
 			name: "with unsupported locale",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -355,7 +355,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "simple short form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-04-12", nil
 				},
 			},
@@ -365,7 +365,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "simple short form with short year and slashes",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -375,7 +375,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "month day year",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "02/04/2023", nil
 				},
 			},
@@ -385,7 +385,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "simple long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "July 31, 1993", nil
 				},
 			},
@@ -395,7 +395,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "date with timestamp",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Mar 14 2023 17:02:59", nil
 				},
 			},
@@ -405,7 +405,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "day of the week long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Monday, May 01, 2023", nil
 				},
 			},
@@ -415,7 +415,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "short weekday, short month, long format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Sat, May 20, 2023", nil
 				},
 			},
@@ -425,7 +425,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "short months",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "Feb 15, 2023", nil
 				},
 			},
@@ -435,7 +435,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "timestamp with time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56 HST", nil
 				},
 			},
@@ -445,7 +445,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "short date with timestamp without time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26T12:34:56 GMT", nil
 				},
 			},
@@ -455,7 +455,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "RFC 3339 in custom format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2012-11-01T22:08:41+0000 EST", nil
 				},
 			},
@@ -465,7 +465,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "RFC 3339 in custom format before 2000",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1986-10-01T00:17:33 MST", nil
 				},
 			},
@@ -475,7 +475,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "no location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2022/01/01", nil
 				},
 			},
@@ -485,7 +485,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "with location - America",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -496,7 +496,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "with location - Asia",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "2023-05-26 12:34:56", nil
 				},
 			},
@@ -507,7 +507,7 @@ func Benchmark_Time(t *testing.B) {
 		{
 			name: "RFC 3339 in custom format before 2000, ignore default location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "1986-10-01T00:17:33 MST", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_to_camel_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_camel_case_test.go
@@ -21,7 +21,7 @@ func Test_toCamelCase(t *testing.T) {
 		{
 			name: "simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -30,7 +30,7 @@ func Test_toCamelCase(t *testing.T) {
 		{
 			name: "already camel",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "SimpleString", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_toCamelCase(t *testing.T) {
 		{
 			name: "hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -48,7 +48,7 @@ func Test_toCamelCase(t *testing.T) {
 		{
 			name: "empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_toCamelCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -83,7 +83,7 @@ func Test_toCamelCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_to_key_value_string.go
+++ b/pkg/ottl/ottlfuncs/func_to_key_value_string.go
@@ -36,7 +36,7 @@ func createToKeyValueStringFunction[K any](_ ottl.FunctionContext, oArgs ottl.Ar
 	return toKeyValueString[K](args.Target, args.Delimiter, args.PairDelimiter, args.SortOutput)
 }
 
-func toKeyValueString[K any](target ottl.PMapGetter[K], d ottl.Optional[string], p ottl.Optional[string], s ottl.Optional[bool]) (ottl.ExprFunc[K], error) {
+func toKeyValueString[K any](target ottl.PMapGetter[K], d, p ottl.Optional[string], s ottl.Optional[bool]) (ottl.ExprFunc[K], error) {
 	delimiter := "="
 	if !d.IsEmpty() {
 		if d.Get() == "" {
@@ -73,7 +73,7 @@ func toKeyValueString[K any](target ottl.PMapGetter[K], d ottl.Optional[string],
 }
 
 // convertMapToKV converts a pcommon.Map to a key value string
-func convertMapToKV(target pcommon.Map, delimiter string, pairDelimiter string, sortOutput bool) string {
+func convertMapToKV(target pcommon.Map, delimiter, pairDelimiter string, sortOutput bool) string {
 	var kvStrings []string
 	if sortOutput {
 		var keyValues []struct {
@@ -105,13 +105,13 @@ func convertMapToKV(target pcommon.Map, delimiter string, pairDelimiter string, 
 	return strings.Join(kvStrings, pairDelimiter)
 }
 
-func buildKVString(k string, v pcommon.Value, delimiter string, pairDelimiter string) string {
+func buildKVString(k string, v pcommon.Value, delimiter, pairDelimiter string) string {
 	key := escapeAndQuoteKV(k, delimiter, pairDelimiter)
 	value := escapeAndQuoteKV(v.AsString(), delimiter, pairDelimiter)
 	return key + delimiter + value
 }
 
-func escapeAndQuoteKV(s string, delimiter string, pairDelimiter string) string {
+func escapeAndQuoteKV(s, delimiter, pairDelimiter string) string {
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	if strings.Contains(s, pairDelimiter) || strings.Contains(s, delimiter) {
 		s = `"` + s + `"`

--- a/pkg/ottl/ottlfuncs/func_to_key_value_string_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_key_value_string_test.go
@@ -23,7 +23,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "default delimiters with no nesting",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1",
 						"key2": "value2",
@@ -37,7 +37,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "custom delimiter with no nesting",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1",
 						"key2": "value2",
@@ -51,7 +51,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "custom pair delimiter with no nesting",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1",
 						"key2": "value2",
@@ -65,7 +65,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "delimiters present in keys and values",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key 1": "value 1",
 						"key2=": "value2=",
@@ -79,7 +79,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "long delimiters present in keys and values",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1":    "value1",
 						"key2,,,": "value2,,,,,,",
@@ -93,7 +93,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "delimiters and quotes present in keys and values",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key 1":   "value 1",
 						"key2\"=": "value2\"=",
@@ -108,7 +108,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "nested",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1",
 						"key2": map[string]any{
@@ -129,7 +129,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "nested with delimiter present",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1",
 						"key2": map[string]any{
@@ -150,7 +150,7 @@ func Test_toKeyValueString(t *testing.T) {
 		{
 			name: "nested with delimiter and quotes present",
 			target: ottl.StandardPMapGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return map[string]any{
 						"key1": "value1\"",
 						"key2": map[string]any{
@@ -188,7 +188,7 @@ func Test_toKeyValueString(t *testing.T) {
 
 func Test_toKeyValueString_equal_delimiters(t *testing.T) {
 	target := ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return map[string]any{
 				"key1": "value1",
 				"key2": "value2",
@@ -207,7 +207,7 @@ func Test_toKeyValueString_equal_delimiters(t *testing.T) {
 
 func Test_toKeyValueString_bad_target(t *testing.T) {
 	target := ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -221,7 +221,7 @@ func Test_toKeyValueString_bad_target(t *testing.T) {
 
 func Test_toKeyValueString_empty_target(t *testing.T) {
 	target := ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "", nil
 		},
 	}
@@ -235,7 +235,7 @@ func Test_toKeyValueString_empty_target(t *testing.T) {
 
 func Test_toKeyValueString_empty_delimiters(t *testing.T) {
 	target := ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "a=b c=d", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_to_lower_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_lower_case_test.go
@@ -21,7 +21,7 @@ func Test_toLowerCase(t *testing.T) {
 		{
 			name: "simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "SIMPLE", nil
 				},
 			},
@@ -30,7 +30,7 @@ func Test_toLowerCase(t *testing.T) {
 		{
 			name: "already lower",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_toLowerCase(t *testing.T) {
 		{
 			name: "complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -48,7 +48,7 @@ func Test_toLowerCase(t *testing.T) {
 		{
 			name: "empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_toLowerCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -83,7 +83,7 @@ func Test_toLowerCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_to_snake_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_snake_case_test.go
@@ -21,7 +21,7 @@ func Test_toSnakeCase(t *testing.T) {
 		{
 			name: "simple toSnake",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simpleString", nil
 				},
 			},
@@ -30,7 +30,7 @@ func Test_toSnakeCase(t *testing.T) {
 		{
 			name: "noop already snake case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_toSnakeCase(t *testing.T) {
 		{
 			name: "multiple uppercase",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "CPUUtilizationMetric", nil
 				},
 			},
@@ -48,7 +48,7 @@ func Test_toSnakeCase(t *testing.T) {
 		{
 			name: "hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -57,7 +57,7 @@ func Test_toSnakeCase(t *testing.T) {
 		{
 			name: "empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -83,7 +83,7 @@ func Test_toSnakeCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -92,7 +92,7 @@ func Test_toSnakeCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_to_upper_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_to_upper_case_test.go
@@ -21,7 +21,7 @@ func Test_toUpperCase(t *testing.T) {
 		{
 			name: "simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "simple", nil
 				},
 			},
@@ -30,7 +30,7 @@ func Test_toUpperCase(t *testing.T) {
 		{
 			name: "already upper",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "SIMPLE", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_toUpperCase(t *testing.T) {
 		{
 			name: "complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -48,7 +48,7 @@ func Test_toUpperCase(t *testing.T) {
 		{
 			name: "empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_toUpperCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -83,7 +83,7 @@ func Test_toUpperCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_trim_test.go
+++ b/pkg/ottl/ottlfuncs/func_trim_test.go
@@ -23,7 +23,7 @@ func Test_trim(t *testing.T) {
 		{
 			name: "trim string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return " this is a test ", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_trim(t *testing.T) {
 		{
 			name: "trim empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "", nil
 				},
 			},
@@ -45,7 +45,7 @@ func Test_trim(t *testing.T) {
 		{
 			name: "No replacement string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return " this is a test ", nil
 				},
 			},
@@ -56,7 +56,7 @@ func Test_trim(t *testing.T) {
 		{
 			name: "Set replacement string to \"\"",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return " this is a test ", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_truncate_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_time_test.go
@@ -24,12 +24,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate to 1s",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					d, _ := time.ParseDuration("1s")
 					return d, nil
 				},
@@ -39,12 +39,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate to 1ms",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					d, _ := time.ParseDuration("1ms")
 					return d, nil
 				},
@@ -54,12 +54,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate old time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1980, 9, 9, 9, 59, 59, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					d, _ := time.ParseDuration("1h")
 					return d, nil
 				},
@@ -88,12 +88,12 @@ func Test_TruncateTimeError(t *testing.T) {
 		{
 			name: "not a time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					d, _ := time.ParseDuration("1ms")
 					return d, nil
 				},
@@ -103,12 +103,12 @@ func Test_TruncateTimeError(t *testing.T) {
 		{
 			name: "not a duration",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Now(), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return "string", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_micro_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_micro_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "April 30, 2001, 3pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2001, 4, 30, 15, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "November 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1980, 11, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_milli_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_milli_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "January 1, 2022",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2022, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "May 30, 2002, 3pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2002, 5, 30, 15, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "September 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1980, 9, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_nano_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_nano_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "April 30, 2000, 1pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2000, 4, 30, 13, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "December 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1980, 12, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_seconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_seconds_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "March 31, 2000, 4pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2000, 3, 31, 16, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "December 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(1980, 12, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_url_test.go
+++ b/pkg/ottl/ottlfuncs/func_url_test.go
@@ -155,7 +155,7 @@ func TestURLParser(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			source := &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tc.Original, nil
 				},
 			}

--- a/pkg/ottl/ottlfuncs/func_useragent_test.go
+++ b/pkg/ottl/ottlfuncs/func_useragent_test.go
@@ -139,7 +139,7 @@ func TestUserAgentParser(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.Name, func(t *testing.T) {
 			source := &ottl.StandardStringGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return tt.UAString, nil
 				},
 			}

--- a/pkg/ottl/ottlfuncs/func_weekday_test.go
+++ b/pkg/ottl/ottlfuncs/func_weekday_test.go
@@ -22,7 +22,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Mon",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 24, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Tue",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 25, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Wed",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 26, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Thu",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 27, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -58,7 +58,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Fri",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 28, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -67,7 +67,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Sat",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 22, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -76,7 +76,7 @@ func Test_Weekday(t *testing.T) {
 		{
 			name: "Sun",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2025, time.February, 23, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -96,7 +96,7 @@ func Test_Weekday(t *testing.T) {
 
 func Test_Weekday_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_year_test.go
+++ b/pkg/ottl/ottlfuncs/func_year_test.go
@@ -22,7 +22,7 @@ func Test_Year(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(_ context.Context, _ any) (any, error) {
+				Getter: func(context.Context, any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Year(t *testing.T) {
 
 func Test_Year_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
+		Getter: func(context.Context, any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -209,7 +209,7 @@ func (p *Parser[K]) ParseCondition(condition string) (*Condition[K], error) {
 	}, nil
 }
 
-func (p *Parser[K]) prependContextToPaths(context string, ottl string, ottlPathsGetter func(ottl string) ([]path, error)) (string, error) {
+func (p *Parser[K]) prependContextToPaths(context, ottl string, ottlPathsGetter func(ottl string) ([]path, error)) (string, error) {
 	if _, ok := p.pathContextNames[context]; !ok {
 		return "", fmt.Errorf(`unknown context "%s" for parser %T, valid options are: %s`, context, p, p.buildPathContextNamesText(""))
 	}
@@ -235,7 +235,7 @@ func (p *Parser[K]) prependContextToPaths(context string, ottl string, ottlPaths
 // to all context-less paths. No modifications are performed for paths which [Path.Context]
 // value matches any WithPathContextNames value.
 // The context argument must be valid WithPathContextNames value, otherwise an error is returned.
-func (p *Parser[K]) prependContextToStatementPaths(context string, statement string) (string, error) {
+func (p *Parser[K]) prependContextToStatementPaths(context, statement string) (string, error) {
 	return p.prependContextToPaths(context, statement, func(ottl string) ([]path, error) {
 		parsed, err := parseStatement(ottl)
 		if err != nil {
@@ -249,7 +249,7 @@ func (p *Parser[K]) prependContextToStatementPaths(context string, statement str
 // to all context-less paths. No modifications are performed for paths which [Path.Context]
 // value matches any WithPathContextNames value.
 // The context argument must be valid WithPathContextNames value, otherwise an error is returned.
-func (p *Parser[K]) prependContextToConditionPaths(context string, condition string) (string, error) {
+func (p *Parser[K]) prependContextToConditionPaths(context, condition string) (string, error) {
 	return p.prependContextToPaths(context, condition, func(ottl string) ([]path, error) {
 		parsed, err := parseCondition(ottl)
 		if err != nil {
@@ -263,7 +263,7 @@ func (p *Parser[K]) prependContextToConditionPaths(context string, condition str
 // to all context-less paths. No modifications are performed for paths which [Path.Context]
 // value matches any WithPathContextNames value.
 // The context argument must be valid WithPathContextNames value, otherwise an error is returned.
-func (p *Parser[K]) prependContextToValueExpressionPaths(context string, expr string) (string, error) {
+func (p *Parser[K]) prependContextToValueExpressionPaths(context, expr string) (string, error) {
 	return p.prependContextToPaths(context, expr, func(ottl string) ([]path, error) {
 		parsed, err := parseValueExpression(ottl)
 		if err != nil {
@@ -318,7 +318,7 @@ func parseValueExpression(raw string) (*value, error) {
 	return parsed, nil
 }
 
-func insertContextIntoPathsOffsets(context string, statement string, offsets []int) (string, error) {
+func insertContextIntoPathsOffsets(context, statement string, offsets []int) (string, error) {
 	if len(offsets) == 0 {
 		return statement, nil
 	}

--- a/pkg/ottl/parser_collection.go
+++ b/pkg/ottl/parser_collection.go
@@ -196,7 +196,7 @@ type (
 )
 
 // createConditionsParserWithConverter is a method to create the necessary parser wrapper and shadowing the K type.
-func createConditionsParserWithConverter[K any, R any](converter ParsedConditionsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, ConditionsGetter] {
+func createConditionsParserWithConverter[K, R any](converter ParsedConditionsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, ConditionsGetter] {
 	return func(pc *ParserCollection[R], context string, conditions ConditionsGetter, prependPathsContext bool) (R, error) {
 		var err error
 		var parsingConditions []string
@@ -233,7 +233,7 @@ func createConditionsParserWithConverter[K any, R any](converter ParsedCondition
 }
 
 // createValueExpressionsParserWithConverter is a method to create the necessary parser wrapper and shadowing the K type.
-func createValueExpressionsParserWithConverter[K any, R any](converter ParsedValueExpressionsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, ValueExpressionsGetter] {
+func createValueExpressionsParserWithConverter[K, R any](converter ParsedValueExpressionsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, ValueExpressionsGetter] {
 	return func(pc *ParserCollection[R], context string, expressions ValueExpressionsGetter, prependPathsContext bool) (R, error) {
 		var err error
 		var parsingValueExpressions []string
@@ -270,7 +270,7 @@ func createValueExpressionsParserWithConverter[K any, R any](converter ParsedVal
 }
 
 // createStatementsParserWithConverter is a method to create the necessary parser wrapper and shadowing the K type.
-func createStatementsParserWithConverter[K any, R any](converter ParsedStatementsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, StatementsGetter] {
+func createStatementsParserWithConverter[K, R any](converter ParsedStatementsConverter[K, R], parser *Parser[K]) parserCollectionContextParserFunc[R, StatementsGetter] {
 	return func(pc *ParserCollection[R], context string, statements StatementsGetter, prependPathsContext bool) (R, error) {
 		var err error
 		var parsingStatements []string
@@ -311,7 +311,7 @@ func createStatementsParserWithConverter[K any, R any](converter ParsedStatement
 // The context's OTTL parser will parse the conditions, and the converter function will transform the parsed conditions into the desired representation.
 //
 // Experimental: *NOTE* this API is subject to change or removal in the future.
-func WithConditionConverter[K any, R any](converter ParsedConditionsConverter[K, R]) ParserCollectionContextOption[K, R] {
+func WithConditionConverter[K, R any](converter ParsedConditionsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseConditions = createConditionsParserWithConverter(converter, parser)
 	}
@@ -322,7 +322,7 @@ func WithConditionConverter[K any, R any](converter ParsedConditionsConverter[K,
 // The context's OTTL parser will parse the value expressions, and the converter function will transform the parsed value expressions into the desired representation.
 //
 // Experimental: *NOTE* this API is subject to change or removal in the future.
-func WithValueExpressionConverter[K any, R any](converter ParsedValueExpressionsConverter[K, R]) ParserCollectionContextOption[K, R] {
+func WithValueExpressionConverter[K, R any](converter ParsedValueExpressionsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseValueExpressions = createValueExpressionsParserWithConverter(converter, parser)
 	}
@@ -333,7 +333,7 @@ func WithValueExpressionConverter[K any, R any](converter ParsedValueExpressions
 // The context's OTTL parser will parse the statements, and the converter function will transform the parsed statements into the desired representation.
 //
 // Experimental: *NOTE* this API is subject to change or removal in the future.
-func WithStatementConverter[K any, R any](converter ParsedStatementsConverter[K, R]) ParserCollectionContextOption[K, R] {
+func WithStatementConverter[K, R any](converter ParsedStatementsConverter[K, R]) ParserCollectionContextOption[K, R] {
 	return func(pcp *ParserCollectionContextParser[R], parser *Parser[K]) {
 		pcp.parseStatements = createStatementsParserWithConverter(converter, parser)
 	}
@@ -344,7 +344,7 @@ func WithStatementConverter[K any, R any](converter ParsedStatementsConverter[K,
 // the ottl.WithPathContextNames option.
 //
 // Experimental: *NOTE* this API is subject to change or removal in the future.
-func WithParserCollectionContext[K any, R any](
+func WithParserCollectionContext[K, R any](
 	context string,
 	parser *Parser[K],
 	opts ...ParserCollectionContextOption[K, R],

--- a/pkg/ottl/parser_collection_test.go
+++ b/pkg/ottl/parser_collection_test.go
@@ -913,7 +913,7 @@ func Test_NewValueExpressionsGetter(t *testing.T) {
 func mockParser(t *testing.T, options ...Option[any]) *Parser[any] {
 	mockSetFactory := NewFactory("set", &mockSetArguments[any]{},
 		func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
-			return func(_ context.Context, _ any) (any, error) {
+			return func(context.Context, any) (any, error) {
 				return nil, nil
 			}, nil
 		})

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1570,7 +1570,7 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 			Getter: func(_ context.Context, tCtx any) (any, error) {
 				return tCtx, nil
 			},
-			Setter: func(_ context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -1585,7 +1585,7 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 				}
 				return m[p.Name()], nil
 			},
-			Setter: func(_ context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -1600,7 +1600,7 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 				}
 				return m[p.Name()], nil
 			},
-			Setter: func(_ context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -2546,7 +2546,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "Condition matched",
 			condition: alwaysTrue[any],
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, nil
 			},
 			expectedCondition: true,
@@ -2555,7 +2555,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "Condition not matched",
 			condition: alwaysFalse[any],
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, nil
 			},
 			expectedCondition: false,
@@ -2564,7 +2564,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "No result",
 			condition: alwaysTrue[any],
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return nil, nil
 			},
 			expectedCondition: true,
@@ -2629,7 +2629,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, errors.New("test")
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, nil
 			},
 			errorMode: IgnoreError,
@@ -2639,7 +2639,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, errors.New("test")
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, nil
 			},
 			errorMode: PropagateError,
@@ -2649,7 +2649,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, errors.New("test")
 			},
 			errorMode: IgnoreError,
@@ -2659,7 +2659,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, errors.New("test")
 			},
 			errorMode: PropagateError,
@@ -2669,7 +2669,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, errors.New("test")
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, nil
 			},
 			errorMode: SilentError,
@@ -2679,7 +2679,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(_ context.Context, _ any) (any, error) {
+			function: func(context.Context, any) (any, error) {
 				return 1, errors.New("test")
 			},
 			errorMode: SilentError,
@@ -2942,7 +2942,7 @@ func Test_prependContextToStatementPaths_Success(t *testing.T) {
 	}
 
 	mockSetFactory := NewFactory("set", &mockSetArguments[any]{}, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
-		return func(_ context.Context, _ any) (any, error) {
+		return func(context.Context, any) (any, error) {
 			return nil, nil
 		}, nil
 	})
@@ -3079,7 +3079,7 @@ func Test_prependContextToConditionPaths_Success(t *testing.T) {
 	}
 
 	mockSetFactory := NewFactory("set", &mockSetArguments[any]{}, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
-		return func(_ context.Context, _ any) (any, error) {
+		return func(context.Context, any) (any, error) {
 			return nil, nil
 		}, nil
 	})
@@ -3216,7 +3216,7 @@ func Test_prependContextToValueExpressionPaths_Success(t *testing.T) {
 	}
 
 	mockSetFactory := NewFactory("set", &mockSetArguments[any]{}, func(_ FunctionContext, _ Arguments) (ExprFunc[any], error) {
-		return func(_ context.Context, _ any) (any, error) {
+		return func(context.Context, any) (any, error) {
 			return nil, nil
 		}, nil
 	})

--- a/pkg/pdatatest/pmetrictest/metrics.go
+++ b/pkg/pdatatest/pmetrictest/metrics.go
@@ -219,7 +219,7 @@ func CompareScopeMetrics(expected, actual pmetric.ScopeMetrics) error {
 	return errs
 }
 
-func CompareMetric(expected pmetric.Metric, actual pmetric.Metric) error {
+func CompareMetric(expected, actual pmetric.Metric) error {
 	var errs error
 
 	if actual.Name() != expected.Name() {

--- a/pkg/pdatatest/pmetrictest/options.go
+++ b/pkg/pdatatest/pmetrictest/options.go
@@ -507,7 +507,7 @@ func maskHistogramSliceAttributeValues(dataPoints pmetric.HistogramDataPointSlic
 }
 
 // MatchMetricAttributeValue is a CompareMetricsOption that transforms a metric attribute value based on a regular expression.
-func MatchMetricAttributeValue(attributeName string, pattern string, metricNames ...string) CompareMetricsOption {
+func MatchMetricAttributeValue(attributeName, pattern string, metricNames ...string) CompareMetricsOption {
 	re := regexp.MustCompile(pattern)
 	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
 		matchMetricAttributeValue(expected, attributeName, re, metricNames)
@@ -610,7 +610,7 @@ func matchHistogramDataPointSliceAttributeValues(dataPoints pmetric.HistogramDat
 }
 
 // MatchResourceAttributeValue is a CompareMetricsOption that transforms a resource attribute value based on a regular expression.
-func MatchResourceAttributeValue(attributeName string, pattern string) CompareMetricsOption {
+func MatchResourceAttributeValue(attributeName, pattern string) CompareMetricsOption {
 	re := regexp.MustCompile(pattern)
 	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
 		matchResourceAttributeValue(expected, attributeName, re)

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -112,7 +112,7 @@ func BenchmarkJoinAttributes(b *testing.B) {
 	}
 }
 
-func initMetricAttributes(capacity int, idx int) pcommon.Map {
+func initMetricAttributes(capacity, idx int) pcommon.Map {
 	dest := pcommon.NewMap()
 	dest.EnsureCapacity(capacity)
 	for i := 0; i < capacity; i++ {

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -39,7 +39,7 @@ func BenchmarkConvertComplex(b *testing.B) {
 	}
 }
 
-func complexEntriesForNDifferentHosts(count int, n int) []*entry.Entry {
+func complexEntriesForNDifferentHosts(count, n int) []*entry.Entry {
 	ret := make([]*entry.Entry, count)
 	for i := 0; i < count; i++ {
 		e := entry.New()
@@ -83,7 +83,7 @@ func complexEntriesForNDifferentHosts(count int, n int) []*entry.Entry {
 	return ret
 }
 
-func complexEntriesForNDifferentHostsMDifferentScopes(count int, n int, m int) []*entry.Entry {
+func complexEntriesForNDifferentHostsMDifferentScopes(count, n, m int) []*entry.Entry {
 	ret := make([]*entry.Entry, count)
 	for i := 0; i < count; i++ {
 		for j := 0; j < m; j++ {

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -28,7 +28,7 @@ func fillBaseMap(m pcommon.Map) {
 	m.PutEmptyBytes("bytes").FromRaw([]byte{0xa1, 0xf0, 0x02, 0xff})
 }
 
-func complexPdataForNDifferentHosts(count int, n int) plog.Logs {
+func complexPdataForNDifferentHosts(count, n int) plog.Logs {
 	pLogs := plog.NewLogs()
 	logs := pLogs.ResourceLogs()
 

--- a/pkg/stanza/errors/error.go
+++ b/pkg/stanza/errors/error.go
@@ -73,7 +73,7 @@ func Wrap(err error, context string) AgentError {
 }
 
 // NewError will create a new agent error.
-func NewError(description string, suggestion string, keyValues ...string) AgentError {
+func NewError(description, suggestion string, keyValues ...string) AgentError {
 	return AgentError{
 		Description: description,
 		Suggestion:  suggestion,

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker.go
@@ -51,7 +51,7 @@ type fileTracker struct {
 	archive archive.Archive
 }
 
-func NewFileTracker(ctx context.Context, set component.TelemetrySettings, maxBatchFiles int, pollsToArchive int, persister operator.Persister) Tracker {
+func NewFileTracker(ctx context.Context, set component.TelemetrySettings, maxBatchFiles, pollsToArchive int, persister operator.Persister) Tracker {
 	knownFiles := make([]*fileset.Fileset[*reader.Metadata], 3)
 	for i := 0; i < len(knownFiles); i++ {
 		knownFiles[i] = fileset.New[*reader.Metadata](maxBatchFiles)

--- a/pkg/stanza/fileconsumer/internal/trie/trie_test.go
+++ b/pkg/stanza/fileconsumer/internal/trie/trie_test.go
@@ -335,7 +335,7 @@ func put(key string, val any) testOp {
 }
 
 // del automatically asserts that the trie no longer contains the key after deleting it.
-func del(key string, why string) testOp {
+func del(key, why string) testOp {
 	return func(t *testing.T, trie *Trie[any]) {
 		val := trie.Get([]byte(key))
 		if val == nil {

--- a/pkg/stanza/fileconsumer/matcher/internal/filter/sort.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/filter/sort.go
@@ -109,7 +109,7 @@ func SortAlphabetical(regexKey string, ascending bool) (Option, error) {
 	)
 }
 
-func SortTemporal(regexKey string, ascending bool, layout string, location string) (Option, error) {
+func SortTemporal(regexKey string, ascending bool, layout, location string) (Option, error) {
 	if layout == "" {
 		return nil, errors.New("layout must be specified")
 	}

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -23,7 +23,7 @@ func Validate(globs []string) error {
 }
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
-func FindFiles(includes []string, excludes []string) ([]string, error) {
+func FindFiles(includes, excludes []string) ([]string, error) {
 	var errs error
 
 	allSet := make(map[string]struct{}, len(includes))

--- a/pkg/stanza/operator/helper/emitter_test.go
+++ b/pkg/stanza/operator/helper/emitter_test.go
@@ -204,7 +204,7 @@ func complexEntry() *entry.Entry {
 	return e
 }
 
-func complexEntriesForNDifferentHosts(count int, n int) []*entry.Entry {
+func complexEntriesForNDifferentHosts(count, n int) []*entry.Entry {
 	ret := make([]*entry.Entry, count)
 	for i := 0; i < count; i++ {
 		e := entry.New()

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -523,11 +523,11 @@ func TestTimeErrors(t *testing.T) {
 	}
 }
 
-func runTimeParseTest(timeParser *TimeParser, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time) func(*testing.T) {
+func runTimeParseTest(timeParser *TimeParser, ent *entry.Entry, buildErr, parseErr bool, expected time.Time) func(*testing.T) {
 	return runLossyTimeParseTest(timeParser, ent, buildErr, parseErr, expected, time.Duration(0))
 }
 
-func runLossyTimeParseTest(timeParser *TimeParser, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
+func runLossyTimeParseTest(timeParser *TimeParser, ent *entry.Entry, buildErr, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
 		err := timeParser.Validate()
 		if buildErr {

--- a/pkg/stanza/operator/input/syslog/input_test.go
+++ b/pkg/stanza/operator/input/syslog/input_test.go
@@ -148,7 +148,7 @@ func TestInput(t *testing.T) {
 	})
 }
 
-func InputTest(t *testing.T, tc syslogtest.Case, cfg *Config, rsrc map[string]any, attr map[string]any) {
+func InputTest(t *testing.T, tc syslogtest.Case, cfg *Config, rsrc, attr map[string]any) {
 	set := componenttest.NewNopTelemetrySettings()
 	op, err := cfg.Build(set)
 	require.NoError(t, err)

--- a/pkg/stanza/operator/input/windows/api.go
+++ b/pkg/stanza/operator/input/windows/api.go
@@ -89,7 +89,7 @@ const (
 var evtSubscribeFunc = evtSubscribe
 
 // evtSubscribe is the direct syscall implementation of EvtSubscribe (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe)
-func evtSubscribe(session uintptr, signalEvent windows.Handle, channelPath *uint16, query *uint16, bookmark uintptr, context uintptr, callback uintptr, flags uint32) (uintptr, error) {
+func evtSubscribe(session uintptr, signalEvent windows.Handle, channelPath, query *uint16, bookmark, context, callback uintptr, flags uint32) (uintptr, error) {
 	handle, _, err := subscribeProc.Call(session, uintptr(signalEvent), uintptr(unsafe.Pointer(channelPath)), uintptr(unsafe.Pointer(query)), bookmark, context, callback, uintptr(flags))
 	if !errors.Is(err, ErrorSuccess) {
 		return 0, err
@@ -99,7 +99,7 @@ func evtSubscribe(session uintptr, signalEvent windows.Handle, channelPath *uint
 }
 
 // evtNext is the direct syscall implementation of EvtNext (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtnext)
-func evtNext(resultSet uintptr, eventsSize uint32, events *uintptr, timeout uint32, flags uint32, returned *uint32) error {
+func evtNext(resultSet uintptr, eventsSize uint32, events *uintptr, timeout, flags uint32, returned *uint32) error {
 	_, _, err := nextProc.Call(resultSet, uintptr(eventsSize), uintptr(unsafe.Pointer(events)), uintptr(timeout), uintptr(flags), uintptr(unsafe.Pointer(returned)))
 	if !errors.Is(err, ErrorSuccess) {
 		return err
@@ -109,7 +109,7 @@ func evtNext(resultSet uintptr, eventsSize uint32, events *uintptr, timeout uint
 }
 
 // evtRender is the direct syscall implementation of EvtRender (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender)
-func evtRender(context uintptr, fragment uintptr, flags uint32, bufferSize uint32, buffer *byte) (*uint32, error) {
+func evtRender(context, fragment uintptr, flags, bufferSize uint32, buffer *byte) (*uint32, error) {
 	bufferUsed := new(uint32)
 	propertyCount := new(uint32)
 	_, _, err := renderProc.Call(context, fragment, uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)))
@@ -151,7 +151,7 @@ func evtCreateRenderContext(valuePathsCount uint32, valuePaths **uint16, flags u
 }
 
 // evtUpdateBookmark is the direct syscall implementation of EvtUpdateBookmark (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtcreatebookmark)
-func evtUpdateBookmark(bookmark uintptr, event uintptr) error {
+func evtUpdateBookmark(bookmark, event uintptr) error {
 	_, _, err := updateBookmarkProc.Call(bookmark, event)
 	if !errors.Is(err, ErrorSuccess) {
 		return err
@@ -161,7 +161,7 @@ func evtUpdateBookmark(bookmark uintptr, event uintptr) error {
 }
 
 // evtOpenPublisherMetadata is the direct syscall implementation of EvtOpenPublisherMetadata (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtopenpublishermetadata)
-func evtOpenPublisherMetadata(session uintptr, publisherIdentity *uint16, logFilePath *uint16, locale uint32, flags uint32) (uintptr, error) {
+func evtOpenPublisherMetadata(session uintptr, publisherIdentity, logFilePath *uint16, locale, flags uint32) (uintptr, error) {
 	handle, _, err := openPublisherMetadataProc.Call(session, uintptr(unsafe.Pointer(publisherIdentity)), uintptr(unsafe.Pointer(logFilePath)), uintptr(locale), uintptr(flags))
 	if !errors.Is(err, ErrorSuccess) {
 		return 0, err
@@ -171,7 +171,7 @@ func evtOpenPublisherMetadata(session uintptr, publisherIdentity *uint16, logFil
 }
 
 // evtFormatMessage is the direct syscall implementation of EvtFormatMessage (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage)
-func evtFormatMessage(publisherMetadata uintptr, event uintptr, messageID uint32, valueCount uint32, values uintptr, flags uint32, bufferSize uint32, buffer *byte) (*uint32, error) {
+func evtFormatMessage(publisherMetadata, event uintptr, messageID, valueCount uint32, values uintptr, flags, bufferSize uint32, buffer *byte) (*uint32, error) {
 	bufferUsed := new(uint32)
 	_, _, err := formatMessageProc.Call(publisherMetadata, event, uintptr(messageID), uintptr(valueCount), values, uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)))
 	if !errors.Is(err, ErrorSuccess) {
@@ -182,7 +182,7 @@ func evtFormatMessage(publisherMetadata uintptr, event uintptr, messageID uint32
 }
 
 // evtOpenSession is the direct syscall implementation of EvtOpenSession (https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtopensession)
-func evtOpenSession(loginClass uint32, login *EvtRPCLogin, timeout uint32, flags uint32) (windows.Handle, error) {
+func evtOpenSession(loginClass uint32, login *EvtRPCLogin, timeout, flags uint32) (windows.Handle, error) {
 	r0, _, e1 := openSessionProc.Call(uintptr(loginClass), uintptr(unsafe.Pointer(login)), uintptr(timeout), uintptr(flags))
 	handle := windows.Handle(r0)
 	if handle == 0 {

--- a/pkg/stanza/operator/input/windows/api_test.go
+++ b/pkg/stanza/operator/input/windows/api_test.go
@@ -20,7 +20,7 @@ func (m MockProc) Call(a ...uintptr) (uintptr, uintptr, error) {
 }
 
 // SimpleMockProc returns a mock proc that will always return the supplied arguments when called.
-func SimpleMockProc(r1 uintptr, r2 uintptr, err syscall.Errno) SyscallProc {
+func SimpleMockProc(r1, r2 uintptr, err syscall.Errno) SyscallProc {
 	return MockProc{
 		call: func(_ ...uintptr) (uintptr, uintptr, error) {
 			return r1, r2, err

--- a/pkg/stanza/operator/input/windows/input_test.go
+++ b/pkg/stanza/operator/input/windows/input_test.go
@@ -106,7 +106,7 @@ func TestInputStart_RemoteAccessDeniedError(t *testing.T) {
 	originalEvtSubscribeFunc := evtSubscribeFunc
 	defer func() { evtSubscribeFunc = originalEvtSubscribeFunc }()
 
-	evtSubscribeFunc = func(_ uintptr, _ windows.Handle, _ *uint16, _ *uint16, _ uintptr, _ uintptr, _ uintptr, _ uint32) (uintptr, error) {
+	evtSubscribeFunc = func(_ uintptr, _ windows.Handle, _, _ *uint16, _, _, _ uintptr, _ uint32) (uintptr, error) {
 		return 0, windows.ERROR_ACCESS_DENIED
 	}
 
@@ -131,7 +131,7 @@ func TestInputStart_BadChannelName(t *testing.T) {
 	originalEvtSubscribeFunc := evtSubscribeFunc
 	defer func() { evtSubscribeFunc = originalEvtSubscribeFunc }()
 
-	evtSubscribeFunc = func(_ uintptr, _ windows.Handle, _ *uint16, _ *uint16, _ uintptr, _ uintptr, _ uintptr, _ uint32) (uintptr, error) {
+	evtSubscribeFunc = func(_ uintptr, _ windows.Handle, _, _ *uint16, _, _, _ uintptr, _ uint32) (uintptr, error) {
 		return 0, windows.ERROR_EVT_CHANNEL_NOT_FOUND
 	}
 

--- a/pkg/stanza/operator/parser/csv/parser.go
+++ b/pkg/stanza/operator/parser/csv/parser.go
@@ -57,7 +57,7 @@ func (p *Parser) Process(ctx context.Context, e *entry.Entry) error {
 // generateParseFunc returns a parse function for a given header, allowing
 // each entry to have a potentially unique set of fields when using dynamic
 // field names retrieved from an entry's attribute
-func generateParseFunc(headers []string, fieldDelimiter rune, lazyQuotes bool, ignoreQuotes bool) parseFunc {
+func generateParseFunc(headers []string, fieldDelimiter rune, lazyQuotes, ignoreQuotes bool) parseFunc {
 	if ignoreQuotes {
 		return generateSplitParseFunc(headers, fieldDelimiter)
 	}

--- a/pkg/stanza/operator/parser/keyvalue/parser.go
+++ b/pkg/stanza/operator/parser/keyvalue/parser.go
@@ -38,7 +38,7 @@ func (p *Parser) parse(value any) (any, error) {
 	}
 }
 
-func (p *Parser) parser(input string, delimiter string, pairDelimiter string) (map[string]any, error) {
+func (p *Parser) parser(input, delimiter, pairDelimiter string) (map[string]any, error) {
 	if input == "" {
 		return nil, fmt.Errorf("parse from field %s is empty", p.ParseFrom.String())
 	}

--- a/pkg/stanza/operator/parser/regex/cache.go
+++ b/pkg/stanza/operator/parser/regex/cache.go
@@ -129,7 +129,7 @@ type limiter interface {
 }
 
 // newStartedAtomicLimiter returns a started atomicLimiter
-func newStartedAtomicLimiter(maxVal uint64, interval uint64) *atomicLimiter {
+func newStartedAtomicLimiter(maxVal, interval uint64) *atomicLimiter {
 	if interval == 0 {
 		interval = 5
 	}

--- a/pkg/stanza/operator/parser/severity/parser_test.go
+++ b/pkg/stanza/operator/parser/severity/parser_test.go
@@ -221,7 +221,7 @@ func TestSeverityParser(t *testing.T) {
 	}
 }
 
-func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected entry.Severity) func(*testing.T) {
+func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr, parseErr bool, expected entry.Severity) func(*testing.T) {
 	return func(t *testing.T) {
 		set := componenttest.NewNopTelemetrySettings()
 		op, err := cfg.Build(set)

--- a/pkg/stanza/operator/parser/time/parser_test.go
+++ b/pkg/stanza/operator/parser/time/parser_test.go
@@ -498,11 +498,11 @@ func makeTestEntry(t *testing.T, field entry.Field, value any) *entry.Entry {
 	return e
 }
 
-func runTimeParseTest(t *testing.T, cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time) func(*testing.T) {
+func runTimeParseTest(t *testing.T, cfg *Config, ent *entry.Entry, buildErr, parseErr bool, expected time.Time) func(*testing.T) {
 	return runLossyTimeParseTest(t, cfg, ent, buildErr, parseErr, expected, time.Duration(0))
 }
 
-func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
+func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
 		set := componenttest.NewNopTelemetrySettings()
 		op, err := cfg.Build(set)

--- a/pkg/stanza/split/split.go
+++ b/pkg/stanza/split/split.go
@@ -57,7 +57,7 @@ func (c Config) Func(enc encoding.Encoding, flushAtEOF bool, maxLogSize int) (bu
 
 // LineStartSplitFunc creates a bufio.SplitFunc that splits an incoming stream into
 // tokens that start with a match to the regex pattern provided
-func LineStartSplitFunc(re *regexp.Regexp, omitPattern bool, flushAtEOF bool) bufio.SplitFunc {
+func LineStartSplitFunc(re *regexp.Regexp, omitPattern, flushAtEOF bool) bufio.SplitFunc {
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		firstLoc := re.FindIndex(data)
 		if firstLoc == nil {
@@ -112,7 +112,7 @@ func LineStartSplitFunc(re *regexp.Regexp, omitPattern bool, flushAtEOF bool) bu
 
 // LineEndSplitFunc creates a bufio.SplitFunc that splits an incoming stream into
 // tokens that end with a match to the regex pattern provided
-func LineEndSplitFunc(re *regexp.Regexp, omitPattern bool, flushAtEOF bool) bufio.SplitFunc {
+func LineEndSplitFunc(re *regexp.Regexp, omitPattern, flushAtEOF bool) bufio.SplitFunc {
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		loc := re.FindIndex(data)
 		if loc == nil {

--- a/pkg/stanza/split/splittest/splittest.go
+++ b/pkg/stanza/split/splittest/splittest.go
@@ -57,7 +57,7 @@ func ExpectError(expectErr string) Step {
 	}
 }
 
-func Eventually(step Step, maxTime time.Duration, tick time.Duration) Step {
+func Eventually(step Step, maxTime, tick time.Duration) Step {
 	step.tick = tick
 	step.timeout = maxTime
 	return step

--- a/pkg/translator/azurelogs/category_logs.go
+++ b/pkg/translator/azurelogs/category_logs.go
@@ -120,7 +120,7 @@ func addRecordAttributes(category string, data []byte, record plog.LogRecord) er
 }
 
 // putInt parses value as an int and puts it in the record
-func putInt(field string, value string, record plog.LogRecord) error {
+func putInt(field, value string, record plog.LogRecord) error {
 	n, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to get number in %q for field %q: %w", value, field, err)
@@ -132,7 +132,7 @@ func putInt(field string, value string, record plog.LogRecord) error {
 // putStr puts the value in the record if the value holds
 // meaningful data. Meaningful data is defined as not being empty
 // or "N/A".
-func putStr(field string, value string, record plog.LogRecord) {
+func putStr(field, value string, record plog.LogRecord) {
 	switch value {
 	case "", "N/A":
 		// ignore
@@ -144,7 +144,7 @@ func putStr(field string, value string, record plog.LogRecord) {
 // handleTime parses the time value and always multiplies it by
 // 1e3. This is so we don't loose so much data if the time is for
 // example "0.154". In that case, the output would be "154".
-func handleTime(field string, value string, record plog.LogRecord) error {
+func handleTime(field, value string, record plog.LogRecord) error {
 	n, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return fmt.Errorf("failed to get number in %q for field %q: %w", value, field, err)
@@ -243,8 +243,8 @@ func addErrorInfoProperties(errorInfo string, record plog.LogRecord) {
 // hostname is filled, then the destination address and port are based on
 // it. If both are filled but different, then the endpoint will cover the
 // network address and port.
-func handleDestination(backendHostname string, endpoint string, record plog.LogRecord) error {
-	addFields := func(full string, addressField string, portField string) error {
+func handleDestination(backendHostname, endpoint string, record plog.LogRecord) error {
+	addFields := func(full, addressField, portField string) error {
 		host, port, err := net.SplitHostPort(full)
 		if err != nil && strings.HasSuffix(err.Error(), missingPort) {
 			// there is no port, so let's keep using the full endpoint for the address

--- a/pkg/translator/azurelogs/property_names.go
+++ b/pkg/translator/azurelogs/property_names.go
@@ -12,7 +12,7 @@ import (
 // TODO @constanca-m remove this file once the logic for the remaining categories
 // is added to category_logs.go
 
-func handleFrontDoorAccessLog(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleFrontDoorAccessLog(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "trackingReference":
 		attrs[string(conventions.AzServiceRequestIDKey)] = value
@@ -73,7 +73,7 @@ func handleFrontDoorAccessLog(field string, value any, attrs map[string]any, att
 	}
 }
 
-func handleFrontDoorHealthProbeLog(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleFrontDoorHealthProbeLog(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "httpVerb":
 		attrs[string(conventions.HTTPRequestMethodKey)] = value
@@ -102,7 +102,7 @@ func handleFrontDoorHealthProbeLog(field string, value any, attrs map[string]any
 	}
 }
 
-func handleAppServiceAppLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceAppLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "ContainerId":
 		attrs[string(conventions.ContainerIDKey)] = value
@@ -121,7 +121,7 @@ func handleAppServiceAppLogs(field string, value any, attrs map[string]any, attr
 	}
 }
 
-func handleAppServiceAuditLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceAuditLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "Protocol":
 		attrs[string(conventions.NetworkProtocolNameKey)] = toLower(value)
@@ -134,7 +134,7 @@ func handleAppServiceAuditLogs(field string, value any, attrs map[string]any, at
 	}
 }
 
-func handleAppServiceAuthenticationLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceAuthenticationLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "StatusCode":
 		attrs[string(conventions.HTTPResponseStatusCodeKey)] = toInt(value)
@@ -143,7 +143,7 @@ func handleAppServiceAuthenticationLogs(field string, value any, attrs map[strin
 	}
 }
 
-func handleAppServiceConsoleLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceConsoleLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "ContainerId":
 		attrs[string(conventions.ContainerIDKey)] = value
@@ -154,7 +154,7 @@ func handleAppServiceConsoleLogs(field string, value any, attrs map[string]any, 
 	}
 }
 
-func handleAppServiceHTTPLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceHTTPLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "CIp":
 		attrs["client.address"] = value
@@ -207,7 +207,7 @@ func handleAppServiceHTTPLogs(field string, value any, attrs map[string]any, att
 	}
 }
 
-func handleAppServiceIPSecAuditLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServiceIPSecAuditLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "CIp":
 		attrs["client.address"] = value
@@ -226,7 +226,7 @@ func handleAppServiceIPSecAuditLogs(field string, value any, attrs map[string]an
 	}
 }
 
-func handleAppServicePlatformLogs(field string, value any, attrs map[string]any, attrsProps map[string]any) {
+func handleAppServicePlatformLogs(field string, value any, attrs, attrsProps map[string]any) {
 	switch field {
 	case "containerId":
 		attrs[string(conventions.ContainerIDKey)] = value

--- a/pkg/translator/azurelogs/resourcelogs_to_logs.go
+++ b/pkg/translator/azurelogs/resourcelogs_to_logs.go
@@ -297,7 +297,7 @@ func copyPropertiesAndApplySemanticConventions(category string, properties []byt
 	case categoryAppServicePlatformLogs:
 		handleFunc = handleAppServicePlatformLogs
 	default:
-		handleFunc = func(field string, value any, _ map[string]any, attrsProps map[string]any) {
+		handleFunc = func(field string, value any, _, attrsProps map[string]any) {
 			attrsProps[field] = value
 		}
 	}

--- a/pkg/translator/faro/keyval.go
+++ b/pkg/translator/faro/keyval.go
@@ -41,21 +41,21 @@ func keyValFromFloatMap(m map[string]float64) *keyVal {
 }
 
 // mergeKeyVal will merge source in target
-func mergeKeyVal(target *keyVal, source *keyVal) {
+func mergeKeyVal(target, source *keyVal) {
 	for el := source.Oldest(); el != nil; el = el.Next() {
 		target.Set(el.Key, el.Value)
 	}
 }
 
 // mergeKeyValWithPrefix will merge source in target, adding a prefix to each key being merged in
-func mergeKeyValWithPrefix(target *keyVal, source *keyVal, prefix string) {
+func mergeKeyValWithPrefix(target, source *keyVal, prefix string) {
 	for el := source.Oldest(); el != nil; el = el.Next() {
 		target.Set(fmt.Sprintf("%s%s", prefix, el.Key), el.Value)
 	}
 }
 
 // keyValAdd adds a key + value string pair to kv
-func keyValAdd(kv *keyVal, key string, value string) {
+func keyValAdd(kv *keyVal, key, value string) {
 	if value != "" {
 		kv.Set(key, value)
 	}

--- a/pkg/translator/faro/logs_to_faro.go
+++ b/pkg/translator/faro/logs_to_faro.go
@@ -725,7 +725,7 @@ func extractExceptionContextFromKeyVal(kv map[string]string) faroTypes.Exception
 	return exceptionContext
 }
 
-func extractStacktraceFromKeyVal(kv map[string]string, exceptionType string, exceptionValue string) (*faroTypes.Stacktrace, error) {
+func extractStacktraceFromKeyVal(kv map[string]string, exceptionType, exceptionValue string) (*faroTypes.Stacktrace, error) {
 	stacktraceStr, ok := kv[faroExceptionStacktrace]
 	if !ok {
 		return nil, nil

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -34,7 +34,7 @@ const (
 
 const attrSeparator = "."
 
-func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map, defaultLabelsEnabled map[string]bool) model.LabelSet {
+func convertAttributesAndMerge(logAttrs, resAttrs pcommon.Map, defaultLabelsEnabled map[string]bool) model.LabelSet {
 	out := getDefaultLabels(resAttrs, defaultLabelsEnabled)
 
 	if resourcesToLabel, found := resAttrs.Get(hintResources); found {

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -161,7 +161,7 @@ func LogToLokiEntry(lr plog.LogRecord, rl pcommon.Resource, scope pcommon.Instru
 	}, nil
 }
 
-func getFormatFromFormatHint(logAttr pcommon.Map, resourceAttr pcommon.Map) string {
+func getFormatFromFormatHint(logAttr, resourceAttr pcommon.Map) string {
 	format := formatJSON
 	formatVal, found := resourceAttr.Get(hintFormat)
 	if !found {
@@ -177,7 +177,7 @@ func getFormatFromFormatHint(logAttr pcommon.Map, resourceAttr pcommon.Map) stri
 // GetTenantFromTenantHint extract an attribute based on the tenant hint.
 // it looks up for the attribute first in resource attributes and fallbacks to
 // record attributes if it is not found.
-func GetTenantFromTenantHint(logAttr pcommon.Map, resourceAttr pcommon.Map) string {
+func GetTenantFromTenantHint(logAttr, resourceAttr pcommon.Map) string {
 	var tenant string
 	hintAttr, found := resourceAttr.Get(hintTenant)
 	if !found {

--- a/pkg/translator/prometheus/testutils_test.go
+++ b/pkg/translator/prometheus/testutils_test.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 // Returns a new Metric of type "Gauge" with specified name and unit
-func createGauge(name string, unit string) pmetric.Metric {
+func createGauge(name, unit string) pmetric.Metric {
 	gauge := ilm.Metrics().AppendEmpty()
 	gauge.SetName(name)
 	gauge.SetUnit(unit)
@@ -25,7 +25,7 @@ func createGauge(name string, unit string) pmetric.Metric {
 }
 
 // Returns a new Metric of type Monotonic Sum with specified name and unit
-func createCounter(name string, unit string) pmetric.Metric {
+func createCounter(name, unit string) pmetric.Metric {
 	counter := ilm.Metrics().AppendEmpty()
 	counter.SetEmptySum().SetIsMonotonic(true)
 	counter.SetName(name)

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -90,7 +90,7 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 	}
 }
 
-func createExportRequest(resourceAttributeCount int, histogramCount int, nonHistogramCount int, labelsPerMetric int, exemplarsPerSeries int, timestamp pcommon.Timestamp) pmetricotlp.ExportRequest {
+func createExportRequest(resourceAttributeCount, histogramCount, nonHistogramCount, labelsPerMetric, exemplarsPerSeries int, timestamp pcommon.Timestamp) pmetricotlp.ExportRequest {
 	request := pmetricotlp.NewExportRequest()
 
 	rm := request.Metrics().ResourceMetrics().AppendEmpty()

--- a/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_test.go
+++ b/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_test.go
@@ -296,7 +296,7 @@ func GenerateMetricsAllTypesNoDataPointsHelp() pmetric.Metrics {
 	return md
 }
 
-func initMetric(m pmetric.Metric, name string, ty pmetric.MetricType, unit string, desc string) {
+func initMetric(m pmetric.Metric, name string, ty pmetric.MetricType, unit, desc string) {
 	m.SetName(name)
 	m.SetUnit(unit)
 	m.SetDescription(desc)

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -147,7 +147,7 @@ func getPromLabels(lbs ...string) []prompb.Label {
 	return pbLbs.Labels
 }
 
-func getLabel(name string, value string) prompb.Label {
+func getLabel(name, value string) prompb.Label {
 	return prompb.Label{
 		Name:  name,
 		Value: value,
@@ -184,7 +184,7 @@ func getTimeSeriesWithSamplesAndExemplars(labels []prompb.Label, samples []promp
 	}
 }
 
-func getHistogramDataPointWithExemplars[V int64 | float64](t *testing.T, time time.Time, value V, traceID string, spanID string, attributeKey string, attributeValue string) pmetric.HistogramDataPoint {
+func getHistogramDataPointWithExemplars[V int64 | float64](t *testing.T, time time.Time, value V, traceID, spanID, attributeKey, attributeValue string) pmetric.HistogramDataPoint {
 	h := pmetric.NewHistogramDataPoint()
 
 	e := h.Exemplars().AppendEmpty()

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -36,7 +36,7 @@ const (
 type FromTranslator struct{}
 
 // FromMetrics converts pmetric.Metrics to SignalFx proto data points.
-func (ft *FromTranslator) FromMetrics(md pmetric.Metrics, dropHistogramBuckets bool, processHistograms bool) ([]*sfxpb.DataPoint, error) {
+func (ft *FromTranslator) FromMetrics(md pmetric.Metrics, dropHistogramBuckets, processHistograms bool) ([]*sfxpb.DataPoint, error) {
 	var sfxDataPoints []*sfxpb.DataPoint
 
 	rms := md.ResourceMetrics()
@@ -57,7 +57,7 @@ func (ft *FromTranslator) FromMetrics(md pmetric.Metrics, dropHistogramBuckets b
 
 // FromMetric converts pmetric.Metric to SignalFx proto data points.
 // TODO: Remove this and change signalfxexporter to us FromMetrics.
-func (ft *FromTranslator) FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension, dropHistogramBuckets bool, processHistograms bool) []*sfxpb.DataPoint {
+func (ft *FromTranslator) FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension, dropHistogramBuckets, processHistograms bool) []*sfxpb.DataPoint {
 	var dps []*sfxpb.DataPoint
 
 	mt := fromMetricTypeToMetricType(m)

--- a/pkg/translator/skywalking/skywalkingproto_to_traces.go
+++ b/pkg/translator/skywalking/skywalkingproto_to_traces.go
@@ -86,7 +86,7 @@ func swTagsToInternalResource(span *agentV3.SpanObject, dest pcommon.Resource) {
 	}
 }
 
-func swSpansToSpanSlice(traceID string, segmentID string, spans []*agentV3.SpanObject, dest ptrace.SpanSlice) {
+func swSpansToSpanSlice(traceID, segmentID string, spans []*agentV3.SpanObject, dest ptrace.SpanSlice) {
 	if len(spans) == 0 {
 		return
 	}
@@ -100,7 +100,7 @@ func swSpansToSpanSlice(traceID string, segmentID string, spans []*agentV3.SpanO
 	}
 }
 
-func swSpanToSpan(traceID string, segmentID string, span *agentV3.SpanObject, dest ptrace.Span) {
+func swSpanToSpan(traceID, segmentID string, span *agentV3.SpanObject, dest ptrace.Span) {
 	dest.SetTraceID(swTraceIDToTraceID(traceID))
 	// skywalking defines segmentId + spanId as unique identifier
 	// so use segmentId to convert to an unique otel-span

--- a/pkg/translator/zipkin/zipkinv1/thrift_test.go
+++ b/pkg/translator/zipkin/zipkinv1/thrift_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // compareTraces compares got to want while ignoring order. Both are modified in place.
-func compareTraces(t *testing.T, want ptrace.Traces, got ptrace.Traces) {
+func compareTraces(t *testing.T, want, got ptrace.Traces) {
 	require.Equal(t, mapperTraces(t, want), mapperTraces(t, got))
 }
 

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -528,7 +528,7 @@ func setTimestampsV2(zspan *zipkinmodel.SpanModel, dest ptrace.Span, destAttrs p
 
 // unmarshalJSON inflates trace id from hex string, possibly enclosed in quotes.
 // TODO: Find a way to avoid this duplicate code. Consider to expose this in pdata.
-func unmarshalJSON(dst []byte, src []byte) error {
+func unmarshalJSON(dst, src []byte) error {
 	if l := len(src); l >= 2 && src[0] == '"' && src[l-1] == '"' {
 		src = src[1 : l-1]
 	}

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
@@ -391,7 +391,7 @@ func PdhGetFormattedCounterValueDouble(hCounter PDH_HCOUNTER, lpdwType *uint32, 
 //			time.Sleep(2000 * time.Millisecond)
 //		}
 //	}
-func PdhGetFormattedCounterArrayDouble(hCounter PDH_HCOUNTER, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetFormattedCounterArrayDouble(hCounter PDH_HCOUNTER, lpdwBufferSize, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdh_GetFormattedCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(PDH_FMT_DOUBLE|PDH_FMT_NOCAP100),
@@ -409,7 +409,7 @@ func PdhGetFormattedCounterArrayDouble(hCounter PDH_HCOUNTER, lpdwBufferSize *ui
 // call PdhGetCounterInfo and access dwQueryUserData of the PDH_COUNTER_INFO structure. phQuery is
 // the handle to the query, and must be used in subsequent calls. This function returns a PDH_
 // constant error code, or ERROR_SUCCESS if the call succeeded.
-func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQUERY) uint32 {
+func PdhOpenQuery(szDataSource, dwUserData uintptr, phQuery *PDH_HQUERY) uint32 {
 	ret, _, _ := pdh_OpenQuery.Call(
 		szDataSource,
 		dwUserData,
@@ -534,7 +534,7 @@ func PdhGetRawCounterValue(hCounter PDH_HCOUNTER, lpdwType *uint32, pValue *PDH_
 //
 // itemBuffer [out]
 // Pointer to a buffer that receives an array of PDH_RAW_COUNTER_ITEM structures. Each structure contains the raw counter value for an instance.
-func PdhGetRawCounterArrayW(hCounter PDH_HCOUNTER, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetRawCounterArrayW(hCounter PDH_HCOUNTER, lpdwBufferSize, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdh_GetRawCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(lpdwBufferSize)),

--- a/pkg/xk8stest/k8s_collector.go
+++ b/pkg/xk8stest/k8s_collector.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func CreateCollectorObjects(t *testing.T, client *K8sClient, testID string, manifestsDir string, templateValues map[string]string, host string) []*unstructured.Unstructured {
+func CreateCollectorObjects(t *testing.T, client *K8sClient, testID, manifestsDir string, templateValues map[string]string, host string) []*unstructured.Unstructured {
 	if manifestsDir == "" {
 		manifestsDir = filepath.Join(".", "testdata", "e2e", "collector")
 	}

--- a/processor/coralogixprocessor/internal/transactions/span_tree_test.go
+++ b/processor/coralogixprocessor/internal/transactions/span_tree_test.go
@@ -72,7 +72,7 @@ func TestBuildSpanTreeEmpty(t *testing.T) {
 	assert.Nil(t, root)
 }
 
-func createSpan(name string, spanID pcommon.SpanID, parentSpanID pcommon.SpanID, startTime int64) ptrace.Span {
+func createSpan(name string, spanID, parentSpanID pcommon.SpanID, startTime int64) ptrace.Span {
 	span := ptrace.NewSpan()
 	span.SetName(name)
 	span.SetSpanID(spanID)

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -105,7 +105,7 @@ func TestNilBatch(t *testing.T) {
 	m.assertBatchesLen(1)
 }
 
-func assertKeyInAttributesMatchesValue(t *testing.T, attr pcommon.Map, key string, expected string) {
+func assertKeyInAttributesMatchesValue(t *testing.T, attr pcommon.Map, key, expected string) {
 	v, ok := attr.Get(key)
 	require.True(t, ok)
 	require.Equal(t, expected, v.AsString())

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -114,7 +114,7 @@ func assertFiltered(t *testing.T, lm pcommon.Map) {
 	}
 }
 
-func filterMetrics(t *testing.T, include []string, exclude []string, mds []pmetric.Metrics) []pmetric.Metrics {
+func filterMetrics(t *testing.T, include, exclude []string, mds []pmetric.Metrics) []pmetric.Metrics {
 	proc, next := testProcessor(t, include, exclude)
 	for _, md := range mds {
 		err := proc.ConsumeMetrics(context.Background(), md)
@@ -123,7 +123,7 @@ func filterMetrics(t *testing.T, include []string, exclude []string, mds []pmetr
 	return next.AllMetrics()
 }
 
-func testProcessor(t *testing.T, include []string, exclude []string) (processor.Metrics, *consumertest.MetricsSink) {
+func testProcessor(t *testing.T, include, exclude []string) (processor.Metrics, *consumertest.MetricsSink) {
 	factory := NewFactory()
 	cfg := exprConfig(factory, include, exclude)
 	ctx := context.Background()
@@ -139,7 +139,7 @@ func testProcessor(t *testing.T, include []string, exclude []string) (processor.
 	return proc, next
 }
 
-func exprConfig(factory processor.Factory, include []string, exclude []string) component.Config {
+func exprConfig(factory processor.Factory, include, exclude []string) component.Config {
 	cfg := factory.CreateDefaultConfig()
 	pCfg := cfg.(*Config)
 	pCfg.Metrics = MetricFilters{}

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -186,7 +186,7 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 	return md, nil
 }
 
-func newSkipResExpr(include *filterconfig.MetricMatchProperties, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlresource.TransformContext], error) {
+func newSkipResExpr(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlresource.TransformContext], error) {
 	if filtermetric.UseOTTLBridge.IsEnabled() {
 		mp := filterconfig.MatchConfig{}
 

--- a/processor/groupbyattrsprocessor/attribute_groups_test.go
+++ b/processor/groupbyattrsprocessor/attribute_groups_test.go
@@ -56,7 +56,7 @@ func TestResourceAttributeScenarios(t *testing.T) {
 		name                    string
 		baseResource            pcommon.Resource
 		fillRecordAttributesFun func(attributeMap pcommon.Map)
-		fillExpectedResourceFun func(baseResource pcommon.Resource, expectedResource pcommon.Resource)
+		fillExpectedResourceFun func(baseResource, expectedResource pcommon.Resource)
 	}{
 		{
 			name:         "When the same key is present at Resource and Record level, the latter value should be used",
@@ -64,7 +64,7 @@ func TestResourceAttributeScenarios(t *testing.T) {
 			fillRecordAttributesFun: func(attributeMap pcommon.Map) {
 				attributeMap.PutStr("somekey1", "replaced-value")
 			},
-			fillExpectedResourceFun: func(baseResource pcommon.Resource, expectedResource pcommon.Resource) {
+			fillExpectedResourceFun: func(baseResource, expectedResource pcommon.Resource) {
 				baseResource.CopyTo(expectedResource)
 				expectedResource.Attributes().PutStr("somekey1", "replaced-value")
 			},
@@ -81,7 +81,7 @@ func TestResourceAttributeScenarios(t *testing.T) {
 			fillRecordAttributesFun: func(attributeMap pcommon.Map) {
 				attributeMap.PutStr("somekey1", "some-value")
 			},
-			fillExpectedResourceFun: func(_ pcommon.Resource, expectedResource pcommon.Resource) {
+			fillExpectedResourceFun: func(_, expectedResource pcommon.Resource) {
 				expectedResource.Attributes().PutStr("somekey1", "some-value")
 			},
 		},
@@ -89,7 +89,7 @@ func TestResourceAttributeScenarios(t *testing.T) {
 			name:                    "Empty Attributes",
 			baseResource:            simpleResource(),
 			fillRecordAttributesFun: nil,
-			fillExpectedResourceFun: func(baseResource pcommon.Resource, expectedResource pcommon.Resource) {
+			fillExpectedResourceFun: func(baseResource, expectedResource pcommon.Resource) {
 				baseResource.CopyTo(expectedResource)
 			},
 		},

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -61,7 +61,7 @@ func filterAttributeMap(attrMap pcommon.Map, selectedKeys []string) pcommon.Map 
 	return filteredAttrMap
 }
 
-func someComplexLogs(withResourceAttrIndex bool, rlCount int, illCount int) plog.Logs {
+func someComplexLogs(withResourceAttrIndex bool, rlCount, illCount int) plog.Logs {
 	logs := plog.NewLogs()
 
 	for i := 0; i < rlCount; i++ {
@@ -80,7 +80,7 @@ func someComplexLogs(withResourceAttrIndex bool, rlCount int, illCount int) plog
 	return logs
 }
 
-func someComplexTraces(withResourceAttrIndex bool, rsCount int, ilsCount int) ptrace.Traces {
+func someComplexTraces(withResourceAttrIndex bool, rsCount, ilsCount int) ptrace.Traces {
 	traces := ptrace.NewTraces()
 
 	for i := 0; i < rsCount; i++ {
@@ -100,7 +100,7 @@ func someComplexTraces(withResourceAttrIndex bool, rsCount int, ilsCount int) pt
 	return traces
 }
 
-func someComplexMetrics(withResourceAttrIndex bool, rmCount int, ilmCount int, dataPointCount int) pmetric.Metrics {
+func someComplexMetrics(withResourceAttrIndex bool, rmCount, ilmCount, dataPointCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 
 	for i := 0; i < rmCount; i++ {
@@ -127,7 +127,7 @@ func someComplexMetrics(withResourceAttrIndex bool, rmCount int, ilmCount int, d
 	return metrics
 }
 
-func someComplexHistogramMetrics(withResourceAttrIndex bool, rmCount int, ilmCount int, dataPointCount int, histogramSize int) pmetric.Metrics {
+func someComplexHistogramMetrics(withResourceAttrIndex bool, rmCount, ilmCount, dataPointCount, histogramSize int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 
 	for i := 0; i < rmCount; i++ {
@@ -624,7 +624,7 @@ func TestAttributeGrouping(t *testing.T) {
 	}
 }
 
-func someSpans(attrs pcommon.Map, instrumentationLibraryCount int, spanCount int) ptrace.Traces {
+func someSpans(attrs pcommon.Map, instrumentationLibraryCount, spanCount int) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -640,7 +640,7 @@ func someSpans(attrs pcommon.Map, instrumentationLibraryCount int, spanCount int
 	return traces
 }
 
-func someLogs(attrs pcommon.Map, instrumentationLibraryCount int, logCount int) plog.Logs {
+func someLogs(attrs pcommon.Map, instrumentationLibraryCount, logCount int) plog.Logs {
 	logs := plog.NewLogs()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -655,7 +655,7 @@ func someLogs(attrs pcommon.Map, instrumentationLibraryCount int, logCount int) 
 	return logs
 }
 
-func someGaugeMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCount int) pmetric.Metrics {
+func someGaugeMetrics(attrs pcommon.Map, instrumentationLibraryCount, metricCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -672,7 +672,7 @@ func someGaugeMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metric
 	return metrics
 }
 
-func someSumMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCount int) pmetric.Metrics {
+func someSumMetrics(attrs pcommon.Map, instrumentationLibraryCount, metricCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -689,7 +689,7 @@ func someSumMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCo
 	return metrics
 }
 
-func someSummaryMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCount int) pmetric.Metrics {
+func someSummaryMetrics(attrs pcommon.Map, instrumentationLibraryCount, metricCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -706,7 +706,7 @@ func someSummaryMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metr
 	return metrics
 }
 
-func someHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCount int) pmetric.Metrics {
+func someHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCount, metricCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)
@@ -723,7 +723,7 @@ func someHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCount int, me
 	return metrics
 }
 
-func someExponentialHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCount int, metricCount int) pmetric.Metrics {
+func someExponentialHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCount, metricCount int) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < instrumentationLibraryCount; i++ {
 		ilName := fmt.Sprint("ils-", i)

--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -86,7 +86,7 @@ type eventMachine struct {
 	closed       bool
 }
 
-func newEventMachine(logger *zap.Logger, bufferSize int, numWorkers int, numTraces int, telemetry *metadata.TelemetryBuilder) *eventMachine {
+func newEventMachine(logger *zap.Logger, bufferSize, numWorkers, numTraces int, telemetry *metadata.TelemetryBuilder) *eventMachine {
 	em := &eventMachine{
 		logger:                    logger,
 		telemetry:                 telemetry,

--- a/processor/intervalprocessor/processor.go
+++ b/processor/intervalprocessor/processor.go
@@ -178,7 +178,7 @@ func (p *intervalProcessor) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	return errs
 }
 
-func aggregateDataPoints[DPS metrics.DataPointSlice[DP], DP metrics.DataPoint[DP]](dataPoints DPS, mCloneDataPoints DPS, metricID identity.Metric, dpLookup map[identity.Stream]DP) {
+func aggregateDataPoints[DPS metrics.DataPointSlice[DP], DP metrics.DataPoint[DP]](dataPoints, mCloneDataPoints DPS, metricID identity.Metric, dpLookup map[identity.Stream]DP) {
 	for i := 0; i < dataPoints.Len(); i++ {
 		dp := dataPoints.At(i)
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -507,7 +507,7 @@ func (c *WatchClient) handleStatefulSetDelete(obj any) {
 	}
 }
 
-func (c *WatchClient) deleteLoop(interval time.Duration, gracePeriod time.Duration) {
+func (c *WatchClient) deleteLoop(interval, gracePeriod time.Duration) {
 	// This loop runs after N seconds and deletes pods from cache.
 	// It iterates over the delete queue and deletes all that aren't
 	// in the grace period anymore.

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -33,7 +33,7 @@ func newFakeAPIClientset(_ k8sconfig.APIConfig) (kubernetes.Interface, error) {
 	return fake.NewSimpleClientset(), nil
 }
 
-func newPodIdentifier(from string, name string, value string) PodIdentifier {
+func newPodIdentifier(from, name, value string) PodIdentifier {
 	if from == "connection" {
 		name = ""
 	}

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -74,7 +74,7 @@ func PodIdentifierAttributeFromConnection(value string) PodIdentifierAttribute {
 }
 
 // PodIdentifierAttributeFromSource builds PodIdentifierAttribute for given resource_attribute name and value
-func PodIdentifierAttributeFromResourceAttribute(key string, value string) PodIdentifierAttribute {
+func PodIdentifierAttributeFromResourceAttribute(key, value string) PodIdentifierAttribute {
 	return PodIdentifierAttributeFromSource(
 		AssociationSource{
 			From: ResourceSource,
@@ -303,38 +303,38 @@ type FieldExtractionRule struct {
 	From string
 }
 
-func (r *FieldExtractionRule) extractFromPodMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromPodMetadata(metadata, tags map[string]string, formatter string) {
 	// By default if the From field is not set for labels and annotations we want to extract them from pod
 	if r.From == MetadataFromPod || r.From == "" {
 		r.extractFromMetadata(metadata, tags, formatter)
 	}
 }
 
-func (r *FieldExtractionRule) extractFromNamespaceMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromNamespaceMetadata(metadata, tags map[string]string, formatter string) {
 	if r.From == MetadataFromNamespace {
 		r.extractFromMetadata(metadata, tags, formatter)
 	}
 }
 
-func (r *FieldExtractionRule) extractFromNodeMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromNodeMetadata(metadata, tags map[string]string, formatter string) {
 	if r.From == MetadataFromNode {
 		r.extractFromMetadata(metadata, tags, formatter)
 	}
 }
 
-func (r *FieldExtractionRule) extractFromDeploymentMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromDeploymentMetadata(metadata, tags map[string]string, formatter string) {
 	if r.From == MetadataFromDeployment {
 		r.extractFromMetadata(metadata, tags, formatter)
 	}
 }
 
-func (r *FieldExtractionRule) extractFromStatefulSetMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromStatefulSetMetadata(metadata, tags map[string]string, formatter string) {
 	if r.From == MetadataFromStatefulSet {
 		r.extractFromMetadata(metadata, tags, formatter)
 	}
 }
 
-func (r *FieldExtractionRule) extractFromMetadata(metadata map[string]string, tags map[string]string, formatter string) {
+func (r *FieldExtractionRule) extractFromMetadata(metadata, tags map[string]string, formatter string) {
 	if r.KeyRegex != nil {
 		for k, v := range metadata {
 			if r.KeyRegex.MatchString(k) && v != "" {

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -206,7 +206,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	}
 }
 
-func setResourceAttribute(attributes pcommon.Map, key string, val string) {
+func setResourceAttribute(attributes pcommon.Map, key, val string) {
 	attr, found := attributes.Get(key)
 	if !found || attr.AsString() == "" {
 		attributes.PutStr(key, val)

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/metadata"
 )
 
-func newPodIdentifier(from string, name string, value string) kube.PodIdentifier {
+func newPodIdentifier(from, name, value string) kube.PodIdentifier {
 	if from == kube.ConnectionSource {
 		return kube.PodIdentifier{
 			kube.PodIdentifierAttributeFromConnection(value),
@@ -244,7 +244,7 @@ func (m *multiTest) assertResourceObjectLen(batchNo int) {
 	assert.Equal(m.t, 1, m.nextProfiles.AllProfiles()[batchNo].ResourceProfiles().Len())
 }
 
-func (m *multiTest) assertResourceAttributesLen(batchNo int, attrsLen int) {
+func (m *multiTest) assertResourceAttributesLen(batchNo, attrsLen int) {
 	assert.Equal(m.t, attrsLen, m.nextTrace.AllTraces()[batchNo].ResourceSpans().At(0).Resource().Attributes().Len())
 	assert.Equal(m.t, attrsLen, m.nextMetrics.AllMetrics()[batchNo].ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(m.t, attrsLen, m.nextLogs.AllLogs()[batchNo].ResourceLogs().At(0).Resource().Attributes().Len())

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -71,7 +71,7 @@ func generateCalculatedMetrics(rm pmetric.ResourceMetrics, metric2 pmetric.Metri
 
 // Calculates a new metric based on the calculation-type rule specified. New data points will be generated for each
 // calculation of the input metrics where overlapping attributes have matching values.
-func generateMetricFromMatchingAttributes(metric1 pmetric.Metric, metric2 pmetric.Metric, rule internalRule, logger *zap.Logger) pmetric.Metric {
+func generateMetricFromMatchingAttributes(metric1, metric2 pmetric.Metric, rule internalRule, logger *zap.Logger) pmetric.Metric {
 	var metric1DataPoints pmetric.NumberDataPointSlice
 	var toDataPoints pmetric.NumberDataPointSlice
 	to := pmetric.NewMetric()
@@ -238,7 +238,7 @@ func appendNewMetric(ilm pmetric.ScopeMetrics, newMetric pmetric.Metric, name, u
 	}
 }
 
-func calculateValue(operand1 float64, operand2 float64, operation string, metricName string) (float64, error) {
+func calculateValue(operand1, operand2 float64, operation, metricName string) (float64, error) {
 	switch operation {
 	case string(add):
 		return operand1 + operand2, nil

--- a/processor/metricstransformprocessor/operation_scale_value.go
+++ b/processor/metricstransformprocessor/operation_scale_value.go
@@ -103,7 +103,7 @@ func scaleExpHistogramOp(metric pmetric.Metric, op internalOperation, f internal
 	}
 }
 
-func updateOffset(scale int32, offset int32, op *internalOperation) int32 {
+func updateOffset(scale, offset int32, op *internalOperation) int32 {
 	// Take the middle of the first bucket.
 	base := math.Pow(2, math.Pow(2, float64(-scale)))
 	value := (math.Pow(base, float64(offset)) + math.Pow(base, float64(offset+1))) / 2

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -1374,7 +1374,7 @@ func TestHashingFunction(t *testing.T) {
 
 // makeSingleSpanWithAttrib is used to construct test data with
 // a specific TraceID and a single attribute.
-func makeSingleSpanWithAttrib(tid pcommon.TraceID, sid pcommon.SpanID, ts string, key string, attribValue pcommon.Value) ptrace.Traces {
+func makeSingleSpanWithAttrib(tid pcommon.TraceID, sid pcommon.SpanID, ts, key string, attribValue pcommon.Value) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
 	span.TraceState().FromRaw(ts)

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
@@ -116,7 +116,7 @@ func constructClusterArn(cluster, region, account string) string {
 
 // Parses ECS Task ARN into subcomponents according to its spec
 // See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
-func parseTaskARN(taskARN string) (region string, account string, taskID string) {
+func parseTaskARN(taskARN string) (region, account, taskID string) {
 	parts := strings.Split(taskARN, ":")
 	if len(parts) >= 5 {
 		region := parts[3]

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -194,7 +194,7 @@ func (p *ResourceProvider) detectResource(ctx context.Context, timeout time.Dura
 	p.detectedResource.schemaURL = mergedSchemaURL
 }
 
-func MergeSchemaURL(currentSchemaURL string, newSchemaURL string) string {
+func MergeSchemaURL(currentSchemaURL, newSchemaURL string) string {
 	if currentSchemaURL == "" {
 		return newSchemaURL
 	}

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -196,7 +196,7 @@ func generateProfileData(attributes map[string]string) pprofile.Profiles {
 	return p
 }
 
-func compareProfileAttributes(t *testing.T, expected pprofile.Profiles, got pprofile.Profiles) {
+func compareProfileAttributes(t *testing.T, expected, got pprofile.Profiles) {
 	require.Equal(t, expected.ResourceProfiles().Len(), got.ResourceProfiles().Len())
 
 	for i := 0; i < expected.ResourceProfiles().Len(); i++ {

--- a/processor/schemaprocessor/internal/migrate/signal.go
+++ b/processor/schemaprocessor/internal/migrate/signal.go
@@ -20,7 +20,7 @@ type SignalNameChange struct {
 
 // NewSignalNameChange will create a `Signal` that will check the provided mappings if it can update a `alias.NamedSignal`
 // and if no values are provided for `matches`, then all values will be updated.
-func NewSignalNameChange[Key SignalType, Value SignalType](mappings map[Key]Value) SignalNameChange {
+func NewSignalNameChange[Key, Value SignalType](mappings map[Key]Value) SignalNameChange {
 	sig := SignalNameChange{
 		updates:  make(map[string]string, len(mappings)),
 		rollback: make(map[string]string, len(mappings)),

--- a/processor/schemaprocessor/internal/transformer/conditional_attributes_test.go
+++ b/processor/schemaprocessor/internal/transformer/conditional_attributes_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor/internal/migrate"
 )
 
-func assertAttributeEquals(t *testing.T, attributes pcommon.Map, key string, value string) {
+func assertAttributeEquals(t *testing.T, attributes pcommon.Map, key, value string) {
 	t.Helper()
 	val, ok := attributes.Get(key)
 	require.True(t, ok)

--- a/processor/schemaprocessor/internal/translation/translation.go
+++ b/processor/schemaprocessor/internal/translation/translation.go
@@ -107,7 +107,7 @@ func newTranslatorFromSchema(log *zap.Logger, targetSchemaURL string, schemaFile
 	return t, nil
 }
 
-func newTranslator(log *zap.Logger, targetSchemaURL string, schema string) (*translator, error) {
+func newTranslator(log *zap.Logger, targetSchemaURL, schema string) (*translator, error) {
 	schemaFileSchema, err := encoder.Parse(strings.NewReader(schema))
 	if err != nil {
 		return nil, err

--- a/processor/schemaprocessor/processor_test.go
+++ b/processor/schemaprocessor/processor_test.go
@@ -35,7 +35,7 @@ versions:%s`, transformations)
 	return data, nil
 }
 
-func newTestSchemaProcessor(t *testing.T, transformations string, targerVerion string) *schemaProcessor {
+func newTestSchemaProcessor(t *testing.T, transformations, targerVerion string) *schemaProcessor {
 	cfg := &Config{
 		Targets: []string{fmt.Sprintf("http://opentelemetry.io/schemas/%s", targerVerion)},
 	}

--- a/processor/sumologicprocessor/aggregate_attributes_processor.go
+++ b/processor/sumologicprocessor/aggregate_attributes_processor.go
@@ -162,7 +162,7 @@ func (proc *aggregateAttributesProcessor) processAttributes(attributes pcommon.M
 }
 
 // Checks if the key has given prefix and trims it if so.
-func getNewKey(key string, prefix string) (bool, string) {
+func getNewKey(key, prefix string) (bool, string) {
 	if strings.HasPrefix(key, prefix) {
 		return true, strings.TrimPrefix(key, prefix)
 	}

--- a/processor/sumologicprocessor/nesting_processor.go
+++ b/processor/sumologicprocessor/nesting_processor.go
@@ -279,7 +279,7 @@ func (proc *nestingProcessor) squashAttribute(value pcommon.Value) string {
 	return ""
 }
 
-func (proc *nestingProcessor) squashKey(key string, keySuffix string) string {
+func (proc *nestingProcessor) squashKey(key, keySuffix string) string {
 	if keySuffix == "" {
 		return key
 	}

--- a/processor/sumologicprocessor/translate_attributes_processor_test.go
+++ b/processor/sumologicprocessor/translate_attributes_processor_test.go
@@ -102,7 +102,7 @@ func TestTranslateAttributesDoesNotOverwriteMultipleExistingAttributes(t *testin
 	assertAttribute(t, attributes, "host.name", "hostname1")
 }
 
-func assertAttribute(t *testing.T, metadata pcommon.Map, attributeName string, expectedValue string) {
+func assertAttribute(t *testing.T, metadata pcommon.Map, attributeName, expectedValue string) {
 	value, exists := metadata.Get(attributeName)
 
 	if expectedValue == "" {

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
@@ -23,7 +23,7 @@ var _ PolicyEvaluator = (*booleanAttributeFilter)(nil)
 
 // NewBooleanAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute that match the supplied boolean value.
-func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value bool, invertMatch bool) PolicyEvaluator {
+func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value, invertMatch bool) PolicyEvaluator {
 	return &booleanAttributeFilter{
 		key:         key,
 		value:       value,

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -21,7 +21,7 @@ type latency struct {
 var _ PolicyEvaluator = (*latency)(nil)
 
 // NewLatency creates a policy evaluator sampling traces with a duration greater than a configured threshold
-func NewLatency(settings component.TelemetrySettings, thresholdMs int64, upperThresholdMs int64) PolicyEvaluator {
+func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThresholdMs int64) PolicyEvaluator {
 	return &latency{
 		logger:           settings.Logger,
 		thresholdMs:      thresholdMs,

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
@@ -253,7 +253,7 @@ func BenchmarkStringTagFilterEvaluateRegex(b *testing.B) {
 	}
 }
 
-func newTraceStringAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValue string) *TraceData {
+func newTraceStringAttrs(nodeAttrs map[string]any, spanAttrKey, spanAttrValue string) *TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	//nolint:errcheck

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -91,7 +91,7 @@ func hasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlice, che
 	return invert
 }
 
-func SetAttrOnScopeSpans(data *TraceData, attrName string, attrKey string) {
+func SetAttrOnScopeSpans(data *TraceData, attrName, attrKey string) {
 	data.Lock()
 	defer data.Unlock()
 

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -21,7 +21,7 @@ func TestSetAttrOnScopeSpans_Empty(_ *testing.T) {
 }
 
 func TestSetAttrOnScopeSpans_Many(t *testing.T) {
-	assertAttrExists := func(t *testing.T, attrs pcommon.Map, key string, value string) {
+	assertAttrExists := func(t *testing.T, attrs pcommon.Map, key, value string) {
 		v, ok := attrs.Get(key)
 		assert.True(t, ok)
 		assert.Equal(t, value, v.AsString())

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -388,7 +388,7 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 	// if the number of traces on the map matches the expected value.
 	cnt := 0
 	tsp := sp.(*tailSamplingSpanProcessor)
-	tsp.idToTrace.Range(func(_ any, _ any) bool {
+	tsp.idToTrace.Range(func(_, _ any) bool {
 		cnt++
 		return true
 	})

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -269,7 +269,7 @@ func parseScopeContextStatements[R any](
 	return result.(R), nil
 }
 
-func parseGlobalExpr[K any, O any](
+func parseGlobalExpr[K, O any](
 	boolExprFunc func([]string, map[string]ottl.Factory[K], ottl.ErrorMode, component.TelemetrySettings, []O) (*ottl.ConditionSequence[K], error),
 	conditions []string,
 	errorMode ottl.ErrorMode,

--- a/processor/transformprocessor/internal/metrics/func_copy_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric.go
@@ -31,7 +31,7 @@ func createCopyMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 	return copyMetric(args.Name, args.Description, args.Unit)
 }
 
-func copyMetric(name ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]], desc ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]], unit ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func copyMetric(name, desc, unit ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
 	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
 		cur := tCtx.GetMetric()
 		metrics := tCtx.GetMetrics()

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -44,7 +44,7 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(_ pmetric.Metrics) {
+			want: func(pmetric.Metrics) {
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func Test_ProcessMetrics_InferredResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(resource.attributes["test"], "pass") where resource.attributes["host.name"] == "wrong"`,
-			want: func(_ pmetric.Metrics) {
+			want: func(pmetric.Metrics) {
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(_ pmetric.Metrics) {
+			want: func(pmetric.Metrics) {
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func Test_ProcessMetrics_InferredScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(scope.attributes["test"], "pass") where scope.version == 2`,
-			want: func(_ pmetric.Metrics) {
+			want: func(pmetric.Metrics) {
 			},
 		},
 		{
@@ -900,7 +900,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(attributes["test"], Split(attributes["not_exist"], "|"))`},
-			want:       func(_ pmetric.Metrics) {},
+			want:       func(pmetric.Metrics) {},
 		},
 		{
 			statements: []string{`set(attributes["test"], Substring(attributes["total.string"], 3, 3))`},
@@ -920,7 +920,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`},
-			want:       func(_ pmetric.Metrics) {},
+			want:       func(pmetric.Metrics) {},
 		},
 		{
 			statements: []string{
@@ -963,8 +963,8 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		{
 			statements: []string{`limit(attributes, 0, []) where metric.name == "operationA"`},
 			want: func(td pmetric.Metrics) {
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
 			},
 		},
 		{
@@ -1343,7 +1343,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(datapoint.attributes["test"], Split(datapoint.attributes["not_exist"], "|"))`},
-			want:       func(_ pmetric.Metrics) {},
+			want:       func(pmetric.Metrics) {},
 		},
 		{
 			statements: []string{`set(datapoint.attributes["test"], Substring(datapoint.attributes["total.string"], 3, 3))`},
@@ -1363,7 +1363,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(datapoint.attributes["test"], Substring(datapoint.attributes["not_exist"], 3, 3))`},
-			want:       func(_ pmetric.Metrics) {},
+			want:       func(pmetric.Metrics) {},
 		},
 		{
 			statements: []string{
@@ -1406,8 +1406,8 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 		{
 			statements: []string{`limit(datapoint.attributes, 0, []) where metric.name == "operationA"`},
 			want: func(td pmetric.Metrics) {
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
 			},
 		},
 		{
@@ -2015,8 +2015,8 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 
 type TestFuncArguments[K any] struct{}
 
-func createTestFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, _ K) (any, error) {
+func createTestFunc[K any](ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(context.Context, K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/profiles/processor_test.go
+++ b/processor/transformprocessor/internal/profiles/processor_test.go
@@ -46,7 +46,7 @@ func Test_ProcessProfiles_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(_ pprofile.Profiles) {
+			want: func(pprofile.Profiles) {
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func Test_ProcessProfiles_InferredResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(resource.attributes["test"], "pass") where resource.attributes["host.name"] == "wrong"`,
-			want: func(_ pprofile.Profiles) {
+			want: func(pprofile.Profiles) {
 			},
 		},
 		{
@@ -128,7 +128,7 @@ func Test_ProcessProfiles_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(_ pprofile.Profiles) {
+			want: func(pprofile.Profiles) {
 			},
 		},
 		{
@@ -169,7 +169,7 @@ func Test_ProcessProfiles_InferredScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(scope.attributes["test"], "pass") where scope.version == 2`,
-			want: func(_ pprofile.Profiles) {
+			want: func(pprofile.Profiles) {
 			},
 		},
 		{
@@ -320,7 +320,7 @@ func Test_ProcessProfiles_ProfileContext(t *testing.T) {
 		},
 		{
 			statement: `set(original_payload_format, Split(resource.attributes["not_exist"], "|"))`,
-			want:      func(_ pprofile.Profiles) {},
+			want:      func(pprofile.Profiles) {},
 		},
 		{
 			statement: `set(original_payload_format, Substring(original_payload_format, 3, 3))`,
@@ -336,7 +336,7 @@ func Test_ProcessProfiles_ProfileContext(t *testing.T) {
 		},
 		{
 			statement: `set(original_payload_format, Substring(attributes["not_exist"], 3, 3))`,
-			want:      func(_ pprofile.Profiles) {},
+			want:      func(pprofile.Profiles) {},
 		},
 		{
 			statement: `set(attributes["test"], ["A", "B", "C"]) where original_payload_format == "operationA"`,
@@ -528,7 +528,7 @@ func Test_ProcessProfiles_InferredProfileContext(t *testing.T) {
 		},
 		{
 			statement: `set(profile.original_payload_format, Split(resource.attributes["not_exist"], "|"))`,
-			want:      func(_ pprofile.Profiles) {},
+			want:      func(pprofile.Profiles) {},
 		},
 		{
 			statement: `set(profile.original_payload_format, Substring(profile.original_payload_format, 3, 3))`,
@@ -544,7 +544,7 @@ func Test_ProcessProfiles_InferredProfileContext(t *testing.T) {
 		},
 		{
 			statement: `set(profile.original_payload_format, Substring(resource.attributes["not_exist"], 3, 3))`,
-			want:      func(_ pprofile.Profiles) {},
+			want:      func(pprofile.Profiles) {},
 		},
 		{
 			statement: `set(profile.attribute_indices, [1, 2, 3]) where profile.original_payload_format == "operationA"`,
@@ -1230,8 +1230,8 @@ func Test_ProcessProfiles_InferredContextFromConditions(t *testing.T) {
 
 type TestFuncArguments[K any] struct{}
 
-func createTestFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, _ K) (any, error) {
+func createTestFunc[K any](ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(context.Context, K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -49,7 +49,7 @@ func Test_ProcessTraces_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(_ ptrace.Traces) {
+			want: func(ptrace.Traces) {
 			},
 		},
 		{
@@ -90,7 +90,7 @@ func Test_ProcessTraces_InferredResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(resource.attributes["test"], "pass") where resource.attributes["host.name"] == "wrong"`,
-			want: func(_ ptrace.Traces) {
+			want: func(ptrace.Traces) {
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func Test_ProcessTraces_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(_ ptrace.Traces) {
+			want: func(ptrace.Traces) {
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func Test_ProcessTraces_InferredScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(scope.attributes["test"], "pass") where scope.version == 2`,
-			want: func(_ ptrace.Traces) {
+			want: func(ptrace.Traces) {
 			},
 		},
 		{
@@ -399,7 +399,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Split(attributes["not_exist"], "|"))`,
-			want:      func(_ ptrace.Traces) {},
+			want:      func(ptrace.Traces) {},
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["total.string"], 3, 3))`,
@@ -416,7 +416,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`,
-			want:      func(_ ptrace.Traces) {},
+			want:      func(ptrace.Traces) {},
 		},
 		{
 			statement: `set(attributes["test"], ["A", "B", "C"]) where name == "operationA"`,
@@ -472,7 +472,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		{
 			statement: `limit(attributes, 0, []) where name == "operationA"`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
 			},
 		},
 		{
@@ -699,7 +699,7 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(span.attributes["test"], Split(span.attributes["not_exist"], "|"))`,
-			want:      func(_ ptrace.Traces) {},
+			want:      func(ptrace.Traces) {},
 		},
 		{
 			statement: `set(span.attributes["test"], Substring(span.attributes["total.string"], 3, 3))`,
@@ -716,7 +716,7 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(span.attributes["test"], Substring(span.attributes["not_exist"], 3, 3))`,
-			want:      func(_ ptrace.Traces) {},
+			want:      func(ptrace.Traces) {},
 		},
 		{
 			statement: `set(span.attributes["test"], ["A", "B", "C"]) where span.name == "operationA"`,
@@ -772,7 +772,7 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 		{
 			statement: `limit(span.attributes, 0, []) where span.name == "operationA"`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(string, pcommon.Value) bool { return true })
 			},
 		},
 		{
@@ -1402,8 +1402,8 @@ func Test_NewProcessor_ConditionsParse(t *testing.T) {
 
 type TestFuncArguments[K any] struct{}
 
-func createTestFunc[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return func(_ context.Context, _ K) (any, error) {
+func createTestFunc[K any](ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return func(context.Context, K) (any, error) {
 		return nil, nil
 	}, nil
 }

--- a/receiver/activedirectorydsreceiver/scraper.go
+++ b/receiver/activedirectorydsreceiver/scraper.go
@@ -252,6 +252,6 @@ func (a *activeDirectoryDSScraper) scrape(_ context.Context) (pmetric.Metrics, e
 	return a.mb.Emit(), nil
 }
 
-func (a *activeDirectoryDSScraper) shutdown(_ context.Context) error {
+func (a *activeDirectoryDSScraper) shutdown(context.Context) error {
 	return a.w.Close()
 }

--- a/receiver/activedirectorydsreceiver/scraper_test.go
+++ b/receiver/activedirectorydsreceiver/scraper_test.go
@@ -141,7 +141,7 @@ type mockPerfCounterWatcher struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounterWatcher) ScrapeRawValue(_ *int64) (bool, error) {
+func (w *mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/apachesparkreceiver/scraper.go
+++ b/receiver/apachesparkreceiver/scraper.go
@@ -125,7 +125,7 @@ func (s *sparkScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 	return s.mb.Emit(), scrapeErrors.Combine()
 }
 
-func (s *sparkScraper) recordCluster(clusterStats *models.ClusterProperties, now pcommon.Timestamp, appID string, appName string) {
+func (s *sparkScraper) recordCluster(clusterStats *models.ClusterProperties, now pcommon.Timestamp, appID, appName string) {
 	if stat, ok := clusterStats.Gauges[appID+".driver.BlockManager.disk.diskSpaceUsed_MB"]; ok {
 		s.mb.RecordSparkDriverBlockManagerDiskUsageDataPoint(now, int64(stat.Value))
 	}
@@ -251,7 +251,7 @@ func (s *sparkScraper) recordCluster(clusterStats *models.ClusterProperties, now
 	s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }
 
-func (s *sparkScraper) recordStages(stageStats []models.Stage, now pcommon.Timestamp, appID string, appName string) {
+func (s *sparkScraper) recordStages(stageStats []models.Stage, now pcommon.Timestamp, appID, appName string) {
 	for _, stage := range stageStats {
 		switch stage.Status {
 		case "ACTIVE":
@@ -302,7 +302,7 @@ func (s *sparkScraper) recordStages(stageStats []models.Stage, now pcommon.Times
 	}
 }
 
-func (s *sparkScraper) recordExecutors(executorStats []models.Executor, now pcommon.Timestamp, appID string, appName string) {
+func (s *sparkScraper) recordExecutors(executorStats []models.Executor, now pcommon.Timestamp, appID, appName string) {
 	for _, executor := range executorStats {
 		s.mb.RecordSparkExecutorMemoryUsageDataPoint(now, executor.MemoryUsed)
 		s.mb.RecordSparkExecutorDiskUsageDataPoint(now, executor.DiskUsed)
@@ -330,7 +330,7 @@ func (s *sparkScraper) recordExecutors(executorStats []models.Executor, now pcom
 	}
 }
 
-func (s *sparkScraper) recordJobs(jobStats []models.Job, now pcommon.Timestamp, appID string, appName string) {
+func (s *sparkScraper) recordJobs(jobStats []models.Job, now pcommon.Timestamp, appID, appName string) {
 	for _, job := range jobStats {
 		s.mb.RecordSparkJobTaskActiveDataPoint(now, job.NumActiveTasks)
 		s.mb.RecordSparkJobTaskResultDataPoint(now, job.NumCompletedTasks, metadata.AttributeJobResultCompleted)

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -176,7 +176,7 @@ func (c *Cadvisor) Shutdown() error {
 	return errs
 }
 
-func (c *Cadvisor) addEbsVolumeInfo(tags map[string]string, ebsVolumeIDsUsedAsPV map[string]string) {
+func (c *Cadvisor) addEbsVolumeInfo(tags, ebsVolumeIDsUsedAsPV map[string]string) {
 	deviceName, ok := tags[ci.DiskDev]
 	if !ok {
 		return

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
@@ -36,7 +36,7 @@ func (d *DiskIOMetricExtractor) GetValue(info *cInfo.ContainerInfo, _ CPUMemInfo
 	return metrics
 }
 
-func (d *DiskIOMetricExtractor) extractIoMetrics(curStatsSet []cInfo.PerDiskStats, namePrefix string, containerType string, infoName string, curTime time.Time) []*CAdvisorMetric {
+func (d *DiskIOMetricExtractor) extractIoMetrics(curStatsSet []cInfo.PerDiskStats, namePrefix, containerType, infoName string, curTime time.Time) []*CAdvisorMetric {
 	var metrics []*CAdvisorMetric
 	expectedKey := []string{ci.DiskIOAsync, ci.DiskIOSync, ci.DiskIORead, ci.DiskIOWrite, ci.DiskIOTotal}
 	for _, cur := range curStatsSet {

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
@@ -44,8 +44,8 @@ type cgroupScannerProvider interface {
 	getMemReserved() int64
 
 	// use for test
-	getCPUReservedInTask(taskID string, clusterName string) int64
-	getMEMReservedInTask(taskID string, clusterName string, containers []ECSContainer) int64
+	getCPUReservedInTask(taskID, clusterName string) int64
+	getMEMReservedInTask(taskID, clusterName string, containers []ECSContainer) int64
 }
 
 func newCGroupScanner(ctx context.Context, mountConfigPath string, logger *zap.Logger, ecsTaskInfoProvider ecsTaskInfoProvider, containerInstanceInfoProvider containerInstanceInfoProvider, refreshInterval time.Duration) cgroupScannerProvider {
@@ -115,7 +115,7 @@ func newCGroupScannerForContainer(ctx context.Context, logger *zap.Logger, ecsTa
 	return newCGroupScanner(ctx, ecsInstanceMountConfigPath, logger, ecsTaskInfoProvider, containerInstanceInfoProvider, refreshInterval)
 }
 
-func (c *cgroupScanner) getCPUReservedInTask(taskID string, clusterName string) int64 {
+func (c *cgroupScanner) getCPUReservedInTask(taskID, clusterName string) int64 {
 	cpuPath, err := getCGroupPathForTask(c.mountPoint, "cpu", taskID, clusterName)
 	if err != nil {
 		c.logger.Warn("Failed to get cpu cgroup path for task: ", zap.Error(err))
@@ -136,7 +136,7 @@ func (c *cgroupScanner) getCPUReservedInTask(taskID string, clusterName string) 
 	return int64(0)
 }
 
-func (c *cgroupScanner) getMEMReservedInTask(taskID string, clusterName string, containers []ECSContainer) int64 {
+func (c *cgroupScanner) getMEMReservedInTask(taskID, clusterName string, containers []ECSContainer) int64 {
 	memPath, err := getCGroupPathForTask(c.mountPoint, "memory", taskID, clusterName)
 	if err != nil {
 		c.logger.Warn("Failed to get memory cgroup path for task: %v", zap.Error(err))
@@ -166,7 +166,7 @@ func (c *cgroupScanner) getMEMReservedInTask(taskID string, clusterName string, 
 	return sum
 }
 
-func readString(dirpath string, file string) (string, error) {
+func readString(dirpath, file string) (string, error) {
 	cgroupFile := filepath.Join(dirpath, file)
 
 	// Read
@@ -179,7 +179,7 @@ func readString(dirpath string, file string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func readInt64(dirpath string, file string) (int64, error) {
+func readInt64(dirpath, file string) (int64, error) {
 	out, err := readString(dirpath, file)
 	if err != nil {
 		return 0, err

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -68,11 +68,11 @@ func (c *MockCgroupScanner) getMemReserved() int64 {
 	return c.memReserved
 }
 
-func (c *MockCgroupScanner) getCPUReservedInTask(_ string, _ string) int64 {
+func (c *MockCgroupScanner) getCPUReservedInTask(_, _ string) int64 {
 	return int64(10)
 }
 
-func (c *MockCgroupScanner) getMEMReservedInTask(_ string, _ string, _ []ECSContainer) int64 {
+func (c *MockCgroupScanner) getMEMReservedInTask(_, _ string, _ []ECSContainer) int64 {
 	return int64(512)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/host/ebsvolume.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ebsvolume.go
@@ -51,7 +51,7 @@ type ebsVolume struct {
 
 type ebsVolumeOption func(*ebsVolume)
 
-func newEBSVolume(ctx context.Context, cfg aws.Config, instanceID string, region string,
+func newEBSVolume(ctx context.Context, cfg aws.Config, instanceID, region string,
 	refreshInterval time.Duration, logger *zap.Logger, options ...ebsVolumeOption,
 ) ebsVolumeProvider {
 	cfg.Region = region

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2metadata.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2metadata.go
@@ -38,7 +38,7 @@ type ec2Metadata struct {
 type ec2MetadataOption func(*ec2Metadata)
 
 func newEC2Metadata(ctx context.Context, cfg aws.Config, refreshInterval time.Duration,
-	instanceIDReadyC chan bool, instanceIPReadyC chan bool, logger *zap.Logger, options ...ec2MetadataOption,
+	instanceIDReadyC, instanceIPReadyC chan bool, logger *zap.Logger, options ...ec2MetadataOption,
 ) ec2MetadataProvider {
 	emd := &ec2Metadata{
 		client:           imds.NewFromConfig(cfg),

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2tags.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2tags.go
@@ -45,7 +45,7 @@ type ec2Tags struct {
 
 type ec2TagsOption func(*ec2Tags)
 
-func newEC2Tags(ctx context.Context, cfg aws.Config, instanceID string, region string, containerOrchestrator string,
+func newEC2Tags(ctx context.Context, cfg aws.Config, instanceID, region, containerOrchestrator string,
 	refreshInterval time.Duration, logger *zap.Logger, options ...ec2TagsOption,
 ) ec2TagsProvider {
 	cfg.Region = region

--- a/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/kubeletutil/kubeletclient.go
@@ -20,7 +20,7 @@ type KubeletClient struct {
 	restClient kubelet.Client
 }
 
-func NewKubeletClient(kubeIP string, port string, logger *zap.Logger) (*KubeletClient, error) {
+func NewKubeletClient(kubeIP, port string, logger *zap.Logger) (*KubeletClient, error) {
 	kubeClient := &KubeletClient{
 		Port:   port,
 		KubeIP: kubeIP,

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore.go
@@ -103,7 +103,7 @@ type PodStore struct {
 	addFullPodNameMetricLabel bool
 }
 
-func NewPodStore(hostIP string, prefFullPodName bool, addFullPodNameMetricLabel bool, logger *zap.Logger) (*PodStore, error) {
+func NewPodStore(hostIP string, prefFullPodName, addFullPodNameMetricLabel bool, logger *zap.Logger) (*PodStore, error) {
 	podClient, err := kubeletutil.NewKubeletClient(hostIP, ci.KubeSecurePort, logger)
 	if err != nil {
 		return nil, err

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -44,7 +44,7 @@ type K8sDecorator struct {
 	podStore *PodStore
 }
 
-func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, tagService, prefFullPodName, addFullPodNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
 	hostIP := os.Getenv("HOST_IP")
 	if hostIP == "" {
 		return nil, errors.New("environment variable HOST_IP is not set in k8s deployment config")

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
@@ -62,7 +62,7 @@ func convertStoppedContainerDataToOTMetrics(prefix string, containerResource pco
 	return md
 }
 
-func appendIntGauge(metricName string, unit string, value int64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
+func appendIntGauge(metricName, unit string, value int64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
 	metric := appendMetric(ilm, metricName, unit)
 
 	intGauge := metric.SetEmptyGauge()
@@ -70,7 +70,7 @@ func appendIntGauge(metricName string, unit string, value int64, ts pcommon.Time
 	appendIntDataPoint(intGauge.DataPoints(), value, ts)
 }
 
-func appendIntSum(metricName string, unit string, value int64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
+func appendIntSum(metricName, unit string, value int64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
 	metric := appendMetric(ilm, metricName, unit)
 
 	intSum := metric.SetEmptySum()
@@ -79,7 +79,7 @@ func appendIntSum(metricName string, unit string, value int64, ts pcommon.Timest
 	appendIntDataPoint(intSum.DataPoints(), value, ts)
 }
 
-func appendDoubleGauge(metricName string, unit string, value float64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
+func appendDoubleGauge(metricName, unit string, value float64, ts pcommon.Timestamp, ilm pmetric.ScopeMetrics) {
 	metric := appendMetric(ilm, metricName, unit)
 	doubleGauge := metric.SetEmptyGauge()
 	dataPoint := doubleGauge.DataPoints().AppendEmpty()

--- a/receiver/awss3receiver/s3intf.go
+++ b/receiver/awss3receiver/s3intf.go
@@ -64,7 +64,7 @@ func (api *s3ListObjectsAPIImpl) NewListObjectsV2Paginator(params *s3.ListObject
 }
 
 // retrieveS3Object retrieves S3 object content for a given bucket and key
-func retrieveS3Object(ctx context.Context, client GetObjectAPI, bucket string, key string) ([]byte, error) {
+func retrieveS3Object(ctx context.Context, client GetObjectAPI, bucket, key string) ([]byte, error) {
 	params := s3.GetObjectInput{
 		Bucket: &bucket,
 		Key:    &key,

--- a/receiver/awss3receiver/sqsintf.go
+++ b/receiver/awss3receiver/sqsintf.go
@@ -18,7 +18,7 @@ type sqsClient interface {
 }
 
 // newSQSClient creates a new SQS client with the provided configuration
-func newSQSClient(ctx context.Context, region string, endpoint string) (sqsClient, error) {
+func newSQSClient(ctx context.Context, region, endpoint string) (sqsClient, error) {
 	optionsFuncs := make([]func(*config.LoadOptions) error, 0)
 	if region != "" {
 		optionsFuncs = append(optionsFuncs, config.WithRegion(region))

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -13,7 +13,7 @@ import (
 )
 
 type blobClient interface {
-	readBlob(ctx context.Context, containerName string, blobName string) (*bytes.Buffer, error)
+	readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error)
 }
 
 type azureBlobClient struct {
@@ -23,7 +23,7 @@ type azureBlobClient struct {
 
 var _ blobClient = (*azureBlobClient)(nil)
 
-func (bc *azureBlobClient) readBlob(ctx context.Context, containerName string, blobName string) (*bytes.Buffer, error) {
+func (bc *azureBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
 	defer func() {
 		_, blobDeleteErr := bc.serviceClient.DeleteBlob(ctx, containerName, blobName, nil)
 		if blobDeleteErr != nil {

--- a/receiver/azureblobreceiver/blobeventhandler.go
+++ b/receiver/azureblobreceiver/blobeventhandler.go
@@ -127,7 +127,7 @@ func (p *azureBlobEventHandler) setTracesDataConsumer(tracesDataConsumer tracesD
 	p.tracesDataConsumer = tracesDataConsumer
 }
 
-func newBlobEventHandler(eventHubConnectionString string, logsContainerName string, tracesContainerName string, blobClient blobClient, logger *zap.Logger) *azureBlobEventHandler {
+func newBlobEventHandler(eventHubConnectionString, logsContainerName, tracesContainerName string, blobClient blobClient, logger *zap.Logger) *azureBlobEventHandler {
 	return &azureBlobEventHandler{
 		blobClient:               blobClient,
 		logsContainerName:        logsContainerName,

--- a/receiver/azureblobreceiver/mock_blobclient.go
+++ b/receiver/azureblobreceiver/mock_blobclient.go
@@ -15,7 +15,7 @@ type mockBlobClient struct {
 }
 
 // ReadBlob provides a mock function with given fields: ctx, containerName, blobName
-func (_m *mockBlobClient) readBlob(ctx context.Context, containerName string, blobName string) (*bytes.Buffer, error) {
+func (_m *mockBlobClient) readBlob(ctx context.Context, containerName, blobName string) (*bytes.Buffer, error) {
 	ret := _m.Called(ctx, containerName, blobName)
 
 	var r0 *bytes.Buffer

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -344,7 +344,7 @@ func (s *azureBatchScraper) getResourceMetricsDefinitionsByType(ctx context.Cont
 }
 
 // TODO: duplicate
-func (s *azureBatchScraper) storeMetricsDefinitionByType(subscriptionID string, resourceType string, name string, compositeKey metricsCompositeKey) {
+func (s *azureBatchScraper) storeMetricsDefinitionByType(subscriptionID, resourceType, name string, compositeKey metricsCompositeKey) {
 	if _, ok := s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey]; ok {
 		s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey].metrics = append(
 			s.resourceTypes[subscriptionID][resourceType].metricsByCompositeKey[compositeKey].metrics, name,

--- a/receiver/bigipreceiver/client.go
+++ b/receiver/bigipreceiver/client.go
@@ -266,7 +266,7 @@ func (c *bigipClient) checkHTTPStatus(resp *http.Response) (err error) {
 }
 
 // combinePoolMembers takes two PoolMembers and returns an aggregate of them both
-func combinePoolMembers(poolMembersA *models.PoolMembers, poolMembersB *models.PoolMembers) *models.PoolMembers {
+func combinePoolMembers(poolMembersA, poolMembersB *models.PoolMembers) *models.PoolMembers {
 	var aSize int
 	if poolMembersA != nil {
 		aSize = len(poolMembersA.Entries)

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -420,7 +420,7 @@ func severityFromStatusCode(statusCode int64) plog.SeverityNumber {
 
 // flattenMap recursively flattens a map[string]any into a single level map
 // with keys joined by the specified separator
-func flattenMap(input map[string]any, prefix string, separator string, result map[string]any) {
+func flattenMap(input map[string]any, prefix, separator string, result map[string]any) {
 	for k, v := range input {
 		// Replace hyphens with underscores in the key. Content-Type becomes Content_Type
 		k = strings.ReplaceAll(k, "-", "_")

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -500,7 +500,7 @@ func TestAttributesWithSeparator(t *testing.T) {
 		},
 	}
 
-	expectedLogs := func(t *testing.T, payload string, separator string) plog.Logs {
+	expectedLogs := func(t *testing.T, payload, separator string) plog.Logs {
 		logs := plog.NewLogs()
 		rl := logs.ResourceLogs().AppendEmpty()
 		sl := rl.ScopeLogs().AppendEmpty()

--- a/receiver/cloudfoundryreceiver/config.go
+++ b/receiver/cloudfoundryreceiver/config.go
@@ -83,7 +83,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func validateURLOption(name string, value string) error {
+func validateURLOption(name, value string) error {
 	if value == "" {
 		return fmt.Errorf("%s not specified", name)
 	}

--- a/receiver/cloudfoundryreceiver/config_test.go
+++ b/receiver/cloudfoundryreceiver/config_test.go
@@ -163,7 +163,7 @@ func loadSuccessfulConfig(t *testing.T) *Config {
 	return configuration
 }
 
-func checkTypeFieldMatch(t *testing.T, fieldName string, localType reflect.Type, standardType reflect.Type) {
+func checkTypeFieldMatch(t *testing.T, fieldName string, localType, standardType reflect.Type) {
 	localField, localFieldPresent := localType.FieldByName(fieldName)
 	standardField, standardFieldPresent := standardType.FieldByName(fieldName)
 

--- a/receiver/cloudfoundryreceiver/uaa.go
+++ b/receiver/cloudfoundryreceiver/uaa.go
@@ -28,7 +28,7 @@ type uaaTokenProvider struct {
 	mutex          *sync.Mutex
 }
 
-func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, username string, password string) (*uaaTokenProvider, error) {
+func newUAATokenProvider(logger *zap.Logger, config LimitedClientConfig, username, password string) (*uaaTokenProvider, error) {
 	client, err := uaago.NewClient(config.Endpoint)
 	if err != nil {
 		return nil, err

--- a/receiver/collectdreceiver/collectd.go
+++ b/receiver/collectdreceiver/collectd.go
@@ -213,7 +213,7 @@ func addIfNotNullOrEmpty(m map[string]string, key string, val *string) {
 	}
 }
 
-func parseAndAddLabels(labels map[string]string, pluginInstance *string, host *string) {
+func parseAndAddLabels(labels map[string]string, pluginInstance, host *string) {
 	parseNameForLabels(labels, "plugin_instance", pluginInstance)
 	parseNameForLabels(labels, "host", host)
 }

--- a/receiver/collectdreceiver/receiver_test.go
+++ b/receiver/collectdreceiver/receiver_test.go
@@ -212,7 +212,7 @@ func createWantedMetrics(wantedRequestBody wantedBody) pmetric.Metrics {
 	return testMetrics
 }
 
-func assertMetricsAreEqual(t *testing.T, expectedData []pmetric.Metrics, actualData []pmetric.Metrics) {
+func assertMetricsAreEqual(t *testing.T, expectedData, actualData []pmetric.Metrics) {
 	for i := 0; i < len(expectedData); i++ {
 		err := pmetrictest.CompareMetrics(expectedData[i], actualData[i])
 		require.NoError(t, err)

--- a/receiver/datadogreceiver/internal/translator/batcher.go
+++ b/receiver/datadogreceiver/internal/translator/batcher.go
@@ -47,7 +47,7 @@ var metricTypeMap = map[string]pmetric.MetricType{
 	"sketch":        pmetric.MetricTypeExponentialHistogram,
 }
 
-func parseSeriesProperties(name string, metricType string, tags []string, host string, version string, stringPool *StringPool) dimensions {
+func parseSeriesProperties(name, metricType string, tags []string, host, version string, stringPool *StringPool) dimensions {
 	attrs := tagsToAttributes(tags, host, stringPool)
 	return dimensions{
 		name:          name,

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -76,7 +76,7 @@ var datadogKnownResourceAttributes = map[string]string{
 }
 
 // translateDatadogTagToKeyValuePair translates a Datadog tag to a key value pair
-func translateDatadogTagToKeyValuePair(tag string) (key string, value string) {
+func translateDatadogTagToKeyValuePair(tag string) (key, value string) {
 	if tag == "" {
 		return "", ""
 	}

--- a/receiver/dockerstatsreceiver/metric_helper.go
+++ b/receiver/dockerstatsreceiver/metric_helper.go
@@ -26,7 +26,7 @@ const nanosInASecond = 1e9
 // For more information, please see https://www.bis.doc.gov
 // See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
 
-func calculateCPUPercent(previous *ctypes.CPUStats, v *ctypes.CPUStats) float64 {
+func calculateCPUPercent(previous, v *ctypes.CPUStats) float64 {
 	var (
 		cpuPercent = 0.0
 		// calculate the change for the cpu usage of the container in between readings
@@ -69,7 +69,7 @@ func calculateMemUsageNoCache(memoryStats *ctypes.MemoryStats) uint64 {
 	return memoryStats.Usage
 }
 
-func calculateMemoryPercent(limit uint64, usedNoCache uint64) float64 {
+func calculateMemoryPercent(limit, usedNoCache uint64) float64 {
 	// MemoryStats.Limit will never be 0 unless the container is not running and we haven't
 	// got any data from cgroup
 	if limit != 0 {

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -224,7 +224,7 @@ func (r *metricsReceiver) recordMemoryMetrics(now pcommon.Timestamp, memoryStats
 	}
 }
 
-type blkioRecorder func(now pcommon.Timestamp, val int64, devMaj string, devMin string, operation string)
+type blkioRecorder func(now pcommon.Timestamp, val int64, devMaj, devMin, operation string)
 
 func (r *metricsReceiver) recordBlkioMetrics(now pcommon.Timestamp, blkioStats *ctypes.BlkioStats) {
 	recordSingleBlkioStat(now, blkioStats.IoMergedRecursive, r.mb.RecordContainerBlockioIoMergedRecursiveDataPoint)
@@ -265,7 +265,7 @@ func (r *metricsReceiver) recordNetworkMetrics(now pcommon.Timestamp, networks *
 	}
 }
 
-func (r *metricsReceiver) recordCPUMetrics(now pcommon.Timestamp, cpuStats *ctypes.CPUStats, prevStats *ctypes.CPUStats) {
+func (r *metricsReceiver) recordCPUMetrics(now pcommon.Timestamp, cpuStats, prevStats *ctypes.CPUStats) {
 	r.mb.RecordContainerCPUUsageSystemDataPoint(now, int64(cpuStats.SystemUsage))
 	r.mb.RecordContainerCPUUsageTotalDataPoint(now, int64(cpuStats.CPUUsage.TotalUsage))
 	r.mb.RecordContainerCPUUsageKernelmodeDataPoint(now, int64(cpuStats.CPUUsage.UsageInKernelmode))

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
@@ -110,7 +110,7 @@ func (ghs *githubScraper) login(
 
 // Returns the default search query string based on input of owner type
 // and GitHubOrg name with a default of archived:false to ignore archived repos
-func genDefaultSearchQuery(ownertype string, ghorg string) string {
+func genDefaultSearchQuery(ownertype, ghorg string) string {
 	return fmt.Sprintf("%s:%s archived:false", ownertype, ghorg)
 }
 
@@ -216,7 +216,7 @@ func (ghs *githubScraper) evalCommits(
 	client graphql.Client,
 	repoName string,
 	branch BranchNode,
-) (additions int, deletions int, age int64, err error) {
+) (additions, deletions int, age int64, err error) {
 	var cursor *string
 	items := defaultReturnItems
 
@@ -299,13 +299,13 @@ func (ghs *githubScraper) getCommitData(
 	return nil, errors.New("GraphQL query did not return the Commit Target")
 }
 
-func getNumPages(p float64, n float64) int {
+func getNumPages(p, n float64) int {
 	numPages := math.Ceil(n / p)
 
 	return int(numPages)
 }
 
 // Get the age/duration between two times in seconds.
-func getAge(start time.Time, end time.Time) int64 {
+func getAge(start, end time.Time) int64 {
 	return int64(end.Sub(start).Seconds())
 }

--- a/receiver/githubreceiver/trace_event_handling.go
+++ b/receiver/githubreceiver/trace_event_handling.go
@@ -345,7 +345,7 @@ func (gtr *githubTracesReceiver) createStepSpan(
 
 // newStepSpanID creates a deterministic Step Span ID based on the provided
 // inputs.
-func newStepSpanID(runID int64, runAttempt int, jobName string, stepName string, number int) (pcommon.SpanID, error) {
+func newStepSpanID(runID int64, runAttempt int, jobName, stepName string, number int) (pcommon.SpanID, error) {
 	input := fmt.Sprintf("%d%d%s%s%d", runID, runAttempt, jobName, stepName, number)
 	hash := sha256.Sum256([]byte(input))
 	spanIDHex := hex.EncodeToString(hash[:])

--- a/receiver/gitlabreceiver/model.go
+++ b/receiver/gitlabreceiver/model.go
@@ -52,7 +52,7 @@ func (p *glPipeline) setSpanIDs(span ptrace.Span, spanID pcommon.SpanID) error {
 	return nil
 }
 
-func (p *glPipeline) setTimeStamps(span ptrace.Span, startTime string, endTime string) error {
+func (p *glPipeline) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 
@@ -99,7 +99,7 @@ func (s *glPipelineStage) setSpanIDs(span ptrace.Span, parentSpanID pcommon.Span
 	return nil
 }
 
-func (s *glPipelineStage) setTimeStamps(span ptrace.Span, startTime string, endTime string) error {
+func (s *glPipelineStage) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 
@@ -171,7 +171,7 @@ func (j *glPipelineJob) setSpanIDs(span ptrace.Span, parentSpanID pcommon.SpanID
 	return nil
 }
 
-func (j *glPipelineJob) setTimeStamps(span ptrace.Span, startTime string, endTime string) error {
+func (j *glPipelineJob) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 

--- a/receiver/gitlabreceiver/traces_event_handling.go
+++ b/receiver/gitlabreceiver/traces_event_handling.go
@@ -171,7 +171,7 @@ func newPipelineSpanID(pipelineID int, finishedAt string) (pcommon.SpanID, error
 
 // newStageSpanID creates a deterministic Stage Span ID based on the provided pipelineID, stageName, and stage startedAt time.
 // It's not possible to create the stageSpanID during a pipeline execution. Details can be found here: https://github.com/open-telemetry/semantic-conventions/issues/1749#issuecomment-2772544215
-func newStageSpanID(pipelineID int, stageName string, startedAt string) (pcommon.SpanID, error) {
+func newStageSpanID(pipelineID int, stageName, startedAt string) (pcommon.SpanID, error) {
 	if stageName == "" {
 		return pcommon.SpanID{}, errors.New("stageName is empty")
 	}
@@ -285,7 +285,7 @@ func (gtr *gitlabTracesReceiver) setStageTime(stage *glPipelineStage, job glPipe
 	return nil
 }
 
-func setSpanTimeStamps(span ptrace.Span, startTime string, endTime string) error {
+func setSpanTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	parsedStartTime, err := parseGitlabTime(startTime)
 	if err != nil {
 		return err

--- a/receiver/googlecloudspannerreceiver/internal/datasource/databaseid.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/databaseid.go
@@ -12,7 +12,7 @@ type DatabaseID struct {
 	id           string
 }
 
-func NewDatabaseID(projectID string, instanceID string, databaseName string) *DatabaseID {
+func NewDatabaseID(projectID, instanceID, databaseName string) *DatabaseID {
 	return &DatabaseID{
 		projectID:    projectID,
 		instanceID:   instanceID,

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
@@ -52,7 +52,7 @@ func (f *currentLimitByTimestamp) get() int {
 	return f.limitByTimestamp
 }
 
-func NewItemCardinalityFilter(metricName string, totalLimit int, limitByTimestamp int,
+func NewItemCardinalityFilter(metricName string, totalLimit, limitByTimestamp int,
 	itemActivityPeriod time.Duration, logger *zap.Logger,
 ) (ItemFilter, error) {
 	if limitByTimestamp > totalLimit {

--- a/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
@@ -42,7 +42,7 @@ func assertGroupedByKey(t *testing.T, items []*Item, groupedItems map[time.Time]
 	}
 }
 
-func assertInitialFiltering(t *testing.T, expected []*Item, actual []*Item) {
+func assertInitialFiltering(t *testing.T, expected, actual []*Item) {
 	require.Len(t, actual, len(expected))
 	for i, expectedItem := range expected {
 		assert.Equal(t, expectedItem.SeriesKey, actual[i].SeriesKey)

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder.go
@@ -92,7 +92,7 @@ func (b filterBuilder) handleHighCardinalityGroups(groups []*metadata.MetricsMet
 	return b.constructFiltersForGroups(totalLimitPerMetric, limitPerMetricByTimestamp, groups, remainingTotalLimit, filterByMetric)
 }
 
-func (b filterBuilder) constructFiltersForGroups(totalLimitPerMetric int, limitPerMetricByTimestamp int,
+func (b filterBuilder) constructFiltersForGroups(totalLimitPerMetric, limitPerMetricByTimestamp int,
 	groups []*metadata.MetricsMetadata, remainingTotalLimit int, filterByMetric map[string]filter.ItemFilter,
 ) (int, error) {
 	newTotalLimit := remainingTotalLimit

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -244,7 +244,7 @@ func newLockRequestSliceLabelValue(metadata LabelValueMetadata, valueHolder any)
 	}
 }
 
-func NewLabelValueMetadata(name string, columnName string, valueType ValueType) (LabelValueMetadata, error) {
+func NewLabelValueMetadata(name, columnName string, valueType ValueType) (LabelValueMetadata, error) {
 	var newLabelValueFunc newLabelValueFunction
 	var valueHolderFunc valueHolderFunction
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -140,7 +140,7 @@ func newNullFloat64MetricValue(metadata MetricValueMetadata, valueHolder any) Me
 	}
 }
 
-func NewMetricValueMetadata(name string, columnName string, dataType MetricType, unit string,
+func NewMetricValueMetadata(name, columnName string, dataType MetricType, unit string,
 	valueType ValueType,
 ) (MetricValueMetadata, error) {
 	var newMetricValueFunc newMetricValueFunction

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
@@ -33,7 +33,7 @@ func createMetricsMetadata(query string) *metadata.MetricsMetadata {
 	return createMetricsMetadataFromTimestampColumn(query, "INTERVAL_END")
 }
 
-func createMetricsMetadataFromTimestampColumn(query string, timestampColumn string) *metadata.MetricsMetadata {
+func createMetricsMetadataFromTimestampColumn(query, timestampColumn string) *metadata.MetricsMetadata {
 	labelValueMetadata, _ := metadata.NewLabelValueMetadata("metric_label", "METRIC_LABEL",
 		metadata.StringValueType)
 	// Labels

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
@@ -12,7 +12,7 @@ type timestampsGenerator struct {
 
 // This slice will always contain at least one value - now shifted to the start of minute(upper bound).
 // In case lastPullTimestamp is greater than now argument slice will contain only one value - now shifted to the start of minute(upper bound).
-func (g *timestampsGenerator) pullTimestamps(lastPullTimestamp time.Time, now time.Time) []time.Time {
+func (g *timestampsGenerator) pullTimestamps(lastPullTimestamp, now time.Time) []time.Time {
 	var timestamps []time.Time
 	upperBound := shiftToStartOfMinute(now)
 
@@ -33,7 +33,7 @@ func (g *timestampsGenerator) pullTimestamps(lastPullTimestamp time.Time, now ti
 
 // This slice will always contain at least one value(upper bound).
 // Difference between each two points is 1 minute.
-func pullTimestampsWithDifference(lowerBound time.Time, upperBound time.Time, difference time.Duration) []time.Time {
+func pullTimestampsWithDifference(lowerBound, upperBound time.Time, difference time.Duration) []time.Time {
 	var timestamps []time.Time
 
 	for value := lowerBound.Add(difference); !value.After(upperBound); value = value.Add(difference) {

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -174,7 +174,7 @@ func getReturnedMetricNames(metrics pmetric.MetricSlice) map[string]struct{} {
 	return metricNames
 }
 
-func appendMapInto(m1 map[string]struct{}, m2 map[string]struct{}) {
+func appendMapInto(m1, m2 map[string]struct{}) {
 	for k, v := range m2 {
 		m1[k] = v
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal/cpu_utilization_calculator.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal/cpu_utilization_calculator.go
@@ -51,7 +51,7 @@ func (c *CPUUtilizationCalculator) CalculateAndRecord(now pcommon.Timestamp, cpu
 }
 
 // cpuUtilization calculates the difference between 2 cpu.TimesStat using spent time between them
-func cpuUtilization(timeStart cpu.TimesStat, timeEnd cpu.TimesStat) CPUUtilization {
+func cpuUtilization(timeStart, timeEnd cpu.TimesStat) CPUUtilization {
 	elapsedSeconds := totalCPU(timeEnd) - totalCPU(timeStart)
 	if elapsedSeconds <= 0 {
 		return CPUUtilization{CPU: timeStart.CPU}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
@@ -70,7 +70,7 @@ func TestScrape_Error(t *testing.T) {
 			scraper, err := newDiskScraper(context.Background(), scrapertest.NewNopSettings(metadata.Type), &Config{})
 			require.NoError(t, err, "Failed to create disk scraper: %v", err)
 
-			scraper.perfCounterFactory = func(_, _, _ string) (winperfcounters.PerfCounterWatcher, error) {
+			scraper.perfCounterFactory = func(string, string, string) (winperfcounters.PerfCounterWatcher, error) {
 				return &testmocks.PerfCounterWatcherMock{
 					ScrapeErr: test.scrapeErr,
 				}, nil

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -175,7 +175,7 @@ func (f *fsFilter) includeMountPoint(mountPoint string) bool {
 }
 
 // translateMountsRootPath translates a mountpoint from the host perspective to the chrooted perspective.
-func translateMountpoint(ctx context.Context, rootPath string, mountpoint string) string {
+func translateMountpoint(ctx context.Context, rootPath, mountpoint string) string {
 	if env, ok := ctx.Value(common.EnvKey).(common.EnvMap); ok {
 		mountInfo := env[common.EnvKeyType("HOST_PROC_MOUNTINFO")]
 		if mountInfo != "" {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -168,7 +168,7 @@ func assertMetricHasSingleDatapoint(t *testing.T, metric pmetric.Metric, expecte
 	assert.Equal(t, 1, metric.Gauge().DataPoints().Len())
 }
 
-func assertCompareAveragePerCPU(t *testing.T, average pmetric.Metric, standard pmetric.Metric, numCPU int) {
+func assertCompareAveragePerCPU(t *testing.T, average, standard pmetric.Metric, numCPU int) {
 	valAverage := average.Gauge().DataPoints().At(0).DoubleValue()
 	valStandard := standard.Gauge().DataPoints().At(0).DoubleValue()
 	if valAverage == 0 && valStandard == 0 {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
@@ -43,7 +43,7 @@ func TestSetSkipScrapeOnFailureToStart(t *testing.T) {
 		perfCounterFactory = originalPerfCounterFactory
 	}()
 
-	perfCounterFactory = func(_ string, _ string, _ string) (winperfcounters.PerfCounterWatcher, error) {
+	perfCounterFactory = func(string, string, string) (winperfcounters.PerfCounterWatcher, error) {
 		return nil, errors.New("error creating perf counter watcher")
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -1035,7 +1035,7 @@ func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError
 	return 1, expectedLen
 }
 
-func getExpectedScrapeFailures(nameError, exeError, timeError, memError, memPercentError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError error, handleCountError, rlimitError, cgroupError, uptimeError error) int {
+func getExpectedScrapeFailures(nameError, exeError, timeError, memError, memPercentError, diskError, pageFaultsError, threadError, contextSwitchError, fileDescriptorError, handleCountError, rlimitError, cgroupError, uptimeError error) int {
 	if runtime.GOOS == "windows" && exeError != nil {
 		return 2
 	}

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func AssertDescriptorEqual(t *testing.T, expected pmetric.Metric, actual pmetric.Metric) {
+func AssertDescriptorEqual(t *testing.T, expected, actual pmetric.Metric) {
 	assert.Equal(t, expected.Name(), actual.Name())
 	assert.Equal(t, expected.Description(), actual.Description())
 	assert.Equal(t, expected.Unit(), actual.Unit())

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -35,7 +35,7 @@ type httpcheckScraper struct {
 }
 
 // extractTLSInfo extracts TLS certificate information from the connection state
-func extractTLSInfo(state *tls.ConnectionState) (issuer string, commonName string, sans []any, timeLeft int64) {
+func extractTLSInfo(state *tls.ConnectionState) (issuer, commonName string, sans []any, timeLeft int64) {
 	if state == nil || len(state.PeerCertificates) == 0 {
 		return "", "", nil, 0
 	}

--- a/receiver/jaegerreceiver/internal/udpserver/thriftudp/transport.go
+++ b/receiver/jaegerreceiver/internal/udpserver/thriftudp/transport.go
@@ -38,7 +38,7 @@ var _ thrift.TTransport = (*TUDPTransport)(nil)
 // Example:
 //
 //	trans, err := thriftudp.NewTUDPClientTransport("192.168.1.1:9090", "")
-func NewTUDPClientTransport(destHostPort string, locHostPort string) (*TUDPTransport, error) {
+func NewTUDPClientTransport(destHostPort, locHostPort string) (*TUDPTransport, error) {
 	destAddr, err := net.ResolveUDPAddr("udp", destHostPort)
 	if err != nil {
 		return nil, thrift.NewTTransportException(thrift.NOT_OPEN, err.Error())

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -102,7 +102,7 @@ func (suite *jmxIntegrationSuite) TestJMXReceiverHappyPath() {
 	}
 }
 
-func integrationTest(version string, jar string, jmxConfig string) func(*testing.T) {
+func integrationTest(version, jar, jmxConfig string) func(*testing.T) {
 	return scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(

--- a/receiver/k8sclusterreceiver/internal/node/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/node/nodes.go
@@ -180,7 +180,7 @@ func GetMetadata(node *corev1.Node) map[experimentalmetricmetadata.ResourceID]*m
 	}
 }
 
-func getContainerRuntimeInfo(rawInfo string) (runtime string, version string) {
+func getContainerRuntimeInfo(rawInfo string) (runtime, version string) {
 	// Kubelet reports container runtime version in the following format:
 	// <runtime-name>://<version>
 	parts := strings.Split(rawInfo, "://")

--- a/receiver/k8sclusterreceiver/internal/utils/kube.go
+++ b/receiver/k8sclusterreceiver/internal/utils/kube.go
@@ -37,7 +37,7 @@ func FindOwnerWithKind(ors []metav1.OwnerReference, kind string) *metav1.OwnerRe
 
 // GetIDForCache returns keys to lookup resources from the cache exposed
 // by shared informers.
-func GetIDForCache(namespace string, resourceName string) string {
+func GetIDForCache(namespace, resourceName string) string {
 	return fmt.Sprintf("%s/%s", namespace, resourceName)
 }
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
@@ -197,7 +197,7 @@ func (m *Metadata) setExtraResources(rb *metadata.ResourceBuilder, podRef stats.
 // getContainerID retrieves container id from metadata for given pod UID and container name,
 // returns an error if no container found in the metadata that matches the requirements
 // or if the apiServer returned a newly created container with empty containerID.
-func (m *Metadata) getContainerID(podUID string, containerName string) (string, error) {
+func (m *Metadata) getContainerID(podUID, containerName string) (string, error) {
 	uid := types.UID(podUID)
 	for _, pod := range m.PodsMetadata.Items {
 		if pod.UID == uid {
@@ -222,7 +222,7 @@ func stripContainerID(id string) string {
 	return containerSchemeRegexp.ReplaceAllString(id, "")
 }
 
-func (m *Metadata) getPodVolume(podUID string, volumeName string) (v1.Volume, error) {
+func (m *Metadata) getPodVolume(podUID, volumeName string) (v1.Volume, error) {
 	for _, pod := range m.PodsMetadata.Items {
 		if pod.UID == types.UID(podUID) {
 			for _, volume := range pod.Spec.Volumes {

--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -10,9 +10,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-type getNetworkDataFunc func(s *stats.NetworkStats) (rx *uint64, tx *uint64)
+type getNetworkDataFunc func(s *stats.NetworkStats) (rx, tx *uint64)
 
-type getInterfaceDataFunc func(s *stats.InterfaceStats) (rx *uint64, tx *uint64)
+type getInterfaceDataFunc func(s *stats.InterfaceStats) (rx, tx *uint64)
 
 func addNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetrics, s *stats.NetworkStats, currentTime pcommon.Timestamp, allInterfaces bool) {
 	if s == nil {

--- a/receiver/kubeletstatsreceiver/mocked_objects_test.go
+++ b/receiver/kubeletstatsreceiver/mocked_objects_test.go
@@ -42,7 +42,7 @@ func getNodeWithCPUCapacity(nodeName string, cpuCap int) *v1.Node {
 	}
 }
 
-func getNodeWithMemoryCapacity(nodeName string, memoryCap string) *v1.Node {
+func getNodeWithMemoryCapacity(nodeName, memoryCap string) *v1.Node {
 	resourceList := make(v1.ResourceList)
 	q := resource.QuantityValue{}
 	_ = q.Set(memoryCap)

--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver/internal/metadata"
 )
 
-func sendToCollector(endpoint string, contentType string, contentEncoding string, body []byte) error {
+func sendToCollector(endpoint, contentType, contentEncoding string, body []byte) error {
 	var buf bytes.Buffer
 
 	switch contentEncoding {

--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -37,7 +37,7 @@ type accessLogStorageRecord struct {
 type accessLogClient interface {
 	GetProject(ctx context.Context, groupID string) (*mongodbatlas.Project, error)
 	GetClusters(ctx context.Context, groupID string) ([]mongodbatlas.Cluster, error)
-	GetAccessLogs(ctx context.Context, groupID string, clusterName string, opts *internal.GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error)
+	GetAccessLogs(ctx context.Context, groupID, clusterName string, opts *internal.GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error)
 }
 
 type accessLogsReceiver struct {

--- a/receiver/mongodbatlasreceiver/access_logs_test.go
+++ b/receiver/mongodbatlasreceiver/access_logs_test.go
@@ -464,7 +464,7 @@ func (mac *mockAccessLogsClient) GetClusters(ctx context.Context, groupID string
 	return args.Get(0).([]mongodbatlas.Cluster), args.Error(1)
 }
 
-func (mac *mockAccessLogsClient) GetAccessLogs(ctx context.Context, groupID string, clusterName string, opts *internal.GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error) {
+func (mac *mockAccessLogsClient) GetAccessLogs(ctx context.Context, groupID, clusterName string, opts *internal.GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error) {
 	args := mac.Called(ctx, groupID, clusterName, opts)
 	return args.Get(0).([]*mongodbatlas.AccessLogs), args.Error(1)
 }

--- a/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
+++ b/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
@@ -728,7 +728,7 @@ type GetAccessLogsOptions struct {
 }
 
 // GetAccessLogs returns the access logs specified for the cluster requested
-func (s *MongoDBAtlasClient) GetAccessLogs(ctx context.Context, groupID string, clusterName string, opts *GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error) {
+func (s *MongoDBAtlasClient) GetAccessLogs(ctx context.Context, groupID, clusterName string, opts *GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error) {
 	options := mongodbatlas.AccessLogOptions{
 		// Earliest Timestamp in epoch milliseconds from when Atlas should access log results
 		Start: strconv.FormatInt(opts.MinDate.UTC().UnixMilli(), 10),

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -218,7 +218,7 @@ func filterClusters(clusters []mongodbatlas.Cluster, projectCfg ProjectConfig) (
 	return filtered, nil
 }
 
-func (s *logsReceiver) getHostLogs(groupID, hostname, logName string, clusterMajorVersion string) ([]model.LogEntry, error) {
+func (s *logsReceiver) getHostLogs(groupID, hostname, logName, clusterMajorVersion string) ([]model.LogEntry, error) {
 	// Get gzip bytes buffer from API
 	buf, err := s.client.GetLogs(context.Background(), groupID, hostname, logName, s.start, s.end)
 	if err != nil {

--- a/receiver/mongodbreceiver/metrics.go
+++ b/receiver/mongodbreceiver/metrics.go
@@ -641,7 +641,7 @@ func (s *mongodbScraper) recordLockDeadlockCount(now pcommon.Timestamp, doc bson
 }
 
 // Index Stats
-func (s *mongodbScraper) recordIndexAccess(now pcommon.Timestamp, documents []bson.M, dbName string, collectionName string, errs *scrapererror.ScrapeErrors) {
+func (s *mongodbScraper) recordIndexAccess(now pcommon.Timestamp, documents []bson.M, dbName, collectionName string, errs *scrapererror.ScrapeErrors) {
 	metricName := "mongodb.index.access.count"
 	var indexAccessTotal int64
 	for _, doc := range documents {

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -218,7 +218,7 @@ func (s *mongodbScraper) collectTopStats(ctx context.Context, now pcommon.Timest
 	s.recordOperationTime(now, topStats, errs)
 }
 
-func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Timestamp, databaseName string, collectionName string, errs *scrapererror.ScrapeErrors) {
+func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Timestamp, databaseName, collectionName string, errs *scrapererror.ScrapeErrors) {
 	if databaseName == "local" {
 		return
 	}
@@ -269,7 +269,7 @@ func (s *mongodbScraper) recordAdminStats(now pcommon.Timestamp, document bson.M
 	s.recordPageFaults(now, document, errs)
 }
 
-func (s *mongodbScraper) recordIndexStats(now pcommon.Timestamp, indexStats []bson.M, databaseName string, collectionName string, errs *scrapererror.ScrapeErrors) {
+func (s *mongodbScraper) recordIndexStats(now pcommon.Timestamp, indexStats []bson.M, databaseName, collectionName string, errs *scrapererror.ScrapeErrors) {
 	s.recordIndexAccess(now, indexStats, databaseName, collectionName, errs)
 }
 

--- a/receiver/nsxtreceiver/client_mock_test.go
+++ b/receiver/nsxtreceiver/client_mock_test.go
@@ -49,7 +49,7 @@ func (m *mockClient) ClusterNodes(ctx context.Context) ([]model.ClusterNode, err
 }
 
 // InterfaceStatus provides a mock function with given fields: ctx, nodeID, interfaceID, class
-func (m *mockClient) InterfaceStatus(ctx context.Context, nodeID string, interfaceID string, class nodeClass) (*model.NetworkInterfaceStats, error) {
+func (m *mockClient) InterfaceStatus(ctx context.Context, nodeID, interfaceID string, class nodeClass) (*model.NetworkInterfaceStats, error) {
 	ret := m.Called(ctx, nodeID, interfaceID, class)
 
 	var r0 *model.NetworkInterfaceStats

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -208,7 +208,7 @@ func TestMetricsGrpcGatewayCors_endToEnd(t *testing.T) {
 	verifyCorsResp(t, url, "disallowed-origin.com", http.StatusNoContent, false)
 }
 
-func verifyCorsResp(t *testing.T, url string, origin string, wantStatus int, wantAllowed bool) {
+func verifyCorsResp(t *testing.T, url, origin string, wantStatus int, wantAllowed bool) {
 	req, err := http.NewRequest(http.MethodOptions, url, http.NoBody)
 	require.NoError(t, err, "Error creating trace OPTIONS request: %v", err)
 	req.Header.Set("Origin", origin)

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -131,7 +131,7 @@ type oracleScraper struct {
 	querySampleCfg             QuerySample
 }
 
-func newScraper(metricsBuilder *metadata.MetricsBuilder, metricsBuilderConfig metadata.MetricsBuilderConfig, scrapeCfg scraperhelper.ControllerConfig, logger *zap.Logger, providerFunc dbProviderFunc, clientProviderFunc clientProviderFunc, instanceName string, hostName string) (scraper.Metrics, error) {
+func newScraper(metricsBuilder *metadata.MetricsBuilder, metricsBuilderConfig metadata.MetricsBuilderConfig, scrapeCfg scraperhelper.ControllerConfig, logger *zap.Logger, providerFunc dbProviderFunc, clientProviderFunc clientProviderFunc, instanceName, hostName string) (scraper.Metrics, error) {
 	s := &oracleScraper{
 		mb:                   metricsBuilder,
 		metricsBuilderConfig: metricsBuilderConfig,

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -1223,7 +1223,7 @@ func TestReceiverAuthHeadersStream(t *testing.T) {
 	t.Run("per-data", func(t *testing.T) { testReceiverAuthHeaders(t, true, true) })
 }
 
-func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
+func testReceiverAuthHeaders(t *testing.T, includeMeta, dataAuth bool) {
 	tc := newHealthyTestChannel(t)
 	ctc := newCommonTestCase(t, tc)
 

--- a/receiver/podmanreceiver/podman_connection.go
+++ b/receiver/podmanreceiver/podman_connection.go
@@ -29,7 +29,7 @@ import (
 // most of this file has been adopted from https://github.com/containers/podman/blob/main/pkg/bindings/connection.go
 // and then simplified to remove things we do not need.
 
-func newPodmanConnection(logger *zap.Logger, endpoint string, sshKey string, sshPassphrase string) (*http.Client, error) {
+func newPodmanConnection(logger *zap.Logger, endpoint, sshKey, sshPassphrase string) (*http.Client, error) {
 	_url, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -71,7 +71,7 @@ type client interface {
 	getVersion(ctx context.Context) (string, error)
 	getQuerySamples(ctx context.Context, limit int64, newestQueryTimestamp float64, logger *zap.Logger) ([]map[string]any, float64, error)
 	getTopQuery(ctx context.Context, limit int64, logger *zap.Logger) ([]map[string]any, error)
-	explainQuery(query string, queryID string, logger *zap.Logger) (string, error)
+	explainQuery(query, queryID string, logger *zap.Logger) (string, error)
 }
 
 type postgreSQLClient struct {
@@ -80,7 +80,7 @@ type postgreSQLClient struct {
 }
 
 // explainQuery implements client.
-func (c *postgreSQLClient) explainQuery(query string, queryID string, logger *zap.Logger) (string, error) {
+func (c *postgreSQLClient) explainQuery(query, queryID string, logger *zap.Logger) (string, error) {
 	normalizedQueryID := strings.ReplaceAll(queryID, "-", "_")
 	var queryBuilder strings.Builder
 	var nulls []string
@@ -945,7 +945,7 @@ func (c *postgreSQLClient) getQuerySamples(ctx context.Context, limit int64, new
 	return finalAttributes, newestQueryTimestamp, errors.Join(errs...)
 }
 
-func convertMillisecondToSecond(column string, value string, logger *zap.Logger) (any, error) {
+func convertMillisecondToSecond(column, value string, logger *zap.Logger) (any, error) {
 	result := float64(0)
 	var err error
 	if value != "" {
@@ -957,7 +957,7 @@ func convertMillisecondToSecond(column string, value string, logger *zap.Logger)
 	return result / 1000.0, err
 }
 
-func convertToInt(column string, value string, logger *zap.Logger) (any, error) {
+func convertToInt(column, value string, logger *zap.Logger) (any, error) {
 	result := 0
 	var err error
 	if value != "" {
@@ -1019,7 +1019,7 @@ func (c *postgreSQLClient) getTopQuery(ctx context.Context, limit int64, logger 
 			tempBlksWrittenColumnName:   convertToInt,
 			totalExecTimeColumnName:     convertMillisecondToSecond,
 			totalPlanTimeColumnName:     convertMillisecondToSecond,
-			"query": func(_ string, val string, logger *zap.Logger) (any, error) {
+			"query": func(_, val string, logger *zap.Logger) (any, error) {
 				// TODO: check if it is truncated.
 				result, err := obfuscateSQL(val)
 				if err != nil {

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -191,7 +191,7 @@ func (p *postgreSQLScraper) scrapeQuerySamples(ctx context.Context, maxRowsPerQu
 	return p.lb.Emit(), nil
 }
 
-func (p *postgreSQLScraper) scrapeTopQuery(ctx context.Context, maxRowsPerQuery int64, topNQuery int64, maxExplainEachInterval int64) (plog.Logs, error) {
+func (p *postgreSQLScraper) scrapeTopQuery(ctx context.Context, maxRowsPerQuery, topNQuery, maxExplainEachInterval int64) (plog.Logs, error) {
 	var errs errsMux
 
 	p.collectTopQuery(ctx, p.clientFactory, maxRowsPerQuery, topNQuery, maxExplainEachInterval, &errs, p.logger)
@@ -229,7 +229,7 @@ func (p *postgreSQLScraper) collectQuerySamples(ctx context.Context, dbClient cl
 	}
 }
 
-func (p *postgreSQLScraper) collectTopQuery(ctx context.Context, clientFactory postgreSQLClientFactory, limit int64, topNQuery int64, maxExplainEachInterval int64, mux *errsMux, logger *zap.Logger) {
+func (p *postgreSQLScraper) collectTopQuery(ctx context.Context, clientFactory postgreSQLClientFactory, limit, topNQuery, maxExplainEachInterval int64, mux *errsMux, logger *zap.Logger) {
 	timestamp := pcommon.NewTimestampFromTime(time.Now())
 
 	defaultDbClient, err := clientFactory.getClient(defaultPostgreSQLDatabase)

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -85,7 +85,7 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 	factory := new(mockClientFactory)
 	factory.initMocks([]string{"otel"})
 
-	runTest := func(separateSchemaAttr bool, file string, fileDefault string) {
+	runTest := func(separateSchemaAttr bool, file, fileDefault string) {
 		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
 		cfg := createDefaultConfig().(*Config)
@@ -512,12 +512,12 @@ type (
 )
 
 // explainQuery implements client.
-func (m *mockClient) explainQuery(_ string, _ string, _ *zap.Logger) (string, error) {
+func (m *mockClient) explainQuery(string, string, *zap.Logger) (string, error) {
 	panic("unimplemented")
 }
 
 // getTopQuery implements client.
-func (m *mockClient) getTopQuery(_ context.Context, _ int64, _ *zap.Logger) ([]map[string]any, error) {
+func (m *mockClient) getTopQuery(context.Context, int64, *zap.Logger) ([]map[string]any, error) {
 	panic("unimplemented")
 }
 
@@ -527,7 +527,7 @@ func (m mockSimpleClientFactory) close() error {
 }
 
 // getClient implements postgreSQLClientFactory.
-func (m mockSimpleClientFactory) getClient(_ string) (client, error) {
+func (m mockSimpleClientFactory) getClient(string) (client, error) {
 	return &postgreSQLClient{
 		client:  m.db,
 		closeFn: m.close,
@@ -535,7 +535,7 @@ func (m mockSimpleClientFactory) getClient(_ string) (client, error) {
 }
 
 // getQuerySamples implements client.
-func (m *mockClient) getQuerySamples(_ context.Context, _ int64, _ float64, _ *zap.Logger) ([]map[string]any, float64, error) {
+func (m *mockClient) getQuerySamples(context.Context, int64, float64, *zap.Logger) ([]map[string]any, float64, error) {
 	panic("this should not be invoked")
 }
 
@@ -638,7 +638,7 @@ func (m *mockClientFactory) initMocks(databases []string) {
 	}
 }
 
-func (m *mockClient) initMocks(database string, schema string, databases []string, index int) {
+func (m *mockClient) initMocks(database, schema string, databases []string, index int) {
 	m.On("Close").Return(nil)
 
 	if database == defaultPostgreSQLDatabase {

--- a/receiver/prometheusreceiver/internal/logger.go
+++ b/receiver/prometheusreceiver/internal/logger.go
@@ -78,7 +78,7 @@ func extractLogData(keyvals []any) logData {
 }
 
 // check if a given key-value pair represents go-kit log message and return it
-func matchLogMessage(key any, val any) (string, bool) {
+func matchLogMessage(key, val any) (string, bool) {
 	if strKey, ok := key.(string); !ok || strKey != msgKey {
 		return "", false
 	}
@@ -91,7 +91,7 @@ func matchLogMessage(key any, val any) (string, bool) {
 }
 
 // check if a given key-value pair represents go-kit log level and return it
-func matchLogLevel(key any, val any) (level.Value, bool) {
+func matchLogLevel(key, val any) (level.Value, bool) {
 	strKey, ok := key.(string)
 	if !ok || strKey != levelKey {
 		return nil, false
@@ -107,7 +107,7 @@ func matchLogLevel(key any, val any) (level.Value, bool) {
 //revive:disable:error-return
 
 // check if a given key-value pair represents an error and return it
-func matchError(key any, val any) (error, bool) {
+func matchError(key, val any) (error, bool) {
 	strKey, ok := key.(string)
 	if !ok || strKey != errKey {
 		return nil, false

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -576,7 +576,7 @@ func convertExemplar(pe exemplar.Exemplar, e pmetric.Exemplar) {
 2. If len(src) = len(dst) -> copy src to dst as it is
 3. If len(src) < len(dst) -> prepend required 0s and then add src to dst. Example -> src = []byte{0xab, 0xcd}, dst = [8]byte, result dst = [8]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xab, 0xcd}
 */
-func decodeAndCopyToLowerBytes(dst []byte, src []byte) error {
+func decodeAndCopyToLowerBytes(dst, src []byte) error {
 	var err error
 	decodedLen := hex.DecodedLen(len(src))
 	if decodedLen >= len(dst) {

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -448,7 +448,7 @@ func assertExpectedAttributes(t *testing.T, want pcommon.Map, got pmetric.Resour
 	}
 }
 
-func assertExpectedMetrics(t *testing.T, metricExpectations []metricExpectation, got pmetric.ResourceMetrics, normalizedNames bool, existsOnly bool) {
+func assertExpectedMetrics(t *testing.T, metricExpectations []metricExpectation, got pmetric.ResourceMetrics, normalizedNames, existsOnly bool) {
 	var defaultExpectations []metricExpectation
 	switch {
 	case existsOnly:

--- a/receiver/receivercreator/discovery.go
+++ b/receiver/receivercreator/discovery.go
@@ -248,7 +248,7 @@ func createLogsConfig(
 	return defaultConfMap
 }
 
-func getHintAnnotation(annotations map[string]string, hintBase string, hintKey string, suffix string) (string, bool) {
+func getHintAnnotation(annotations map[string]string, hintBase, hintKey, suffix string) (string, bool) {
 	// try to scope the hint more on container level by suffixing
 	// with .<port> in case of Port event or .<container_name> in case of Pod Container event
 	containerLevelHint, ok := annotations[fmt.Sprintf("%s.%s/%s", hintBase, suffix, hintKey)]
@@ -261,7 +261,7 @@ func getHintAnnotation(annotations map[string]string, hintBase string, hintKey s
 	return podLevelHint, ok
 }
 
-func discoveryEnabled(annotations map[string]string, hintBase string, scopeSuffix string) bool {
+func discoveryEnabled(annotations map[string]string, hintBase, scopeSuffix string) bool {
 	enabledHint, found := getHintAnnotation(annotations, hintBase, discoveryEnabledHint, scopeSuffix)
 	if !found {
 		return false

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -900,7 +900,7 @@ func Test_sfxReceiver_EventAccessTokenPassthrough(t *testing.T) {
 	}
 }
 
-func buildSFxDatapointMsg(time int64, value int64, dimensions uint) *sfxpb.DataPointUploadMessage {
+func buildSFxDatapointMsg(time, value int64, dimensions uint) *sfxpb.DataPointUploadMessage {
 	return &sfxpb.DataPointUploadMessage{
 		Datapoints: []*sfxpb.DataPoint{
 			{

--- a/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
+++ b/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
@@ -37,7 +37,7 @@ func SwMetricsToMetrics(collection *agent.JVMMetricCollection) pmetric.Metrics {
 	return md
 }
 
-func jvmMetricToResource(serviceName string, serviceInstance string, resource pcommon.Resource) {
+func jvmMetricToResource(serviceName, serviceInstance string, resource pcommon.Resource) {
 	attrs := resource.Attributes()
 	attrs.EnsureCapacity(2)
 	attrs.PutStr(string(semconv.ServiceNameKey), serviceName)
@@ -147,7 +147,7 @@ func cpuMetricToMetrics(timestamp int64, cpu *common.CPU, dest pmetric.ScopeMetr
 	fillNumberDataPointDoubleValue(timestamp, cpu.UsagePercent, metricDps.AppendEmpty(), pcommon.NewMap())
 }
 
-func fillNumberDataPointIntValue(timestamp int64, value int64, point pmetric.NumberDataPoint, attrs pcommon.Map) {
+func fillNumberDataPointIntValue(timestamp, value int64, point pmetric.NumberDataPoint, attrs pcommon.Map) {
 	attrs.CopyTo(point.Attributes())
 	point.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(timestamp)))
 	point.SetIntValue(value)

--- a/receiver/snmpreceiver/config_test.go
+++ b/receiver/snmpreceiver/config_test.go
@@ -266,7 +266,7 @@ func TestLoadConfigConnectionConfigs(t *testing.T) {
 	}
 }
 
-func getBaseMetricConfig(gauge bool, scalar bool) map[string]*MetricConfig {
+func getBaseMetricConfig(gauge, scalar bool) map[string]*MetricConfig {
 	metricCfg := map[string]*MetricConfig{
 		"m3": {
 			Unit: "By",

--- a/receiver/snmpreceiver/otel_metric_helper.go
+++ b/receiver/snmpreceiver/otel_metric_helper.go
@@ -122,7 +122,7 @@ func (h *otelMetricHelper) createResource(resourceKey string, resourceAttributes
 }
 
 // getMetric returns a metric (if already created) by resource key and metric name
-func (h otelMetricHelper) getMetric(resourceKey string, metricName string) *pmetric.Metric {
+func (h otelMetricHelper) getMetric(resourceKey, metricName string) *pmetric.Metric {
 	if h.metricsByResource[resourceKey] == nil {
 		h.metricsByResource[resourceKey] = map[string]*pmetric.Metric{}
 	}
@@ -131,7 +131,7 @@ func (h otelMetricHelper) getMetric(resourceKey string, metricName string) *pmet
 }
 
 // createResource creates a new metric using on the resource key'd resource using the given metric config data
-func (h *otelMetricHelper) createMetric(resourceKey string, metricName string, metricCfg *MetricConfig) (*pmetric.Metric, error) {
+func (h *otelMetricHelper) createMetric(resourceKey, metricName string, metricCfg *MetricConfig) (*pmetric.Metric, error) {
 	resource := h.getResource(resourceKey)
 	if resource == nil {
 		return nil, fmt.Errorf("cannot create metric '%s' as no resource exists for it to be attached", metricName)
@@ -162,7 +162,7 @@ func (h *otelMetricHelper) createMetric(resourceKey string, metricName string, m
 
 // addMetricDataPoint creates a datapoint on the metric (metricName) attached to a resource (resourceKey) and populates it
 // based on the given data
-func (h *otelMetricHelper) addMetricDataPoint(resourceKey string, metricName string, metricCfg *MetricConfig, data snmpData, attributes map[string]string) (*pmetric.NumberDataPoint, error) {
+func (h *otelMetricHelper) addMetricDataPoint(resourceKey, metricName string, metricCfg *MetricConfig, data snmpData, attributes map[string]string) (*pmetric.NumberDataPoint, error) {
 	metric := h.getMetric(resourceKey, metricName)
 	if metric == nil {
 		return nil, fmt.Errorf("cannot retrieve datapoints from metric '%s' as it does not currently exist", metricName)

--- a/receiver/splunkenterprisereceiver/client.go
+++ b/receiver/splunkenterprisereceiver/client.go
@@ -133,7 +133,7 @@ func (c *splunkEntClient) createRequest(eptType string, sr *searchResponse) (req
 }
 
 // forms an *http.Request for use with Splunk built-in API's (like introspection).
-func (c *splunkEntClient) createAPIRequest(eptType string, apiEndpoint string) (req *http.Request, err error) {
+func (c *splunkEntClient) createAPIRequest(eptType, apiEndpoint string) (req *http.Request, err error) {
 	var u string
 	ctx := context.WithValue(context.Background(), endpointType("type"), eptType)
 

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1439,11 +1439,11 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						currAckID++
 						return currAckID
 					},
-					ack: func(_ string, _ uint64) {},
+					ack: func(string, uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -1461,11 +1461,11 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						currAckID++
 						return currAckID
 					},
-					ack: func(_ string, _ uint64) {},
+					ack: func(string, uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -1482,11 +1482,11 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						currAckID++
 						return currAckID
 					},
-					ack: func(_ string, _ uint64) {},
+					ack: func(string, uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -1614,10 +1614,10 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						return uint64(1)
 					},
-					ack: func(_ string, _ uint64) {
+					ack: func(string, uint64) {
 					},
 				}
 			},
@@ -1639,10 +1639,10 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						return uint64(1)
 					},
-					ack: func(_ string, _ uint64) {
+					ack: func(string, uint64) {
 					},
 				}
 			},
@@ -1663,10 +1663,10 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			}(),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
-					processEvent: func(_ string) (ackID uint64) {
+					processEvent: func(string) (ackID uint64) {
 						return uint64(1)
 					},
-					ack: func(_ string, _ uint64) {
+					ack: func(string, uint64) {
 					},
 				}
 			},
@@ -2046,11 +2046,11 @@ type mockAckExtension struct {
 	processEvent func(partitionID string) (ackID uint64)
 }
 
-func (ae *mockAckExtension) Start(_ context.Context, _ component.Host) error {
+func (ae *mockAckExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (ae *mockAckExtension) Shutdown(_ context.Context) error {
+func (ae *mockAckExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -330,7 +330,7 @@ func Test_SplunkHecToLogData(t *testing.T) {
 	n := len(tests)
 	for _, tt := range tests[n-1:] {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := splunkHecToLogData(zap.NewNop(), tt.events, func(_ pcommon.Resource) {}, tt.hecConfig)
+			result, err := splunkHecToLogData(zap.NewNop(), tt.events, func(pcommon.Resource) {}, tt.hecConfig)
 			assert.Equal(t, tt.wantErr, err)
 			require.Equal(t, tt.output.Len(), result.ResourceLogs().Len())
 			for i := 0; i < result.ResourceLogs().Len(); i++ {

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -307,7 +307,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(_ pcommon.Resource) {}, tt.hecConfig)
+			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(pcommon.Resource) {}, tt.hecConfig)
 			assert.Equal(t, tt.wantDroppedTimeseries, numDroppedTimeseries)
 			assert.NoError(t, pmetrictest.CompareMetrics(tt.wantMetricsData, md, pmetrictest.IgnoreMetricsOrder()))
 		})

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -67,7 +67,7 @@ var (
 		SQLParameter: func(position int) string {
 			return fmt.Sprintf("$%d", position)
 		},
-		CheckCompatibility: func(_ *testing.T) {
+		CheckCompatibility: func(*testing.T) {
 			// No compatibility checks needed for Postgres
 		},
 		ConnectionString: func(host string, externalPort nat.Port) string {
@@ -94,10 +94,10 @@ var (
 	}
 	MySQL = dbEngineUnderTest{
 		Port: mysqlPort,
-		SQLParameter: func(_ int) string {
+		SQLParameter: func(int) string {
 			return "?"
 		},
-		CheckCompatibility: func(_ *testing.T) {
+		CheckCompatibility: func(*testing.T) {
 			// No compatibility checks needed for MySQL
 		},
 		ConnectionString: func(host string, externalPort nat.Port) string {
@@ -184,7 +184,7 @@ var (
 	}
 	SapASE = dbEngineUnderTest{
 		Port: sapAsePort,
-		SQLParameter: func(_ int) string {
+		SQLParameter: func(int) string {
 			return "?"
 		},
 		CheckCompatibility: func(t *testing.T) {

--- a/receiver/sqlqueryreceiver/internal/database_sql.go
+++ b/receiver/sqlqueryreceiver/internal/database_sql.go
@@ -20,7 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery"
 )
 
-func NewPool(opener sqlquery.SQLOpenerFunc, driver string, dsn string, maxOpenConns int) interface {
+func NewPool(opener sqlquery.SQLOpenerFunc, driver, dsn string, maxOpenConns int) interface {
 	DB() (*sql.DB, error)
 } {
 	return &sqlPool{

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -345,7 +345,7 @@ func rowToLog(row sqlquery.StringMap, config sqlquery.LogsCfg, logRecord plog.Lo
 	return errors.Join(errs...)
 }
 
-func (queryReceiver *logsQueryReceiver) shutdown(_ context.Context) error {
+func (queryReceiver *logsQueryReceiver) shutdown(context.Context) error {
 	if queryReceiver.db == nil {
 		return nil
 	}

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -153,7 +153,7 @@ func (s *sqlServerScraperHelper) ScrapeLogs(ctx context.Context) (plog.Logs, err
 	return s.lb.Emit(metadata.WithLogsResource(resources)), err
 }
 
-func (s *sqlServerScraperHelper) Shutdown(_ context.Context) error {
+func (s *sqlServerScraperHelper) Shutdown(context.Context) error {
 	if s.db != nil {
 		return s.db.Close()
 	}
@@ -807,7 +807,7 @@ func (s *sqlServerScraperHelper) retrieveValue(
 // cacheAndDiff store row(in int) with query hash and query plan hash variables
 // (1) returns true if the key is cached before
 // (2) returns positive value if the value is larger than the cached value
-func (s *sqlServerScraperHelper) cacheAndDiff(queryHash string, queryPlanHash string, column string, val int64) (bool, int64) {
+func (s *sqlServerScraperHelper) cacheAndDiff(queryHash, queryPlanHash, column string, val int64) (bool, int64) {
 	if val < 0 {
 		return false, 0
 	}

--- a/receiver/sqlserverreceiver/scraper_windows.go
+++ b/receiver/sqlserverreceiver/scraper_windows.go
@@ -48,7 +48,7 @@ func newSQLServerPCScraper(params receiver.Settings, cfg *Config) *sqlServerPCSc
 }
 
 // start creates and sets the watchers for the scraper.
-func (s *sqlServerPCScraper) start(_ context.Context, _ component.Host) error {
+func (s *sqlServerPCScraper) start(context.Context, component.Host) error {
 	s.watcherRecorders = []watcherRecorder{}
 
 	for _, pcr := range perfCounterRecorders {
@@ -72,7 +72,7 @@ func (s *sqlServerPCScraper) start(_ context.Context, _ component.Host) error {
 }
 
 // scrape collects windows performance counter data from all watchers and then records/emits it using the metricBuilder
-func (s *sqlServerPCScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
+func (s *sqlServerPCScraper) scrape(context.Context) (pmetric.Metrics, error) {
 	recordersByDatabase, errs := recordersPerDatabase(s.watcherRecorders)
 
 	for dbName, recorders := range recordersByDatabase {
@@ -133,7 +133,7 @@ func (s *sqlServerPCScraper) emitMetricGroup(recorders []curriedRecorder, databa
 }
 
 // shutdown stops all of the watchers for the scraper.
-func (s sqlServerPCScraper) shutdown(_ context.Context) error {
+func (s sqlServerPCScraper) shutdown(context.Context) error {
 	var errs error
 	for _, wr := range s.watcherRecorders {
 		err := wr.watcher.Close()

--- a/receiver/sqlserverreceiver/scraper_windows_test.go
+++ b/receiver/sqlserverreceiver/scraper_windows_test.go
@@ -29,7 +29,7 @@ type mockPerfCounterWatcher struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (_m *mockPerfCounterWatcher) ScrapeRawValue(_ *int64) (bool, error) {
+func (_m *mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/sshcheckreceiver/internal/configssh/configssh.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh.go
@@ -73,7 +73,7 @@ type SFTPClient struct {
 }
 
 // ToClient creates an SSHClient.
-func (scs *SSHClientSettings) ToClient(_ component.Host, _ component.TelemetrySettings) (*Client, error) {
+func (scs *SSHClientSettings) ToClient(component.Host, component.TelemetrySettings) (*Client, error) {
 	var (
 		auth ssh.AuthMethod
 		hkc  ssh.HostKeyCallback

--- a/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
@@ -150,7 +150,7 @@ func Test_Client_Dial(t *testing.T) {
 				Username: username,
 				KeyFile:  keyfile,
 			},
-			dial: func(_, _ string, _ *ssh.ClientConfig) (*ssh.Client, error) {
+			dial: func(string, string, *ssh.ClientConfig) (*ssh.Client, error) {
 				return &ssh.Client{}, nil
 			},
 			shouldError: false,
@@ -163,7 +163,7 @@ func Test_Client_Dial(t *testing.T) {
 				Username: username,
 				KeyFile:  keyfile,
 			},
-			dial: func(_, _ string, _ *ssh.ClientConfig) (*ssh.Client, error) {
+			dial: func(string, string, *ssh.ClientConfig) (*ssh.Client, error) {
 				return nil, errors.New("dial")
 			},
 			shouldError: true,
@@ -223,7 +223,7 @@ func Test_Client_ToSFTPClient(t *testing.T) {
 				Username: username,
 				KeyFile:  keyfile,
 			},
-			dial: func(_, _ string, _ *ssh.ClientConfig) (*ssh.Client, error) {
+			dial: func(string, string, *ssh.ClientConfig) (*ssh.Client, error) {
 				return &ssh.Client{}, nil
 			},
 			shouldError: false,
@@ -236,7 +236,7 @@ func Test_Client_ToSFTPClient(t *testing.T) {
 				Username: username,
 				KeyFile:  keyfile,
 			},
-			dial: func(_, _ string, _ *ssh.ClientConfig) (*ssh.Client, error) {
+			dial: func(string, string, *ssh.ClientConfig) (*ssh.Client, error) {
 				return nil, errors.New("dial")
 			},
 			shouldError: true,

--- a/receiver/statsdreceiver/internal/parser/parser.go
+++ b/receiver/statsdreceiver/internal/parser/parser.go
@@ -14,7 +14,7 @@ import (
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
-	Initialize(enableMetricType bool, enableSimpleTags bool, isMonotonicCounter bool, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping) error
+	Initialize(enableMetricType, enableSimpleTags, isMonotonicCounter, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping) error
 	GetMetrics() []BatchMetrics
 	Aggregate(line string, addr net.Addr) error
 }

--- a/receiver/statsdreceiver/internal/parser/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser.go
@@ -136,7 +136,7 @@ func (p *StatsDParser) resetState(when time.Time) {
 	p.instrumentsByAddress = make(map[netAddr]*instruments)
 }
 
-func (p *StatsDParser) Initialize(enableMetricType bool, enableSimpleTags bool, isMonotonicCounter bool, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping) error {
+func (p *StatsDParser) Initialize(enableMetricType, enableSimpleTags, isMonotonicCounter, enableIPOnlyAggregation bool, sendTimerHistogram []protocol.TimerHistogramMapping) error {
 	p.resetState(timeNowFunc())
 
 	p.histogramEvents = defaultObserverCategory
@@ -343,7 +343,7 @@ func (p *StatsDParser) Aggregate(line string, addr net.Addr) error {
 	return nil
 }
 
-func parseMessageToMetric(line string, enableMetricType bool, enableSimpleTags bool) (statsDMetric, error) {
+func parseMessageToMetric(line string, enableMetricType, enableSimpleTags bool) (statsDMetric, error) {
 	result := statsDMetric{}
 
 	nameValue, rest, foundName := strings.Cut(line, "|")

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -645,7 +645,7 @@ func testStatsDMetric(
 	}
 }
 
-func testDescription(name string, metricType MetricType, keys []string, values []string) statsDMetricDescription {
+func testDescription(name string, metricType MetricType, keys, values []string) statsDMetricDescription {
 	var kvs []attribute.KeyValue
 	for n, k := range keys {
 		kvs = append(kvs, attribute.String(k, values[n]))

--- a/receiver/statsdreceiver/internal/transport/client/client.go
+++ b/receiver/statsdreceiver/internal/transport/client/client.go
@@ -19,7 +19,7 @@ type StatsD struct {
 
 // NewStatsD creates a new StatsD instance to support the need for testing
 // the statsdreceiver package and is not intended/tested to be used in production.
-func NewStatsD(transport string, address string) (*StatsD, error) {
+func NewStatsD(transport, address string) (*StatsD, error) {
 	statsd := &StatsD{
 		transport: transport,
 		address:   address,

--- a/receiver/statsdreceiver/internal/transport/mock_reporter.go
+++ b/receiver/statsdreceiver/internal/transport/mock_reporter.go
@@ -22,7 +22,7 @@ func NewMockReporter(expectedOnMetricsProcessedCalls int) *MockReporter {
 	return &m
 }
 
-func (m *MockReporter) OnDebugf(_ string, _ ...any) {
+func (m *MockReporter) OnDebugf(string, ...any) {
 }
 
 // WaitAllOnMetricsProcessedCalls blocks until the number of expected calls

--- a/receiver/statsdreceiver/internal/transport/server_test.go
+++ b/receiver/statsdreceiver/internal/transport/server_test.go
@@ -25,7 +25,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 		transport         Transport
 		buildServerFn     func(transport Transport, addr string) (Server, error)
 		getFreeEndpointFn func(tb testing.TB, transport string) string
-		buildClientFn     func(transport string, address string) (*client.StatsD, error)
+		buildClientFn     func(transport, address string) (*client.StatsD, error)
 	}{
 		{
 			name:              "udp",
@@ -94,7 +94,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 	}
 }
 
-func testFreeEndpoint(t *testing.T, transport string, address string) {
+func testFreeEndpoint(t *testing.T, transport, address string) {
 	t.Helper()
 
 	var ln0, ln1 io.Closer

--- a/receiver/stefreceiver/stef.go
+++ b/receiver/stefreceiver/stef.go
@@ -79,7 +79,7 @@ func (r *stefReceiver) Start(ctx context.Context, host component.Host) error {
 }
 
 // Shutdown is a method to turn off receiving.
-func (r *stefReceiver) Shutdown(_ context.Context) error {
+func (r *stefReceiver) Shutdown(context.Context) error {
 	r.stopping.Store(true)
 
 	if r.serverGRPC != nil {

--- a/receiver/systemdreceiver/receiver.go
+++ b/receiver/systemdreceiver/receiver.go
@@ -10,10 +10,10 @@ import (
 
 type systemdReceiver struct{}
 
-func (s systemdReceiver) Start(_ context.Context, _ component.Host) error {
+func (s systemdReceiver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (s systemdReceiver) Shutdown(_ context.Context) error {
+func (s systemdReceiver) Shutdown(context.Context) error {
 	return nil
 }

--- a/receiver/tcpcheckreceiver/internal/configtcp/configtcp.go
+++ b/receiver/tcpcheckreceiver/internal/configtcp/configtcp.go
@@ -32,7 +32,7 @@ func (c *Client) Dial() (err error) {
 	return nil
 }
 
-func (tcs *TCPClientSettings) ToClient(_ component.Host, _ component.TelemetrySettings) (*Client, error) {
+func (tcs *TCPClientSettings) ToClient(component.Host, component.TelemetrySettings) (*Client, error) {
 	return &Client{
 		TCPAddrConfig: confignet.TCPAddrConfig{
 			Endpoint: tcs.Endpoint,

--- a/receiver/tcpcheckreceiver/scraper_test.go
+++ b/receiver/tcpcheckreceiver/scraper_test.go
@@ -31,7 +31,7 @@ type mockTCPserver struct {
 	listener net.Listener
 }
 
-func newTCPServer(host string, port string) *mockTCPserver {
+func newTCPServer(host, port string) *mockTCPserver {
 	return &mockTCPserver{
 		host: host,
 		port: port,

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -140,7 +140,7 @@ func (er *eventReceiver) Start(ctx context.Context, host component.Host) error {
 }
 
 // Shutdown function manages receiver shutdown tasks. part of the receiver.Logs interface.
-func (er *eventReceiver) Shutdown(_ context.Context) error {
+func (er *eventReceiver) Shutdown(context.Context) error {
 	// server must exist to be closed.
 	if er.server == nil {
 		return nil

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -38,7 +38,7 @@ type mockPerfCounter struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounter) ScrapeRawValue(_ *int64) (bool, error) {
+func (w *mockPerfCounter) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/windowsservicereceiver/factory.go
+++ b/receiver/windowsservicereceiver/factory.go
@@ -38,16 +38,16 @@ func createMetricsReceiver(
 	return rcvr, nil
 }
 
-func newMetricsReceiver(_ *Config, _ consumer.Metrics) *windowsServiceReceiver {
+func newMetricsReceiver(*Config, consumer.Metrics) *windowsServiceReceiver {
 	return &windowsServiceReceiver{}
 }
 
 type windowsServiceReceiver struct{}
 
-func (r *windowsServiceReceiver) Start(_ context.Context, _ component.Host) error {
+func (r *windowsServiceReceiver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (r *windowsServiceReceiver) Shutdown(_ context.Context) error {
+func (r *windowsServiceReceiver) Shutdown(context.Context) error {
 	return nil
 }

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -33,16 +33,16 @@ func newWindowsServiceScraper(settings receiver.Settings, _ *Config) windowsServ
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) start(_ context.Context, _ component.Host) (err error) {
+func (ws *windowsServiceScraper) start(context.Context, component.Host) (err error) {
 	return nil
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) shutdown(_ context.Context) (err error) {
+func (ws *windowsServiceScraper) shutdown(context.Context) (err error) {
 	return nil
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
+func (ws *windowsServiceScraper) scrape(context.Context) (pmetric.Metrics, error) {
 	return ws.mb.Emit(), nil
 }

--- a/receiver/zipkinreceiver/proto_parse_test.go
+++ b/receiver/zipkinreceiver/proto_parse_test.go
@@ -164,7 +164,7 @@ func newTestZipkinReceiver() *zipkinReceiver {
 	}
 }
 
-func compareResourceSpans(t *testing.T, wantRS ptrace.ResourceSpans, reqsRS ptrace.ResourceSpans) {
+func compareResourceSpans(t *testing.T, wantRS, reqsRS ptrace.ResourceSpans) {
 	assert.Equal(t, wantRS.ScopeSpans().Len(), reqsRS.ScopeSpans().Len())
 	wantIL := wantRS.ScopeSpans().At(0)
 	reqsIL := reqsRS.ScopeSpans().At(0)

--- a/receiver/zookeeperreceiver/integration_test.go
+++ b/receiver/zookeeperreceiver/integration_test.go
@@ -26,7 +26,7 @@ func TestIntegration(t *testing.T) {
 	t.Run("3.5.10-standalone", integrationTest("3.5.10-standalone", "docker.io/library/zookeeper:3.5.10", true))
 }
 
-func integrationTest(name string, image string, standalone bool) func(*testing.T) {
+func integrationTest(name, image string, standalone bool) func(*testing.T) {
 	return scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(

--- a/scraper/zookeeperscraper/scraper_test.go
+++ b/scraper/zookeeperscraper/scraper_test.go
@@ -192,7 +192,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
 			},
 			expectedNumResourceMetrics: 1,
-			setConnectionDeadline: func(_ net.Conn, _ time.Time) error {
+			setConnectionDeadline: func(net.Conn, time.Time) error {
 				return errors.New("")
 			},
 		},
@@ -222,7 +222,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
 			},
 			expectedNumResourceMetrics: 1,
-			closeConnection: func(_ net.Conn) error {
+			closeConnection: func(net.Conn) error {
 				return errors.New("")
 			},
 		},
@@ -238,7 +238,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 					level: zapcore.ErrorLevel,
 				},
 			},
-			sendCmd: func(_ net.Conn, _ string) (*bufio.Scanner, error) {
+			sendCmd: func(net.Conn, string) (*bufio.Scanner, error) {
 				return nil, errors.New("")
 			},
 		},

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -248,7 +248,7 @@ func ConstructReceiver(t *testing.T, exporter string) testbed.DataReceiver {
 	return receiver
 }
 
-func ConstructConnector(t *testing.T, connector string, receiverType string) testbed.DataConnector {
+func ConstructConnector(t *testing.T, connector, receiverType string) testbed.DataConnector {
 	var dataconnector testbed.DataConnector
 	switch connector {
 	case "spanmetrics":

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -27,7 +27,7 @@ type SyslogWriter struct {
 
 var _ testbed.LogDataSender = (*SyslogWriter)(nil)
 
-func NewSyslogWriter(network string, host string, port int, batchSize int) *SyslogWriter {
+func NewSyslogWriter(network, host string, port, batchSize int) *SyslogWriter {
 	f := &SyslogWriter{
 		network: network,
 		bufSize: batchSize,

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -28,7 +28,7 @@ type TCPUDPWriter struct {
 
 var _ testbed.LogDataSender = (*TCPUDPWriter)(nil)
 
-func NewTCPUDPWriter(network string, host string, port int, batchSize int) *TCPUDPWriter {
+func NewTCPUDPWriter(network, host string, port, batchSize int) *TCPUDPWriter {
 	f := &TCPUDPWriter{
 		network: network,
 		bufSize: batchSize,

--- a/testbed/testbed/data_providers.go
+++ b/testbed/testbed/data_providers.go
@@ -176,7 +176,7 @@ type goldenDataProvider struct {
 
 // NewGoldenDataProvider creates a new instance of goldenDataProvider which generates test data based
 // on the pairwise combinations specified in the tracePairsFile and spanPairsFile input variables.
-func NewGoldenDataProvider(tracePairsFile string, spanPairsFile string, metricPairsFile string) DataProvider {
+func NewGoldenDataProvider(tracePairsFile, spanPairsFile, metricPairsFile string) DataProvider {
 	return &goldenDataProvider{
 		tracePairsFile:  tracePairsFile,
 		spanPairsFile:   spanPairsFile,

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -46,7 +46,7 @@ func (ipp *inProcessCollector) PrepareConfig(t *testing.T, configStr string) (co
 	return configCleanup, err
 }
 
-func (ipp *inProcessCollector) Start(_ StartParams) error {
+func (ipp *inProcessCollector) Start(StartParams) error {
 	var err error
 
 	confFile, err := os.CreateTemp(ipp.t.TempDir(), "conf-")

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -121,7 +121,7 @@ type CorrectnessTestValidator struct {
 	ignoreSpanLinksAttrs bool
 }
 
-func NewCorrectTestValidator(senderName string, receiverName string, provider DataProvider) *CorrectnessTestValidator {
+func NewCorrectTestValidator(senderName, receiverName string, provider DataProvider) *CorrectnessTestValidator {
 	// TODO: Fix Jaeger span links attributes and tracestate.
 	return &CorrectnessTestValidator{
 		dataProvider:         provider,
@@ -186,7 +186,7 @@ func (v *CorrectnessTestValidator) assertSentRecdTracingDataEqual(tracesList []p
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpan(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpan(sentSpan, recdSpan ptrace.Span) {
 	v.diffSpanTraceID(sentSpan, recdSpan)
 	v.diffSpanSpanID(sentSpan, recdSpan)
 	v.diffSpanTraceState(sentSpan, recdSpan)
@@ -200,7 +200,7 @@ func (v *CorrectnessTestValidator) diffSpan(sentSpan ptrace.Span, recdSpan ptrac
 	v.diffSpanStatus(sentSpan, recdSpan)
 }
 
-func (v *CorrectnessTestValidator) diffSpanTraceID(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanTraceID(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.TraceID() != recdSpan.TraceID() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -213,7 +213,7 @@ func (v *CorrectnessTestValidator) diffSpanTraceID(sentSpan ptrace.Span, recdSpa
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanSpanID(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanSpanID(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.SpanID() != recdSpan.SpanID() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -226,7 +226,7 @@ func (v *CorrectnessTestValidator) diffSpanSpanID(sentSpan ptrace.Span, recdSpan
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanTraceState(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanTraceState(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.TraceState().AsRaw() != recdSpan.TraceState().AsRaw() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -239,7 +239,7 @@ func (v *CorrectnessTestValidator) diffSpanTraceState(sentSpan ptrace.Span, recd
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanParentSpanID(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanParentSpanID(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.ParentSpanID() != recdSpan.ParentSpanID() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -252,7 +252,7 @@ func (v *CorrectnessTestValidator) diffSpanParentSpanID(sentSpan ptrace.Span, re
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanName(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanName(sentSpan, recdSpan ptrace.Span) {
 	// Because of https://github.com/openzipkin/zipkin-go/pull/166 compare lower cases.
 	if !strings.EqualFold(sentSpan.Name(), recdSpan.Name()) {
 		af := &TraceAssertionFailure{
@@ -266,7 +266,7 @@ func (v *CorrectnessTestValidator) diffSpanName(sentSpan ptrace.Span, recdSpan p
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanKind(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanKind(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.Kind() != recdSpan.Kind() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -279,7 +279,7 @@ func (v *CorrectnessTestValidator) diffSpanKind(sentSpan ptrace.Span, recdSpan p
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanTimestamps(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanTimestamps(sentSpan, recdSpan ptrace.Span) {
 	if notWithinOneMillisecond(sentSpan.StartTimestamp(), recdSpan.StartTimestamp()) {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -302,7 +302,7 @@ func (v *CorrectnessTestValidator) diffSpanTimestamps(sentSpan ptrace.Span, recd
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanAttributes(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanAttributes(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.Attributes().Len() != recdSpan.Attributes().Len() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -327,7 +327,7 @@ func (v *CorrectnessTestValidator) diffSpanAttributes(sentSpan ptrace.Span, recd
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanEvents(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanEvents(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.Events().Len() != recdSpan.Events().Len() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -385,7 +385,7 @@ func (v *CorrectnessTestValidator) diffSpanEvents(sentSpan ptrace.Span, recdSpan
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanLinks(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanLinks(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.Links().Len() != recdSpan.Links().Len() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -441,7 +441,7 @@ func (v *CorrectnessTestValidator) diffSpanLinks(sentSpan ptrace.Span, recdSpan 
 	}
 }
 
-func (v *CorrectnessTestValidator) diffSpanStatus(sentSpan ptrace.Span, recdSpan ptrace.Span) {
+func (v *CorrectnessTestValidator) diffSpanStatus(sentSpan, recdSpan ptrace.Span) {
 	if sentSpan.Status().Code() != recdSpan.Status().Code() {
 		af := &TraceAssertionFailure{
 			typeName:      "Span",
@@ -455,7 +455,7 @@ func (v *CorrectnessTestValidator) diffSpanStatus(sentSpan ptrace.Span, recdSpan
 }
 
 func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
-	sentAttrs pcommon.Map, recdAttrs pcommon.Map, fmtStr string,
+	sentAttrs, recdAttrs pcommon.Map, fmtStr string,
 ) {
 	for sentKey, sentVal := range sentAttrs.All() {
 		recdVal, ok := recdAttrs.Get(sentKey)
@@ -479,8 +479,8 @@ func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
 	}
 }
 
-func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal pcommon.Value, recdVal pcommon.Value,
-	fmtStr string, attrKey string,
+func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal, recdVal pcommon.Value,
+	fmtStr, attrKey string,
 ) {
 	if reflect.DeepEqual(sentVal.AsRaw(), recdVal.AsRaw()) {
 		sentStr := sentVal.AsString()
@@ -499,7 +499,7 @@ func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal 
 }
 
 func (v *CorrectnessTestValidator) compareKeyValueList(
-	spanName string, sentVal pcommon.Value, recdVal pcommon.Value, fmtStr string, attrKey string,
+	spanName string, sentVal, recdVal pcommon.Value, fmtStr, attrKey string,
 ) {
 	switch recdVal.Type() {
 	case pcommon.ValueTypeMap:
@@ -543,7 +543,7 @@ func convertLinksSliceToMap(links ptrace.SpanLinkSlice) map[string]ptrace.SpanLi
 	return linkMap
 }
 
-func notWithinOneMillisecond(sentNs pcommon.Timestamp, recdNs pcommon.Timestamp) bool {
+func notWithinOneMillisecond(sentNs, recdNs pcommon.Timestamp) bool {
 	var diff pcommon.Timestamp
 	if sentNs > recdNs {
 		diff = sentNs - recdNs


### PR DESCRIPTION
#### Description

Check if code and import statements are formatted, with additional rules.

* https://golangci-lint.run/usage/formatters/#gofumpt
* https://go-critic.com/overview.html#paramtypecombine

This is the application of golangci-lint fmt ./... , the Makefile has been update to include this behavior

Related to #41202
