### PR TITLE
[chore]: enable stringXbytes rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,7 +137,6 @@ linters:
         - sloppyReassign
         - stringsCompare
         - stringConcatSimplify
-        - stringXbytes
         - todoCommentWithoutDetail
         - tooManyResultsChecker
         - truncateCmp

--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -573,7 +573,7 @@ func fillGoStacktrace(stacktrace string, exceptions []awsxray.Exception) []awsxr
 
 	exception.Stack = nil
 	for {
-		match := re.Match([]byte(line))
+		match := re.MatchString(line)
 		if match {
 			line, _ = r.ReadLine()
 		}

--- a/exporter/coralogixexporter/profiles_client_test.go
+++ b/exporter/coralogixexporter/profiles_client_test.go
@@ -359,11 +359,11 @@ func TestProfilesExporter_PushProfiles_PartialSuccess(t *testing.T) {
 
 	profile1 := scopeProfiles.Profiles().AppendEmpty()
 	var id1 [16]byte
-	copy(id1[:], []byte("profile1-unique"))
+	copy(id1[:], "profile1-unique")
 	profile1.SetProfileID(id1)
 	profile2 := scopeProfiles.Profiles().AppendEmpty()
 	var id2 [16]byte
-	copy(id2[:], []byte("profile2-unique"))
+	copy(id2[:], "profile2-unique")
 	profile2.SetProfileID(id2)
 
 	partialSuccess := pprofileotlp.NewExportPartialSuccess()

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -346,5 +346,5 @@ func (tc *TestCase) AgentLogsContains(text string) bool {
 	}
 
 	res, _ := grep.Output()
-	return string(res) != ""
+	return len(res) != 0
 }


### PR DESCRIPTION
#### Description

Enables and fixes [stringXbytes](https://go-critic.com/overview.html#stringxbytes) rule from go-critic

Related to #41202