### PR TITLE
[chore]: enable badRegexp rule from go-critic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,7 +118,6 @@ linters:
 
     gocritic:
       disabled-checks:
-        - badRegexp
         - commentedOutCode
         - deferInLoop
         - equalFold


### PR DESCRIPTION
#### Description

Enables and fixes [badRegexp](https://go-critic.com/overview.html#badregexp) rule from go-critic

Related to #41202