### PR TITLE
[chore] fix panic when accessing log records

### DIFF
--- a/receiver/sqlserverreceiver/integration_test.go
+++ b/receiver/sqlserverreceiver/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
@@ -151,9 +152,13 @@ func TestEventsScraper(t *testing.T) {
 					// collection interval it will not be considered as a top query.
 					return queryCount.Load() > currentQueriesCount+1
 				}, 10*time.Second, 2*time.Second, "Query did not execute enough times")
-				actualLog, err := scraper.ScrapeLogs(context.Background())
-				assert.NotNil(t, actualLog)
-				assert.NoError(t, err)
+				var actualLog plog.Logs
+				assert.EventuallyWithT(t, func(tt *assert.CollectT) {
+					actualLog, err = scraper.ScrapeLogs(context.Background())
+					assert.NotNil(tt, actualLog)
+					assert.NoError(tt, err)
+					assert.Positive(tt, actualLog.LogRecordCount())
+				}, 10*time.Second, 100*time.Millisecond)
 				found := false
 				logRecords := actualLog.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 				for i := 0; i < logRecords.Len(); i++ {


### PR DESCRIPTION
This fixes a flaky test for sqlreceiver which panics when trying to access logs without checking for their presence first.