### PR TITLE
[chore]: enable truncateCmp rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,7 +138,6 @@ linters:
         - stringConcatSimplify
         - todoCommentWithoutDetail
         - tooManyResultsChecker
-        - truncateCmp
         - typeAssertChain
         - typeDefFirst
         - unnamedResult

--- a/extension/observer/ecsobserver/docker_label.go
+++ b/extension/observer/ecsobserver/docker_label.go
@@ -98,7 +98,7 @@ func (d *dockerLabelMatcher) matchTargets(_ *taskAnnotated, c ecstypes.Container
 	// Checks if the task does have the container port
 	portExists := false
 	for _, portMapping := range c.PortMappings {
-		if aws.ToInt32(portMapping.ContainerPort) == int32(port) {
+		if int64(aws.ToInt32(portMapping.ContainerPort)) == port {
 			portExists = true
 			break
 		}


### PR DESCRIPTION
#### Description

Enables and fixes [truncateCmp](https://go-critic.com/overview.html#truncatecmp) rule from go-critic

Related to #41202