### PR TITLE
[chore]: enable unused-receiver rule from revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,6 +223,8 @@ linters:
         - name: unreachable-code
         # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
         - name: unused-parameter
+        # Methods with unused receivers can be a symptom of an unfinished refactoring or a bug.
+        - name: unused-receiver
         # Since Go 1.18, interface{} has an alias: any. This rule proposes to replace instances of interface{} with any.
         - name: use-any
         # identifies calls to fmt.Errorf that can be safely replaced by, the more efficient, errors.New.

--- a/cmd/golden/internal/consumer.go
+++ b/cmd/golden/internal/consumer.go
@@ -24,7 +24,7 @@ type MetricsSink struct {
 	Error      error
 }
 
-func (m *MetricsSink) Capabilities() consumer.Capabilities {
+func (*MetricsSink) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{
 		MutatesData: false,
 	}

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -50,7 +50,7 @@ func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.Conn
 	}
 }
 
-func (fs flattenedSettings) OnConnected(context.Context, serverTypes.Connection) {}
+func (flattenedSettings) OnConnected(context.Context, serverTypes.Connection) {}
 
 func (fs flattenedSettings) OnMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
 	if fs.onMessage != nil {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -874,7 +874,7 @@ func (s *Supervisor) stopOpAMPClient() error {
 	return nil
 }
 
-func (s *Supervisor) getHeadersFromSettings(protoHeaders *protobufs.Headers) http.Header {
+func (*Supervisor) getHeadersFromSettings(protoHeaders *protobufs.Headers) http.Header {
 	headers := make(http.Header)
 	for _, header := range protoHeaders.Headers {
 		headers.Add(header.Key, header.Value)
@@ -1247,7 +1247,7 @@ func (s *Supervisor) createEffectiveConfigMsg() *protobufs.EffectiveConfig {
 	return cfg
 }
 
-func (s *Supervisor) updateOwnTelemetryData(data map[string]any, signal string, settings *protobufs.TelemetryConnectionSettings) map[string]any {
+func (*Supervisor) updateOwnTelemetryData(data map[string]any, signal string, settings *protobufs.TelemetryConnectionSettings) map[string]any {
 	if settings == nil || settings.DestinationEndpoint == "" {
 		return data
 	}
@@ -1894,7 +1894,7 @@ func (s *Supervisor) isFeatureGateSupported(gate string) bool {
 	return ok
 }
 
-func (s *Supervisor) findRandomPort() (int, error) {
+func (*Supervisor) findRandomPort() (int, error) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return 0, err

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -1422,11 +1422,11 @@ func (m mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (me
 	return msgChan, nil
 }
 
-func (m mockOpAMPClient) SetAvailableComponents(*protobufs.AvailableComponents) (err error) {
+func (mockOpAMPClient) SetAvailableComponents(*protobufs.AvailableComponents) (err error) {
 	return nil
 }
 
-func (m mockOpAMPClient) SetFlags(protobufs.AgentToServerFlags) {}
+func (mockOpAMPClient) SetFlags(protobufs.AgentToServerFlags) {}
 
 type mockConn struct {
 	sendFunc func(ctx context.Context, message *protobufs.ServerToAgent) error

--- a/cmd/telemetrygen/internal/common/config.go
+++ b/cmd/telemetrygen/internal/common/config.go
@@ -28,7 +28,7 @@ type KeyValue map[string]any
 
 var _ pflag.Value = (*KeyValue)(nil)
 
-func (v *KeyValue) String() string {
+func (*KeyValue) String() string {
 	return ""
 }
 
@@ -58,7 +58,7 @@ func (v *KeyValue) Set(s string) error {
 	return nil
 }
 
-func (v *KeyValue) Type() string {
+func (*KeyValue) Type() string {
 	return "map[string]any"
 }
 

--- a/cmd/telemetrygen/pkg/logs/worker_test.go
+++ b/cmd/telemetrygen/pkg/logs/worker_test.go
@@ -33,11 +33,11 @@ func (m *mockExporter) Export(_ context.Context, records []sdklog.Record) error 
 	return nil
 }
 
-func (m *mockExporter) Shutdown(context.Context) error {
+func (*mockExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func (m *mockExporter) ForceFlush(context.Context) error {
+func (*mockExporter) ForceFlush(context.Context) error {
 	return nil
 }
 

--- a/cmd/telemetrygen/pkg/metrics/aggregation_temporality.go
+++ b/cmd/telemetrygen/pkg/metrics/aggregation_temporality.go
@@ -28,7 +28,7 @@ func (t *AggregationTemporality) String() string {
 	return string(metricdata.Temporality(*t))
 }
 
-func (t *AggregationTemporality) Type() string {
+func (*AggregationTemporality) Type() string {
 	return "temporality"
 }
 

--- a/cmd/telemetrygen/pkg/metrics/clock.go
+++ b/cmd/telemetrygen/pkg/metrics/clock.go
@@ -13,7 +13,7 @@ type Clock interface {
 
 type realClock struct{}
 
-func (c *realClock) Now() time.Time {
+func (*realClock) Now() time.Time {
 	return time.Now()
 }
 

--- a/cmd/telemetrygen/pkg/metrics/metrics_types.go
+++ b/cmd/telemetrygen/pkg/metrics/metrics_types.go
@@ -32,6 +32,6 @@ func (e *MetricType) Set(v string) error {
 }
 
 // Type is only used in help text
-func (e *MetricType) Type() string {
+func (*MetricType) Type() string {
 	return "MetricType"
 }

--- a/cmd/telemetrygen/pkg/metrics/worker_test.go
+++ b/cmd/telemetrygen/pkg/metrics/worker_test.go
@@ -33,11 +33,11 @@ type mockExporter struct {
 	rms []*metricdata.ResourceMetrics
 }
 
-func (m *mockExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
+func (*mockExporter) Temporality(sdkmetric.InstrumentKind) metricdata.Temporality {
 	return metricdata.DeltaTemporality
 }
 
-func (m *mockExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+func (*mockExporter) Aggregation(sdkmetric.InstrumentKind) sdkmetric.Aggregation {
 	return sdkmetric.AggregationDefault{}
 }
 
@@ -46,11 +46,11 @@ func (m *mockExporter) Export(_ context.Context, metrics *metricdata.ResourceMet
 	return nil
 }
 
-func (m *mockExporter) ForceFlush(context.Context) error {
+func (*mockExporter) ForceFlush(context.Context) error {
 	return nil
 }
 
-func (m *mockExporter) Shutdown(context.Context) error {
+func (mockExporter) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/cmd/telemetrygen/pkg/traces/worker_test.go
+++ b/cmd/telemetrygen/pkg/traces/worker_test.go
@@ -351,7 +351,7 @@ func (m *mockSyncer) ExportSpans(_ context.Context, spanData []sdktrace.ReadOnly
 	return nil
 }
 
-func (m *mockSyncer) Shutdown(context.Context) error {
+func (*mockSyncer) Shutdown(context.Context) error {
 	panic("implement me")
 }
 

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -40,7 +40,7 @@ type count struct {
 	profilesMetricDefs   map[string]metricDef[ottlprofile.TransformContext]
 }
 
-func (c *count) Capabilities() consumer.Capabilities {
+func (*count) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -159,7 +159,7 @@ func (c *traceToMetricConnector) Shutdown(context.Context) error {
 
 // Capabilities implements the consumer interface.
 // tells use whether the component(connector) will mutate the data passed into it. if set to true the connector does modify the data
-func (c *traceToMetricConnector) Capabilities() consumer.Capabilities {
+func (*traceToMetricConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/datadogconnector/connector_native.go
+++ b/connector/datadogconnector/connector_native.go
@@ -128,7 +128,7 @@ func (c *traceToMetricConnectorNative) Shutdown(context.Context) error {
 
 // Capabilities implements the consumer interface.
 // tells use whether the component(connector) will mutate the data passed into it. if set to true the connector does modify the data
-func (c *traceToMetricConnectorNative) Capabilities() consumer.Capabilities {
+func (*traceToMetricConnectorNative) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/datadogconnector/traces_connector.go
+++ b/connector/datadogconnector/traces_connector.go
@@ -26,18 +26,18 @@ func newTraceToTraceConnector(logger *zap.Logger, nextConsumer consumer.Traces) 
 }
 
 // Start implements the component interface.
-func (c *traceToTraceConnector) Start(context.Context, component.Host) error {
+func (*traceToTraceConnector) Start(context.Context, component.Host) error {
 	return nil
 }
 
 // Shutdown implements the component interface.
-func (c *traceToTraceConnector) Shutdown(context.Context) error {
+func (*traceToTraceConnector) Shutdown(context.Context) error {
 	return nil
 }
 
 // Capabilities implements the consumer interface.
 // tells use whether the component(connector) will mutate the data passed into it. if set to true the connector does modify the data
-func (c *traceToTraceConnector) Capabilities() consumer.Capabilities {
+func (*traceToTraceConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/exceptionsconnector/connector_logs.go
+++ b/connector/exceptionsconnector/connector_logs.go
@@ -42,7 +42,7 @@ func newLogsConnector(logger *zap.Logger, config component.Config) *logsConnecto
 }
 
 // Capabilities implements the consumer interface.
-func (c *logsConnector) Capabilities() consumer.Capabilities {
+func (*logsConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -86,7 +86,7 @@ func (c *logsConnector) exportLogs(ctx context.Context, ld plog.Logs) error {
 	return nil
 }
 
-func (c *logsConnector) newScopeLogs(ld plog.Logs) plog.ScopeLogs {
+func (*logsConnector) newScopeLogs(ld plog.Logs) plog.ScopeLogs {
 	rl := ld.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
 	return sl

--- a/connector/exceptionsconnector/connector_metrics.go
+++ b/connector/exceptionsconnector/connector_metrics.go
@@ -66,7 +66,7 @@ func newMetricsConnector(logger *zap.Logger, config component.Config) *metricsCo
 }
 
 // Capabilities implements the consumer interface.
-func (c *metricsConnector) Capabilities() consumer.Capabilities {
+func (*metricsConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/failoverconnector/logs.go
+++ b/connector/failoverconnector/logs.go
@@ -78,7 +78,7 @@ type logsFailover struct {
 	logger   *zap.Logger
 }
 
-func (f *logsFailover) Capabilities() consumer.Capabilities {
+func (*logsFailover) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/failoverconnector/metrics.go
+++ b/connector/failoverconnector/metrics.go
@@ -78,7 +78,7 @@ type metricsFailover struct {
 	logger   *zap.Logger
 }
 
-func (f *metricsFailover) Capabilities() consumer.Capabilities {
+func (*metricsFailover) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -79,7 +79,7 @@ type tracesFailover struct {
 	logger   *zap.Logger
 }
 
-func (f *tracesFailover) Capabilities() consumer.Capabilities {
+func (*tracesFailover) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/grafanacloudconnector/connector.go
+++ b/connector/grafanacloudconnector/connector.go
@@ -64,7 +64,7 @@ func newConnector(logger *zap.Logger, set component.TelemetrySettings, config co
 }
 
 // Capabilities implements connector.Traces.
-func (c *connectorImp) Capabilities() consumer.Capabilities {
+func (*connectorImp) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/otlpjsonconnector/logs.go
+++ b/connector/otlpjsonconnector/logs.go
@@ -35,7 +35,7 @@ func newLogsConnector(set connector.Settings, config component.Config, logsConsu
 }
 
 // Capabilities implements the consumer interface
-func (c *connectorLogs) Capabilities() consumer.Capabilities {
+func (*connectorLogs) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/otlpjsonconnector/metrics.go
+++ b/connector/otlpjsonconnector/metrics.go
@@ -36,7 +36,7 @@ func newMetricsConnector(set connector.Settings, config component.Config, metric
 }
 
 // Capabilities implements the consumer interface.
-func (c *connectorMetrics) Capabilities() consumer.Capabilities {
+func (*connectorMetrics) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/otlpjsonconnector/traces.go
+++ b/connector/otlpjsonconnector/traces.go
@@ -36,7 +36,7 @@ func newTracesConnector(set connector.Settings, config component.Config, tracesC
 }
 
 // Capabilities implements the consumer interface.
-func (c *connectorTraces) Capabilities() consumer.Capabilities {
+func (*connectorTraces) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/roundrobinconnector/connector.go
+++ b/connector/roundrobinconnector/connector.go
@@ -70,7 +70,7 @@ type roundRobin struct {
 	nextTraces   []consumer.Traces
 }
 
-func (rr *roundRobin) Capabilities() consumer.Capabilities {
+func (*roundRobin) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -55,7 +55,7 @@ func newLogsConnector(
 	}, nil
 }
 
-func (c *logsConnector) Capabilities() consumer.Capabilities {
+func (*logsConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -56,7 +56,7 @@ func newMetricsConnector(
 	}, nil
 }
 
-func (c *metricsConnector) Capabilities() consumer.Capabilities {
+func (*metricsConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -205,7 +205,7 @@ func (p *serviceGraphConnector) Shutdown(context.Context) error {
 	return nil
 }
 
-func (p *serviceGraphConnector) Capabilities() consumer.Capabilities {
+func (*serviceGraphConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -327,7 +327,7 @@ func (p *serviceGraphConnector) upsertDimensions(kind string, m map[string]strin
 	}
 }
 
-func (p *serviceGraphConnector) upsertPeerAttributes(m []string, peers map[string]string, spanAttr pcommon.Map) {
+func (*serviceGraphConnector) upsertPeerAttributes(m []string, peers map[string]string, spanAttr pcommon.Map) {
 	for _, s := range m {
 		if v, ok := pdatautil.GetAttributeValue(s, spanAttr); ok {
 			peers[s] = v
@@ -639,7 +639,7 @@ func (p *serviceGraphConnector) storeExpirationLoop(d time.Duration) {
 	}
 }
 
-func (p *serviceGraphConnector) getPeerHost(m []string, peers map[string]string) string {
+func (*serviceGraphConnector) getPeerHost(m []string, peers map[string]string) string {
 	peerStr := "unknown"
 	for _, s := range m {
 		if peer, ok := peers[s]; ok {

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -397,11 +397,11 @@ type mockMetricsExporter struct {
 	md  []pmetric.Metrics
 }
 
-func (m *mockMetricsExporter) Start(context.Context, component.Host) error { return nil }
+func (*mockMetricsExporter) Start(context.Context, component.Host) error { return nil }
 
-func (m *mockMetricsExporter) Shutdown(context.Context) error { return nil }
+func (*mockMetricsExporter) Shutdown(context.Context) error { return nil }
 
-func (m *mockMetricsExporter) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
+func (*mockMetricsExporter) Capabilities() consumer.Capabilities { return consumer.Capabilities{} }
 
 func (m *mockMetricsExporter) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
 	m.mtx.Lock()

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -38,7 +38,7 @@ type signalToMetrics struct {
 	component.ShutdownFunc
 }
 
-func (sm *signalToMetrics) Capabilities() consumer.Capabilities {
+func (*signalToMetrics) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -236,7 +236,7 @@ func (p *connectorImp) Shutdown(context.Context) error {
 }
 
 // Capabilities implements the consumer interface.
-func (p *connectorImp) Capabilities() consumer.Capabilities {
+func (*connectorImp) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -705,11 +705,11 @@ type errConsumer struct {
 	fakeErr error
 }
 
-func (e *errConsumer) Capabilities() consumer.Capabilities {
+func (*errConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (e *errConsumer) ConsumeMetrics(_ context.Context, _ pmetric.Metrics) error {
+func (e *errConsumer) ConsumeMetrics(context.Context, pmetric.Metrics) error {
 	e.wg.Done()
 	return e.fakeErr
 }

--- a/connector/sumconnector/connector.go
+++ b/connector/sumconnector/connector.go
@@ -36,7 +36,7 @@ type sum struct {
 	logsMetricDefs       map[string]metricDef[ottllog.TransformContext]
 }
 
-func (c *sum) Capabilities() consumer.Capabilities {
+func (*sum) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -79,7 +79,7 @@ func (c *logServiceClientImpl) sendLogs(logs []*sls.Log) error {
 }
 
 // Success is impl of producer.CallBack
-func (c *logServiceClientImpl) Success(*producer.Result) {}
+func (*logServiceClientImpl) Success(*producer.Result) {}
 
 // Fail is impl of producer.CallBack
 func (c *logServiceClientImpl) Fail(result *producer.Result) {

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -113,7 +113,7 @@ func (e *cwlExporter) consumeLogs(ctx context.Context, ld plog.Logs) error {
 	return errs
 }
 
-func (e *cwlExporter) shutdown(_ context.Context) error {
+func (*cwlExporter) shutdown(context.Context) error {
 	return nil
 }
 

--- a/exporter/awss3exporter/exporter.go
+++ b/exporter/awss3exporter/exporter.go
@@ -83,7 +83,7 @@ func (e *s3Exporter) start(ctx context.Context, host component.Host) error {
 	return nil
 }
 
-func (e *s3Exporter) Capabilities() consumer.Capabilities {
+func (*s3Exporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -95,7 +95,7 @@ func GenerateUUIDv7() string {
 	return id.String()
 }
 
-func (pki *PartitionKeyBuilder) randInt() string {
+func (*PartitionKeyBuilder) randInt() string {
 	// This follows the original "uniqueness" algorithm
 	// to avoid collisions on file uploads across different nodes.
 	const (

--- a/exporter/awss3exporter/marshaler_test.go
+++ b/exporter/awss3exporter/marshaler_test.go
@@ -58,11 +58,11 @@ func (h hostWithExtensions) GetExtensions() map[component.ID]component.Component
 
 type encodingExtension struct{}
 
-func (e encodingExtension) Start(_ context.Context, _ component.Host) error {
+func (encodingExtension) Start(context.Context, component.Host) error {
 	panic("unsupported")
 }
 
-func (e encodingExtension) Shutdown(_ context.Context) error {
+func (encodingExtension) Shutdown(context.Context) error {
 	panic("unsupported")
 }
 

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -178,7 +178,7 @@ func (e *azureBlobExporter) generateBlobName(signal pipeline.Signal) (string, er
 	return blobName, nil
 }
 
-func (e *azureBlobExporter) Capabilities() consumer.Capabilities {
+func (*azureBlobExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -264,6 +264,6 @@ type readSeekCloserWrapper struct {
 	*bytes.Reader
 }
 
-func (r readSeekCloserWrapper) Close() error {
+func (readSeekCloserWrapper) Close() error {
 	return nil
 }

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -258,7 +258,7 @@ func (m *mockingestor) FromReader(_ context.Context, reader io.Reader, _ ...azku
 	return &azkustoingest.Result{}, nil
 }
 
-func (m *mockingestor) FromFile(_ context.Context, _ string, _ ...azkustoingest.FileOption) (*azkustoingest.Result, error) {
+func (*mockingestor) FromFile(context.Context, string, ...azkustoingest.FileOption) (*azkustoingest.Result, error) {
 	return &azkustoingest.Result{}, nil
 }
 
@@ -271,7 +271,7 @@ func (m *mockingestor) Records() []string {
 	return m.records
 }
 
-func (m *mockingestor) Close() error {
+func (*mockingestor) Close() error {
 	return nil
 }
 

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -20,7 +20,7 @@ type logPacker struct {
 	config *Config
 }
 
-func (packer *logPacker) initEnvelope(logRecord plog.LogRecord) (*contracts.Envelope, *contracts.Data) {
+func (*logPacker) initEnvelope(logRecord plog.LogRecord) (*contracts.Envelope, *contracts.Data) {
 	envelope := contracts.NewEnvelope()
 	envelope.Tags = make(map[string]string)
 	envelope.Time = toTime(timestampFromLogRecord(logRecord)).Format(time.RFC3339Nano)
@@ -132,7 +132,7 @@ func (packer *logPacker) sanitize(sanitizeFunc func() []string) {
 	}
 }
 
-func (packer *logPacker) toAiSeverityLevel(sn plog.SeverityNumber) contracts.SeverityLevel {
+func (*logPacker) toAiSeverityLevel(sn plog.SeverityNumber) contracts.SeverityLevel {
 	switch {
 	case sn >= plog.SeverityNumberTrace && sn <= plog.SeverityNumberDebug4:
 		return contracts.Verbose

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -212,7 +212,7 @@ func (mp *MetricsProducer) createSingleDatapointMetric(dp pmetric.NumberDataPoin
 }
 
 // Update the entity information for the BMC Helix Operations Management payload
-func (mp *MetricsProducer) updateEntityInformation(labels map[string]string, metricName string, resourceAttrs map[string]string, dpAttributes map[string]any) error {
+func (*MetricsProducer) updateEntityInformation(labels map[string]string, metricName string, resourceAttrs map[string]string, dpAttributes map[string]any) error {
 	// Try to get the hostname from resource attributes first
 	hostname, found := resourceAttrs[string(conventions.HostNameKey)]
 	if !found || hostname == "" {

--- a/exporter/carbonexporter/exporter.go
+++ b/exporter/carbonexporter/exporter.go
@@ -131,11 +131,11 @@ func (cp *nopConnPool) get() (net.Conn, error) {
 	return createTCPConn(cp.tcpConfig, cp.timeout)
 }
 
-func (cp *nopConnPool) put(conn net.Conn) {
+func (*nopConnPool) put(conn net.Conn) {
 	_ = conn.Close()
 }
 
-func (cp *nopConnPool) close() error {
+func (*nopConnPool) close() error {
 	return nil
 }
 

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -172,7 +172,7 @@ func (f *factory) StopReporter() {
 	})
 }
 
-func (f *factory) TraceAgent(ctx context.Context, wg *sync.WaitGroup, params exporter.Settings, cfg *datadogconfig.Config, sourceProvider source.Provider, attrsTranslator *attributes.Translator) (*agent.Agent, error) {
+func (*factory) TraceAgent(ctx context.Context, wg *sync.WaitGroup, params exporter.Settings, cfg *datadogconfig.Config, sourceProvider source.Provider, attrsTranslator *attributes.Translator) (*agent.Agent, error) {
 	mc, err := metricsclient.InitializeMetricClient(params.MeterProvider, metricsclient.ExporterSourceTag)
 	if err != nil {
 		return nil, err
@@ -212,7 +212,7 @@ func defaultClientConfig() confighttp.ClientConfig {
 }
 
 // createDefaultConfig creates the default exporter configuration
-func (f *factory) createDefaultConfig() component.Config {
+func (*factory) createDefaultConfig() component.Config {
 	return datadogconfig.CreateDefaultConfig()
 }
 
@@ -227,7 +227,7 @@ func checkAndCastConfig(c component.Config, logger *zap.Logger) *datadogconfig.C
 	return cfg
 }
 
-func (f *factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, statsIn <-chan []byte, statsWriter *writer.DatadogStatsWriter, tracerVersion, agentVersion string, logger *zap.Logger) {
+func (*factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, statsIn <-chan []byte, statsWriter *writer.DatadogStatsWriter, tracerVersion, agentVersion string, logger *zap.Logger) {
 	for i := 0; i < runtime.NumCPU(); i++ {
 		wg.Add(1)
 		go func() {

--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -42,7 +42,7 @@ func NewConsumer(gatewayUsage *attributes.GatewayUsage) *Consumer {
 }
 
 // toDataType maps translator datatypes to DatadogV2's datatypes.
-func (c *Consumer) toDataType(dt metrics.DataType) (out datadogV2.MetricIntakeType) {
+func (*Consumer) toDataType(dt metrics.DataType) (out datadogV2.MetricIntakeType) {
 	out = datadogV2.METRICINTAKETYPE_UNSPECIFIED
 
 	switch dt {

--- a/exporter/datadogexporter/internal/metrics/consumer_deprecated.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_deprecated.go
@@ -38,7 +38,7 @@ func NewZorkianConsumer() *ZorkianConsumer {
 }
 
 // toDataType maps translator datatypes to Zorkian's datatypes.
-func (c *ZorkianConsumer) toDataType(dt metrics.DataType) (out MetricType) {
+func (*ZorkianConsumer) toDataType(dt metrics.DataType) (out MetricType) {
 	out = MetricType("unknown")
 
 	switch dt {

--- a/exporter/dorisexporter/metrics_exponential_histogram.go
+++ b/exporter/dorisexporter/metrics_exponential_histogram.go
@@ -38,11 +38,11 @@ type metricModelExponentialHistogram struct {
 	metricModelCommon[dMetricExponentialHistogram]
 }
 
-func (m *metricModelExponentialHistogram) metricType() pmetric.MetricType {
+func (*metricModelExponentialHistogram) metricType() pmetric.MetricType {
 	return pmetric.MetricTypeExponentialHistogram
 }
 
-func (m *metricModelExponentialHistogram) tableSuffix() string {
+func (*metricModelExponentialHistogram) tableSuffix() string {
 	return "_exponential_histogram"
 }
 

--- a/exporter/dorisexporter/metrics_gauge.go
+++ b/exporter/dorisexporter/metrics_gauge.go
@@ -27,11 +27,11 @@ type metricModelGauge struct {
 	metricModelCommon[dMetricGauge]
 }
 
-func (m *metricModelGauge) metricType() pmetric.MetricType {
+func (*metricModelGauge) metricType() pmetric.MetricType {
 	return pmetric.MetricTypeGauge
 }
 
-func (m *metricModelGauge) tableSuffix() string {
+func (*metricModelGauge) tableSuffix() string {
 	return "_gauge"
 }
 

--- a/exporter/dorisexporter/metrics_histogram.go
+++ b/exporter/dorisexporter/metrics_histogram.go
@@ -33,11 +33,11 @@ type metricModelHistogram struct {
 	metricModelCommon[dMetricHistogram]
 }
 
-func (m *metricModelHistogram) metricType() pmetric.MetricType {
+func (*metricModelHistogram) metricType() pmetric.MetricType {
 	return pmetric.MetricTypeHistogram
 }
 
-func (m *metricModelHistogram) tableSuffix() string {
+func (*metricModelHistogram) tableSuffix() string {
 	return "_histogram"
 }
 

--- a/exporter/dorisexporter/metrics_sum.go
+++ b/exporter/dorisexporter/metrics_sum.go
@@ -29,11 +29,11 @@ type metricModelSum struct {
 	metricModelCommon[dMetricSum]
 }
 
-func (m *metricModelSum) metricType() pmetric.MetricType {
+func (*metricModelSum) metricType() pmetric.MetricType {
 	return pmetric.MetricTypeSum
 }
 
-func (m *metricModelSum) tableSuffix() string {
+func (*metricModelSum) tableSuffix() string {
 	return "_sum"
 }
 

--- a/exporter/dorisexporter/metrics_summary.go
+++ b/exporter/dorisexporter/metrics_summary.go
@@ -34,11 +34,11 @@ type metricModelSummary struct {
 	metricModelCommon[dMetricSummary]
 }
 
-func (m *metricModelSummary) metricType() pmetric.MetricType {
+func (*metricModelSummary) metricType() pmetric.MetricType {
 	return pmetric.MetricTypeSummary
 }
 
-func (m *metricModelSummary) tableSuffix() string {
+func (*metricModelSummary) tableSuffix() string {
 	return "_summary"
 }
 

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -156,7 +156,7 @@ func (s *syncBulkIndexer) StartSession(context.Context) bulkIndexerSession {
 }
 
 // Close is a no-op.
-func (s *syncBulkIndexer) Close(context.Context) error {
+func (*syncBulkIndexer) Close(context.Context) error {
 	return nil
 }
 
@@ -194,7 +194,7 @@ func (s *syncBulkIndexerSession) Add(ctx context.Context, index, docID, pipeline
 }
 
 // End is a no-op.
-func (s *syncBulkIndexerSession) End() {
+func (*syncBulkIndexerSession) End() {
 	// TODO acquire docappender.BulkIndexer from pool in StartSession, release here
 }
 
@@ -332,11 +332,11 @@ func (s asyncBulkIndexerSession) Add(ctx context.Context, index, docID, pipeline
 }
 
 // End is a no-op.
-func (s asyncBulkIndexerSession) End() {
+func (asyncBulkIndexerSession) End() {
 }
 
 // Flush is a no-op.
-func (s asyncBulkIndexerSession) Flush(context.Context) error {
+func (asyncBulkIndexerSession) Flush(context.Context) error {
 	return nil
 }
 
@@ -761,7 +761,7 @@ func (s errBulkIndexerSession) Add(context.Context, string, string, string, io.W
 	return fmt.Errorf("creating bulk indexer session failed, cannot add item: %w", s.err)
 }
 
-func (s errBulkIndexerSession) End() {}
+func (errBulkIndexerSession) End() {}
 
 func (s errBulkIndexerSession) Flush(context.Context) error {
 	return fmt.Errorf("creating bulk indexer session failed, cannot flush: %w", s.err)

--- a/exporter/elasticsearchexporter/esclient_test.go
+++ b/exporter/elasticsearchexporter/esclient_test.go
@@ -84,6 +84,6 @@ func (tsr *testStatusReporter) Report(event *componentstatus.Event) {
 	tsr.statusChan <- event
 }
 
-func (tsr *testStatusReporter) GetExtensions() map[component.ID]component.Component {
+func (*testStatusReporter) GetExtensions() map[component.ID]component.Component {
 	return make(map[component.ID]component.Component)
 }

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -568,7 +568,7 @@ func (e *elasticsearchExporter) pushProfilesData(ctx context.Context, pd pprofil
 	return errors.Join(errs...)
 }
 
-func (e *elasticsearchExporter) pushProfileRecord(
+func (*elasticsearchExporter) pushProfileRecord(
 	ctx context.Context,
 	encoder documentEncoder,
 	ec encodingContext,

--- a/exporter/elasticsearchexporter/integrationtest/collector.go
+++ b/exporter/elasticsearchexporter/integrationtest/collector.go
@@ -247,15 +247,15 @@ func (c *recreatableOtelCol) Restart(graceful bool, shutdownFor time.Duration) e
 	return c.run()
 }
 
-func (c *recreatableOtelCol) WatchResourceConsumption() error {
+func (*recreatableOtelCol) WatchResourceConsumption() error {
 	return nil
 }
 
-func (c *recreatableOtelCol) GetProcessMon() *process.Process {
+func (*recreatableOtelCol) GetProcessMon() *process.Process {
 	return nil
 }
 
-func (c *recreatableOtelCol) GetTotalConsumption() *testbed.ResourceConsumption {
+func (*recreatableOtelCol) GetTotalConsumption() *testbed.ResourceConsumption {
 	return &testbed.ResourceConsumption{
 		CPUPercentAvg: 0,
 		CPUPercentMax: 0,
@@ -264,7 +264,7 @@ func (c *recreatableOtelCol) GetTotalConsumption() *testbed.ResourceConsumption 
 	}
 }
 
-func (c *recreatableOtelCol) GetResourceConsumption() string {
+func (*recreatableOtelCol) GetResourceConsumption() string {
 	return ""
 }
 

--- a/exporter/elasticsearchexporter/integrationtest/datareceiver.go
+++ b/exporter/elasticsearchexporter/integrationtest/datareceiver.go
@@ -184,7 +184,7 @@ func (es *esDataReceiver) GenConfigYAMLStr() string {
 	return cfgFormat + "\n"
 }
 
-func (es *esDataReceiver) ProtocolName() string {
+func (*esDataReceiver) ProtocolName() string {
 	return "elasticsearch"
 }
 

--- a/exporter/elasticsearchexporter/integrationtest/validator.go
+++ b/exporter/elasticsearchexporter/integrationtest/validator.go
@@ -34,4 +34,4 @@ func (v *countValidator) Validate(tc *testbed.TestCase) {
 	)
 }
 
-func (v *countValidator) RecordResults(_ *testbed.TestCase) {}
+func (*countValidator) RecordResults(*testbed.TestCase) {}

--- a/exporter/elasticsearchexporter/internal/datapoints/number.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/number.go
@@ -71,7 +71,7 @@ func (dp Number) DynamicTemplate(metric pmetric.Metric) string {
 	return ""
 }
 
-func (dp Number) DocCount() uint64 {
+func (Number) DocCount() uint64 {
 	return 1
 }
 

--- a/exporter/elasticsearchexporter/internal/datapoints/summary.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/summary.go
@@ -34,7 +34,7 @@ func (dp Summary) Value() (pcommon.Value, error) {
 	return vm, nil
 }
 
-func (dp Summary) DynamicTemplate(_ pmetric.Metric) string {
+func (Summary) DynamicTemplate(pmetric.Metric) string {
 	return "summary"
 }
 

--- a/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
+++ b/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
@@ -48,7 +48,7 @@ func (h *ECSDataPointHasher) UpdateResource(resource pcommon.Resource) {
 	h.resource = resource
 }
 
-func (h *ECSDataPointHasher) UpdateScope(_ pcommon.InstrumentationScope) {
+func (*ECSDataPointHasher) UpdateScope(pcommon.InstrumentationScope) {
 }
 
 func (h *ECSDataPointHasher) UpdateDataPoint(dp datapoints.DataPoint) {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -180,7 +180,7 @@ func (e legacyModeEncoder) encodeLog(ec encodingContext, record plog.LogRecord, 
 	return document.Serialize(buf, false)
 }
 
-func (e ecsModeEncoder) encodeLog(
+func (ecsModeEncoder) encodeLog(
 	ec encodingContext,
 	record plog.LogRecord,
 	idx elasticsearch.Index,
@@ -228,7 +228,7 @@ func (e ecsModeEncoder) encodeLog(
 	return document.Serialize(buf, true)
 }
 
-func (e ecsModeEncoder) encodeSpan(
+func (ecsModeEncoder) encodeSpan(
 	ec encodingContext,
 	span ptrace.Span,
 	idx elasticsearch.Index,
@@ -334,7 +334,7 @@ func (e otelModeEncoder) encodeProfile(
 	return e.serializer.SerializeProfile(dic, ec.resource, ec.scope, profile, pushData)
 }
 
-func (e bodymapModeEncoder) encodeLog(
+func (bodymapModeEncoder) encodeLog(
 	_ encodingContext,
 	record plog.LogRecord,
 	_ elasticsearch.Index,

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1175,7 +1175,7 @@ type oTelResource struct {
 
 type oTelSpanID pcommon.SpanID
 
-func (o oTelSpanID) MarshalJSON() ([]byte, error) {
+func (oTelSpanID) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 
@@ -1190,7 +1190,7 @@ func (o *oTelSpanID) UnmarshalJSON(data []byte) error {
 
 type oTelTraceID pcommon.TraceID
 
-func (o oTelTraceID) MarshalJSON() ([]byte, error) {
+func (oTelTraceID) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
 

--- a/exporter/faroexporter/exporter.go
+++ b/exporter/faroexporter/exporter.go
@@ -158,6 +158,6 @@ func (fe *faroExporter) consume(ctx context.Context, fp []faro.Payload) error {
 	return errs
 }
 
-func (fe *faroExporter) Capabilities() consumer.Capabilities {
+func (*faroExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -619,11 +619,11 @@ func tempFileName(tb testing.TB) string {
 // errorWriter is an io.Writer that will return an error all ways
 type errorWriter struct{}
 
-func (e errorWriter) Write([]byte) (n int, err error) {
+func (errorWriter) Write([]byte) (n int, err error) {
 	return 0, errors.New("all ways return error")
 }
 
-func (e *errorWriter) Close() error {
+func (*errorWriter) Close() error {
 	return nil
 }
 

--- a/exporter/googlecloudpubsubexporter/exporter_test.go
+++ b/exporter/googlecloudpubsubexporter/exporter_test.go
@@ -472,6 +472,6 @@ func (m *mockPublisher) Publish(_ context.Context, request *pb.PublishRequest, _
 	return &pb.PublishResponse{}, nil
 }
 
-func (m *mockPublisher) Close() error {
+func (*mockPublisher) Close() error {
 	return nil
 }

--- a/exporter/kafkaexporter/internal/marshaler/raw_marshaler.go
+++ b/exporter/kafkaexporter/internal/marshaler/raw_marshaler.go
@@ -63,7 +63,7 @@ func (r RawLogsMarshaler) logBodyAsBytes(value pcommon.Value) ([]byte, error) {
 	}
 }
 
-func (r RawLogsMarshaler) interfaceAsBytes(value any) ([]byte, error) {
+func (RawLogsMarshaler) interfaceAsBytes(value any) ([]byte, error) {
 	if value == nil {
 		return []byte{}, nil
 	}

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -1154,11 +1154,11 @@ func (f ptraceMarshalerFuncExtension) MarshalTraces(td ptrace.Traces) ([]byte, e
 	return f(td)
 }
 
-func (f ptraceMarshalerFuncExtension) Start(context.Context, component.Host) error {
+func (ptraceMarshalerFuncExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (f ptraceMarshalerFuncExtension) Shutdown(context.Context) error {
+func (ptraceMarshalerFuncExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -1168,11 +1168,11 @@ func (f pmetricMarshalerFuncExtension) MarshalMetrics(td pmetric.Metrics) ([]byt
 	return f(td)
 }
 
-func (f pmetricMarshalerFuncExtension) Start(context.Context, component.Host) error {
+func (pmetricMarshalerFuncExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (f pmetricMarshalerFuncExtension) Shutdown(context.Context) error {
+func (pmetricMarshalerFuncExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -1182,11 +1182,11 @@ func (f plogMarshalerFuncExtension) MarshalLogs(td plog.Logs) ([]byte, error) {
 	return f(td)
 }
 
-func (f plogMarshalerFuncExtension) Start(context.Context, component.Host) error {
+func (plogMarshalerFuncExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (f plogMarshalerFuncExtension) Shutdown(context.Context) error {
+func (plogMarshalerFuncExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/exporter/kineticaexporter/logs_exporter.go
+++ b/exporter/kineticaexporter/logs_exporter.go
@@ -28,12 +28,12 @@ func newLogsExporter(logger *zap.Logger, _ *Config) *kineticaLogsExporter {
 	return logsExp
 }
 
-func (e *kineticaLogsExporter) start(_ context.Context, _ component.Host) error {
+func (*kineticaLogsExporter) start(context.Context, component.Host) error {
 	return nil
 }
 
 // shutdown will shut down the exporter.
-func (e *kineticaLogsExporter) shutdown(_ context.Context) error {
+func (*kineticaLogsExporter) shutdown(context.Context) error {
 	return nil
 }
 
@@ -43,6 +43,6 @@ func (e *kineticaLogsExporter) shutdown(_ context.Context) error {
 //	@param ctx
 //	@param ld
 //	@return error
-func (e *kineticaLogsExporter) pushLogsData(_ context.Context, _ plog.Logs) error {
+func (*kineticaLogsExporter) pushLogsData(context.Context, plog.Logs) error {
 	return nil
 }

--- a/exporter/kineticaexporter/metrics_exporter.go
+++ b/exporter/kineticaexporter/metrics_exporter.go
@@ -239,7 +239,7 @@ func createSchema(ctx context.Context, kiWriter *kiWriter, config Config) error 
 }
 
 // shutdown will shut down the exporter.
-func (e *kineticaMetricsExporter) shutdown(_ context.Context) error {
+func (*kineticaMetricsExporter) shutdown(context.Context) error {
 	return nil
 }
 
@@ -1354,7 +1354,7 @@ func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ strin
 }
 
 // Utility functions
-func (e *kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID, key string, vtPair valueTypePair) (*gaugeResourceAttribute, error) {
+func (*kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID, key string, vtPair valueTypePair) (*gaugeResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1367,7 +1367,7 @@ func (e *kineticaMetricsExporter) newGaugeResourceAttributeValue(gaugeID, key st
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID, datapointID, key string, vtPair valueTypePair) (*gaugeDatapointAttribute, error) {
+func (*kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID, datapointID, key string, vtPair valueTypePair) (*gaugeDatapointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1380,7 +1380,7 @@ func (e *kineticaMetricsExporter) newGaugeDatapointAttributeValue(gaugeID, datap
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*gaugeScopeAttribute, error) {
+func (*kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*gaugeScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1393,7 +1393,7 @@ func (e *kineticaMetricsExporter) newGaugeScopeAttributeValue(gaugeID, key, scop
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSumDatapointAttributeValue(sumID, datapointID, key string, vtPair valueTypePair) (*sumDataPointAttribute, error) {
+func (*kineticaMetricsExporter) newSumDatapointAttributeValue(sumID, datapointID, key string, vtPair valueTypePair) (*sumDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1406,7 +1406,7 @@ func (e *kineticaMetricsExporter) newSumDatapointAttributeValue(sumID, datapoint
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newSumResourceAttributeValue(sumID, key string, vtPair valueTypePair) (*sumResourceAttribute, error) {
+func (*kineticaMetricsExporter) newSumResourceAttributeValue(sumID, key string, vtPair valueTypePair) (*sumResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1419,7 +1419,7 @@ func (e *kineticaMetricsExporter) newSumResourceAttributeValue(sumID, key string
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newSumScopeAttributeValue(sumID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*sumScopeAttribute, error) {
+func (*kineticaMetricsExporter) newSumScopeAttributeValue(sumID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*sumScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1432,7 +1432,7 @@ func (e *kineticaMetricsExporter) newSumScopeAttributeValue(sumID, key, scopeNam
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID, sumDatapointID, sumDatapointExemplarID, key string, vtPair valueTypePair) (*sumDataPointExemplarAttribute, error) {
+func (*kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID, sumDatapointID, sumDatapointExemplarID, key string, vtPair valueTypePair) (*sumDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1445,7 +1445,7 @@ func (e *kineticaMetricsExporter) newSumDatapointExemplarAttributeValue(sumID, s
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttributeValue(histogramID, histogramDatapointID, histogramDatapointExemplarID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointExemplarAttribute, error) {
+func (*kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttributeValue(histogramID, histogramDatapointID, histogramDatapointExemplarID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1458,7 +1458,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramDatapointExemplarAttrib
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointAttribute, error) {
+func (*kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*exponentialHistogramDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1471,7 +1471,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramDatapointAttributeValue
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(histogramID, datapointID, exemplarID, key string, vtPair valueTypePair) (*histogramDataPointExemplarAttribute, error) {
+func (*kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(histogramID, datapointID, exemplarID, key string, vtPair valueTypePair) (*histogramDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1484,7 +1484,7 @@ func (e *kineticaMetricsExporter) newHistogramDatapointExemplarAttributeValue(hi
 	return ga, nil
 }
 
-func (e *kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeID, gaugeDatapointID, gaugeDatapointExemplarID, key string, vtPair valueTypePair) (*gaugeDataPointExemplarAttribute, error) {
+func (*kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeID, gaugeDatapointID, gaugeDatapointExemplarID, key string, vtPair valueTypePair) (*gaugeDataPointExemplarAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1497,7 +1497,7 @@ func (e *kineticaMetricsExporter) newGaugeDatapointExemplarAttributeValue(gaugeI
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*histogramResourceAttribute, error) {
+func (*kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*histogramResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1510,7 +1510,7 @@ func (e *kineticaMetricsExporter) newHistogramResourceAttributeValue(histogramID
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*histogramScopeAttribute, error) {
+func (*kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*histogramScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1523,7 +1523,7 @@ func (e *kineticaMetricsExporter) newHistogramScopeAttributeValue(histogramID, k
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*exponentialHistogramResourceAttribute, error) {
+func (*kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(histogramID, key string, vtPair valueTypePair) (*exponentialHistogramResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1536,7 +1536,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramResourceAttributeValue(
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*exponentialHistogramScopeAttribute, error) {
+func (*kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(histogramID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*exponentialHistogramScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1549,7 +1549,7 @@ func (e *kineticaMetricsExporter) newExponentialHistogramScopeAttributeValue(his
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID, key string, vtPair valueTypePair) (*summaryResourceAttribute, error) {
+func (*kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID, key string, vtPair valueTypePair) (*summaryResourceAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1562,7 +1562,7 @@ func (e *kineticaMetricsExporter) newSummaryResourceAttributeValue(summaryID, ke
 	return ra, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*summaryScopeAttribute, error) {
+func (*kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID, key, scopeName, scopeVersion string, vtPair valueTypePair) (*summaryScopeAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1575,7 +1575,7 @@ func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID, key, 
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID, summaryDatapointID, key string, vtPair valueTypePair) (*SummaryDataPointAttribute, error) {
+func (*kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID, summaryDatapointID, key string, vtPair valueTypePair) (*SummaryDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 
@@ -1588,7 +1588,7 @@ func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID, s
 	return sa, nil
 }
 
-func (e *kineticaMetricsExporter) newHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*histogramDataPointAttribute, error) {
+func (*kineticaMetricsExporter) newHistogramDatapointAttributeValue(histogramID, datapointID, key string, vtPair valueTypePair) (*histogramDataPointAttribute, error) {
 	var av *attributeValue
 	var err error
 

--- a/exporter/kineticaexporter/trace_exporter.go
+++ b/exporter/kineticaexporter/trace_exporter.go
@@ -29,12 +29,12 @@ func newTracesExporter(logger *zap.Logger, _ *Config) *kineticaTracesExporter {
 	return tracesExp
 }
 
-func (e *kineticaTracesExporter) start(_ context.Context, _ component.Host) error {
+func (*kineticaTracesExporter) start(context.Context, component.Host) error {
 	return nil
 }
 
 // shutdown will shut down the exporter.
-func (e *kineticaTracesExporter) shutdown(_ context.Context) error {
+func (*kineticaTracesExporter) shutdown(context.Context) error {
 	return nil
 }
 
@@ -44,6 +44,6 @@ func (e *kineticaTracesExporter) shutdown(_ context.Context) error {
 //	@param ctx
 //	@param td
 //	@return error
-func (e *kineticaTracesExporter) pushTraceData(_ context.Context, _ ptrace.Traces) error {
+func (*kineticaTracesExporter) pushTraceData(context.Context, ptrace.Traces) error {
 	return nil
 }

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -60,7 +60,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	}, nil
 }
 
-func (e *logExporterImp) Capabilities() consumer.Capabilities {
+func (*logExporterImp) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -524,7 +524,7 @@ type mockLogsExporter struct {
 	consumeErr    error
 }
 
-func (e *mockLogsExporter) Capabilities() consumer.Capabilities {
+func (*mockLogsExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -78,7 +78,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	return &metricExporter, nil
 }
 
-func (e *metricExporterImp) Capabilities() consumer.Capabilities {
+func (*metricExporterImp) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -1049,7 +1049,7 @@ func newNopMockMetricsExporter() exporter.Metrics {
 	return &mockMetricsExporter{Component: mockComponent{}}
 }
 
-func (e *mockMetricsExporter) Capabilities() consumer.Capabilities {
+func (*mockMetricsExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -84,7 +84,7 @@ func newTracesExporter(params exporter.Settings, cfg component.Config) (*traceEx
 	return &traceExporter, nil
 }
 
-func (e *traceExporterImp) Capabilities() consumer.Capabilities {
+func (*traceExporterImp) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -900,7 +900,7 @@ func (e *mockTracesExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func (e *mockTracesExporter) Capabilities() consumer.Capabilities {
+func (*mockTracesExporter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/exporter/logzioexporter/logger.go
+++ b/exporter/logzioexporter/logger.go
@@ -20,9 +20,9 @@ type hclog2ZapLogger struct {
 	name string
 }
 
-func (l *hclog2ZapLogger) Log(_ hclog.Level, _ string, _ ...any) {}
+func (*hclog2ZapLogger) Log(hclog.Level, string, ...any) {}
 
-func (l *hclog2ZapLogger) ImpliedArgs() []any {
+func (*hclog2ZapLogger) ImpliedArgs() []any {
 	return nil
 }
 
@@ -30,12 +30,12 @@ func (l *hclog2ZapLogger) Name() string {
 	return l.name
 }
 
-func (l *hclog2ZapLogger) StandardWriter(_ *hclog.StandardLoggerOptions) io.Writer {
+func (*hclog2ZapLogger) StandardWriter(*hclog.StandardLoggerOptions) io.Writer {
 	return nil
 }
 
 // Trace implementation.
-func (l *hclog2ZapLogger) Trace(_ string, _ ...any) {}
+func (*hclog2ZapLogger) Trace(string, ...any) {}
 
 // Debug implementation.
 func (l *hclog2ZapLogger) Debug(msg string, args ...any) {
@@ -58,19 +58,19 @@ func (l *hclog2ZapLogger) Error(msg string, args ...any) {
 }
 
 // IsTrace implementation.
-func (l *hclog2ZapLogger) IsTrace() bool { return false }
+func (*hclog2ZapLogger) IsTrace() bool { return false }
 
 // IsDebug implementation.
-func (l *hclog2ZapLogger) IsDebug() bool { return false }
+func (*hclog2ZapLogger) IsDebug() bool { return false }
 
 // IsInfo implementation.
-func (l *hclog2ZapLogger) IsInfo() bool { return false }
+func (*hclog2ZapLogger) IsInfo() bool { return false }
 
 // IsWarn implementation.
-func (l *hclog2ZapLogger) IsWarn() bool { return false }
+func (*hclog2ZapLogger) IsWarn() bool { return false }
 
 // IsError implementation.
-func (l *hclog2ZapLogger) IsError() bool { return false }
+func (*hclog2ZapLogger) IsError() bool { return false }
 
 // With implementation.
 func (l *hclog2ZapLogger) With(args ...any) hclog.Logger {
@@ -83,24 +83,24 @@ func (l *hclog2ZapLogger) Named(name string) hclog.Logger {
 }
 
 // ResetNamed implementation.
-func (l *hclog2ZapLogger) ResetNamed(_ string) hclog.Logger {
+func (*hclog2ZapLogger) ResetNamed(string) hclog.Logger {
 	// no need to implement that as go-plugin doesn't use this method.
 	return &hclog2ZapLogger{}
 }
 
 // SetLevel implementation.
-func (l *hclog2ZapLogger) SetLevel(_ hclog.Level) {
+func (*hclog2ZapLogger) SetLevel(hclog.Level) {
 	// no need to implement that as go-plugin doesn't use this method.
 }
 
 // GetLevel implementation.
-func (l *hclog2ZapLogger) GetLevel() hclog.Level {
+func (*hclog2ZapLogger) GetLevel() hclog.Level {
 	// no need to implement that as go-plugin doesn't use this method.
 	return hclog.NoLevel
 }
 
 // StandardLogger implementation.
-func (l *hclog2ZapLogger) StandardLogger(_ *hclog.StandardLoggerOptions) *log.Logger {
+func (*hclog2ZapLogger) StandardLogger(*hclog.StandardLoggerOptions) *log.Logger {
 	// no need to implement that as go-plugin doesn't use this method.
 	return log.New(io.Discard, "", 0)
 }

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -335,9 +335,9 @@ type badProtoForCoverage struct {
 	Foo string `protobuf:"bytes,1,opt,name=labels,proto3" json:"foo"`
 }
 
-func (p *badProtoForCoverage) Reset()         {}
-func (p *badProtoForCoverage) String() string { return "" }
-func (p *badProtoForCoverage) ProtoMessage()  {}
-func (p *badProtoForCoverage) Marshal() (dAtA []byte, err error) {
+func (*badProtoForCoverage) Reset()         {}
+func (*badProtoForCoverage) String() string { return "" }
+func (*badProtoForCoverage) ProtoMessage()  {}
+func (*badProtoForCoverage) Marshal() (dAtA []byte, err error) {
 	return nil, errors.New("this is a bad proto")
 }

--- a/exporter/opencensusexporter/config.go
+++ b/exporter/opencensusexporter/config.go
@@ -23,6 +23,6 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/exporter/otelarrowexporter/internal/arrow/common_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/common_test.go
@@ -194,7 +194,7 @@ func (tc *healthyTestChannel) sendChannel() chan *arrowpb.BatchArrowRecords {
 	return tc.sent
 }
 
-func (tc *healthyTestChannel) onConnect(_ context.Context) error {
+func (*healthyTestChannel) onConnect(_ context.Context) error {
 	return nil
 }
 
@@ -243,17 +243,17 @@ func newUnresponsiveTestChannel() *unresponsiveTestChannel {
 	}
 }
 
-func (tc *unresponsiveTestChannel) onConnect(_ context.Context) error {
+func (*unresponsiveTestChannel) onConnect(context.Context) error {
 	return nil
 }
 
-func (tc *unresponsiveTestChannel) onCloseSend() func() error {
+func (*unresponsiveTestChannel) onCloseSend() func() error {
 	return func() error {
 		return nil
 	}
 }
 
-func (tc *unresponsiveTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
+func (*unresponsiveTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
 	return func(_ *arrowpb.BatchArrowRecords) error {
 		select {
 		case <-ctx.Done():
@@ -287,27 +287,27 @@ func newArrowUnsupportedTestChannel() *arrowUnsupportedTestChannel {
 	return &arrowUnsupportedTestChannel{}
 }
 
-func (tc *arrowUnsupportedTestChannel) onConnect(_ context.Context) error {
+func (*arrowUnsupportedTestChannel) onConnect(context.Context) error {
 	// Note: this matches gRPC's apparent behavior. the stream
 	// connection succeeds and the unsupported code is returned to
 	// the Recv() call.
 	return nil
 }
 
-func (tc *arrowUnsupportedTestChannel) onCloseSend() func() error {
+func (*arrowUnsupportedTestChannel) onCloseSend() func() error {
 	return func() error {
 		return nil
 	}
 }
 
-func (tc *arrowUnsupportedTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
-	return func(_ *arrowpb.BatchArrowRecords) error {
+func (*arrowUnsupportedTestChannel) onSend(ctx context.Context) func(*arrowpb.BatchArrowRecords) error {
+	return func(*arrowpb.BatchArrowRecords) error {
 		<-ctx.Done()
 		return ctx.Err()
 	}
 }
 
-func (tc *arrowUnsupportedTestChannel) onRecv(_ context.Context) func() (*arrowpb.BatchStatus, error) {
+func (*arrowUnsupportedTestChannel) onRecv(context.Context) func() (*arrowpb.BatchStatus, error) {
 	return func() (*arrowpb.BatchStatus, error) {
 		err := status.Error(codes.Unimplemented, "arrow will not be served")
 		return &arrowpb.BatchStatus{}, err
@@ -321,24 +321,24 @@ func newDisconnectedTestChannel() *disconnectedTestChannel {
 	return &disconnectedTestChannel{}
 }
 
-func (tc *disconnectedTestChannel) onConnect(ctx context.Context) error {
+func (*disconnectedTestChannel) onConnect(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()
 }
 
-func (tc *disconnectedTestChannel) onCloseSend() func() error {
+func (*disconnectedTestChannel) onCloseSend() func() error {
 	return func() error {
 		panic("unreachable")
 	}
 }
 
-func (tc *disconnectedTestChannel) onSend(_ context.Context) func(*arrowpb.BatchArrowRecords) error {
-	return func(_ *arrowpb.BatchArrowRecords) error {
+func (*disconnectedTestChannel) onSend(_ context.Context) func(*arrowpb.BatchArrowRecords) error {
+	return func(*arrowpb.BatchArrowRecords) error {
 		panic("unreachable")
 	}
 }
 
-func (tc *disconnectedTestChannel) onRecv(_ context.Context) func() (*arrowpb.BatchStatus, error) {
+func (*disconnectedTestChannel) onRecv(context.Context) func() (*arrowpb.BatchStatus, error) {
 	return func() (*arrowpb.BatchStatus, error) {
 		panic("unreachable")
 	}
@@ -355,17 +355,17 @@ func newSendErrorTestChannel() *sendErrorTestChannel {
 	}
 }
 
-func (tc *sendErrorTestChannel) onConnect(_ context.Context) error {
+func (*sendErrorTestChannel) onConnect(context.Context) error {
 	return nil
 }
 
-func (tc *sendErrorTestChannel) onCloseSend() func() error {
+func (*sendErrorTestChannel) onCloseSend() func() error {
 	return func() error {
 		return nil
 	}
 }
 
-func (tc *sendErrorTestChannel) onSend(_ context.Context) func(*arrowpb.BatchArrowRecords) error {
+func (*sendErrorTestChannel) onSend(context.Context) func(*arrowpb.BatchArrowRecords) error {
 	return func(*arrowpb.BatchArrowRecords) error {
 		return io.EOF
 	}
@@ -389,23 +389,23 @@ func newConnectErrorTestChannel() *connectErrorTestChannel {
 	return &connectErrorTestChannel{}
 }
 
-func (tc *connectErrorTestChannel) onConnect(_ context.Context) error {
+func (*connectErrorTestChannel) onConnect(context.Context) error {
 	return errors.New("test connect error")
 }
 
-func (tc *connectErrorTestChannel) onCloseSend() func() error {
+func (*connectErrorTestChannel) onCloseSend() func() error {
 	return func() error {
 		panic("unreachable")
 	}
 }
 
-func (tc *connectErrorTestChannel) onSend(_ context.Context) func(*arrowpb.BatchArrowRecords) error {
+func (*connectErrorTestChannel) onSend(context.Context) func(*arrowpb.BatchArrowRecords) error {
 	return func(*arrowpb.BatchArrowRecords) error {
 		panic("not reached")
 	}
 }
 
-func (tc *connectErrorTestChannel) onRecv(_ context.Context) func() (*arrowpb.BatchStatus, error) {
+func (*connectErrorTestChannel) onRecv(context.Context) func() (*arrowpb.BatchStatus, error) {
 	return func() (*arrowpb.BatchStatus, error) {
 		panic("not reached")
 	}

--- a/exporter/otelarrowexporter/metadata.go
+++ b/exporter/otelarrowexporter/metadata.go
@@ -179,7 +179,7 @@ func (e *metadataExporter) getOrCreateExporter(ctx context.Context, s attribute.
 
 // getAttrSet is code taken from the core collector's batchprocessor multibatch logic.
 // https://github.com/open-telemetry/opentelemetry-collector/blob/v0.107.0/processor/batchprocessor/batch_processor.go#L298
-func (e *metadataExporter) getAttrSet(ctx context.Context, keys []string) (attribute.Set, metadata.MD) {
+func (*metadataExporter) getAttrSet(ctx context.Context, keys []string) (attribute.Set, metadata.MD) {
 	// Get each metadata key value, form the corresponding
 	// attribute set for use as a map lookup key.
 	info := client.FromContext(ctx)

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -97,7 +97,7 @@ func convertExemplars(exemplars pmetric.ExemplarSlice) []prometheus.Exemplar {
 
 // Describe is a no-op, because the collector dynamically allocates metrics.
 // https://github.com/prometheus/client_golang/blob/v1.9.0/prometheus/collector.go#L28-L40
-func (c *collector) Describe(_ chan<- *prometheus.Desc) {}
+func (*collector) Describe(chan<- *prometheus.Desc) {}
 
 /*
 Processing

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -32,7 +32,7 @@ type mockAccumulator struct {
 	scopeAttributes    []pcommon.Map
 }
 
-func (a *mockAccumulator) Accumulate(pmetric.ResourceMetrics) (n int) {
+func (*mockAccumulator) Accumulate(pmetric.ResourceMetrics) (n int) {
 	return 0
 }
 

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -42,6 +42,6 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/exporter/pulsarexporter/config.go
+++ b/exporter/pulsarexporter/config.go
@@ -89,7 +89,7 @@ type Producer struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }
 

--- a/exporter/pulsarexporter/jaeger_marshaler.go
+++ b/exporter/pulsarexporter/jaeger_marshaler.go
@@ -55,11 +55,11 @@ type jaegerProtoBatchMarshaler struct{}
 
 var _ jaegerBatchMarshaler = (*jaegerProtoBatchMarshaler)(nil)
 
-func (p jaegerProtoBatchMarshaler) marshal(batch *jaegerproto.Batch) ([]byte, error) {
+func (jaegerProtoBatchMarshaler) marshal(batch *jaegerproto.Batch) ([]byte, error) {
 	return batch.Marshal()
 }
 
-func (p jaegerProtoBatchMarshaler) encoding() string {
+func (jaegerProtoBatchMarshaler) encoding() string {
 	return "jaeger_proto"
 }
 
@@ -81,6 +81,6 @@ func (p jaegerJSONBatchMarshaler) marshal(batch *jaegerproto.Batch) ([]byte, err
 	return out.Bytes(), err
 }
 
-func (p jaegerJSONBatchMarshaler) encoding() string {
+func (jaegerJSONBatchMarshaler) encoding() string {
 	return "jaeger_json"
 }

--- a/exporter/pulsarexporter/pulsar_exporter_test.go
+++ b/exporter/pulsarexporter/pulsar_exporter_test.go
@@ -67,7 +67,7 @@ type customTraceMarshaler struct {
 	encoding string
 }
 
-func (c *customTraceMarshaler) Marshal(ptrace.Traces, string) ([]*pulsar.ProducerMessage, error) {
+func (*customTraceMarshaler) Marshal(ptrace.Traces, string) ([]*pulsar.ProducerMessage, error) {
 	return nil, errors.New("unsupported encoding")
 }
 
@@ -90,24 +90,24 @@ func (c *mockProducer) Name() string {
 	return c.name
 }
 
-func (c *mockProducer) Send(context.Context, *pulsar.ProducerMessage) (pulsar.MessageID, error) {
+func (*mockProducer) Send(context.Context, *pulsar.ProducerMessage) (pulsar.MessageID, error) {
 	return nil, nil
 }
 
-func (c *mockProducer) SendAsync(context.Context, *pulsar.ProducerMessage, func(pulsar.MessageID, *pulsar.ProducerMessage, error)) {
+func (*mockProducer) SendAsync(context.Context, *pulsar.ProducerMessage, func(pulsar.MessageID, *pulsar.ProducerMessage, error)) {
 }
 
-func (c *mockProducer) LastSequenceID() int64 {
+func (*mockProducer) LastSequenceID() int64 {
 	return 1
 }
 
-func (c *mockProducer) Flush() error {
+func (*mockProducer) Flush() error {
 	return nil
 }
 
-func (c *mockProducer) FlushWithCtx(context.Context) error {
+func (*mockProducer) FlushWithCtx(context.Context) error {
 	return nil
 }
 
-func (c *mockProducer) Close() {
+func (*mockProducer) Close() {
 }

--- a/exporter/rabbitmqexporter/marshaler_test.go
+++ b/exporter/rabbitmqexporter/marshaler_test.go
@@ -44,22 +44,22 @@ func (h *mockHostWithEncodings) GetExtensions() map[component.ID]component.Compo
 	return args.Get(0).(map[component.ID]component.Component)
 }
 
-func (m *mockEncodingExtension) MarshalLogs(plog.Logs) ([]byte, error) {
+func (*mockEncodingExtension) MarshalLogs(plog.Logs) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *mockEncodingExtension) MarshalTraces(ptrace.Traces) ([]byte, error) {
+func (*mockEncodingExtension) MarshalTraces(ptrace.Traces) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *mockEncodingExtension) MarshalMetrics(pmetric.Metrics) ([]byte, error) {
+func (*mockEncodingExtension) MarshalMetrics(pmetric.Metrics) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *mockEncodingExtension) Start(context.Context, component.Host) error {
+func (*mockEncodingExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (m *mockEncodingExtension) Shutdown(context.Context) error {
+func (*mockEncodingExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -661,8 +661,8 @@ func (t *mockTransport) SendEvents(transactions []*sentry.Event) {
 	t.called = true
 }
 
-func (t *mockTransport) Configure(_ sentry.ClientOptions) {}
-func (t *mockTransport) Flush(_ context.Context) bool {
+func (*mockTransport) Configure(sentry.ClientOptions) {}
+func (*mockTransport) Flush(context.Context) bool {
 	return true
 }
 

--- a/exporter/signalfxexporter/internal/apm/log/log.go
+++ b/exporter/signalfxexporter/internal/apm/log/log.go
@@ -9,26 +9,26 @@ type Fields map[string]any
 
 type nilLogger struct{}
 
-func (n nilLogger) Debug(string) {
+func (nilLogger) Debug(string) {
 }
 
-func (n nilLogger) Warn(string) {
+func (nilLogger) Warn(string) {
 }
 
-func (n nilLogger) Error(string) {
+func (nilLogger) Error(string) {
 }
 
-func (n nilLogger) Info(string) {
+func (nilLogger) Info(string) {
 }
 
-func (n nilLogger) Panic(string) {
+func (nilLogger) Panic(string) {
 }
 
-func (n nilLogger) WithFields(Fields) Logger {
+func (nilLogger) WithFields(Fields) Logger {
 	return nilLogger{}
 }
 
-func (n nilLogger) WithError(error) Logger {
+func (nilLogger) WithError(error) Logger {
 	return nilLogger{}
 }
 

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -85,8 +85,8 @@ type correlationTestClient struct {
 	correlateCounter int64
 }
 
-func (c *correlationTestClient) Start()    { /*no-op*/ }
-func (c *correlationTestClient) Shutdown() { /*no-op*/ }
+func (*correlationTestClient) Start()    { /*no-op*/ }
+func (*correlationTestClient) Shutdown() { /*no-op*/ }
 func (c *correlationTestClient) Get(_, dimValue string, cb correlations.SuccessfulGetCB) {
 	atomic.AddInt64(&c.getCounter, 1)
 	go func() {

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata.go
@@ -77,7 +77,7 @@ func (s *Syncer) syncOnResource(res pcommon.Resource) {
 	s.logger.Info("Host metadata synchronized")
 }
 
-func (s *Syncer) prepareMetadataUpdate(props map[string]string, hostID splunk.HostID) *metadata.MetadataUpdate {
+func (*Syncer) prepareMetadataUpdate(props map[string]string, hostID splunk.HostID) *metadata.MetadataUpdate {
 	return &metadata.MetadataUpdate{
 		ResourceIDKey: string(hostID.Key),
 		ResourceID:    metadata.ResourceID(hostID.ID),

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -46,7 +46,7 @@ func (c *cancellableBytesWriter) Reset() {
 	c.innerWriter.Reset()
 }
 
-func (c *cancellableBytesWriter) Close() error {
+func (*cancellableBytesWriter) Close() error {
 	return nil
 }
 

--- a/exporter/splunkhecexporter/heartbeat.go
+++ b/exporter/splunkhecexporter/heartbeat.go
@@ -96,7 +96,7 @@ func (h *heartbeater) shutdown() {
 	close(h.hbDoneChan)
 }
 
-func (h *heartbeater) sendHeartbeat(config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error) error {
+func (*heartbeater) sendHeartbeat(config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error) error {
 	return pushLogFn(context.Background(), generateHeartbeatLog(config.HecToOtelAttrs, buildInfo))
 }
 

--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -294,7 +294,7 @@ func (se *sumologicexporter) getDataURLs() (logs, metrics, traces string) {
 	return se.dataURLLogs, se.dataURLMetrics, se.dataURLTraces
 }
 
-func (se *sumologicexporter) shutdown(context.Context) error {
+func (*sumologicexporter) shutdown(context.Context) error {
 	return nil
 }
 

--- a/exporter/sumologicexporter/fields.go
+++ b/exporter/sumologicexporter/fields.go
@@ -72,7 +72,7 @@ func (f fields) string() string {
 
 // sanitizeFields sanitize field (key or value) to be correctly parsed by sumologic receiver
 // It modifies the field in place.
-func (f fields) sanitizeField(fld []byte) {
+func (fields) sanitizeField(fld []byte) {
 	for i := 0; i < len(fld); i++ {
 		switch fld[i] {
 		case ',':

--- a/exporter/sumologicexporter/prometheus_formatter.go
+++ b/exporter/sumologicexporter/prometheus_formatter.go
@@ -219,22 +219,22 @@ func (f *prometheusFormatter) numberDataPointValueLine(name string, dp pmetric.N
 }
 
 // sumMetric returns _sum suffixed metric name
-func (f *prometheusFormatter) sumMetric(name string) string {
+func (*prometheusFormatter) sumMetric(name string) string {
 	return fmt.Sprintf("%s_sum", name)
 }
 
 // countMetric returns _count suffixed metric name
-func (f *prometheusFormatter) countMetric(name string) string {
+func (*prometheusFormatter) countMetric(name string) string {
 	return fmt.Sprintf("%s_count", name)
 }
 
 // bucketMetric returns _bucket suffixed metric name
-func (f *prometheusFormatter) bucketMetric(name string) string {
+func (*prometheusFormatter) bucketMetric(name string) string {
 	return fmt.Sprintf("%s_bucket", name)
 }
 
 // mergeAttributes gets two pcommon.Maps and returns new which contains values from both of them
-func (f *prometheusFormatter) mergeAttributes(attributes, additionalAttributes pcommon.Map) pcommon.Map {
+func (*prometheusFormatter) mergeAttributes(attributes, additionalAttributes pcommon.Map) pcommon.Map {
 	mergedAttributes := pcommon.NewMap()
 	mergedAttributes.EnsureCapacity(attributes.Len() + additionalAttributes.Len())
 

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -337,12 +337,12 @@ func (s *sender) createRequest(ctx context.Context, pipeline PipelineType, data 
 }
 
 // logToText converts LogRecord to a plain text line, returns it and error eventually
-func (s *sender) logToText(record plog.LogRecord) string {
+func (*sender) logToText(record plog.LogRecord) string {
 	return record.Body().AsString()
 }
 
 // logToJSON converts LogRecord to a json line, returns it and error eventually
-func (s *sender) logToJSON(record plog.LogRecord) (string, error) {
+func (*sender) logToJSON(record plog.LogRecord) (string, error) {
 	recordCopy := plog.NewLogRecord()
 	record.CopyTo(recordCopy)
 

--- a/exporter/syslogexporter/rfc3164_formatter.go
+++ b/exporter/syslogexporter/rfc3164_formatter.go
@@ -30,19 +30,19 @@ func (f *rfc3164Formatter) format(logRecord plog.LogRecord) string {
 	return formatted
 }
 
-func (f *rfc3164Formatter) formatPriority(logRecord plog.LogRecord) string {
+func (*rfc3164Formatter) formatPriority(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, priority, strconv.Itoa(defaultPriority))
 }
 
-func (f *rfc3164Formatter) formatTimestamp(logRecord plog.LogRecord) string {
+func (*rfc3164Formatter) formatTimestamp(logRecord plog.LogRecord) string {
 	return logRecord.Timestamp().AsTime().Format("Jan 02 15:04:05")
 }
 
-func (f *rfc3164Formatter) formatHostname(logRecord plog.LogRecord) string {
+func (*rfc3164Formatter) formatHostname(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, hostname, emptyValue)
 }
 
-func (f *rfc3164Formatter) formatAppname(logRecord plog.LogRecord) string {
+func (*rfc3164Formatter) formatAppname(logRecord plog.LogRecord) string {
 	value := getAttributeValueOrDefault(logRecord, app, "")
 	if value != "" {
 		value += ":"
@@ -50,6 +50,6 @@ func (f *rfc3164Formatter) formatAppname(logRecord plog.LogRecord) string {
 	return value
 }
 
-func (f *rfc3164Formatter) formatMessage(logRecord plog.LogRecord) string {
+func (*rfc3164Formatter) formatMessage(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, message, emptyMessage)
 }

--- a/exporter/syslogexporter/rfc5424_formatter.go
+++ b/exporter/syslogexporter/rfc5424_formatter.go
@@ -42,35 +42,35 @@ func (f *rfc5424Formatter) format(logRecord plog.LogRecord) string {
 	return formatted
 }
 
-func (f *rfc5424Formatter) formatPriority(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatPriority(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, priority, strconv.Itoa(defaultPriority))
 }
 
-func (f *rfc5424Formatter) formatVersion(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatVersion(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, version, strconv.Itoa(versionRFC5424))
 }
 
-func (f *rfc5424Formatter) formatTimestamp(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatTimestamp(logRecord plog.LogRecord) string {
 	return logRecord.Timestamp().AsTime().Format(time.RFC3339Nano)
 }
 
-func (f *rfc5424Formatter) formatHostname(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatHostname(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, hostname, emptyValue)
 }
 
-func (f *rfc5424Formatter) formatAppname(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatAppname(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, app, emptyValue)
 }
 
-func (f *rfc5424Formatter) formatPid(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatPid(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, pid, emptyValue)
 }
 
-func (f *rfc5424Formatter) formatMessageID(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatMessageID(logRecord plog.LogRecord) string {
 	return getAttributeValueOrDefault(logRecord, msgID, emptyValue)
 }
 
-func (f *rfc5424Formatter) formatStructuredData(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatStructuredData(logRecord plog.LogRecord) string {
 	structuredDataAttributeValue, found := logRecord.Attributes().Get(structuredData)
 	if !found {
 		return emptyValue
@@ -98,7 +98,7 @@ func (f *rfc5424Formatter) formatStructuredData(logRecord plog.LogRecord) string
 	return sdBuilder.String()
 }
 
-func (f *rfc5424Formatter) formatMessage(logRecord plog.LogRecord) string {
+func (*rfc5424Formatter) formatMessage(logRecord plog.LogRecord) string {
 	formatted := getAttributeValueOrDefault(logRecord, message, emptyMessage)
 	if formatted != "" {
 		formatted = " " + formatted

--- a/exporter/tinybirdexporter/exporter.go
+++ b/exporter/tinybirdexporter/exporter.go
@@ -74,7 +74,7 @@ func (e *tinybirdExporter) pushTraces(ctx context.Context, td ptrace.Traces) err
 	return nil
 }
 
-func (e *tinybirdExporter) pushMetrics(_ context.Context, _ pmetric.Metrics) error {
+func (*tinybirdExporter) pushMetrics(context.Context, pmetric.Metrics) error {
 	return errors.New("this component is under development and metrics are not yet supported, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40475 to track development progress")
 }
 

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -152,7 +152,7 @@ func (r *mockZipkinReporter) Send(span zipkinmodel.SpanModel) {
 	r.batch = append(r.batch, &span)
 }
 
-func (r *mockZipkinReporter) Close() error {
+func (*mockZipkinReporter) Close() error {
 	return nil
 }
 

--- a/extension/ackextension/inmemory.go
+++ b/extension/ackextension/inmemory.go
@@ -66,12 +66,12 @@ func (as *ackPartition) computeAcks(ackIDs []uint64) map[uint64]bool {
 }
 
 // Start of inMemoryAckExtension does nothing and returns nil
-func (i *inMemoryAckExtension) Start(context.Context, component.Host) error {
+func (*inMemoryAckExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
 // Shutdown of inMemoryAckExtension does nothing and returns nil
-func (i *inMemoryAckExtension) Shutdown(context.Context) error {
+func (*inMemoryAckExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/asapauthextension/extension_test.go
+++ b/extension/asapauthextension/extension_test.go
@@ -17,7 +17,7 @@ import (
 // So, the caller can make assertions using the returned response.
 type mockRoundTripper struct{}
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (*mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{StatusCode: http.StatusOK, Header: map[string][]string{}}
 	for k, v := range req.Header {
 		resp.Header.Set(k, v[0])
@@ -30,7 +30,7 @@ var _ http.RoundTripper = (*mockRoundTripper)(nil)
 // mockKeyFetcher implements asap.KeyFetcher, eliminating the need to contact a key server.
 type mockKeyFetcher struct{}
 
-func (k *mockKeyFetcher) Fetch(string) (any, error) {
+func (*mockKeyFetcher) Fetch(string) (any, error) {
 	return asap.NewPublicKey([]byte(publicKey))
 }
 

--- a/extension/awsproxy/factory_test.go
+++ b/extension/awsproxy/factory_test.go
@@ -100,7 +100,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/extension/azureauthextension/config.go
+++ b/extension/azureauthextension/config.go
@@ -61,7 +61,7 @@ type ServicePrincipal struct {
 
 var _ component.Config = (*Config)(nil)
 
-func (cfg *ManagedIdentity) Validate() error {
+func (*ManagedIdentity) Validate() error {
 	return nil
 }
 

--- a/extension/azureauthextension/extension.go
+++ b/extension/azureauthextension/extension.go
@@ -118,11 +118,11 @@ func getCertificateAndKey(filename string) (*x509.Certificate, crypto.PrivateKey
 	return certs[0], privateKey, nil
 }
 
-func (a *authenticator) Start(context.Context, component.Host) error {
+func (*authenticator) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (a *authenticator) Shutdown(context.Context) error {
+func (*authenticator) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/basicauthextension/extension.go
+++ b/extension/basicauthextension/extension.go
@@ -189,7 +189,7 @@ func (p *perRPCAuth) GetRequestMetadata(context.Context, ...string) (map[string]
 }
 
 // RequireTransportSecurity always returns true for this implementation.
-func (p *perRPCAuth) RequireTransportSecurity() bool {
+func (*perRPCAuth) RequireTransportSecurity() bool {
 	return true
 }
 

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -218,7 +218,7 @@ func TestPerRPCAuth(t *testing.T) {
 
 type mockRoundTripper struct{}
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (*mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{StatusCode: http.StatusOK, Header: map[string][]string{}}
 	for k, v := range req.Header {
 		resp.Header[k] = v

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -34,7 +34,7 @@ func (c *perRPCAuth) GetRequestMetadata(context.Context, ...string) (map[string]
 }
 
 // RequireTransportSecurity always returns true for this implementation. Passing bearer tokens in plain-text connections is a bad idea.
-func (c *perRPCAuth) RequireTransportSecurity() bool {
+func (*perRPCAuth) RequireTransportSecurity() bool {
 	return true
 }
 

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -41,7 +41,7 @@ func TestPerRPCAuth(t *testing.T) {
 
 type mockRoundTripper struct{}
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (*mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{StatusCode: http.StatusOK, Header: map[string][]string{}}
 	for k, v := range req.Header {
 		resp.Header.Set(k, v[0])

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -38,7 +38,7 @@ type uuidProvider interface {
 type realUUIDProvider struct{}
 
 // NewString returns a new UUID string using the real uuid package.
-func (p *realUUIDProvider) NewString() string {
+func (*realUUIDProvider) NewString() string {
 	return uuid.New().String()
 }
 
@@ -167,17 +167,17 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 }
 
 // Ready implements the extensioncapabilities.PipelineWatcher interface.
-func (e *datadogExtension) Ready() error {
+func (*datadogExtension) Ready() error {
 	return nil
 }
 
 // NotReady implements the extensioncapabilities.PipelineWatcher interface.
-func (e *datadogExtension) NotReady() error {
+func (*datadogExtension) NotReady() error {
 	return nil
 }
 
 // ComponentStatusChanged implements the componentstatus.Watcher interface.
-func (e *datadogExtension) ComponentStatusChanged(
+func (*datadogExtension) ComponentStatusChanged(
 	*componentstatus.InstanceID,
 	*componentstatus.Event,
 ) {

--- a/extension/datadogextension/extension_test.go
+++ b/extension/datadogextension/extension_test.go
@@ -624,21 +624,21 @@ func (m *mockSerializer) State() uint32 {
 	return m.state
 }
 
-func (m *mockSerializer) SendMetadata(marshaler.JSONMarshaler) error            { return nil }
-func (m *mockSerializer) SendEvents(event.Events) error                         { return nil }
-func (m *mockSerializer) SendServiceChecks(servicecheck.ServiceChecks) error    { return nil }
-func (m *mockSerializer) SendIterableSeries(metrics.SerieSource) error          { return nil }
-func (m *mockSerializer) AreSeriesEnabled() bool                                { return false }
-func (m *mockSerializer) SendSketch(metrics.SketchesSource) error               { return nil }
-func (m *mockSerializer) AreSketchesEnabled() bool                              { return false }
-func (m *mockSerializer) SendHostMetadata(marshaler.JSONMarshaler) error        { return nil }
-func (m *mockSerializer) SendProcessesMetadata(any) error                       { return nil }
-func (m *mockSerializer) SendAgentchecksMetadata(marshaler.JSONMarshaler) error { return nil }
-func (m *mockSerializer) SendOrchestratorMetadata([]types.ProcessMessageBody, string, string, int) error {
+func (*mockSerializer) SendMetadata(marshaler.JSONMarshaler) error            { return nil }
+func (*mockSerializer) SendEvents(event.Events) error                         { return nil }
+func (*mockSerializer) SendServiceChecks(servicecheck.ServiceChecks) error    { return nil }
+func (*mockSerializer) SendIterableSeries(metrics.SerieSource) error          { return nil }
+func (*mockSerializer) AreSeriesEnabled() bool                                { return false }
+func (*mockSerializer) SendSketch(metrics.SketchesSource) error               { return nil }
+func (*mockSerializer) AreSketchesEnabled() bool                              { return false }
+func (*mockSerializer) SendHostMetadata(marshaler.JSONMarshaler) error        { return nil }
+func (*mockSerializer) SendProcessesMetadata(any) error                       { return nil }
+func (*mockSerializer) SendAgentchecksMetadata(marshaler.JSONMarshaler) error { return nil }
+func (*mockSerializer) SendOrchestratorMetadata([]types.ProcessMessageBody, string, string, int) error {
 	return nil
 }
 
-func (m *mockSerializer) SendOrchestratorManifests([]types.ProcessMessageBody, string, string) error {
+func (*mockSerializer) SendOrchestratorManifests([]types.ProcessMessageBody, string, string) error {
 	return nil
 }
 
@@ -647,7 +647,7 @@ type mockFailingSerializer struct {
 	mockSerializer
 }
 
-func (m *mockFailingSerializer) SendMetadata(marshaler.JSONMarshaler) error {
+func (*mockFailingSerializer) SendMetadata(marshaler.JSONMarshaler) error {
 	return errors.New("payload send failed")
 }
 

--- a/extension/datadogextension/factory.go
+++ b/extension/datadogextension/factory.go
@@ -44,7 +44,7 @@ func NewFactory() extension.Factory {
 	)
 }
 
-func (f *factory) createDefaultConfig() component.Config {
+func (*factory) createDefaultConfig() component.Config {
 	return &Config{
 		ClientConfig: confighttp.NewDefaultClientConfig(),
 		API: datadogconfig.APIConfig{

--- a/extension/datadogextension/internal/httpserver/helpers_test.go
+++ b/extension/datadogextension/internal/httpserver/helpers_test.go
@@ -30,47 +30,47 @@ func (m *mockSerializer) SendMetadata(jm marshaler.JSONMarshaler) error {
 	return nil
 }
 
-func (m *mockSerializer) SendEvents(event.Events) error {
+func (*mockSerializer) SendEvents(event.Events) error {
 	return nil
 }
 
-func (m *mockSerializer) SendServiceChecks(servicecheck.ServiceChecks) error {
+func (*mockSerializer) SendServiceChecks(servicecheck.ServiceChecks) error {
 	return nil
 }
 
-func (m *mockSerializer) SendIterableSeries(metrics.SerieSource) error {
+func (*mockSerializer) SendIterableSeries(metrics.SerieSource) error {
 	return nil
 }
 
-func (m *mockSerializer) AreSeriesEnabled() bool {
+func (*mockSerializer) AreSeriesEnabled() bool {
 	return false
 }
 
-func (m *mockSerializer) SendSketch(metrics.SketchesSource) error {
+func (*mockSerializer) SendSketch(metrics.SketchesSource) error {
 	return nil
 }
 
-func (m *mockSerializer) AreSketchesEnabled() bool {
+func (*mockSerializer) AreSketchesEnabled() bool {
 	return false
 }
 
-func (m *mockSerializer) SendHostMetadata(marshaler.JSONMarshaler) error {
+func (*mockSerializer) SendHostMetadata(marshaler.JSONMarshaler) error {
 	return nil
 }
 
-func (m *mockSerializer) SendProcessesMetadata(any) error {
+func (*mockSerializer) SendProcessesMetadata(any) error {
 	return nil
 }
 
-func (m *mockSerializer) SendAgentchecksMetadata(marshaler.JSONMarshaler) error {
+func (*mockSerializer) SendAgentchecksMetadata(marshaler.JSONMarshaler) error {
 	return nil
 }
 
-func (m *mockSerializer) SendOrchestratorMetadata([]types.ProcessMessageBody, string, string, int) error {
+func (*mockSerializer) SendOrchestratorMetadata([]types.ProcessMessageBody, string, string, int) error {
 	return nil
 }
 
-func (m *mockSerializer) SendOrchestratorManifests([]types.ProcessMessageBody, string, string) error {
+func (*mockSerializer) SendOrchestratorManifests([]types.ProcessMessageBody, string, string) error {
 	return nil
 }
 
@@ -90,10 +90,10 @@ func (m *mockSerializer) Stop() {
 // mockJSONErrorPayload implements marshaler.JSONMarshaler but always fails to marshal
 type mockJSONErrorPayload struct{}
 
-func (m *mockJSONErrorPayload) MarshalJSON() ([]byte, error) {
+func (*mockJSONErrorPayload) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("mock marshal error")
 }
 
-func (m *mockJSONErrorPayload) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
+func (*mockJSONErrorPayload) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, errors.New("mock split error")
 }

--- a/extension/datadogextension/internal/payload/moduleinfojson.go
+++ b/extension/datadogextension/internal/payload/moduleinfojson.go
@@ -20,7 +20,7 @@ func NewModuleInfoJSON() *ModuleInfoJSON {
 	}
 }
 
-func (m *ModuleInfoJSON) getKey(typeStr, kindStr string) string {
+func (*ModuleInfoJSON) getKey(typeStr, kindStr string) string {
 	return typeStr + ":" + kindStr
 }
 

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -75,7 +75,7 @@ func (p *OtelCollectorPayload) MarshalJSON() ([]byte, error) {
 }
 
 // SplitPayload implements marshaler.AbstractMarshaler#SplitPayload.
-func (p *OtelCollectorPayload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
+func (*OtelCollectorPayload) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, errors.New(payloadSplitErr)
 }
 

--- a/extension/encoding/avrologencodingextension/extension.go
+++ b/extension/encoding/avrologencodingextension/extension.go
@@ -78,10 +78,10 @@ func transformValue(value any) any {
 	return value
 }
 
-func (e *avroLogExtension) Start(_ context.Context, _ component.Host) error {
+func (*avroLogExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e *avroLogExtension) Shutdown(_ context.Context) error {
+func (*avroLogExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
@@ -170,7 +170,7 @@ func (c *formatJSONUnmarshaler) UnmarshalMetrics(record []byte) (pmetric.Metrics
 // addMetricToResource adds a new cloudwatchMetric to the
 // resource it belongs to according to resourceKey. It then
 // sets the data point for the cloudwatchMetric.
-func (c *formatJSONUnmarshaler) addMetricToResource(
+func (*formatJSONUnmarshaler) addMetricToResource(
 	byResource map[resourceKey]map[metricKey]pmetric.Metric,
 	cwMetric cloudwatchMetric,
 ) {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
@@ -105,7 +105,7 @@ func (u *CloudTrailLogUnmarshaler) processRecords(records []CloudTrailRecord) (p
 	return logs, nil
 }
 
-func (u *CloudTrailLogUnmarshaler) setResourceAttributes(attrs pcommon.Map, record CloudTrailRecord) {
+func (*CloudTrailLogUnmarshaler) setResourceAttributes(attrs pcommon.Map, record CloudTrailRecord) {
 	attrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
 	attrs.PutStr(string(conventions.CloudRegionKey), record.AwsRegion)
 	attrs.PutStr(string(conventions.CloudAccountIDKey), record.RecipientAccountID)
@@ -121,7 +121,7 @@ func (u *CloudTrailLogUnmarshaler) setLogRecord(logRecord plog.LogRecord, record
 	return nil
 }
 
-func (u *CloudTrailLogUnmarshaler) setLogAttributes(attrs pcommon.Map, record CloudTrailRecord) {
+func (*CloudTrailLogUnmarshaler) setLogAttributes(attrs pcommon.Map, record CloudTrailRecord) {
 	attrs.PutStr("aws.cloudtrail.event_version", record.EventVersion)
 
 	attrs.PutStr("aws.cloudtrail.event_id", record.EventID)

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/s3-access-log/unmarshaler.go
@@ -76,7 +76,7 @@ func (s *s3AccessLogUnmarshaler) createLogs() (plog.Logs, plog.ResourceLogs, plo
 }
 
 // setResourceAttributes based on the resourceAttributes
-func (s *s3AccessLogUnmarshaler) setResourceAttributes(r *resourceAttributes, logs plog.ResourceLogs) {
+func (*s3AccessLogUnmarshaler) setResourceAttributes(r *resourceAttributes, logs plog.ResourceLogs) {
 	attr := logs.Resource().Attributes()
 	attr.PutStr(string(semconv.CloudProviderKey), semconv.CloudProviderAWS.Value.AsString())
 	if r.bucketName != "" {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/vpc-flow-log/unmarshaler.go
@@ -125,7 +125,7 @@ func (v *vpcFlowLogUnmarshaler) createLogs() (plog.Logs, plog.ResourceLogs, plog
 }
 
 // setResourceAttributes based on the resourceKey
-func (v *vpcFlowLogUnmarshaler) setResourceAttributes(key *resourceKey, logs plog.ResourceLogs) {
+func (*vpcFlowLogUnmarshaler) setResourceAttributes(key *resourceKey, logs plog.ResourceLogs) {
 	attr := logs.Resource().Attributes()
 	attr.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
 	if key.accountID != "" {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/waf/unmarshaler.go
@@ -138,7 +138,7 @@ func setResourceAttributes(resourceLogs plog.ResourceLogs, webACLID string) erro
 	return nil
 }
 
-func (w *wafLogUnmarshaler) addWAFLog(log wafLog, record plog.LogRecord) error {
+func (*wafLogUnmarshaler) addWAFLog(log wafLog, record plog.LogRecord) error {
 	// timestamp is in milliseconds, so we need to convert it to ns first
 	nanos := log.Timestamp * 1_000_000
 	ts := pcommon.Timestamp(nanos)

--- a/extension/encoding/googlecloudlogentryencodingextension/extension.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/extension.go
@@ -45,7 +45,7 @@ func (ex *ext) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-func (ex *ext) Shutdown(_ context.Context) error {
+func (*ext) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/encoding/jaegerencodingextension/extension.go
+++ b/extension/encoding/jaegerencodingextension/extension.go
@@ -39,6 +39,6 @@ func (e *jaegerExtension) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-func (e *jaegerExtension) Shutdown(_ context.Context) error {
+func (*jaegerExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/extension/encoding/jaegerencodingextension/jaeger.go
+++ b/extension/encoding/jaegerencodingextension/jaeger.go
@@ -15,7 +15,7 @@ import (
 
 type jaegerProtobufTrace struct{}
 
-func (j jaegerProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
+func (jaegerProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := span.Unmarshal(buf)
 	if err != nil {
@@ -26,7 +26,7 @@ func (j jaegerProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) 
 
 type jaegerJSONTrace struct{}
 
-func (j jaegerJSONTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
+func (jaegerJSONTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := jsonpb.Unmarshal(bytes.NewReader(buf), span)
 	if err != nil {

--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -130,11 +130,11 @@ func (e *jsonLogExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	return p, nil
 }
 
-func (e *jsonLogExtension) Start(_ context.Context, _ component.Host) error {
+func (*jsonLogExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e *jsonLogExtension) Shutdown(_ context.Context) error {
+func (*jsonLogExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/encoding/otlpencodingextension/extension.go
+++ b/extension/encoding/otlpencodingextension/extension.go
@@ -114,10 +114,10 @@ func (ex *otlpExtension) MarshalProfiles(profiles pprofile.Profiles) ([]byte, er
 	return ex.profileMarshaler.MarshalProfiles(profiles)
 }
 
-func (ex *otlpExtension) Start(_ context.Context, _ component.Host) error {
+func (*otlpExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (ex *otlpExtension) Shutdown(_ context.Context) error {
+func (*otlpExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/extension/encoding/skywalkingencodingextension/extension.go
+++ b/extension/encoding/skywalkingencodingextension/extension.go
@@ -18,10 +18,10 @@ func (e *skywalkingExtension) UnmarshalTraces(buf []byte) (ptrace.Traces, error)
 	return e.unmarshaler.UnmarshalTraces(buf)
 }
 
-func (e *skywalkingExtension) Start(_ context.Context, _ component.Host) error {
+func (*skywalkingExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e *skywalkingExtension) Shutdown(_ context.Context) error {
+func (*skywalkingExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/extension/encoding/skywalkingencodingextension/skywalking.go
+++ b/extension/encoding/skywalkingencodingextension/skywalking.go
@@ -13,7 +13,7 @@ import (
 
 type skywalkingProtobufTrace struct{}
 
-func (j skywalkingProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
+func (skywalkingProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	segment := &agentV3.SegmentObject{}
 	err := proto.Unmarshal(buf, segment)
 	if err != nil {

--- a/extension/encoding/textencodingextension/extension.go
+++ b/extension/encoding/textencodingextension/extension.go
@@ -43,6 +43,6 @@ func (e *textExtension) Start(_ context.Context, _ component.Host) error {
 	return err
 }
 
-func (e *textExtension) Shutdown(_ context.Context) error {
+func (*textExtension) Shutdown(context.Context) error {
 	return nil
 }

--- a/extension/encoding/zipkinencodingextension/extension.go
+++ b/extension/encoding/zipkinencodingextension/extension.go
@@ -86,11 +86,11 @@ func newExtension(config *Config) (*zipkinExtension, error) {
 	return ex, err
 }
 
-func (ex *zipkinExtension) Start(_ context.Context, _ component.Host) error {
+func (*zipkinExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (ex *zipkinExtension) Shutdown(_ context.Context) error {
+func (*zipkinExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/extension/headerssetterextension/extension.go
+++ b/extension/headerssetterextension/extension.go
@@ -129,7 +129,7 @@ func (h *headersPerRPC) GetRequestMetadata(
 // RequireTransportSecurity always returns false for this implementation.
 // The header setter is not sending auth data, so it should not require
 // a transport security.
-func (h *headersPerRPC) RequireTransportSecurity() bool {
+func (*headersPerRPC) RequireTransportSecurity() bool {
 	return false
 }
 

--- a/extension/headerssetterextension/extension_test.go
+++ b/extension/headerssetterextension/extension_test.go
@@ -15,7 +15,7 @@ import (
 
 type mockRoundTripper struct{}
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (*mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{StatusCode: http.StatusOK, Header: map[string][]string{}}
 	for k, v := range req.Header {
 		resp.Header.Set(k, v[0])

--- a/extension/healthcheckextension/internal/healthcheck/handler.go
+++ b/extension/healthcheckextension/internal/healthcheck/handler.go
@@ -108,7 +108,7 @@ func (hc *HealthCheck) Handler() http.Handler {
 	})
 }
 
-func (hc *HealthCheck) createRespBody(state state, template healthCheckResponse) []byte {
+func (*HealthCheck) createRespBody(state state, template healthCheckResponse) []byte {
 	resp := template // clone
 	if state.status == Ready {
 		resp.UpSince = state.upSince

--- a/extension/healthcheckv2extension/extension.go
+++ b/extension/healthcheckv2extension/extension.go
@@ -163,7 +163,7 @@ func (hc *healthCheckExtension) Ready() error {
 }
 
 // NotReady implements the extension.PipelineWatcher interface.
-func (hc *healthCheckExtension) NotReady() error {
+func (*healthCheckExtension) NotReady() error {
 	return nil
 }
 

--- a/extension/jaegerremotesampling/internal/mocks/mock_source.go
+++ b/extension/jaegerremotesampling/internal/mocks/mock_source.go
@@ -13,7 +13,7 @@ type MockCfgMgr struct {
 	GetSamplingStrategyFunc func(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error)
 }
 
-func (m *MockCfgMgr) Close() error {
+func (*MockCfgMgr) Close() error {
 	return nil
 }
 

--- a/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache.go
+++ b/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache.go
@@ -120,14 +120,14 @@ func (c *serviceStrategyTTLCache) staleItem(ctx context.Context, item serviceStr
 
 type noopStrategyCache struct{}
 
-func (n *noopStrategyCache) get(_ context.Context, _ string) (*api_v2.SamplingStrategyResponse, bool) {
+func (*noopStrategyCache) get(context.Context, string) (*api_v2.SamplingStrategyResponse, bool) {
 	return nil, false
 }
 
-func (n *noopStrategyCache) put(_ context.Context, _ string, _ *api_v2.SamplingStrategyResponse) {
+func (*noopStrategyCache) put(context.Context, string, *api_v2.SamplingStrategyResponse) {
 }
 
-func (n *noopStrategyCache) Close() error {
+func (*noopStrategyCache) Close() error {
 	return nil
 }
 

--- a/extension/k8sleaderelector/k8sleaderelectortest/fake_extension.go
+++ b/extension/k8sleaderelector/k8sleaderelectortest/fake_extension.go
@@ -23,7 +23,7 @@ func (fh *FakeHost) GetExtensions() map[component.ID]component.Component {
 	}
 }
 
-func (fh *FakeHost) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
+func (*FakeHost) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
 	return nil
 }
 
@@ -43,9 +43,9 @@ func (fle *FakeLeaderElection) InvokeOnLeading() {
 	}
 }
 
-func (fle *FakeLeaderElection) Start(_ context.Context, _ component.Host) error { return nil }
+func (*FakeLeaderElection) Start(context.Context, component.Host) error { return nil }
 
-func (fle *FakeLeaderElection) Shutdown(_ context.Context) error { return nil }
+func (*FakeLeaderElection) Shutdown(context.Context) error { return nil }
 
 func (fle *FakeLeaderElection) InvokeOnStopping() {
 	if fle.OnStopping != nil {

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -187,7 +187,7 @@ type testRoundTripper struct {
 	testString string
 }
 
-func (b *testRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (*testRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, nil
 }
 

--- a/extension/observer/dockerobserver/integration_test.go
+++ b/extension/observer/dockerobserver/integration_test.go
@@ -236,7 +236,7 @@ type mockNotifier struct {
 	changeCount  int
 }
 
-func (m *mockNotifier) ID() observer.NotifyID {
+func (*mockNotifier) ID() observer.NotifyID {
 	return "mockNotifier"
 }
 

--- a/extension/observer/ecsobserver/docker_label.go
+++ b/extension/observer/ecsobserver/docker_label.go
@@ -72,7 +72,7 @@ type dockerLabelMatcher struct {
 	exportSetting *commonExportSetting
 }
 
-func (d *dockerLabelMatcher) matcherType() matcherType {
+func (*dockerLabelMatcher) matcherType() matcherType {
 	return matcherTypeDockerLabel
 }
 

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -81,7 +81,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -390,7 +390,7 @@ func (f *taskFetcher) getAllServices(ctx context.Context) ([]ecstypes.Service, e
 
 // attachService map service to task using deployment id.
 // Each service can have multiple deployment and each task keep track of the deployment in task.StartedBy.
-func (f *taskFetcher) attachService(tasks []*taskAnnotated, services []ecstypes.Service) {
+func (*taskFetcher) attachService(tasks []*taskAnnotated, services []ecstypes.Service) {
 	// Map deployment ID to service name
 	idToService := make(map[string]*ecstypes.Service)
 	for _, svc := range services {

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -76,7 +76,7 @@ type serviceMatcher struct {
 	exportSetting      *commonExportSetting
 }
 
-func (s *serviceMatcher) matcherType() matcherType {
+func (*serviceMatcher) matcherType() matcherType {
 	return matcherTypeService
 }
 

--- a/extension/observer/ecsobserver/task.go
+++ b/extension/observer/ecsobserver/task.go
@@ -86,7 +86,7 @@ func (e *errPrivateIPNotFound) Error() string {
 	return m
 }
 
-func (e *errPrivateIPNotFound) message() string {
+func (*errPrivateIPNotFound) message() string {
 	return "private ip not found"
 }
 
@@ -151,7 +151,7 @@ func (e *errMappedPortNotFound) Error() string {
 		e.ContainerPort, e.NetworkMode, e.ContainerName, e.TaskArn)
 }
 
-func (e *errMappedPortNotFound) message() string {
+func (*errMappedPortNotFound) message() string {
 	return "mapped port not found"
 }
 

--- a/extension/observer/ecsobserver/task_definition.go
+++ b/extension/observer/ecsobserver/task_definition.go
@@ -77,7 +77,7 @@ type taskDefinitionMatcher struct {
 	exportSetting      *commonExportSetting
 }
 
-func (m *taskDefinitionMatcher) matcherType() matcherType {
+func (*taskDefinitionMatcher) matcherType() matcherType {
 	return matcherTypeTaskDefinition
 }
 

--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -134,7 +134,7 @@ func (s *K8sService) Env() EndpointEnv {
 	}
 }
 
-func (s *K8sService) Type() EndpointType {
+func (*K8sService) Type() EndpointType {
 	return K8sServiceType
 }
 
@@ -171,7 +171,7 @@ func (s *K8sIngress) Env() EndpointEnv {
 	}
 }
 
-func (s *K8sIngress) Type() EndpointType {
+func (*K8sIngress) Type() EndpointType {
 	return K8sIngressType
 }
 
@@ -199,7 +199,7 @@ func (p *Pod) Env() EndpointEnv {
 	}
 }
 
-func (p *Pod) Type() EndpointType {
+func (*Pod) Type() EndpointType {
 	return PodType
 }
 
@@ -224,7 +224,7 @@ func (p *PodContainer) Env() EndpointEnv {
 	}
 }
 
-func (p *PodContainer) Type() EndpointType {
+func (*PodContainer) Type() EndpointType {
 	return PodContainerType
 }
 
@@ -249,7 +249,7 @@ func (p *Port) Env() EndpointEnv {
 	}
 }
 
-func (p *Port) Type() EndpointType {
+func (*Port) Type() EndpointType {
 	return PortType
 }
 
@@ -279,7 +279,7 @@ func (h *HostPort) Env() EndpointEnv {
 	}
 }
 
-func (h *HostPort) Type() EndpointType {
+func (*HostPort) Type() EndpointType {
 	return HostPortType
 }
 
@@ -323,7 +323,7 @@ func (c *Container) Env() EndpointEnv {
 	}
 }
 
-func (c *Container) Type() EndpointType {
+func (*Container) Type() EndpointType {
 	return ContainerType
 }
 
@@ -367,16 +367,16 @@ func (n *K8sNode) Env() EndpointEnv {
 	}
 }
 
-func (n *K8sNode) Type() EndpointType {
+func (*K8sNode) Type() EndpointType {
 	return K8sNodeType
 }
 
 type KafkaTopic struct{}
 
-func (k *KafkaTopic) Env() EndpointEnv {
+func (*KafkaTopic) Env() EndpointEnv {
 	return map[string]any{}
 }
 
-func (k *KafkaTopic) Type() EndpointType {
+func (*KafkaTopic) Type() EndpointType {
 	return KafkaTopicType
 }

--- a/extension/observer/hostobserver/extension.go
+++ b/extension/observer/hostobserver/extension.go
@@ -53,7 +53,7 @@ func newObserver(params extension.Settings, config *Config) (extension.Extension
 	return h, nil
 }
 
-func (h *hostObserver) Start(context.Context, component.Host) error {
+func (*hostObserver) Start(context.Context, component.Host) error {
 	return nil
 }
 

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -249,7 +249,7 @@ type mockNotifier struct {
 	endpointsMap map[observer.EndpointID]observer.Endpoint
 }
 
-func (m mockNotifier) ID() observer.NotifyID {
+func (mockNotifier) ID() observer.NotifyID {
 	return "mockNotifier"
 }
 

--- a/extension/observer/k8sobserver/mocks_test.go
+++ b/extension/observer/k8sobserver/mocks_test.go
@@ -20,7 +20,7 @@ type endpointSink struct {
 	changed []observer.Endpoint
 }
 
-func (e *endpointSink) ID() observer.NotifyID {
+func (*endpointSink) ID() observer.NotifyID {
 	return "endpointSink"
 }
 

--- a/extension/observer/kafkatopicsobserver/extension.go
+++ b/extension/observer/kafkatopicsobserver/extension.go
@@ -63,11 +63,11 @@ func newObserver(
 	return o, nil
 }
 
-func (k *kafkaTopicsObserver) Start(_ context.Context, _ component.Host) error {
+func (*kafkaTopicsObserver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (k *kafkaTopicsObserver) Shutdown(_ context.Context) error {
+func (k *kafkaTopicsObserver) Shutdown(context.Context) error {
 	k.StopListAndWatch()
 	k.cancelKafkaAdmin()
 	err := k.adminClient.Close()

--- a/extension/observer/kafkatopicsobserver/extension_test.go
+++ b/extension/observer/kafkatopicsobserver/extension_test.go
@@ -128,7 +128,7 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 
 type channelNotifier chan notifyOp
 
-func (ch channelNotifier) ID() observer.NotifyID {
+func (channelNotifier) ID() observer.NotifyID {
 	return "channel-notifier"
 }
 

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -276,11 +276,11 @@ func newAvailableComponentsHost(t *testing.T) component.Host {
 	}
 }
 
-func (ach *availableComponentsHost) GetFactory(component.Kind, component.Type) component.Factory {
+func (*availableComponentsHost) GetFactory(component.Kind, component.Type) component.Factory {
 	return nil
 }
 
-func (ach *availableComponentsHost) GetExtensions() map[component.ID]component.Component {
+func (*availableComponentsHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 
@@ -802,19 +802,19 @@ type mockOpAMPClient struct {
 	setHealthFunc func(health *protobufs.ComponentHealth) error
 }
 
-func (m mockOpAMPClient) Start(_ context.Context, _ types.StartSettings) error {
+func (mockOpAMPClient) Start(_ context.Context, _ types.StartSettings) error {
 	return nil
 }
 
-func (m mockOpAMPClient) Stop(_ context.Context) error {
+func (mockOpAMPClient) Stop(_ context.Context) error {
 	return nil
 }
 
-func (m mockOpAMPClient) SetAgentDescription(_ *protobufs.AgentDescription) error {
+func (mockOpAMPClient) SetAgentDescription(_ *protobufs.AgentDescription) error {
 	return nil
 }
 
-func (m mockOpAMPClient) AgentDescription() *protobufs.AgentDescription {
+func (mockOpAMPClient) AgentDescription() *protobufs.AgentDescription {
 	return nil
 }
 
@@ -822,33 +822,33 @@ func (m mockOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
 	return m.setHealthFunc(health)
 }
 
-func (m mockOpAMPClient) UpdateEffectiveConfig(_ context.Context) error {
+func (mockOpAMPClient) UpdateEffectiveConfig(context.Context) error {
 	return nil
 }
 
-func (m mockOpAMPClient) SetRemoteConfigStatus(_ *protobufs.RemoteConfigStatus) error {
+func (mockOpAMPClient) SetRemoteConfigStatus(*protobufs.RemoteConfigStatus) error {
 	return nil
 }
 
-func (m mockOpAMPClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error {
+func (mockOpAMPClient) SetPackageStatuses(*protobufs.PackageStatuses) error {
 	return nil
 }
 
-func (m mockOpAMPClient) RequestConnectionSettings(_ *protobufs.ConnectionSettingsRequest) error {
+func (mockOpAMPClient) RequestConnectionSettings(*protobufs.ConnectionSettingsRequest) error {
 	return nil
 }
 
-func (m mockOpAMPClient) SetCustomCapabilities(_ *protobufs.CustomCapabilities) error {
+func (mockOpAMPClient) SetCustomCapabilities(*protobufs.CustomCapabilities) error {
 	return nil
 }
 
-func (m mockOpAMPClient) SendCustomMessage(_ *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error) {
+func (mockOpAMPClient) SendCustomMessage(*protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error) {
 	return nil, nil
 }
 
-func (m mockOpAMPClient) SetFlags(_ protobufs.AgentToServerFlags) {}
+func (mockOpAMPClient) SetFlags(protobufs.AgentToServerFlags) {}
 
-func (m mockOpAMPClient) SetAvailableComponents(_ *protobufs.AvailableComponents) error {
+func (mockOpAMPClient) SetAvailableComponents(*protobufs.AvailableComponents) error {
 	return nil
 }
 

--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -33,6 +33,6 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -19,7 +19,7 @@ import (
 
 type errorRoundTripper struct{}
 
-func (ert *errorRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (*errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, errors.New("error")
 }
 

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -54,7 +54,7 @@ func (lfs *localFileStorage) Start(context.Context, component.Host) error {
 }
 
 // Shutdown will close any open databases
-func (lfs *localFileStorage) Shutdown(context.Context) error {
+func (*localFileStorage) Shutdown(context.Context) error {
 	// TODO clean up data files that did not have a client
 	// and are older than a threshold (possibly configurable)
 	return nil

--- a/extension/storage/redisstorageextension/extension.go
+++ b/extension/storage/redisstorageextension/extension.go
@@ -120,7 +120,7 @@ func (rc redisClient) Batch(ctx context.Context, ops ...*storage.Operation) erro
 	return err
 }
 
-func (rc redisClient) Close(_ context.Context) error {
+func (redisClient) Close(context.Context) error {
 	return nil
 }
 

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -383,19 +383,19 @@ type UnknownError struct {
 	otherField string
 }
 
-func (err *UnknownError) Error() string {
+func (*UnknownError) Error() string {
 	return "Error"
 }
 
-func (err *UnknownError) Code() string {
+func (*UnknownError) Code() string {
 	return "Code"
 }
 
-func (err *UnknownError) Message() string {
+func (*UnknownError) Message() string {
 	return "Message"
 }
 
-func (err *UnknownError) OrigErr() error {
+func (*UnknownError) OrigErr() error {
 	return errors.New("OrigErr")
 }
 

--- a/internal/aws/ecsutil/client_test.go
+++ b/internal/aws/ecsutil/client_test.go
@@ -184,7 +184,7 @@ var _ io.Reader = (*failingReader)(nil)
 
 type failingReader struct{}
 
-func (f *failingReader) Read([]byte) (n int, err error) {
+func (*failingReader) Read([]byte) (n int, err error) {
 	return 0, errors.New("error on read")
 }
 

--- a/internal/aws/ecsutil/rest_client.go
+++ b/internal/aws/ecsutil/rest_client.go
@@ -25,7 +25,7 @@ type nopHost struct {
 	component.Host
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return map[component.ID]component.Component{}
 }
 

--- a/internal/aws/ecsutil/rest_client_test.go
+++ b/internal/aws/ecsutil/rest_client_test.go
@@ -17,7 +17,7 @@ import (
 
 type fakeClient struct{}
 
-func (f *fakeClient) Get(path string) ([]byte, error) {
+func (*fakeClient) Get(path string) ([]byte, error) {
 	return []byte(path), nil
 }
 
@@ -38,7 +38,7 @@ func TestRestClientFromClient(t *testing.T) {
 
 type fakeErrorClient struct{}
 
-func (f *fakeErrorClient) Get(_ string) ([]byte, error) {
+func (*fakeErrorClient) Get(_ string) ([]byte, error) {
 	return nil, errors.New("")
 }
 
@@ -52,7 +52,7 @@ func TestRestClientError(t *testing.T) {
 
 type fakeMetadataErrorClient struct{}
 
-func (f *fakeMetadataErrorClient) Get(_ string) ([]byte, error) {
+func (*fakeMetadataErrorClient) Get(_ string) ([]byte, error) {
 	return nil, errors.New("")
 }
 

--- a/internal/aws/k8s/k8sclient/endpoint.go
+++ b/internal/aws/k8s/k8sclient/endpoint.go
@@ -177,7 +177,7 @@ func transformFuncEndpoint(obj any) (any, error) {
 	return info, nil
 }
 
-func (c *epClient) createEndpointListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
+func (*epClient) createEndpointListWatch(client kubernetes.Interface, ns string) cache.ListerWatcher {
 	ctx := context.Background()
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {

--- a/internal/aws/k8s/k8sclient/helpers_test.go
+++ b/internal/aws/k8s/k8sclient/helpers_test.go
@@ -13,7 +13,7 @@ import (
 
 type mockReflectorSyncChecker struct{}
 
-func (m *mockReflectorSyncChecker) Check(_ cacheReflector, _ string) {
+func (*mockReflectorSyncChecker) Check(cacheReflector, string) {
 }
 
 var kubeConfigPath string

--- a/internal/aws/k8s/k8sclient/job.go
+++ b/internal/aws/k8s/k8sclient/job.go
@@ -29,11 +29,11 @@ type JobClient interface {
 
 type noOpJobClient struct{}
 
-func (nc *noOpJobClient) JobToCronJob() map[string]string {
+func (*noOpJobClient) JobToCronJob() map[string]string {
 	return map[string]string{}
 }
 
-func (nc *noOpJobClient) shutdown() {
+func (*noOpJobClient) shutdown() {
 }
 
 type jobClientOption func(*jobClient)

--- a/internal/aws/k8s/k8sclient/obj_store.go
+++ b/internal/aws/k8s/k8sclient/obj_store.go
@@ -122,12 +122,12 @@ func (s *ObjStore) ListKeys() []string {
 }
 
 // Get implements the Get method of the store interface.
-func (s *ObjStore) Get(_ any) (item any, exists bool, err error) {
+func (*ObjStore) Get(any) (item any, exists bool, err error) {
 	return nil, false, nil
 }
 
 // GetByKey implements the GetByKey method of the store interface.
-func (s *ObjStore) GetByKey(_ string) (item any, exists bool, err error) {
+func (*ObjStore) GetByKey(string) (item any, exists bool, err error) {
 	return nil, false, nil
 }
 
@@ -149,6 +149,6 @@ func (s *ObjStore) Replace(list []any, _ string) error {
 }
 
 // Resync implements the Resync method of the store interface.
-func (s *ObjStore) Resync() error {
+func (*ObjStore) Resync() error {
 	return nil
 }

--- a/internal/aws/k8s/k8sclient/replicaset.go
+++ b/internal/aws/k8s/k8sclient/replicaset.go
@@ -29,11 +29,11 @@ type ReplicaSetClient interface {
 
 type noOpReplicaSetClient struct{}
 
-func (nc *noOpReplicaSetClient) ReplicaSetToDeployment() map[string]string {
+func (*noOpReplicaSetClient) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}
 }
 
-func (nc *noOpReplicaSetClient) shutdown() {
+func (*noOpReplicaSetClient) shutdown() {
 }
 
 type replicaSetClientOption func(*replicaSetClient)

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -288,7 +288,7 @@ type fakeTicker struct {
 }
 
 func (f *fakeTicker) C() <-chan time.Time { return f.ch }
-func (f *fakeTicker) Stop()               {}
+func (*fakeTicker) Stop()                 {}
 
 func newFakeTicker() (*fakeTicker, func(time.Time)) {
 	ch := make(chan time.Time, 10)

--- a/internal/aws/proxy/conn_test.go
+++ b/internal/aws/proxy/conn_test.go
@@ -402,19 +402,19 @@ func TestGetSTSCredsFromPrimaryRegionEndpoint(t *testing.T) {
 
 type mockAWSErr struct{}
 
-func (m *mockAWSErr) Error() string {
+func (*mockAWSErr) Error() string {
 	return "mockAWSErr"
 }
 
-func (m *mockAWSErr) Code() string {
+func (*mockAWSErr) Code() string {
 	return sts.ErrCodeRegionDisabledException
 }
 
-func (m *mockAWSErr) Message() string {
+func (*mockAWSErr) Message() string {
 	return ""
 }
 
-func (m *mockAWSErr) OrigErr() error {
+func (*mockAWSErr) OrigErr() error {
 	return errors.New("mockAWSErr")
 }
 
@@ -430,7 +430,7 @@ func (m *mockProvider) Retrieve() (credentials.Value, error) {
 	return val, nil
 }
 
-func (m *mockProvider) IsExpired() bool {
+func (*mockProvider) IsExpired() bool {
 	return true
 }
 

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -256,6 +256,6 @@ func (m *mockReadCloser) Read(_ []byte) (n int, err error) {
 	return 0, nil
 }
 
-func (m *mockReadCloser) Close() error {
+func (*mockReadCloser) Close() error {
 	return nil
 }

--- a/internal/aws/xray/telemetry/nop_sender.go
+++ b/internal/aws/xray/telemetry/nop_sender.go
@@ -18,31 +18,31 @@ var nopSenderInstance Sender = &nopSender{}
 
 type nopSender struct{}
 
-func (n nopSender) Rotate() types.TelemetryRecord {
+func (nopSender) Rotate() types.TelemetryRecord {
 	return types.TelemetryRecord{}
 }
 
-func (n nopSender) HasRecording() bool {
+func (nopSender) HasRecording() bool {
 	return false
 }
 
-func (n nopSender) Start(_ context.Context) {
+func (nopSender) Start(context.Context) {
 }
 
-func (n nopSender) Stop() {
+func (nopSender) Stop() {
 }
 
-func (n nopSender) RecordSegmentsReceived(int) {
+func (nopSender) RecordSegmentsReceived(int) {
 }
 
-func (n nopSender) RecordSegmentsSent(int) {
+func (nopSender) RecordSegmentsSent(int) {
 }
 
-func (n nopSender) RecordSegmentsSpillover(int) {
+func (nopSender) RecordSegmentsSpillover(int) {
 }
 
-func (n nopSender) RecordSegmentsRejected(int) {
+func (nopSender) RecordSegmentsRejected(int) {
 }
 
-func (n nopSender) RecordConnectionError(error) {
+func (nopSender) RecordConnectionError(error) {
 }

--- a/internal/datadog/hostmetadata/internal/gcp/provider_test.go
+++ b/internal/datadog/hostmetadata/internal/gcp/provider_test.go
@@ -47,7 +47,7 @@ func (m *mockDetector) GCEHostName() (string, error) {
 	return m.instanceName, nil
 }
 
-func (m *mockDetector) GKEClusterName() (string, error) {
+func (*mockDetector) GKEClusterName() (string, error) {
 	return "", errors.New("not available")
 }
 

--- a/internal/filter/expr/matcher.go
+++ b/internal/filter/expr/matcher.go
@@ -27,7 +27,7 @@ func Not[K any](matcher BoolExpr[K]) BoolExpr[K] {
 
 type alwaysTrueMatcher[K any] struct{}
 
-func (alm alwaysTrueMatcher[K]) Eval(_ context.Context, _ K) (bool, error) {
+func (alwaysTrueMatcher[K]) Eval(context.Context, K) (bool, error) {
 	return true, nil
 }
 

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -497,7 +497,7 @@ var _ io.Reader = (*failingReader)(nil)
 
 type failingReader struct{}
 
-func (f *failingReader) Read([]byte) (n int, err error) {
+func (*failingReader) Read([]byte) (n int, err error) {
 	return 0, errors.New("")
 }
 

--- a/internal/metadataproviders/system/metadata.go
+++ b/internal/metadataproviders/system/metadata.go
@@ -189,7 +189,7 @@ func (p systemMetadataProvider) OSDescription(ctx context.Context) (string, erro
 }
 
 // OSName returns the OS name from host metadata.
-func (p systemMetadataProvider) OSName(ctx context.Context) (string, error) {
+func (systemMetadataProvider) OSName(ctx context.Context) (string, error) {
 	info, err := host.InfoWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("OSName failed to get platform: %w", err)
@@ -198,7 +198,7 @@ func (p systemMetadataProvider) OSName(ctx context.Context) (string, error) {
 }
 
 // OSBuildID returns the OS build ID based on the platform.
-func (p systemMetadataProvider) OSBuildID(ctx context.Context) (string, error) {
+func (systemMetadataProvider) OSBuildID(ctx context.Context) (string, error) {
 	info, err := host.InfoWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("OSBuildID failed to get host info: %w", err)
@@ -271,7 +271,7 @@ func (systemMetadataProvider) HostArch() (string, error) {
 	return internal.GOARCHtoHostArch(runtime.GOARCH), nil
 }
 
-func (p systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
+func (systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
@@ -304,7 +304,7 @@ func (p systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
 	return ips, err
 }
 
-func (p systemMetadataProvider) HostMACs() (macs []net.HardwareAddr, err error) {
+func (systemMetadataProvider) HostMACs() (macs []net.HardwareAddr, err error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return nil, err
@@ -321,10 +321,10 @@ func (p systemMetadataProvider) HostMACs() (macs []net.HardwareAddr, err error) 
 	return macs, err
 }
 
-func (p systemMetadataProvider) CPUInfo(ctx context.Context) ([]cpu.InfoStat, error) {
+func (systemMetadataProvider) CPUInfo(ctx context.Context) ([]cpu.InfoStat, error) {
 	return cpu.InfoWithContext(ctx)
 }
 
-func (p systemMetadataProvider) HostInterfaces() ([]net.Interface, error) {
+func (systemMetadataProvider) HostInterfaces() ([]net.Interface, error) {
 	return net.Interfaces()
 }

--- a/internal/otelarrow/admission2/boundedqueue_test.go
+++ b/internal/otelarrow/admission2/boundedqueue_test.go
@@ -262,7 +262,7 @@ func TestBoundedQueueLimits(t *testing.T) {
 	}
 }
 
-func (bq bqTest) verifyPoint(t *testing.T, m metricdata.Metrics) int64 {
+func (bqTest) verifyPoint(t *testing.T, m metricdata.Metrics) int64 {
 	switch a := m.Data.(type) {
 	case metricdata.Sum[int64]:
 		require.Len(t, a.DataPoints, 1)

--- a/pkg/datadog/agentcomponents/zaplogger.go
+++ b/pkg/datadog/agentcomponents/zaplogger.go
@@ -19,10 +19,10 @@ type ZapLogger struct {
 }
 
 // Trace implements Logger.
-func (z *ZapLogger) Trace(_ ...any) { /* N/A */ }
+func (*ZapLogger) Trace(...any) { /* N/A */ }
 
 // Tracef implements Logger.
-func (z *ZapLogger) Tracef(_ string, _ ...any) { /* N/A */ }
+func (*ZapLogger) Tracef(string, ...any) { /* N/A */ }
 
 // Debug implements Logger.
 func (z *ZapLogger) Debug(v ...any) {

--- a/pkg/experimentalmetricmetadata/metadata_test.go
+++ b/pkg/experimentalmetricmetadata/metadata_test.go
@@ -11,7 +11,7 @@ import (
 
 type mockMetadataExporter struct{}
 
-func (m *mockMetadataExporter) ConsumeMetadata(_ []*MetadataUpdate) error {
+func (*mockMetadataExporter) ConsumeMetadata(_ []*MetadataUpdate) error {
 	return nil
 }
 

--- a/pkg/ottl/compare.go
+++ b/pkg/ottl/compare.go
@@ -47,7 +47,7 @@ type ottlValueComparator struct{}
 
 // invalidComparison returns false for everything except ne (where it returns true to indicate that the
 // objects were definitely not equivalent).
-func (p *ottlValueComparator) invalidComparison(op compareOp) bool {
+func (*ottlValueComparator) invalidComparison(op compareOp) bool {
 	return op == ne
 }
 
@@ -72,7 +72,7 @@ func comparePrimitives[T constraints.Ordered](a, b T, op compareOp) bool {
 	}
 }
 
-func (p *ottlValueComparator) compareBools(a, b bool, op compareOp) bool {
+func (*ottlValueComparator) compareBools(a, b bool, op compareOp) bool {
 	switch op {
 	case eq:
 		return a == b
@@ -91,7 +91,7 @@ func (p *ottlValueComparator) compareBools(a, b bool, op compareOp) bool {
 	}
 }
 
-func (p *ottlValueComparator) compareBytes(a, b []byte, op compareOp) bool {
+func (*ottlValueComparator) compareBytes(a, b []byte, op compareOp) bool {
 	switch op {
 	case eq:
 		return bytes.Equal(a, b)

--- a/pkg/ottl/context_inferrer.go
+++ b/pkg/ottl/context_inferrer.go
@@ -263,7 +263,7 @@ func (s *priorityContextInferrer) sortContextCandidates(candidates []string) {
 // getConditionsHints extracts all path, function names (editor and converter), and enumSymbol
 // from the given condition. These values are used by the context inferrer as hints to
 // select a context in which the function/enum are supported.
-func (s *priorityContextInferrer) getConditionsHints(conditions []string) ([]priorityContextInferrerHints, error) {
+func (*priorityContextInferrer) getConditionsHints(conditions []string) ([]priorityContextInferrerHints, error) {
 	hints := make([]priorityContextInferrerHints, 0, len(conditions))
 	for _, condition := range conditions {
 		parsed, err := parseCondition(condition)
@@ -281,7 +281,7 @@ func (s *priorityContextInferrer) getConditionsHints(conditions []string) ([]pri
 // getStatementsHints extracts all path, function names (editor and converter), and enumSymbol
 // from the given statement. These values are used by the context inferrer as hints to
 // select a context in which the function/enum are supported.
-func (s *priorityContextInferrer) getStatementsHints(statements []string) ([]priorityContextInferrerHints, error) {
+func (*priorityContextInferrer) getStatementsHints(statements []string) ([]priorityContextInferrerHints, error) {
 	hints := make([]priorityContextInferrerHints, 0, len(statements))
 	for _, statement := range statements {
 		parsed, err := parseStatement(statement)
@@ -301,7 +301,7 @@ func (s *priorityContextInferrer) getStatementsHints(statements []string) ([]pri
 // getValueExpressionsHints extracts all path, function (converter) names, and enumSymbol
 // from the given value expressions. These values are used by the context inferrer as hints to
 // select a context in which the function/enum are supported.
-func (s *priorityContextInferrer) getValueExpressionsHints(exprs []string) ([]priorityContextInferrerHints, error) {
+func (*priorityContextInferrer) getValueExpressionsHints(exprs []string) ([]priorityContextInferrerHints, error) {
 	hints := make([]priorityContextInferrerHints, 0, len(exprs))
 	for _, expr := range exprs {
 		parsed, err := parseValueExpression(expr)
@@ -332,7 +332,7 @@ func newGrammarContextInferrerVisitor() priorityContextInferrerHints {
 	}
 }
 
-func (v *priorityContextInferrerHints) visitMathExprLiteral(_ *mathExprLiteral) {}
+func (*priorityContextInferrerHints) visitMathExprLiteral(*mathExprLiteral) {}
 
 func (v *priorityContextInferrerHints) visitEditor(e *editor) {
 	v.functions[e.Function] = struct{}{}

--- a/pkg/ottl/contexts/internal/ctxcommon/parser_test.go
+++ b/pkg/ottl/contexts/internal/ctxcommon/parser_test.go
@@ -240,7 +240,7 @@ func (p testPath) Next() ottl.Path[testContext] {
 	return p.nextPath
 }
 
-func (p testPath) Keys() []ottl.Key[testContext] {
+func (testPath) Keys() []ottl.Key[testContext] {
 	return nil
 }
 
@@ -255,10 +255,10 @@ type testGetSetter struct {
 	value any
 }
 
-func (m *testGetSetter) Get(_ context.Context, _ testContext) (any, error) {
+func (m *testGetSetter) Get(context.Context, testContext) (any, error) {
 	return m.value, nil
 }
 
-func (m *testGetSetter) Set(_ context.Context, _ testContext, _ any) error {
+func (*testGetSetter) Set(context.Context, testContext, any) error {
 	return nil
 }

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events_test.go
@@ -483,7 +483,7 @@ func (l *testContext) GetSpanEvent() ptrace.SpanEvent {
 	return l.spanEvent
 }
 
-func (l *testContext) GetEventIndex() (int64, error) {
+func (*testContext) GetEventIndex() (int64, error) {
 	return 1, nil
 }
 

--- a/pkg/ottl/factory.go
+++ b/pkg/ottl/factory.go
@@ -43,7 +43,7 @@ type factory[K any] struct {
 }
 
 //nolint:unused
-func (f *factory[K]) unexportedFactoryFunc() {}
+func (*factory[K]) unexportedFactoryFunc() {}
 
 func (f *factory[K]) Name() string {
 	return f.name

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -730,7 +730,7 @@ type Optional[T any] struct {
 }
 
 // This is called only by reflection.
-func (o Optional[T]) set(val any) reflect.Value {
+func (Optional[T]) set(val any) reflect.Value {
 	return reflect.ValueOf(Optional[T]{
 		val:      val.(T),
 		hasValue: true,

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -577,11 +577,11 @@ func (g *grammarCustomErrorsVisitor) join() error {
 	return &grammarCustomError{errs: g.errs}
 }
 
-func (g *grammarCustomErrorsVisitor) visitPath(_ *path) {}
+func (*grammarCustomErrorsVisitor) visitPath(*path) {}
 
-func (g *grammarCustomErrorsVisitor) visitValue(_ *value) {}
+func (*grammarCustomErrorsVisitor) visitValue(*value) {}
 
-func (g *grammarCustomErrorsVisitor) visitConverter(_ *converter) {}
+func (*grammarCustomErrorsVisitor) visitConverter(*converter) {}
 
 func (g *grammarCustomErrorsVisitor) visitEditor(v *editor) {
 	if v.Keys != nil {

--- a/pkg/ottl/paths.go
+++ b/pkg/ottl/paths.go
@@ -8,10 +8,10 @@ type grammarPathVisitor struct {
 	paths []path
 }
 
-func (v *grammarPathVisitor) visitEditor(_ *editor)                   {}
-func (v *grammarPathVisitor) visitConverter(_ *converter)             {}
-func (v *grammarPathVisitor) visitValue(_ *value)                     {}
-func (v *grammarPathVisitor) visitMathExprLiteral(_ *mathExprLiteral) {}
+func (*grammarPathVisitor) visitEditor(*editor)                   {}
+func (*grammarPathVisitor) visitConverter(*converter)             {}
+func (*grammarPathVisitor) visitValue(*value)                     {}
+func (*grammarPathVisitor) visitMathExprLiteral(*mathExprLiteral) {}
 
 func (v *grammarPathVisitor) visitPath(value *path) {
 	v.paths = append(v.paths, *value)

--- a/pkg/pdatatest/pprofiletest/options.go
+++ b/pkg/pdatatest/pprofiletest/options.go
@@ -120,7 +120,7 @@ func (opt ignoreProfileTimestampValues) applyOnProfiles(expected, actual pprofil
 	opt.maskProfileTimestampValues(actual)
 }
 
-func (opt ignoreProfileTimestampValues) maskProfileTimestampValues(profiles pprofile.Profiles) {
+func (ignoreProfileTimestampValues) maskProfileTimestampValues(profiles pprofile.Profiles) {
 	rls := profiles.ResourceProfiles()
 	for i := 0; i < profiles.ResourceProfiles().Len(); i++ {
 		sls := rls.At(i).ScopeProfiles()

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -32,7 +32,7 @@ func (wme *wrapperMetricsExporter) ConsumeMetrics(ctx context.Context, md pmetri
 	return wme.Metrics.ConsumeMetrics(ctx, convertToMetricsAttributes(md))
 }
 
-func (wme *wrapperMetricsExporter) Capabilities() consumer.Capabilities {
+func (*wrapperMetricsExporter) Capabilities() consumer.Capabilities {
 	// Always return true since this wrapper modifies data inplace.
 	return consumer.Capabilities{MutatesData: true}
 }

--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -111,11 +111,11 @@ type BenchConfig struct {
 }
 type BenchReceiverType struct{}
 
-func (f BenchReceiverType) Type() component.Type {
+func (BenchReceiverType) Type() component.Type {
 	return benchType
 }
 
-func (f BenchReceiverType) CreateDefaultConfig() component.Config {
+func (BenchReceiverType) CreateDefaultConfig() component.Config {
 	return &BenchConfig{
 		BaseConfig: BaseConfig{
 			Operators: []operator.Config{},
@@ -124,11 +124,11 @@ func (f BenchReceiverType) CreateDefaultConfig() component.Config {
 	}
 }
 
-func (f BenchReceiverType) BaseConfig(cfg component.Config) BaseConfig {
+func (BenchReceiverType) BaseConfig(cfg component.Config) BaseConfig {
 	return cfg.(*BenchConfig).BaseConfig
 }
 
-func (f BenchReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (BenchReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(cfg.(*BenchConfig))
 }
 

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -46,16 +46,16 @@ func (c *UnstartableConfig) Build(set component.TelemetrySettings) (operator.Ope
 }
 
 // Start will return an error
-func (o *UnstartableOperator) Start(_ operator.Persister) error {
+func (*UnstartableOperator) Start(_ operator.Persister) error {
 	return errors.New("something very unusual happened")
 }
 
-func (o *UnstartableOperator) ProcessBatch(_ context.Context, _ []*entry.Entry) error {
+func (*UnstartableOperator) ProcessBatch(_ context.Context, _ []*entry.Entry) error {
 	return nil
 }
 
 // Process will return nil
-func (o *UnstartableOperator) Process(_ context.Context, _ *entry.Entry) error {
+func (*UnstartableOperator) Process(_ context.Context, _ *entry.Entry) error {
 	return nil
 }
 
@@ -69,11 +69,11 @@ type TestConfig struct {
 }
 type TestReceiverType struct{}
 
-func (f TestReceiverType) Type() component.Type {
+func (TestReceiverType) Type() component.Type {
 	return testType
 }
 
-func (f TestReceiverType) CreateDefaultConfig() component.Config {
+func (TestReceiverType) CreateDefaultConfig() component.Config {
 	return &TestConfig{
 		BaseConfig: BaseConfig{
 			Operators: []operator.Config{},
@@ -82,10 +82,10 @@ func (f TestReceiverType) CreateDefaultConfig() component.Config {
 	}
 }
 
-func (f TestReceiverType) BaseConfig(cfg component.Config) BaseConfig {
+func (TestReceiverType) BaseConfig(cfg component.Config) BaseConfig {
 	return cfg.(*TestConfig).BaseConfig
 }
 
-func (f TestReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (TestReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return cfg.(*TestConfig).Input
 }

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -411,11 +411,11 @@ type testInputBuilder struct {
 	produceBatches     bool
 }
 
-func (t *testInputBuilder) ID() string {
+func (*testInputBuilder) ID() string {
 	return testInputOperatorTypeStr
 }
 
-func (t *testInputBuilder) Type() string {
+func (*testInputBuilder) Type() string {
 	return testInputOperatorTypeStr
 }
 
@@ -434,7 +434,7 @@ func (t *testInputBuilder) Build(settings component.TelemetrySettings) (operator
 	}, nil
 }
 
-func (t *testInputBuilder) SetID(_ string) {}
+func (*testInputBuilder) SetID(string) {}
 
 var _ operator.Operator = &testInputOperator{}
 
@@ -446,11 +446,11 @@ type testInputOperator struct {
 	cancelFunc         context.CancelFunc
 }
 
-func (t *testInputOperator) ID() string {
+func (*testInputOperator) ID() string {
 	return testInputOperatorTypeStr
 }
 
-func (t *testInputOperator) Type() string {
+func (*testInputOperator) Type() string {
 	return testInputOperatorTypeStr
 }
 
@@ -493,7 +493,7 @@ type testConsumer struct {
 	receivedLogs    atomic.Uint32
 }
 
-func (t *testConsumer) Capabilities() consumer.Capabilities {
+func (*testConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
 

--- a/pkg/stanza/entry/nil_field.go
+++ b/pkg/stanza/entry/nil_field.go
@@ -12,21 +12,21 @@ package entry // import "github.com/open-telemetry/opentelemetry-collector-contr
 type NilField struct{}
 
 // Get will return always return nil
-func (l NilField) Get(_ *Entry) (any, bool) {
+func (NilField) Get(*Entry) (any, bool) {
 	return nil, true
 }
 
 // Set will do nothing and return no error
-func (l NilField) Set(_ *Entry, _ any) error {
+func (NilField) Set(*Entry, any) error {
 	return nil
 }
 
 // Delete will do nothing and return no error
-func (l NilField) Delete(_ *Entry) (any, bool) {
+func (NilField) Delete(*Entry) (any, bool) {
 	return nil, true
 }
 
-func (l NilField) String() string {
+func (NilField) String() string {
 	return "$nil"
 }
 

--- a/pkg/stanza/fileconsumer/attrs/owner_windows.go
+++ b/pkg/stanza/fileconsumer/attrs/owner_windows.go
@@ -10,6 +10,6 @@ import (
 	"os"
 )
 
-func (r *Resolver) addOwnerInfo(_ *os.File, _ map[string]any) error {
+func (*Resolver) addOwnerInfo(_ *os.File, _ map[string]any) error {
 	return errors.New("owner info not implemented for windows")
 }

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -788,6 +788,6 @@ func newMockOperatorConfig(cfg *Config) *mockOperatorConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *mockOperatorConfig) Build(_ component.TelemetrySettings) (operator.Operator, error) {
+func (*mockOperatorConfig) Build(_ component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/fileconsumer/file_windows.go
+++ b/pkg/stanza/fileconsumer/file_windows.go
@@ -10,5 +10,5 @@ import (
 )
 
 // Noop on windows because we close files immediately after reading.
-func (m *Manager) readLostFiles(_ context.Context) {
+func (*Manager) readLostFiles(context.Context) {
 }

--- a/pkg/stanza/fileconsumer/internal/reader/reader_other.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_other.go
@@ -5,9 +5,9 @@
 
 package reader // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
 
-func (r *Reader) tryLockFile() bool {
+func (*Reader) tryLockFile() bool {
 	return true
 }
 
-func (r *Reader) unlockFile() {
+func (*Reader) unlockFile() {
 }

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker.go
@@ -69,7 +69,7 @@ func NewFileTracker(ctx context.Context, set component.TelemetrySettings, maxBat
 	return t
 }
 
-func (t *fileTracker) Name() string {
+func (*fileTracker) Name() string {
 	return FileTracker
 }
 
@@ -165,7 +165,7 @@ func NewNoStateTracker(set component.TelemetrySettings, maxBatchFiles int) Track
 	}
 }
 
-func (t *noStateTracker) Name() string {
+func (*noStateTracker) Name() string {
 	return NoStateTracker
 }
 
@@ -190,18 +190,18 @@ func (t *noStateTracker) EndConsume() (filesClosed int) {
 	return
 }
 
-func (t *noStateTracker) GetOpenFile(_ *fingerprint.Fingerprint) *reader.Reader { return nil }
+func (*noStateTracker) GetOpenFile(*fingerprint.Fingerprint) *reader.Reader { return nil }
 
-func (t *noStateTracker) GetClosedFile(_ *fingerprint.Fingerprint) *reader.Metadata { return nil }
+func (*noStateTracker) GetClosedFile(*fingerprint.Fingerprint) *reader.Metadata { return nil }
 
-func (t *noStateTracker) GetMetadata() []*reader.Metadata { return nil }
+func (*noStateTracker) GetMetadata() []*reader.Metadata { return nil }
 
-func (t *noStateTracker) LoadMetadata(_ []*reader.Metadata) {}
+func (*noStateTracker) LoadMetadata([]*reader.Metadata) {}
 
-func (t *noStateTracker) PreviousPollFiles() []*reader.Reader { return nil }
+func (*noStateTracker) PreviousPollFiles() []*reader.Reader { return nil }
 
-func (t *noStateTracker) ClosePreviousFiles() int { return 0 }
+func (*noStateTracker) ClosePreviousFiles() int { return 0 }
 
-func (t *noStateTracker) EndPoll(context.Context) {}
+func (*noStateTracker) EndPoll(context.Context) {}
 
-func (t *noStateTracker) TotalReaders() int { return 0 }
+func (*noStateTracker) TotalReaders() int { return 0 }

--- a/pkg/stanza/fileconsumer/matcher/internal/filter/filter_test.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/filter/filter_test.go
@@ -109,7 +109,7 @@ func TestFilter(t *testing.T) {
 
 type removeFirst struct{}
 
-func (o *removeFirst) apply(items []*item) ([]*item, error) {
+func (*removeFirst) apply(items []*item) ([]*item, error) {
 	if len(items) == 0 {
 		return items, nil
 	}

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -18,12 +18,12 @@ type FakeBuilder struct {
 	Array        []string `json:"array" yaml:"array"`
 }
 
-func (f *FakeBuilder) Build(_ component.TelemetrySettings) (Operator, error) {
+func (*FakeBuilder) Build(component.TelemetrySettings) (Operator, error) {
 	return nil, nil
 }
-func (f *FakeBuilder) ID() string     { return "operator" }
-func (f *FakeBuilder) Type() string   { return "operator" }
-func (f *FakeBuilder) SetID(_ string) {}
+func (*FakeBuilder) ID() string   { return "operator" }
+func (*FakeBuilder) Type() string { return "operator" }
+func (*FakeBuilder) SetID(string) {}
 
 func TestUnmarshalJSONErrors(t *testing.T) {
 	t.Cleanup(func() {

--- a/pkg/stanza/operator/helper/emitter.go
+++ b/pkg/stanza/operator/helper/emitter.go
@@ -212,11 +212,11 @@ func NewSynchronousLogEmitter(set component.TelemetrySettings, consumerFunc func
 	}
 }
 
-func (e *SynchronousLogEmitter) Start(_ operator.Persister) error {
+func (*SynchronousLogEmitter) Start(operator.Persister) error {
 	return nil
 }
 
-func (e *SynchronousLogEmitter) Stop() error {
+func (*SynchronousLogEmitter) Stop() error {
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/expr_string.go
+++ b/pkg/stanza/operator/helper/expr_string.go
@@ -127,7 +127,7 @@ func (e *ExprString) Render(env map[string]any) (string, error) {
 
 type patcher struct{}
 
-func (p *patcher) Visit(node *ast.Node) {
+func (*patcher) Visit(node *ast.Node) {
 	n, ok := (*node).(*ast.CallNode)
 	if !ok {
 		return

--- a/pkg/stanza/operator/helper/helper_test.go
+++ b/pkg/stanza/operator/helper/helper_test.go
@@ -35,6 +35,6 @@ func newHelpersConfig() *helpersConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *helpersConfig) Build(_ component.TelemetrySettings) (operator.Operator, error) {
+func (*helpersConfig) Build(component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -78,7 +78,7 @@ func (i *InputOperator) NewEntry(value any) (*entry.Entry, error) {
 }
 
 // CanProcess will always return false for an input operator.
-func (i *InputOperator) CanProcess() bool {
+func (*InputOperator) CanProcess() bool {
 	return false
 }
 

--- a/pkg/stanza/operator/helper/ip_resolver.go
+++ b/pkg/stanza/operator/helper/ip_resolver.go
@@ -106,7 +106,7 @@ func (r *IPResolver) GetHostFromIP(ip string) (host string) {
 }
 
 // lookupIPAddr resturns hostname based on ip address
-func (r *IPResolver) lookupIPAddr(ip string) (host string) {
+func (*IPResolver) lookupIPAddr(ip string) (host string) {
 	res, err := net.LookupAddr(ip)
 	if err != nil || len(res) == 0 {
 		return ip

--- a/pkg/stanza/operator/helper/operator.go
+++ b/pkg/stanza/operator/helper/operator.go
@@ -98,11 +98,11 @@ func (p *BasicOperator) Logger() *zap.Logger {
 }
 
 // Start will start the operator.
-func (p *BasicOperator) Start(_ operator.Persister) error {
+func (*BasicOperator) Start(operator.Persister) error {
 	return nil
 }
 
 // Stop will stop the operator.
-func (p *BasicOperator) Stop() error {
+func (*BasicOperator) Stop() error {
 	return nil
 }

--- a/pkg/stanza/operator/helper/output.go
+++ b/pkg/stanza/operator/helper/output.go
@@ -42,27 +42,27 @@ type OutputOperator struct {
 }
 
 // CanProcess will always return true for an output operator.
-func (o *OutputOperator) CanProcess() bool {
+func (*OutputOperator) CanProcess() bool {
 	return true
 }
 
 // CanOutput will always return false for an output operator.
-func (o *OutputOperator) CanOutput() bool {
+func (*OutputOperator) CanOutput() bool {
 	return false
 }
 
 // Outputs will always return an empty array for an output operator.
-func (o *OutputOperator) Outputs() []operator.Operator {
+func (*OutputOperator) Outputs() []operator.Operator {
 	return []operator.Operator{}
 }
 
 // GetOutputIDs will always return an empty array for an output ID.
-func (o *OutputOperator) GetOutputIDs() []string {
+func (*OutputOperator) GetOutputIDs() []string {
 	return []string{}
 }
 
 // SetOutputs will return an error if called.
-func (o *OutputOperator) SetOutputs(_ []operator.Operator) error {
+func (*OutputOperator) SetOutputs(_ []operator.Operator) error {
 	return errors.NewError(
 		"Operator can not output, but is attempting to set an output.",
 		"This is an unexpected internal error. Please submit a bug/issue.",
@@ -70,5 +70,5 @@ func (o *OutputOperator) SetOutputs(_ []operator.Operator) error {
 }
 
 // SetOutputIDs will return nothing and does nothing.
-func (o *OutputOperator) SetOutputIDs(_ []string) {
+func (*OutputOperator) SetOutputIDs([]string) {
 }

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -74,11 +74,11 @@ type TransformerOperator struct {
 }
 
 // CanProcess will always return true for a transformer operator.
-func (t *TransformerOperator) CanProcess() bool {
+func (*TransformerOperator) CanProcess() bool {
 	return true
 }
 
-func (t *TransformerOperator) ProcessBatchWith(ctx context.Context, entries []*entry.Entry, process ProcessFunction) error {
+func (*TransformerOperator) ProcessBatchWith(ctx context.Context, entries []*entry.Entry, process ProcessFunction) error {
 	var errs error
 	for i := range entries {
 		errs = multierr.Append(errs, process(ctx, entries[i]))

--- a/pkg/stanza/operator/helper/writer.go
+++ b/pkg/stanza/operator/helper/writer.go
@@ -81,7 +81,7 @@ func (w *WriterOperator) Write(ctx context.Context, e *entry.Entry) error {
 }
 
 // CanOutput always returns true for a writer operator.
-func (w *WriterOperator) CanOutput() bool {
+func (*WriterOperator) CanOutput() bool {
 	return true
 }
 
@@ -122,7 +122,7 @@ func (w *WriterOperator) SetOutputIDs(opIDs []string) {
 }
 
 // FindOperator will find an operator matching the supplied id.
-func (w *WriterOperator) findOperator(operators []operator.Operator, operatorID string) (operator.Operator, bool) {
+func (*WriterOperator) findOperator(operators []operator.Operator, operatorID string) (operator.Operator, bool) {
 	for _, operator := range operators {
 		if operator.ID() == operatorID {
 			return operator, true

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -87,43 +87,43 @@ func newBenchmarkOutput(totalLogs int, doneChan chan<- struct{}) *benchmarkOutpu
 }
 
 // CanOutput implements operator.Operator.
-func (o *benchmarkOutput) CanOutput() bool { return false }
+func (*benchmarkOutput) CanOutput() bool { return false }
 
 // CanProcess implements operator.Operator.
-func (o *benchmarkOutput) CanProcess() bool { return true }
+func (*benchmarkOutput) CanProcess() bool { return true }
 
 // GetOutputIDs implements operator.Operator.
-func (o *benchmarkOutput) GetOutputIDs() []string { return nil }
+func (*benchmarkOutput) GetOutputIDs() []string { return nil }
 
 const benchmarkOutputID = "benchmark"
 
 // ID implements operator.Operator.
-func (o *benchmarkOutput) ID() string { return benchmarkOutputID }
+func (*benchmarkOutput) ID() string { return benchmarkOutputID }
 
 // Logger implements operator.Operator.
-func (o *benchmarkOutput) Logger() *zap.Logger { return nil }
+func (*benchmarkOutput) Logger() *zap.Logger { return nil }
 
 // Outputs implements operator.Operator.
-func (o *benchmarkOutput) Outputs() []operator.Operator { return nil }
+func (*benchmarkOutput) Outputs() []operator.Operator { return nil }
 
 // SetOutputIDs implements operator.Operator.
-func (o *benchmarkOutput) SetOutputIDs([]string) {}
+func (*benchmarkOutput) SetOutputIDs([]string) {}
 
 // SetOutputs implements operator.Operator.
-func (o *benchmarkOutput) SetOutputs([]operator.Operator) error { return nil }
+func (*benchmarkOutput) SetOutputs([]operator.Operator) error { return nil }
 
 // Start implements operator.Operator.
-func (o *benchmarkOutput) Start(operator.Persister) error {
+func (*benchmarkOutput) Start(operator.Persister) error {
 	return nil
 }
 
 // Stop implements operator.Operator.
-func (o *benchmarkOutput) Stop() error {
+func (*benchmarkOutput) Stop() error {
 	return nil
 }
 
 // Type implements operator.Operator.
-func (o *benchmarkOutput) Type() string { return "benchmark_output" }
+func (*benchmarkOutput) Type() string { return "benchmark_output" }
 
 func (o *benchmarkOutput) Process(_ context.Context, _ *entry.Entry) error {
 	o.logsReceived++

--- a/pkg/stanza/operator/input/journald/config_nonlinux.go
+++ b/pkg/stanza/operator/input/journald/config_nonlinux.go
@@ -13,6 +13,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c Config) Build(_ component.TelemetrySettings) (operator.Operator, error) {
+func (Config) Build(component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("journald input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/journald/input_test.go
+++ b/pkg/stanza/operator/input/journald/input_test.go
@@ -35,7 +35,7 @@ func (f *fakeJournaldCmd) Start() error {
 	return f.startError
 }
 
-func (f *fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
+func (*fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
 	response := `{ "_BOOT_ID": "c4fa36de06824d21835c05ff80c54468", "_CAP_EFFECTIVE": "0", "_TRANSPORT": "journal", "_UID": "1000", "_EXE": "/usr/lib/systemd/systemd", "_AUDIT_LOGINUID": "1000", "MESSAGE": "run-docker-netns-4f76d707d45f.mount: Succeeded.", "_PID": "13894", "_CMDLINE": "/lib/systemd/systemd --user", "_MACHINE_ID": "d777d00e7caf45fbadedceba3975520d", "_SELINUX_CONTEXT": "unconfined\n", "CODE_FUNC": "unit_log_success", "SYSLOG_IDENTIFIER": "systemd", "_HOSTNAME": "myhostname", "MESSAGE_ID": "7ad2d189f7e94e70a38c781354912448", "_SYSTEMD_CGROUP": "/user.slice/user-1000.slice/user@1000.service/init.scope", "_SOURCE_REALTIME_TIMESTAMP": "1587047866229317", "USER_UNIT": "run-docker-netns-4f76d707d45f.mount", "SYSLOG_FACILITY": "3", "_SYSTEMD_SLICE": "user-1000.slice", "_AUDIT_SESSION": "286", "CODE_FILE": "../src/core/unit.c", "_SYSTEMD_USER_UNIT": "init.scope", "_COMM": "systemd", "USER_INVOCATION_ID": "88f7ca6bbf244dc8828fa901f9fe9be1", "CODE_LINE": "5487", "_SYSTEMD_INVOCATION_ID": "83f7fc7799064520b26eb6de1630429c", "PRIORITY": "6", "_GID": "1000", "__REALTIME_TIMESTAMP": "1587047866229555", "_SYSTEMD_UNIT": "user@1000.service", "_SYSTEMD_USER_SLICE": "-.slice", "__CURSOR": "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36", "__MONOTONIC_TIMESTAMP": "685540311557", "_SYSTEMD_OWNER_UID": "1000" }
 `
 	reader := bytes.NewReader([]byte(response))

--- a/pkg/stanza/operator/input/namedpipe/input_nonlinux.go
+++ b/pkg/stanza/operator/input/namedpipe/input_nonlinux.go
@@ -13,6 +13,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c *Config) Build(_ component.TelemetrySettings) (operator.Operator, error) {
+func (*Config) Build(component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("namedpipe input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/udp/input.go
+++ b/pkg/stanza/operator/input/udp/input.go
@@ -233,7 +233,7 @@ func (i *Input) readMessage(buffer []byte) ([]byte, net.Addr, int, error) {
 }
 
 // This will remove trailing characters and NULs from the buffer
-func (i *Input) removeTrailingCharactersAndNULsFromBuffer(buffer []byte, n int) []byte {
+func (*Input) removeTrailingCharactersAndNULsFromBuffer(buffer []byte, n int) []byte {
 	// Remove trailing characters and NULs
 	for ; (n > 0) && (buffer[n-1] < 32); n-- { //nolint:revive
 	}

--- a/pkg/stanza/operator/input/windows/subscription.go
+++ b/pkg/stanza/operator/input/windows/subscription.go
@@ -145,7 +145,7 @@ func (s *Subscription) readWithRetry(maxReads int) ([]Event, int, error) {
 }
 
 // createFlags will create the necessary subscription flags from the supplied arguments.
-func (s *Subscription) createFlags(startAt string, bookmark Bookmark) uint32 {
+func (*Subscription) createFlags(startAt string, bookmark Bookmark) uint32 {
 	if bookmark.handle != 0 {
 		return EvtSubscribeStartAfterBookmark
 	}

--- a/pkg/stanza/operator/output/drop/output.go
+++ b/pkg/stanza/operator/output/drop/output.go
@@ -15,11 +15,11 @@ type Output struct {
 	helper.OutputOperator
 }
 
-func (o *Output) ProcessBatch(_ context.Context, _ []*entry.Entry) error {
+func (*Output) ProcessBatch(context.Context, []*entry.Entry) error {
 	return nil
 }
 
 // Process will drop the incoming entry.
-func (o *Output) Process(_ context.Context, _ *entry.Entry) error {
+func (*Output) Process(context.Context, *entry.Entry) error {
 	return nil
 }

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -195,7 +195,7 @@ func (p *Parser) detectFormat(e *entry.Entry) (string, error) {
 }
 
 // parseCRIO will parse a crio log value based on a fixed regexp
-func (p *Parser) parseCRIO(value any) (any, error) {
+func (*Parser) parseCRIO(value any) (any, error) {
 	raw, ok := value.(string)
 	if !ok {
 		return "", fmt.Errorf("type '%T' cannot be parsed as cri-o container logs", value)
@@ -205,7 +205,7 @@ func (p *Parser) parseCRIO(value any) (any, error) {
 }
 
 // parseContainerd will parse a containerd log value based on a fixed regexp
-func (p *Parser) parseContainerd(value any) (any, error) {
+func (*Parser) parseContainerd(value any) (any, error) {
 	raw, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("type '%T' cannot be parsed as containerd logs", value)
@@ -215,7 +215,7 @@ func (p *Parser) parseContainerd(value any) (any, error) {
 }
 
 // parseDocker will parse a docker log value as JSON
-func (p *Parser) parseDocker(value any) (any, error) {
+func (*Parser) parseDocker(value any) (any, error) {
 	raw, ok := value.(string)
 	if !ok {
 		return nil, fmt.Errorf("type '%T' cannot be parsed as docker container logs", value)
@@ -249,7 +249,7 @@ func (p *Parser) handleTimeAndAttributeMappings(e *entry.Entry) error {
 }
 
 // handleMoveAttributes moves fields to final attributes
-func (p *Parser) handleMoveAttributes(e *entry.Entry) error {
+func (*Parser) handleMoveAttributes(e *entry.Entry) error {
 	// move `log` to `body` explicitly first to avoid
 	// moving after more attributes have been added under the `log.*` key
 	err := moveFieldToBody(e, "log", "body")

--- a/pkg/stanza/operator/parser/syslog/parser.go
+++ b/pkg/stanza/operator/parser/syslog/parser.go
@@ -175,7 +175,7 @@ func (p *Parser) parseRFC5424(syslogMessage *rfc5424.SyslogMessage, skipPriHeade
 }
 
 // toSafeMap will dereference any pointers on the supplied map.
-func (p *Parser) toSafeMap(message map[string]any) (map[string]any, error) {
+func (*Parser) toSafeMap(message map[string]any) (map[string]any, error) {
 	for key, val := range message {
 		switch v := val.(type) {
 		case *string:

--- a/pkg/stanza/operator/parser/uri/parser.go
+++ b/pkg/stanza/operator/parser/uri/parser.go
@@ -42,7 +42,7 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
 }
 
 // parse will parse a uri from a field and attach it to an entry.
-func (p *Parser) parse(value any) (any, error) {
+func (*Parser) parse(value any) (any, error) {
 	switch m := value.(type) {
 	case string:
 		return parseutils.ParseURI(m, semconvCompliantFeatureGate.IsEnabled())

--- a/pkg/stanza/operator/transformer/assignkeys/transformer.go
+++ b/pkg/stanza/operator/transformer/assignkeys/transformer.go
@@ -51,7 +51,7 @@ func (t *Transformer) Transform(entry *entry.Entry) error {
 	return nil
 }
 
-func (t *Transformer) AssignKeys(keys []string, values []any) map[string]any {
+func (*Transformer) AssignKeys(keys []string, values []any) map[string]any {
 	outputMap := make(map[string]any, len(keys))
 	for i, key := range keys {
 		outputMap[key] = values[i]

--- a/pkg/stanza/operator/transformer/router/transformer.go
+++ b/pkg/stanza/operator/transformer/router/transformer.go
@@ -32,7 +32,7 @@ type Route struct {
 }
 
 // CanProcess will always return true for a router operator
-func (t *Transformer) CanProcess() bool {
+func (*Transformer) CanProcess() bool {
 	return true
 }
 
@@ -80,7 +80,7 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 }
 
 // CanOutput will always return true for a router operator
-func (t *Transformer) CanOutput() bool {
+func (*Transformer) CanOutput() bool {
 	return true
 }
 
@@ -116,7 +116,7 @@ func (t *Transformer) SetOutputs(operators []operator.Operator) error {
 }
 
 // SetOutputIDs will do nothing.
-func (t *Transformer) SetOutputIDs(_ []string) {}
+func (*Transformer) SetOutputIDs(_ []string) {}
 
 // findOperators will find a subset of operators from a collection.
 func (t *Transformer) findOperators(operators []operator.Operator, operatorIDs []string) ([]operator.Operator, error) {
@@ -132,7 +132,7 @@ func (t *Transformer) findOperators(operators []operator.Operator, operatorIDs [
 }
 
 // findOperator will find an operator from a collection.
-func (t *Transformer) findOperator(operators []operator.Operator, operatorID string) (operator.Operator, error) {
+func (*Transformer) findOperator(operators []operator.Operator, operatorID string) (operator.Operator, error) {
 	for _, operator := range operators {
 		if operator.ID() == operatorID {
 			return operator, nil

--- a/pkg/stanza/testutil/mocks.go
+++ b/pkg/stanza/testutil/mocks.go
@@ -52,37 +52,37 @@ func NewFakeOutputWithProcessError(tb testing.TB) *FakeOutput {
 }
 
 // CanOutput always returns false for a fake output
-func (f *FakeOutput) CanOutput() bool { return false }
+func (*FakeOutput) CanOutput() bool { return false }
 
 // CanProcess always returns true for a fake output
-func (f *FakeOutput) CanProcess() bool { return true }
+func (*FakeOutput) CanProcess() bool { return true }
 
 // ID always returns `fake` as the ID of a fake output operator
-func (f *FakeOutput) ID() string { return "fake" }
+func (*FakeOutput) ID() string { return "fake" }
 
 // Logger returns the logger of a fake output
 func (f *FakeOutput) Logger() *zap.Logger { return f.logger }
 
 // Outputs always returns nil for a fake output
-func (f *FakeOutput) Outputs() []operator.Operator { return nil }
+func (*FakeOutput) Outputs() []operator.Operator { return nil }
 
 // Outputs always returns nil for a fake output
-func (f *FakeOutput) GetOutputIDs() []string { return nil }
+func (*FakeOutput) GetOutputIDs() []string { return nil }
 
 // SetOutputs immediately returns nil for a fake output
-func (f *FakeOutput) SetOutputs(_ []operator.Operator) error { return nil }
+func (*FakeOutput) SetOutputs([]operator.Operator) error { return nil }
 
 // SetOutputIDs immediately returns nil for a fake output
-func (f *FakeOutput) SetOutputIDs(_ []string) {}
+func (*FakeOutput) SetOutputIDs([]string) {}
 
 // Start immediately returns nil for a fake output
-func (f *FakeOutput) Start(_ operator.Persister) error { return nil }
+func (*FakeOutput) Start(operator.Persister) error { return nil }
 
 // Stop immediately returns nil for a fake output
-func (f *FakeOutput) Stop() error { return nil }
+func (*FakeOutput) Stop() error { return nil }
 
 // Type always return `fake_output` for a fake output
-func (f *FakeOutput) Type() string { return "fake_output" }
+func (*FakeOutput) Type() string { return "fake_output" }
 
 func (f *FakeOutput) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
 	var errs error

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -170,7 +170,7 @@ func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {
 
 // addExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
 // the exemplar is added to the bucket bound's time series, provided that the time series' has samples.
-func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
+func (*prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
 	if len(bucketBounds) == 0 {
 		return
 	}

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -57,7 +57,7 @@ func (ft *FromTranslator) FromMetrics(md pmetric.Metrics, dropHistogramBuckets, 
 
 // FromMetric converts pmetric.Metric to SignalFx proto data points.
 // TODO: Remove this and change signalfxexporter to us FromMetrics.
-func (ft *FromTranslator) FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension, dropHistogramBuckets, processHistograms bool) []*sfxpb.DataPoint {
+func (*FromTranslator) FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension, dropHistogramBuckets, processHistograms bool) []*sfxpb.DataPoint {
 	var dps []*sfxpb.DataPoint
 
 	mt := fromMetricTypeToMetricType(m)

--- a/pkg/translator/signalfx/to_metrics.go
+++ b/pkg/translator/signalfx/to_metrics.go
@@ -18,7 +18,7 @@ const numMetricTypes = 4
 type ToTranslator struct{}
 
 // ToMetrics converts SignalFx proto data points to pmetric.Metrics.
-func (tt *ToTranslator) ToMetrics(sfxDataPoints []*model.DataPoint) (pmetric.Metrics, error) {
+func (*ToTranslator) ToMetrics(sfxDataPoints []*model.DataPoint) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()
 	ilm := rm.ScopeMetrics().AppendEmpty()

--- a/pkg/translator/zipkin/zipkinv1/thrift.go
+++ b/pkg/translator/zipkin/zipkinv1/thrift.go
@@ -24,7 +24,7 @@ import (
 type thriftUnmarshaler struct{}
 
 // UnmarshalTraces from Thrift bytes.
-func (t thriftUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
+func (thriftUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	spans, err := jaegerzipkin.DeserializeThrift(context.TODO(), buf)
 	if err != nil {
 		return ptrace.Traces{}, err

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -35,7 +35,7 @@ type FromTranslator struct{}
 
 // FromTraces translates internal trace data into Zipkin v2 spans.
 // Returns a slice of Zipkin SpanModel's.
-func (t FromTranslator) FromTraces(td ptrace.Traces) ([]*zipkinmodel.SpanModel, error) {
+func (FromTranslator) FromTraces(td ptrace.Traces) ([]*zipkinmodel.SpanModel, error) {
 	resourceSpans := td.ResourceSpans()
 	if resourceSpans.Len() == 0 {
 		return nil, nil

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -440,7 +440,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/processor/deltatocumulativeprocessor/benchmark_test.go
+++ b/processor/deltatocumulativeprocessor/benchmark_test.go
@@ -266,7 +266,7 @@ func (cs *countingSink) ConsumeMetrics(_ context.Context, md pmetric.Metrics) er
 	return nil
 }
 
-func (cs *countingSink) Capabilities() consumer.Capabilities {
+func (*countingSink) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
 

--- a/processor/deltatocumulativeprocessor/internal/data/add.go
+++ b/processor/deltatocumulativeprocessor/internal/data/add.go
@@ -31,7 +31,7 @@ type Adder struct{}
 
 var maxBuckets = 160
 
-func (add Adder) Numbers(state, dp pmetric.NumberDataPoint) error {
+func (Adder) Numbers(state, dp pmetric.NumberDataPoint) error {
 	switch dp.ValueType() {
 	case pmetric.NumberDataPointValueTypeDouble:
 		v := state.DoubleValue() + dp.DoubleValue()
@@ -43,7 +43,7 @@ func (add Adder) Numbers(state, dp pmetric.NumberDataPoint) error {
 	return nil
 }
 
-func (add Adder) Histograms(state, dp pmetric.HistogramDataPoint) error {
+func (Adder) Histograms(state, dp pmetric.HistogramDataPoint) error {
 	// bounds different: no way to merge, so reset observation to new boundaries
 	if !pslice.Equal(state.ExplicitBounds(), dp.ExplicitBounds()) {
 		dp.CopyTo(state)
@@ -82,7 +82,7 @@ func (add Adder) Histograms(state, dp pmetric.HistogramDataPoint) error {
 	return nil
 }
 
-func (add Adder) Exponential(state, dp pmetric.ExponentialHistogramDataPoint) error {
+func (Adder) Exponential(state, dp pmetric.ExponentialHistogramDataPoint) error {
 	type H = pmetric.ExponentialHistogramDataPoint
 
 	if state.Scale() != dp.Scale() {

--- a/processor/deltatocumulativeprocessor/internal/data/datatest/equal_test.go
+++ b/processor/deltatocumulativeprocessor/internal/data/datatest/equal_test.go
@@ -51,19 +51,19 @@ func (s structFunc) Get() int {
 	return s.a
 }
 
-func (s structFunc) Func() func() {
+func (structFunc) Func() func() {
 	return func() {}
 }
 
 // iter.Seq is a reflect.Func
-func (s structFunc) Seq() iter.Seq[int] {
-	return func(_ func(v int) bool) {
+func (structFunc) Seq() iter.Seq[int] {
+	return func(func(v int) bool) {
 	}
 }
 
 // iter.Seq2 is a reflect.Func
-func (s structFunc) Seq2() iter.Seq2[int, string] {
-	return func(_ func(k int, v string) bool) {
+func (structFunc) Seq2() iter.Seq2[int, string] {
+	return func(func(k int, v string) bool) {
 	}
 }
 
@@ -81,9 +81,9 @@ type fakeT struct {
 	testing.TB
 }
 
-func (t fakeT) Helper() {}
+func (fakeT) Helper() {}
 
-func (t fakeT) Errorf(format string, args ...any) {
+func (fakeT) Errorf(format string, args ...any) {
 	var from string
 	for i := 0; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)

--- a/processor/deltatocumulativeprocessor/internal/metrics/data.go
+++ b/processor/deltatocumulativeprocessor/internal/metrics/data.go
@@ -59,7 +59,7 @@ func (s Gauge) Ident() Ident {
 	return (*Metric)(&s).Ident()
 }
 
-func (s Gauge) SetAggregationTemporality(pmetric.AggregationTemporality) {}
+func (Gauge) SetAggregationTemporality(pmetric.AggregationTemporality) {}
 
 type Summary Metric
 
@@ -71,4 +71,4 @@ func (s Summary) Ident() Ident {
 	return (*Metric)(&s).Ident()
 }
 
-func (s Summary) SetAggregationTemporality(pmetric.AggregationTemporality) {}
+func (Summary) SetAggregationTemporality(pmetric.AggregationTemporality) {}

--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -218,7 +218,7 @@ func (p *deltaToCumulativeProcessor) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (p *deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
+func (*deltaToCumulativeProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/processor/deltatorateprocessor/processor.go
+++ b/processor/deltatorateprocessor/processor.go
@@ -32,7 +32,7 @@ func newDeltaToRateProcessor(config *Config, logger *zap.Logger) *deltaToRatePro
 }
 
 // Start is invoked during service startup.
-func (dtrp *deltaToRateProcessor) Start(context.Context, component.Host) error {
+func (*deltaToRateProcessor) Start(context.Context, component.Host) error {
 	return nil
 }
 
@@ -82,7 +82,7 @@ func (dtrp *deltaToRateProcessor) processMetrics(_ context.Context, md pmetric.M
 }
 
 // Shutdown is invoked during service shutdown.
-func (dtrp *deltaToRateProcessor) Shutdown(context.Context) error {
+func (*deltaToRateProcessor) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/processor/dnslookupprocessor/config.go
+++ b/processor/dnslookupprocessor/config.go
@@ -6,6 +6,6 @@ package dnslookupprocessor // import "github.com/open-telemetry/opentelemetry-co
 // Config holds the configuration for the DnsLookup processor.
 type Config struct{}
 
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/processor/dnslookupprocessor/dnslookup_processor.go
+++ b/processor/dnslookupprocessor/dnslookup_processor.go
@@ -17,14 +17,14 @@ func newDNSLookupProcessor() *dnsLookupProcessor {
 	return &dnsLookupProcessor{}
 }
 
-func (g *dnsLookupProcessor) processMetrics(_ context.Context, ms pmetric.Metrics) (pmetric.Metrics, error) {
+func (*dnsLookupProcessor) processMetrics(_ context.Context, ms pmetric.Metrics) (pmetric.Metrics, error) {
 	return ms, nil
 }
 
-func (g *dnsLookupProcessor) processTraces(_ context.Context, ts ptrace.Traces) (ptrace.Traces, error) {
+func (*dnsLookupProcessor) processTraces(_ context.Context, ts ptrace.Traces) (ptrace.Traces, error) {
 	return ts, nil
 }
 
-func (g *dnsLookupProcessor) processLogs(_ context.Context, ls plog.Logs) (plog.Logs, error) {
+func (*dnsLookupProcessor) processLogs(_ context.Context, ls plog.Logs) (plog.Logs, error) {
 	return ls, nil
 }

--- a/processor/geoipprocessor/internal/provider/maxmindprovider/factory.go
+++ b/processor/geoipprocessor/internal/provider/maxmindprovider/factory.go
@@ -22,12 +22,12 @@ type Factory struct{}
 var _ provider.GeoIPProviderFactory = (*Factory)(nil)
 
 // CreateDefaultConfig creates the default configuration for the Provider.
-func (f *Factory) CreateDefaultConfig() provider.Config {
+func (*Factory) CreateDefaultConfig() provider.Config {
 	return &Config{}
 }
 
 // CreateGeoIPProvider creates a provider based on this config.
-func (f *Factory) CreateGeoIPProvider(_ context.Context, _ processor.Settings, cfg provider.Config) (provider.GeoIPProvider, error) {
+func (*Factory) CreateGeoIPProvider(_ context.Context, _ processor.Settings, cfg provider.Config) (provider.GeoIPProvider, error) {
 	maxMindConfig := cfg.(*Config)
 	return newMaxMindProvider(maxMindConfig)
 }

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -569,7 +569,7 @@ func (tt *testTelemetry) newTelemetrySettings() component.TelemetrySettings {
 	return set
 }
 
-func (tt *testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) metricdata.Metrics {
+func (*testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) metricdata.Metrics {
 	for _, sm := range got.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			if m.Name == name {

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -83,7 +83,7 @@ func (sp *groupByTraceProcessor) ConsumeTraces(_ context.Context, td ptrace.Trac
 	return errs
 }
 
-func (sp *groupByTraceProcessor) Capabilities() consumer.Capabilities {
+func (*groupByTraceProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -599,15 +599,15 @@ func (m *mockProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 	return nil
 }
 
-func (m *mockProcessor) Capabilities() consumer.Capabilities {
+func (*mockProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
-func (m *mockProcessor) Shutdown(context.Context) error {
+func (*mockProcessor) Shutdown(context.Context) error {
 	return nil
 }
 
-func (m *mockProcessor) Start(_ context.Context, _ component.Host) error {
+func (*mockProcessor) Start(context.Context, component.Host) error {
 	return nil
 }
 
@@ -662,7 +662,7 @@ type blockingConsumer struct {
 
 var _ consumer.Traces = (*blockingConsumer)(nil)
 
-func (b *blockingConsumer) Capabilities() consumer.Capabilities {
+func (*blockingConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/processor/intervalprocessor/processor.go
+++ b/processor/intervalprocessor/processor.go
@@ -90,7 +90,7 @@ func (p *intervalProcessor) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (p *intervalProcessor) Capabilities() consumer.Capabilities {
+func (*intervalProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -2446,7 +2446,7 @@ type neverSyncedResourceEventHandlerRegistration struct {
 	cache.ResourceEventHandlerRegistration
 }
 
-func (n *neverSyncedResourceEventHandlerRegistration) HasSynced() bool {
+func (*neverSyncedResourceEventHandlerRegistration) HasSynced() bool {
 	return false
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -43,19 +43,19 @@ func (f *FakeInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHand
 	return f, nil
 }
 
-func (f *FakeInformer) RemoveEventHandler(_ cache.ResourceEventHandlerRegistration) error {
+func (*FakeInformer) RemoveEventHandler(cache.ResourceEventHandlerRegistration) error {
 	return nil
 }
 
-func (f *FakeInformer) IsStopped() bool {
+func (*FakeInformer) IsStopped() bool {
 	return false
 }
 
-func (f *FakeInformer) SetTransform(_ cache.TransformFunc) error {
+func (*FakeInformer) SetTransform(cache.TransformFunc) error {
 	return nil
 }
 
-func (f *FakeInformer) GetStore() cache.Store {
+func (*FakeInformer) GetStore() cache.Store {
 	return cache.NewStore(func(_ any) (string, error) { return "", nil })
 }
 
@@ -75,13 +75,13 @@ func NewFakeNamespaceInformer(
 	}
 }
 
-func (f *FakeNamespaceInformer) AddEventHandler(_ cache.ResourceEventHandler) {}
+func (*FakeNamespaceInformer) AddEventHandler(cache.ResourceEventHandler) {}
 
-func (f *FakeNamespaceInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) {
+func (*FakeNamespaceInformer) AddEventHandlerWithResyncPeriod(cache.ResourceEventHandler, time.Duration) {
 }
 
-func (f *FakeNamespaceInformer) GetStore() cache.Store {
-	return cache.NewStore(func(_ any) (string, error) { return "", nil })
+func (*FakeNamespaceInformer) GetStore() cache.Store {
+	return cache.NewStore(func(any) (string, error) { return "", nil })
 }
 
 func (f *FakeNamespaceInformer) GetController() cache.Controller {
@@ -101,17 +101,17 @@ func NewFakeReplicaSetInformer(
 	}
 }
 
-func (f *FakeReplicaSetInformer) AddEventHandler(_ cache.ResourceEventHandler) {}
+func (*FakeReplicaSetInformer) AddEventHandler(cache.ResourceEventHandler) {}
 
-func (f *FakeReplicaSetInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) {
+func (*FakeReplicaSetInformer) AddEventHandlerWithResyncPeriod(cache.ResourceEventHandler, time.Duration) {
 }
 
-func (f *FakeReplicaSetInformer) SetTransform(_ cache.TransformFunc) error {
+func (*FakeReplicaSetInformer) SetTransform(cache.TransformFunc) error {
 	return nil
 }
 
-func (f *FakeReplicaSetInformer) GetStore() cache.Store {
-	return cache.NewStore(func(_ any) (string, error) { return "", nil })
+func (*FakeReplicaSetInformer) GetStore() cache.Store {
+	return cache.NewStore(func(any) (string, error) { return "", nil })
 }
 
 func (f *FakeReplicaSetInformer) GetController() cache.Controller {
@@ -123,7 +123,7 @@ type FakeController struct {
 	stopped bool
 }
 
-func (c *FakeController) HasSynced() bool {
+func (*FakeController) HasSynced() bool {
 	return true
 }
 
@@ -140,11 +140,11 @@ func (c *FakeController) HasStopped() bool {
 	return c.stopped
 }
 
-func (c *FakeController) LastSyncResourceVersion() string {
+func (*FakeController) LastSyncResourceVersion() string {
 	return ""
 }
 
-func (f *FakeInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
+func (*FakeInformer) SetWatchErrorHandler(cache.WatchErrorHandler) error {
 	return nil
 }
 
@@ -173,20 +173,20 @@ func (f *NoOpInformer) AddEventHandler(handler cache.ResourceEventHandler) (cach
 	return f.AddEventHandlerWithResyncPeriod(handler, time.Second)
 }
 
-func (f *NoOpInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+func (f *NoOpInformer) AddEventHandlerWithResyncPeriod(cache.ResourceEventHandler, time.Duration) (cache.ResourceEventHandlerRegistration, error) {
 	return f, nil
 }
 
-func (f *NoOpInformer) RemoveEventHandler(_ cache.ResourceEventHandlerRegistration) error {
+func (*NoOpInformer) RemoveEventHandler(cache.ResourceEventHandlerRegistration) error {
 	return nil
 }
 
-func (f *NoOpInformer) SetTransform(_ cache.TransformFunc) error {
+func (*NoOpInformer) SetTransform(cache.TransformFunc) error {
 	return nil
 }
 
-func (f *NoOpInformer) GetStore() cache.Store {
-	return cache.NewStore(func(_ any) (string, error) { return "", nil })
+func (*NoOpInformer) GetStore() cache.Store {
+	return cache.NewStore(func(any) (string, error) { return "", nil })
 }
 
 func (f *NoOpInformer) GetController() cache.Controller {
@@ -208,14 +208,14 @@ func (c *NoOpController) IsStopped() bool {
 	return c.hasStopped
 }
 
-func (c *NoOpController) HasSynced() bool {
+func (*NoOpController) HasSynced() bool {
 	return true
 }
 
-func (c *NoOpController) LastSyncResourceVersion() string {
+func (*NoOpController) LastSyncResourceVersion() string {
 	return ""
 }
 
-func (c *NoOpController) SetWatchErrorHandler(cache.WatchErrorHandler) error {
+func (*NoOpController) SetWatchErrorHandler(cache.WatchErrorHandler) error {
 	return nil
 }

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -362,7 +362,7 @@ func withContainerRunID(containerRunID string) generateResourceFunc {
 
 type strAddr string
 
-func (s strAddr) String() string {
+func (strAddr) String() string {
 	return "1.1.1.1:3200"
 }
 
@@ -1766,7 +1766,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -67,12 +67,12 @@ func (p *logDedupProcessor) Start(ctx context.Context, _ component.Host) error {
 }
 
 // Capabilities returns the consumer's capabilities.
-func (p *logDedupProcessor) Capabilities() consumer.Capabilities {
+func (*logDedupProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
 // Shutdown stops the processor.
-func (p *logDedupProcessor) Shutdown(_ context.Context) error {
+func (p *logDedupProcessor) Shutdown(context.Context) error {
 	if p.cancel != nil {
 		// Call cancel to stop the export interval goroutine and wait for it to finish.
 		p.cancel()

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -59,7 +59,7 @@ func newProcessor(config *Config, nextConsumer consumer.Logs, set component.Tele
 	return p, nil
 }
 
-func (ltp *logsTransformProcessor) Capabilities() consumer.Capabilities {
+func (*logsTransformProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -223,7 +223,7 @@ func (t *laggyOperator) Process(ctx context.Context, e *entry.Entry) error {
 	return t.Write(ctx, e)
 }
 
-func (t *laggyOperator) CanProcess() bool {
+func (*laggyOperator) CanProcess() bool {
 	return true
 }
 

--- a/processor/metricsgenerationprocessor/processor.go
+++ b/processor/metricsgenerationprocessor/processor.go
@@ -44,7 +44,7 @@ func newMetricsGenerationProcessor(rules []internalRule, logger *zap.Logger) *me
 }
 
 // Start is invoked during service startup.
-func (mgp *metricsGenerationProcessor) Start(context.Context, component.Host) error {
+func (*metricsGenerationProcessor) Start(context.Context, component.Host) error {
 	return nil
 }
 
@@ -98,6 +98,6 @@ func (mgp *metricsGenerationProcessor) processMetrics(_ context.Context, md pmet
 }
 
 // Shutdown is invoked during service shutdown.
-func (mgp *metricsGenerationProcessor) Shutdown(context.Context) error {
+func (*metricsGenerationProcessor) Shutdown(context.Context) error {
 	return nil
 }

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
@@ -85,7 +85,7 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 	return metrics, nil
 }
 
-func (a *Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
+func (*Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
 	histogram := current.Histogram()
 	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only dealing with CumulativeDistributions.
@@ -124,7 +124,7 @@ func (a *Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, cu
 	}
 }
 
-func (a *Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
+func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
 	histogram := current.ExponentialHistogram()
 	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only dealing with CumulativeDistributions.
@@ -163,7 +163,7 @@ func (a *Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timese
 	}
 }
 
-func (a *Adjuster) adjustMetricSum(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
+func (*Adjuster) adjustMetricSum(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
 	currentPoints := current.Sum().DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSum := currentPoints.At(i)
@@ -196,7 +196,7 @@ func (a *Adjuster) adjustMetricSum(tsm *datapointstorage.TimeseriesMap, current 
 	}
 }
 
-func (a *Adjuster) adjustMetricSummary(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
+func (*Adjuster) adjustMetricSummary(tsm *datapointstorage.TimeseriesMap, current pmetric.Metric) {
 	currentPoints := current.Summary().DataPoints()
 
 	for i := 0; i < currentPoints.Len(); i++ {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -61,7 +61,7 @@ type internalFilterStrict struct {
 	attrMatchers map[string]StringMatcher
 }
 
-func (f internalFilterStrict) getSubexpNames() []string {
+func (internalFilterStrict) getSubexpNames() []string {
 	return nil
 }
 

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -57,11 +57,11 @@ func (f internalFilterStrict) matchMetric(metric pmetric.Metric) bool {
 	return false
 }
 
-func (f internalFilterStrict) submatches(_ pmetric.Metric) []int {
+func (internalFilterStrict) submatches(pmetric.Metric) []int {
 	return nil
 }
 
-func (f internalFilterStrict) expand(_, _ string) string {
+func (internalFilterStrict) expand(string, string) string {
 	return ""
 }
 

--- a/processor/probabilisticsamplerprocessor/logsprocessor.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor.go
@@ -108,7 +108,7 @@ func (rc *recordCarrier) clearThreshold() {
 	rc.record.Attributes().Remove("sampling.threshold")
 }
 
-func (rc *recordCarrier) reserialize() error {
+func (*recordCarrier) reserialize() error {
 	return nil
 }
 
@@ -167,7 +167,7 @@ func (th *hashingSampler) randomnessFromLogRecord(logRec plog.LogRecord) (random
 
 // randomnessFromLogRecord (hashingSampler) uses OTEP 235 semantic
 // conventions basing its decision only on the TraceID.
-func (ctc *consistentTracestateCommon) randomnessFromLogRecord(logRec plog.LogRecord) (randomnessNamer, samplingCarrier, error) {
+func (*consistentTracestateCommon) randomnessFromLogRecord(logRec plog.LogRecord) (randomnessNamer, samplingCarrier, error) {
 	lrc, err := newLogRecordCarrier(logRec)
 	rnd := newMissingRandomnessMethod()
 

--- a/processor/probabilisticsamplerprocessor/sampler_mode.go
+++ b/processor/probabilisticsamplerprocessor/sampler_mode.go
@@ -93,7 +93,7 @@ type (
 
 type missingRandomnessMethod struct{}
 
-func (rm missingRandomnessMethod) randomness() sampling.Randomness {
+func (missingRandomnessMethod) randomness() sampling.Randomness {
 	return sampling.AllProbabilitiesRandomness
 }
 

--- a/processor/probabilisticsamplerprocessor/tracesprocessor.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor.go
@@ -148,7 +148,7 @@ func (th *hashingSampler) randomnessFromSpan(s ptrace.Span) (randomnessNamer, sa
 	return rnd, tsc, err
 }
 
-func (ctc *consistentTracestateCommon) randomnessFromSpan(s ptrace.Span) (randomnessNamer, samplingCarrier, error) {
+func (*consistentTracestateCommon) randomnessFromSpan(s ptrace.Span) (randomnessNamer, samplingCarrier, error) {
 	rnd := newMissingRandomnessMethod()
 	tsc, err := newTracestateCarrier(s)
 	if err != nil {
@@ -163,7 +163,7 @@ func (ctc *consistentTracestateCommon) randomnessFromSpan(s ptrace.Span) (random
 	return rnd, tsc, err
 }
 
-func (th *neverSampler) randomnessFromSpan(span ptrace.Span) (randomnessNamer, samplingCarrier, error) {
+func (*neverSampler) randomnessFromSpan(span ptrace.Span) (randomnessNamer, samplingCarrier, error) {
 	// We return a fake randomness value, since it will not be used.
 	// This avoids a consistency check error for missing randomness.
 	tsc, err := newTracestateCarrier(span)
@@ -198,7 +198,7 @@ func (tp *traceProcessor) processTraces(ctx context.Context, td ptrace.Traces) (
 	return td, nil
 }
 
-func (tp *traceProcessor) priorityFunc(s ptrace.Span, rnd randomnessNamer, threshold sampling.Threshold) (randomnessNamer, sampling.Threshold) {
+func (*traceProcessor) priorityFunc(s ptrace.Span, rnd randomnessNamer, threshold sampling.Threshold) (randomnessNamer, sampling.Threshold) {
 	switch parseSpanSamplingPriority(s) {
 	case doNotSampleSpan:
 		// OpenTracing mentions this as a "hint". We take a stronger

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -1171,7 +1171,7 @@ type assertTraces struct {
 
 var _ consumer.Traces = &assertTraces{}
 
-func (a *assertTraces) Capabilities() consumer.Capabilities {
+func (*assertTraces) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -38,7 +38,7 @@ type ec2ifaceBuilder interface {
 
 type ec2ClientBuilder struct{}
 
-func (e *ec2ClientBuilder) buildClient(ctx context.Context, region string, client *http.Client) (ec2.DescribeTagsAPIClient, error) {
+func (*ec2ClientBuilder) buildClient(ctx context.Context, region string, client *http.Client) (ec2.DescribeTagsAPIClient, error) {
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
 		config.WithHTTPClient(client),

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -40,17 +40,17 @@ var _ ec2provider.Provider = (*mockMetadata)(nil)
 
 type mockClientBuilder struct{}
 
-func (e *mockClientBuilder) buildClient(_ context.Context, _ string, _ *http.Client) (ec2.DescribeTagsAPIClient, error) {
+func (*mockClientBuilder) buildClient(context.Context, string, *http.Client) (ec2.DescribeTagsAPIClient, error) {
 	return &mockEC2Client{}, nil
 }
 
 type mockClientBuilderError struct{}
 
-func (e *mockClientBuilderError) buildClient(_ context.Context, _ string, _ *http.Client) (ec2.DescribeTagsAPIClient, error) {
+func (*mockClientBuilderError) buildClient(context.Context, string, *http.Client) (ec2.DescribeTagsAPIClient, error) {
 	return &mockEC2ClientError{}, nil
 }
 
-func (mm mockMetadata) InstanceID(_ context.Context) (string, error) {
+func (mm mockMetadata) InstanceID(context.Context) (string, error) {
 	if !mm.isAvailable {
 		return "", errUnavailable
 	}
@@ -115,14 +115,14 @@ func TestNewDetector(t *testing.T) {
 type mockEC2ClientError struct{}
 
 // override the DescribeTags function to mock the output from an actual EC2 instance
-func (m *mockEC2ClientError) DescribeTags(_ context.Context, _ *ec2.DescribeTagsInput, _ ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error) {
+func (*mockEC2ClientError) DescribeTags(context.Context, *ec2.DescribeTagsInput, ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error) {
 	return nil, errors.New("Error fetching tags")
 }
 
 type mockEC2Client struct{}
 
 // override the DescribeTags function to mock the output from an actual EC2 instance
-func (m *mockEC2Client) DescribeTags(_ context.Context, input *ec2.DescribeTagsInput, _ ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error) {
+func (*mockEC2Client) DescribeTags(_ context.Context, input *ec2.DescribeTagsInput, _ ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error) {
 	if len(input.Filters) > 0 && len(input.Filters[0].Values) > 0 && input.Filters[0].Values[0] == "error" {
 		return nil, errors.New("error")
 	}

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector.go
@@ -190,7 +190,7 @@ func (e eksDetectorUtils) isIMDSAccessible(ctx context.Context) bool {
 	return true
 }
 
-func (e eksDetectorUtils) getAWSConfig(ctx context.Context, checkAccess bool) (aws.Config, error) {
+func (eksDetectorUtils) getAWSConfig(ctx context.Context, checkAccess bool) (aws.Config, error) {
 	awsConfig, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return aws.Config{}, err

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -359,7 +359,7 @@ func (m *mockDetectorUtils) isIMDSAccessible(_ context.Context) bool {
 	return m.imdsAccessible
 }
 
-func (m *mockDetectorUtils) getAWSConfig(_ context.Context, _ bool) (aws.Config, error) {
+func (*mockDetectorUtils) getAWSConfig(context.Context, bool) (aws.Config, error) {
 	return aws.Config{}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/fs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/fs.go
@@ -16,10 +16,10 @@ type fileSystem interface {
 
 type ebFileSystem struct{}
 
-func (fs ebFileSystem) Open(name string) (io.ReadCloser, error) {
+func (ebFileSystem) Open(name string) (io.ReadCloser, error) {
 	return os.Open(name)
 }
 
-func (fs ebFileSystem) IsWindows() bool {
+func (ebFileSystem) IsWindows() bool {
 	return runtime.GOOS == "windows"
 }

--- a/processor/resourcedetectionprocessor/internal/env/env.go
+++ b/processor/resourcedetectionprocessor/internal/env/env.go
@@ -41,7 +41,7 @@ func NewDetector(processor.Settings, internal.DetectorConfig) (internal.Detector
 	return &Detector{}, nil
 }
 
-func (d *Detector) Detect(context.Context) (resource pcommon.Resource, schemaURL string, err error) {
+func (*Detector) Detect(context.Context) (resource pcommon.Resource, schemaURL string, err error) {
 	res := pcommon.NewResource()
 
 	labels := strings.TrimSpace(os.Getenv(envVar))

--- a/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp"
 )
 
-func (rb *ResourceBuilder) SetFromCallable(set func(string), detect func() (string, error)) error {
+func (*ResourceBuilder) SetFromCallable(set func(string), detect func() (string, error)) error {
 	v, err := detect()
 	if err != nil {
 		return err

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -35,7 +35,7 @@ func (p *mockDetector) Detect(_ context.Context) (pcommon.Resource, string, erro
 
 type mockDetectorConfig struct{}
 
-func (d *mockDetectorConfig) GetConfigFromType(_ DetectorType) DetectorConfig {
+func (*mockDetectorConfig) GetConfigFromType(_ DetectorType) DetectorConfig {
 	return nil
 }
 

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -207,7 +207,7 @@ func TestShutdown(t *testing.T) {
 
 type mockProcessor struct{}
 
-func (mp *mockProcessor) processTraces(context.Context, ptrace.Traces) (ptrace.Traces, error) {
+func (*mockProcessor) processTraces(context.Context, ptrace.Traces) (ptrace.Traces, error) {
 	return ptrace.NewTraces(), nil
 }
 

--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -148,7 +148,7 @@ func (p *logProcessor) route(ctx context.Context, l plog.Logs) error {
 	return errs
 }
 
-func (p *logProcessor) group(
+func (*logProcessor) group(
 	key string,
 	groups map[string]logsGroup,
 	exporters []exporter.Logs,
@@ -199,10 +199,10 @@ func (p *logProcessor) routeForContext(ctx context.Context, l plog.Logs) error {
 	return errs
 }
 
-func (p *logProcessor) Shutdown(context.Context) error {
+func (*logProcessor) Shutdown(context.Context) error {
 	return nil
 }
 
-func (p *logProcessor) Capabilities() consumer.Capabilities {
+func (*logProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -147,7 +147,7 @@ func (p *metricsProcessor) route(ctx context.Context, tm pmetric.Metrics) error 
 	return errs
 }
 
-func (p *metricsProcessor) group(
+func (*metricsProcessor) group(
 	key string,
 	groups map[string]metricsGroup,
 	exporters []exporter.Metrics,
@@ -199,10 +199,10 @@ func (p *metricsProcessor) routeForContext(ctx context.Context, m pmetric.Metric
 	return errs
 }
 
-func (p *metricsProcessor) Capabilities() consumer.Capabilities {
+func (*metricsProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (p *metricsProcessor) Shutdown(context.Context) error {
+func (*metricsProcessor) Shutdown(context.Context) error {
 	return nil
 }

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -146,7 +146,7 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 	return errs
 }
 
-func (p *tracesProcessor) group(key string, groups map[string]spanGroup, exporters []exporter.Traces, spans ptrace.ResourceSpans) {
+func (*tracesProcessor) group(key string, groups map[string]spanGroup, exporters []exporter.Traces, spans ptrace.ResourceSpans) {
 	group, ok := groups[key]
 	if !ok {
 		group.traces = ptrace.NewTraces()
@@ -192,10 +192,10 @@ func (p *tracesProcessor) routeForContext(ctx context.Context, t ptrace.Traces) 
 	return errs
 }
 
-func (p *tracesProcessor) Capabilities() consumer.Capabilities {
+func (*tracesProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (p *tracesProcessor) Shutdown(context.Context) error {
+func (*tracesProcessor) Shutdown(context.Context) error {
 	return nil
 }

--- a/processor/schemaprocessor/factory.go
+++ b/processor/schemaprocessor/factory.go
@@ -41,7 +41,7 @@ func NewFactory() processor.Factory {
 	)
 }
 
-func (f factory) createLogsProcessor(
+func (factory) createLogsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
@@ -62,7 +62,7 @@ func (f factory) createLogsProcessor(
 	)
 }
 
-func (f factory) createMetricsProcessor(
+func (factory) createMetricsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
@@ -83,7 +83,7 @@ func (f factory) createMetricsProcessor(
 	)
 }
 
-func (f factory) createTracesProcessor(
+func (factory) createTracesProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,

--- a/processor/schemaprocessor/internal/migrate/attributes.go
+++ b/processor/schemaprocessor/internal/migrate/attributes.go
@@ -36,7 +36,7 @@ func NewAttributeChangeSet(mappings map[string]string) AttributeChangeSet {
 	return attr
 }
 
-func (a AttributeChangeSet) IsMigrator() {}
+func (AttributeChangeSet) IsMigrator() {}
 
 func (a *AttributeChangeSet) Do(ss StateSelector, attrs pcommon.Map) (errs error) {
 	var (

--- a/processor/schemaprocessor/internal/migrate/conditional.go
+++ b/processor/schemaprocessor/internal/migrate/conditional.go
@@ -32,7 +32,7 @@ func NewConditionalAttributeSet[Match ValueMatch](mappings map[string]string, ma
 	}
 }
 
-func (ca ConditionalAttributeSet) IsMigrator() {}
+func (ConditionalAttributeSet) IsMigrator() {}
 
 // Do applies the attribute changes specified in the constructor if any of the values in values matches the matches specified in the constructor.
 func (ca *ConditionalAttributeSet) Do(ss StateSelector, attrs pcommon.Map, values ...string) (errs error) {

--- a/processor/schemaprocessor/internal/migrate/multi_conditional.go
+++ b/processor/schemaprocessor/internal/migrate/multi_conditional.go
@@ -35,7 +35,7 @@ func NewMultiConditionalAttributeSet[Match ValueMatch](mappings map[string]strin
 	}
 }
 
-func (ca MultiConditionalAttributeSet) IsMigrator() {}
+func (MultiConditionalAttributeSet) IsMigrator() {}
 
 // Do function applies the attribute changes if the passed in values match the expected values provided in the constructor.  Uses the Do method of the embedded AttributeChangeSet
 func (ca *MultiConditionalAttributeSet) Do(ss StateSelector, attrs pcommon.Map, keyToCheckVals map[string]string) (errs error) {

--- a/processor/schemaprocessor/internal/migrate/signal.go
+++ b/processor/schemaprocessor/internal/migrate/signal.go
@@ -32,7 +32,7 @@ func NewSignalNameChange[Key, Value SignalType](mappings map[Key]Value) SignalNa
 	return sig
 }
 
-func (s SignalNameChange) IsMigrator() {}
+func (SignalNameChange) IsMigrator() {}
 
 func (s *SignalNameChange) Do(ss StateSelector, signal alias.NamedSignal) {
 	var (

--- a/processor/schemaprocessor/internal/transformer/attributes_operators.go
+++ b/processor/schemaprocessor/internal/transformer/attributes_operators.go
@@ -22,7 +22,7 @@ type MetricAttributes struct {
 	AttributeChange migrate.AttributeChangeSet
 }
 
-func (o MetricAttributes) IsMigrator() {}
+func (MetricAttributes) IsMigrator() {}
 
 func (o MetricAttributes) Do(ss migrate.StateSelector, metric pmetric.Metric) error {
 	// todo(ankit) handle MetricTypeEmpty
@@ -76,7 +76,7 @@ type LogAttributes struct {
 	AttributeChange migrate.AttributeChangeSet
 }
 
-func (o LogAttributes) IsMigrator() {}
+func (LogAttributes) IsMigrator() {}
 
 func (o LogAttributes) Do(ss migrate.StateSelector, log plog.LogRecord) error {
 	return o.AttributeChange.Do(ss, log.Attributes())
@@ -88,7 +88,7 @@ type SpanAttributes struct {
 	AttributeChange migrate.AttributeChangeSet
 }
 
-func (o SpanAttributes) IsMigrator() {}
+func (SpanAttributes) IsMigrator() {}
 
 func (o SpanAttributes) Do(ss migrate.StateSelector, span ptrace.Span) error {
 	return o.AttributeChange.Do(ss, span.Attributes())
@@ -99,7 +99,7 @@ type SpanEventAttributes struct {
 	AttributeChange migrate.AttributeChangeSet
 }
 
-func (o SpanEventAttributes) IsMigrator() {}
+func (SpanEventAttributes) IsMigrator() {}
 
 func (o SpanEventAttributes) Do(ss migrate.StateSelector, spanEvent ptrace.SpanEvent) error {
 	return o.AttributeChange.Do(ss, spanEvent.Attributes())
@@ -111,7 +111,7 @@ type ResourceAttributes struct {
 	AttributeChange migrate.AttributeChangeSet
 }
 
-func (o ResourceAttributes) IsMigrator() {}
+func (ResourceAttributes) IsMigrator() {}
 
 func (o ResourceAttributes) Do(ss migrate.StateSelector, resource pcommon.Resource) error {
 	return o.AttributeChange.Do(ss, resource.Attributes())
@@ -137,7 +137,7 @@ func NewAllAttributesTransformer(set migrate.AttributeChangeSet) AllAttributes {
 	}
 }
 
-func (o AllAttributes) IsMigrator() {}
+func (AllAttributes) IsMigrator() {}
 
 func (o AllAttributes) Do(ss migrate.StateSelector, data any) error {
 	switch typedData := data.(type) {

--- a/processor/schemaprocessor/internal/transformer/conditional_attributes.go
+++ b/processor/schemaprocessor/internal/transformer/conditional_attributes.go
@@ -19,7 +19,7 @@ type MetricDataPointAttributes struct {
 	ConditionalAttributeChange migrate.ConditionalAttributeSet
 }
 
-func (o MetricDataPointAttributes) IsMigrator() {}
+func (MetricDataPointAttributes) IsMigrator() {}
 
 func (o MetricDataPointAttributes) Do(ss migrate.StateSelector, metric pmetric.Metric) error {
 	// todo(ankit) handle MetricTypeEmpty
@@ -73,7 +73,7 @@ type SpanConditionalAttributes struct {
 	Migrator migrate.ConditionalAttributeSet
 }
 
-func (o SpanConditionalAttributes) IsMigrator() {}
+func (SpanConditionalAttributes) IsMigrator() {}
 
 func (o SpanConditionalAttributes) Do(ss migrate.StateSelector, span ptrace.Span) error {
 	return o.Migrator.Do(ss, span.Attributes(), span.Name())

--- a/processor/schemaprocessor/internal/transformer/multi_conditional_attributes.go
+++ b/processor/schemaprocessor/internal/transformer/multi_conditional_attributes.go
@@ -15,7 +15,7 @@ type SpanEventConditionalAttributes struct {
 	MultiConditionalAttributeSet migrate.MultiConditionalAttributeSet
 }
 
-func (o SpanEventConditionalAttributes) IsMigrator() {}
+func (SpanEventConditionalAttributes) IsMigrator() {}
 
 func (o SpanEventConditionalAttributes) Do(ss migrate.StateSelector, span ptrace.Span) error {
 	for e := 0; e < span.Events().Len(); e++ {

--- a/processor/schemaprocessor/internal/transformer/signal_name.go
+++ b/processor/schemaprocessor/internal/transformer/signal_name.go
@@ -16,7 +16,7 @@ type SpanEventSignalNameChange struct {
 	SignalNameChange migrate.SignalNameChange
 }
 
-func (c SpanEventSignalNameChange) IsMigrator() {}
+func (SpanEventSignalNameChange) IsMigrator() {}
 
 func (c SpanEventSignalNameChange) Do(ss migrate.StateSelector, span ptrace.Span) error {
 	for e := 0; e < span.Events().Len(); e++ {
@@ -32,7 +32,7 @@ type MetricSignalNameChange struct {
 	SignalNameChange migrate.SignalNameChange
 }
 
-func (c MetricSignalNameChange) IsMigrator() {}
+func (MetricSignalNameChange) IsMigrator() {}
 
 func (c MetricSignalNameChange) Do(ss migrate.StateSelector, metric pmetric.Metric) error {
 	c.SignalNameChange.Do(ss, metric)

--- a/processor/schemaprocessor/internal/translation/manager_test.go
+++ b/processor/schemaprocessor/internal/translation/manager_test.go
@@ -68,7 +68,7 @@ func TestRequestTranslation(t *testing.T) {
 
 type errorProvider struct{}
 
-func (p *errorProvider) Retrieve(_ context.Context, _ string) (string, error) {
+func (*errorProvider) Retrieve(_ context.Context, _ string) (string, error) {
 	return "", errors.New("error")
 }
 

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -87,6 +87,6 @@ type Status struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks if the processor configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/processor/sumologicprocessor/config.go
+++ b/processor/sumologicprocessor/config.go
@@ -77,6 +77,6 @@ func createDefaultConfig() component.Config {
 }
 
 // Validate config
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/processor/sumologicprocessor/log_fields_conversion_processor.go
+++ b/processor/sumologicprocessor/log_fields_conversion_processor.go
@@ -130,12 +130,12 @@ func (proc *logFieldsConversionProcessor) processLogs(logs plog.Logs) error {
 	return nil
 }
 
-func (proc *logFieldsConversionProcessor) processMetrics(_ pmetric.Metrics) error {
+func (*logFieldsConversionProcessor) processMetrics(pmetric.Metrics) error {
 	// No-op. Metrics should not be translated.
 	return nil
 }
 
-func (proc *logFieldsConversionProcessor) processTraces(_ ptrace.Traces) error {
+func (*logFieldsConversionProcessor) processTraces(ptrace.Traces) error {
 	// No-op. Traces should not be translated.
 	return nil
 }

--- a/processor/sumologicprocessor/translate_attributes_processor.go
+++ b/processor/sumologicprocessor/translate_attributes_processor.go
@@ -70,7 +70,7 @@ func (proc *translateAttributesProcessor) processMetrics(metrics pmetric.Metrics
 	return nil
 }
 
-func (proc *translateAttributesProcessor) processTraces(_ ptrace.Traces) error {
+func (*translateAttributesProcessor) processTraces(ptrace.Traces) error {
 	// No-op. Traces should not be translated.
 	return nil
 }

--- a/processor/sumologicprocessor/translate_docker_metrics_processor.go
+++ b/processor/sumologicprocessor/translate_docker_metrics_processor.go
@@ -80,7 +80,7 @@ func newTranslateDockerMetricsProcessor(shouldTranslate bool) *translateDockerMe
 	}
 }
 
-func (proc *translateDockerMetricsProcessor) processLogs(_ plog.Logs) error {
+func (*translateDockerMetricsProcessor) processLogs(plog.Logs) error {
 	// No-op, this subprocessor doesn't process logs.
 	return nil
 }
@@ -106,7 +106,7 @@ func (proc *translateDockerMetricsProcessor) processMetrics(metrics pmetric.Metr
 	return nil
 }
 
-func (proc *translateDockerMetricsProcessor) processTraces(_ ptrace.Traces) error {
+func (*translateDockerMetricsProcessor) processTraces(ptrace.Traces) error {
 	// No-op, this subprocessor doesn't process traces.
 	return nil
 }

--- a/processor/sumologicprocessor/translate_telegraf_metrics_processor.go
+++ b/processor/sumologicprocessor/translate_telegraf_metrics_processor.go
@@ -78,7 +78,7 @@ func newTranslateTelegrafMetricsProcessor(shouldTranslate bool) *translateTelegr
 	}
 }
 
-func (proc *translateTelegrafMetricsProcessor) processLogs(_ plog.Logs) error {
+func (*translateTelegrafMetricsProcessor) processLogs(plog.Logs) error {
 	// No-op, this subprocessor doesn't process logs.
 	return nil
 }
@@ -103,7 +103,7 @@ func (proc *translateTelegrafMetricsProcessor) processMetrics(metrics pmetric.Me
 	return nil
 }
 
-func (proc *translateTelegrafMetricsProcessor) processTraces(_ ptrace.Traces) error {
+func (*translateTelegrafMetricsProcessor) processTraces(ptrace.Traces) error {
 	// No-op, this subprocessor doesn't process traces.
 	return nil
 }

--- a/processor/tailsamplingprocessor/cache/lru_cache.go
+++ b/processor/tailsamplingprocessor/cache/lru_cache.go
@@ -41,7 +41,7 @@ func (c *lruDecisionCache[V]) Put(id pcommon.TraceID, v V) {
 }
 
 // Delete is no-op since LRU relies on least recently used key being evicting automatically
-func (c *lruDecisionCache[V]) Delete(_ pcommon.TraceID) {}
+func (*lruDecisionCache[V]) Delete(pcommon.TraceID) {}
 
 func rightHalfTraceID(id pcommon.TraceID) uint64 {
 	return binary.LittleEndian.Uint64(id[8:])

--- a/processor/tailsamplingprocessor/cache/nop_cache.go
+++ b/processor/tailsamplingprocessor/cache/nop_cache.go
@@ -13,12 +13,12 @@ func NewNopDecisionCache[V any]() Cache[V] {
 	return &nopDecisionCache[V]{}
 }
 
-func (n *nopDecisionCache[V]) Get(_ pcommon.TraceID) (V, bool) {
+func (*nopDecisionCache[V]) Get(pcommon.TraceID) (V, bool) {
 	var v V
 	return v, false
 }
 
-func (n *nopDecisionCache[V]) Put(_ pcommon.TraceID, _ V) {
+func (*nopDecisionCache[V]) Put(_ pcommon.TraceID, _ V) {
 }
 
-func (n *nopDecisionCache[V]) Delete(_ pcommon.TraceID) {}
+func (*nopDecisionCache[V]) Delete(_ pcommon.TraceID) {}

--- a/processor/tailsamplingprocessor/internal/sampling/time_provider.go
+++ b/processor/tailsamplingprocessor/internal/sampling/time_provider.go
@@ -18,6 +18,6 @@ type TimeProvider interface {
 // to have fake clocks).
 type MonotonicClock struct{}
 
-func (c MonotonicClock) getCurSecond() int64 {
+func (MonotonicClock) getCurSecond() int64 {
 	return time.Now().Unix()
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -484,7 +484,7 @@ func (tsp *tailSamplingSpanProcessor) ConsumeTraces(_ context.Context, td ptrace
 	return nil
 }
 
-func (tsp *tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans ptrace.ResourceSpans) map[pcommon.TraceID][]spanAndScope {
+func (*tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans ptrace.ResourceSpans) map[pcommon.TraceID][]spanAndScope {
 	idToSpans := make(map[pcommon.TraceID][]spanAndScope)
 	ilss := resourceSpans.ScopeSpans()
 	for j := 0; j < ilss.Len(); j++ {
@@ -596,7 +596,7 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.Resourc
 	tsp.telemetry.ProcessorTailSamplingNewTraceIDReceived.Add(tsp.ctx, newTraceIDs)
 }
 
-func (tsp *tailSamplingSpanProcessor) Capabilities() consumer.Capabilities {
+func (*tailSamplingSpanProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/processor/tailsamplingprocessor/processor_telemetry_test.go
+++ b/processor/tailsamplingprocessor/processor_telemetry_test.go
@@ -698,7 +698,7 @@ func (tt *testTelemetry) newSettings() processor.Settings {
 	return set
 }
 
-func (tt *testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) metricdata.Metrics {
+func (*testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) metricdata.Metrics {
 	for _, sm := range got.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			if m.Name == name {
@@ -710,7 +710,7 @@ func (tt *testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) 
 	return metricdata.Metrics{}
 }
 
-func (tt *testTelemetry) len(got metricdata.ResourceMetrics) int {
+func (*testTelemetry) len(got metricdata.ResourceMetrics) int {
 	metricsCount := 0
 	for _, sm := range got.ScopeMetrics {
 		metricsCount += len(sm.Metrics)

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -811,7 +811,7 @@ func (s *syncIDBatcher) CloseCurrentAndTakeFirstBatch() (idbatcher.Batch, bool) 
 	return firstBatch, true
 }
 
-func (s *syncIDBatcher) Stop() {
+func (*syncIDBatcher) Stop() {
 }
 
 func simpleTraces() ptrace.Traces {

--- a/processor/transformprocessor/internal/common/logs.go
+++ b/processor/transformprocessor/internal/common/logs.go
@@ -25,7 +25,7 @@ type logStatements struct {
 	expr.BoolExpr[ottllog.TransformContext]
 }
 
-func (l logStatements) Context() ContextID {
+func (logStatements) Context() ContextID {
 	return Log
 }
 

--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -27,7 +27,7 @@ type metricStatements struct {
 	expr.BoolExpr[ottlmetric.TransformContext]
 }
 
-func (m metricStatements) Context() ContextID {
+func (metricStatements) Context() ContextID {
 	return Metric
 }
 
@@ -60,7 +60,7 @@ type dataPointStatements struct {
 	expr.BoolExpr[ottldatapoint.TransformContext]
 }
 
-func (d dataPointStatements) Context() ContextID {
+func (dataPointStatements) Context() ContextID {
 	return DataPoint
 }
 

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -26,7 +26,7 @@ type resourceStatements struct {
 	expr.BoolExpr[ottlresource.TransformContext]
 }
 
-func (r resourceStatements) Context() ContextID {
+func (resourceStatements) Context() ContextID {
 	return Resource
 }
 
@@ -105,7 +105,7 @@ type scopeStatements struct {
 	expr.BoolExpr[ottlscope.TransformContext]
 }
 
-func (s scopeStatements) Context() ContextID {
+func (scopeStatements) Context() ContextID {
 	return Scope
 }
 

--- a/processor/transformprocessor/internal/common/profiles.go
+++ b/processor/transformprocessor/internal/common/profiles.go
@@ -25,7 +25,7 @@ type profileStatements struct {
 	expr.BoolExpr[ottlprofile.TransformContext]
 }
 
-func (l profileStatements) Context() ContextID {
+func (profileStatements) Context() ContextID {
 	return Profile
 }
 

--- a/processor/transformprocessor/internal/common/traces.go
+++ b/processor/transformprocessor/internal/common/traces.go
@@ -26,7 +26,7 @@ type traceStatements struct {
 	expr.BoolExpr[ottlspan.TransformContext]
 }
 
-func (t traceStatements) Context() ContextID {
+func (traceStatements) Context() ContextID {
 	return Span
 }
 
@@ -59,7 +59,7 @@ type spanEventStatements struct {
 	expr.BoolExpr[ottlspanevent.TransformContext]
 }
 
-func (s spanEventStatements) Context() ContextID {
+func (spanEventStatements) Context() ContextID {
 	return SpanEvent
 }
 

--- a/receiver/activedirectorydsreceiver/scraper_test.go
+++ b/receiver/activedirectorydsreceiver/scraper_test.go
@@ -141,12 +141,12 @@ type mockPerfCounterWatcher struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
+func (*mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 
 // ScrapeRawValues implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounterWatcher) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
+func (*mockPerfCounterWatcher) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/aerospikereceiver/integration_test.go
+++ b/receiver/aerospikereceiver/integration_test.go
@@ -72,7 +72,7 @@ func integrationTest(cfgMod func(*Config)) func(*testing.T) {
 
 type waitStrategy struct{}
 
-func (ws waitStrategy) WaitUntilReady(ctx context.Context, st wait.StrategyTarget) error {
+func (waitStrategy) WaitUntilReady(ctx context.Context, st wait.StrategyTarget) error {
 	if err := wait.ForAll(
 		wait.ForListeningPort(nat.Port(aerospikePort)),
 		wait.ForLog("service ready: soon there will be cake!"),

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -58,7 +58,7 @@ func TestIntegration(t *testing.T) {
 
 type waitStrategy struct{}
 
-func (ws waitStrategy) WaitUntilReady(ctx context.Context, st wait.StrategyTarget) error {
+func (waitStrategy) WaitUntilReady(ctx context.Context, st wait.StrategyTarget) error {
 	if err := wait.ForListeningPort(apachePort).
 		WithStartupTimeout(time.Minute).
 		WaitUntilReady(ctx, st); err != nil {

--- a/receiver/awscloudwatchreceiver/persister.go
+++ b/receiver/awscloudwatchreceiver/persister.go
@@ -121,7 +121,7 @@ func (p *cloudwatchCheckpointPersister) Shutdown(ctx context.Context) error {
 }
 
 // getCheckpointKey generates a unique storage key
-func (p *cloudwatchCheckpointPersister) getCheckpointKey(logGroupName string) string {
+func (*cloudwatchCheckpointPersister) getCheckpointKey(logGroupName string) string {
 	if logGroupName == "" {
 		return ""
 	}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
@@ -28,7 +28,7 @@ type mockCadvisorManager struct {
 
 // Start the manager. Calling other manager methods before this returns
 // may produce undefined behavior.
-func (m *mockCadvisorManager) Start() error {
+func (*mockCadvisorManager) Start() error {
 	return nil
 }
 
@@ -40,44 +40,44 @@ func (m *mockCadvisorManager) SubcontainersInfo(_ string, _ *info.ContainerInfoR
 
 type mockCadvisorManager2 struct{}
 
-func (m *mockCadvisorManager2) Start() error {
+func (*mockCadvisorManager2) Start() error {
 	return errors.New("new error")
 }
 
-func (m *mockCadvisorManager2) SubcontainersInfo(_ string, _ *info.ContainerInfoRequest) ([]*info.ContainerInfo, error) {
+func (*mockCadvisorManager2) SubcontainersInfo(string, *info.ContainerInfoRequest) ([]*info.ContainerInfo, error) {
 	return nil, nil
 }
 
 func newMockCreateManager(t *testing.T) createCadvisorManager {
-	return func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
-		_ container.MetricSet, _ *http.Client, _ []string,
-		_ string,
+	return func(*memory.InMemoryCache, sysfs.SysFs, manager.HousekeepingConfig,
+		container.MetricSet, *http.Client, []string,
+		string,
 	) (cadvisorManager, error) {
 		return &mockCadvisorManager{t: t}, nil
 	}
 }
 
-var mockCreateManager2 = func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
-	_ container.MetricSet, _ *http.Client, _ []string,
-	_ string,
+var mockCreateManager2 = func(*memory.InMemoryCache, sysfs.SysFs, manager.HousekeepingConfig,
+	container.MetricSet, *http.Client, []string,
+	string,
 ) (cadvisorManager, error) {
 	return &mockCadvisorManager2{}, nil
 }
 
-var mockCreateManagerWithError = func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
-	_ container.MetricSet, _ *http.Client, _ []string,
-	_ string,
+var mockCreateManagerWithError = func(*memory.InMemoryCache, sysfs.SysFs, manager.HousekeepingConfig,
+	container.MetricSet, *http.Client, []string,
+	string,
 ) (cadvisorManager, error) {
 	return nil, errors.New("error")
 }
 
 type MockK8sDecorator struct{}
 
-func (m *MockK8sDecorator) Decorate(metric *extractors.CAdvisorMetric) *extractors.CAdvisorMetric {
+func (*MockK8sDecorator) Decorate(metric *extractors.CAdvisorMetric) *extractors.CAdvisorMetric {
 	return metric
 }
 
-func (m *MockK8sDecorator) Shutdown() error {
+func (*MockK8sDecorator) Shutdown() error {
 	return nil
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -50,10 +50,10 @@ func New(_ string, _ HostInfo, _ *zap.Logger, _ ...Option) (*Cadvisor, error) {
 }
 
 // GetMetrics is a dummy function that always returns empty metrics for windows
-func (c *Cadvisor) GetMetrics() []pmetric.Metrics {
+func (*Cadvisor) GetMetrics() []pmetric.Metrics {
 	return []pmetric.Metrics{}
 }
 
-func (c *Cadvisor) Shutdown() error {
+func (*Cadvisor) Shutdown() error {
 	return nil
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
@@ -20,7 +20,7 @@ type CPUMetricExtractor struct {
 	rateCalculator awsmetrics.MetricCalculator
 }
 
-func (c *CPUMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
+func (*CPUMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
 	return info.Spec.HasCpu
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor.go
@@ -20,7 +20,7 @@ type DiskIOMetricExtractor struct {
 	rateCalculator awsmetrics.MetricCalculator
 }
 
-func (d *DiskIOMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
+func (*DiskIOMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
 	return info.Spec.HasDiskIo
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor.go
@@ -19,7 +19,7 @@ type FileSystemMetricExtractor struct {
 	logger          *zap.Logger
 }
 
-func (f *FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
+func (*FileSystemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasFilesystem
 }
 
@@ -63,7 +63,7 @@ func (f *FileSystemMetricExtractor) GetValue(info *cinfo.ContainerInfo, _ CPUMem
 	return metrics
 }
 
-func (f *FileSystemMetricExtractor) Shutdown() error {
+func (*FileSystemMetricExtractor) Shutdown() error {
 	return nil
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
@@ -18,7 +18,7 @@ type MemMetricExtractor struct {
 	rateCalculator awsmetrics.MetricCalculator
 }
 
-func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
+func (*MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasMemory
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor.go
@@ -26,7 +26,7 @@ func getInterfacesStats(stats *cinfo.ContainerStats) []cinfo.InterfaceStats {
 	return ifceStats
 }
 
-func (n *NetMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
+func (*NetMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
 	return info.Spec.HasNetwork
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/ecshelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/ecshelpers.go
@@ -8,22 +8,22 @@ type MockECSInfo struct {
 	InstanceIP  string
 }
 
-func (e *MockECSInfo) GetRunningTaskCount() int64 {
+func (*MockECSInfo) GetRunningTaskCount() int64 {
 	return 2
 }
 
-func (e *MockECSInfo) GetCPUReserved() int64 {
+func (*MockECSInfo) GetCPUReserved() int64 {
 	return 32
 }
 
-func (e *MockECSInfo) GetMemReserved() int64 {
+func (*MockECSInfo) GetMemReserved() int64 {
 	return 213
 }
 
-func (e *MockECSInfo) GetContainerInstanceID() string {
+func (*MockECSInfo) GetContainerInstanceID() string {
 	return "eeee12.dsfr"
 }
 
-func (e *MockECSInfo) GetClusterName() string {
+func (*MockECSInfo) GetClusterName() string {
 	return "ecs-cluster"
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -36,11 +36,11 @@ func LoadContainerInfo(t *testing.T, file string) []*cinfo.ContainerInfo {
 
 type MockCPUMemInfo struct{}
 
-func (m MockCPUMemInfo) GetNumCores() int64 {
+func (MockCPUMemInfo) GetNumCores() int64 {
 	return 2
 }
 
-func (m MockCPUMemInfo) GetMemoryCapacity() int64 {
+func (MockCPUMemInfo) GetMemoryCapacity() int64 {
 	return 1073741824
 }
 
@@ -54,22 +54,22 @@ func (m MockHostInfo) GetClusterName() string {
 	return m.ClusterName
 }
 
-func (m MockHostInfo) GetEBSVolumeID(string) string {
+func (MockHostInfo) GetEBSVolumeID(string) string {
 	return "ebs-volume-id"
 }
 
-func (m MockHostInfo) GetInstanceID() string {
+func (MockHostInfo) GetInstanceID() string {
 	return "instance-id"
 }
 
-func (m MockHostInfo) GetInstanceType() string {
+func (MockHostInfo) GetInstanceType() string {
 	return "instance-id"
 }
 
-func (m MockHostInfo) GetAutoScalingGroupName() string {
+func (MockHostInfo) GetAutoScalingGroupName() string {
 	return "asg"
 }
 
-func (m MockHostInfo) ExtractEbsIDsUsedByKubernetes() map[string]string {
+func (MockHostInfo) ExtractEbsIDsUsedByKubernetes() map[string]string {
 	return map[string]string{}
 }

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
@@ -19,11 +19,11 @@ import (
 
 type MockHostInfo struct{}
 
-func (mi *MockHostInfo) GetInstanceIP() string {
+func (*MockHostInfo) GetInstanceIP() string {
 	return "0.0.0.0"
 }
 
-func (mi *MockHostInfo) GetInstanceIPReadyC() chan bool {
+func (*MockHostInfo) GetInstanceIPReadyC() chan bool {
 	readyC := make(chan bool)
 	return readyC
 }

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -15,15 +15,15 @@ import (
 
 type FakehostInfo struct{}
 
-func (hi *FakehostInfo) GetInstanceIP() string {
+func (*FakehostInfo) GetInstanceIP() string {
 	return "host-ip-address"
 }
 
-func (hi *FakehostInfo) GetClusterName() string {
+func (*FakehostInfo) GetClusterName() string {
 	return ""
 }
 
-func (hi *FakehostInfo) GetInstanceIPReadyC() chan bool {
+func (*FakehostInfo) GetInstanceIPReadyC() chan bool {
 	readyC := make(chan bool)
 	close(readyC)
 	return readyC
@@ -68,11 +68,11 @@ func (c *MockCgroupScanner) getMemReserved() int64 {
 	return c.memReserved
 }
 
-func (c *MockCgroupScanner) getCPUReservedInTask(_, _ string) int64 {
+func (*MockCgroupScanner) getCPUReservedInTask(_, _ string) int64 {
 	return int64(10)
 }
 
-func (c *MockCgroupScanner) getMEMReservedInTask(_, _ string, _ []ECSContainer) int64 {
+func (*MockCgroupScanner) getMEMReservedInTask(_, _ string, _ []ECSContainer) int64 {
 	return int64(512)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
@@ -26,27 +26,27 @@ func (m mockEBSVolumeClient) DescribeVolumes(ctx context.Context, params *ec2.De
 
 type mockFileInfo struct{}
 
-func (m *mockFileInfo) Name() string {
+func (*mockFileInfo) Name() string {
 	return "mockFileInfo"
 }
 
-func (m *mockFileInfo) Size() int64 {
+func (*mockFileInfo) Size() int64 {
 	return 256
 }
 
-func (m *mockFileInfo) Mode() os.FileMode {
+func (*mockFileInfo) Mode() os.FileMode {
 	return os.ModeSymlink
 }
 
-func (m *mockFileInfo) ModTime() time.Time {
+func (*mockFileInfo) ModTime() time.Time {
 	return time.Now()
 }
 
-func (m *mockFileInfo) IsDir() bool {
+func (*mockFileInfo) IsDir() bool {
 	return false
 }
 
-func (m *mockFileInfo) Sys() any {
+func (*mockFileInfo) Sys() any {
 	return nil
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -19,49 +19,49 @@ import (
 
 type mockNodeCapacity struct{}
 
-func (m *mockNodeCapacity) getMemoryCapacity() int64 {
+func (*mockNodeCapacity) getMemoryCapacity() int64 {
 	return 1024
 }
 
-func (m *mockNodeCapacity) getNumCores() int64 {
+func (*mockNodeCapacity) getNumCores() int64 {
 	return 2
 }
 
 type mockEC2Metadata struct{}
 
-func (m *mockEC2Metadata) getInstanceID() string {
+func (*mockEC2Metadata) getInstanceID() string {
 	return "instance-id"
 }
 
-func (m *mockEC2Metadata) getInstanceIP() string {
+func (*mockEC2Metadata) getInstanceIP() string {
 	return "instance-ip"
 }
 
-func (m *mockEC2Metadata) getInstanceType() string {
+func (*mockEC2Metadata) getInstanceType() string {
 	return "instance-type"
 }
 
-func (m *mockEC2Metadata) getRegion() string {
+func (*mockEC2Metadata) getRegion() string {
 	return "region"
 }
 
 type mockEBSVolume struct{}
 
-func (m *mockEBSVolume) getEBSVolumeID(_ string) string {
+func (*mockEBSVolume) getEBSVolumeID(_ string) string {
 	return "ebs-volume-id"
 }
 
-func (m *mockEBSVolume) extractEbsIDsUsedByKubernetes() map[string]string {
+func (*mockEBSVolume) extractEbsIDsUsedByKubernetes() map[string]string {
 	return map[string]string{}
 }
 
 type mockEC2Tags struct{}
 
-func (m *mockEC2Tags) getClusterName() string {
+func (*mockEC2Tags) getClusterName() string {
 	return "cluster-name"
 }
 
-func (m *mockEC2Tags) getAutoScalingGroupName() string {
+func (*mockEC2Tags) getAutoScalingGroupName() string {
 	return "asg"
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -33,26 +33,26 @@ var mockClient = new(MockClient)
 
 type mockK8sClient struct{}
 
-func (m *mockK8sClient) GetClientSet() kubernetes.Interface {
+func (*mockK8sClient) GetClientSet() kubernetes.Interface {
 	return fake.NewSimpleClientset()
 }
 
-func (m *mockK8sClient) GetEpClient() k8sclient.EpClient {
+func (*mockK8sClient) GetEpClient() k8sclient.EpClient {
 	return mockClient
 }
 
-func (m *mockK8sClient) GetNodeClient() k8sclient.NodeClient {
+func (*mockK8sClient) GetNodeClient() k8sclient.NodeClient {
 	return mockClient
 }
 
-func (m *mockK8sClient) GetPodClient() k8sclient.PodClient {
+func (*mockK8sClient) GetPodClient() k8sclient.PodClient {
 	return mockClient
 }
 
-func (m *mockK8sClient) ShutdownNodeClient() {
+func (*mockK8sClient) ShutdownNodeClient() {
 }
 
-func (m *mockK8sClient) ShutdownPodClient() {
+func (*mockK8sClient) ShutdownPodClient() {
 }
 
 type MockClient struct {
@@ -88,15 +88,15 @@ func (client *MockClient) ServiceToPodNum() map[k8sclient.Service]int {
 
 type mockEventBroadcaster struct{}
 
-func (m *mockEventBroadcaster) StartRecordingToSink(_ record.EventSink) watch.Interface {
+func (*mockEventBroadcaster) StartRecordingToSink(_ record.EventSink) watch.Interface {
 	return watch.NewFake()
 }
 
-func (m *mockEventBroadcaster) StartLogging(_ func(format string, args ...any)) watch.Interface {
+func (*mockEventBroadcaster) StartLogging(_ func(format string, args ...any)) watch.Interface {
 	return watch.NewFake()
 }
 
-func (m *mockEventBroadcaster) NewRecorder(_ *runtime.Scheme, _ v1.EventSource) record.EventRecorderLogger {
+func (*mockEventBroadcaster) NewRecorder(_ *runtime.Scheme, _ v1.EventSource) record.EventRecorderLogger {
 	return record.NewFakeRecorder(100)
 }
 
@@ -142,7 +142,7 @@ func assertMetricValueEqual(t *testing.T, m pmetric.Metrics, metricName string, 
 
 type MockClusterNameProvider struct{}
 
-func (m MockClusterNameProvider) GetClusterName() string {
+func (MockClusterNameProvider) GetClusterName() string {
 	return "cluster-name"
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -388,25 +388,25 @@ func TestGetJobNamePrefix(t *testing.T) {
 
 type mockReplicaSetInfo1 struct{}
 
-func (m *mockReplicaSetInfo1) ReplicaSetToDeployment() map[string]string {
+func (*mockReplicaSetInfo1) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}
 }
 
 type mockK8sClient1 struct{}
 
-func (m *mockK8sClient1) GetReplicaSetClient() k8sclient.ReplicaSetClient {
+func (*mockK8sClient1) GetReplicaSetClient() k8sclient.ReplicaSetClient {
 	return &mockReplicaSetInfo1{}
 }
 
 type mockReplicaSetInfo2 struct{}
 
-func (m *mockReplicaSetInfo2) ReplicaSetToDeployment() map[string]string {
+func (*mockReplicaSetInfo2) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{"DeploymentTest-sftrz2785": "DeploymentTest"}
 }
 
 type mockK8sClient2 struct{}
 
-func (m *mockK8sClient2) GetReplicaSetClient() k8sclient.ReplicaSetClient {
+func (*mockK8sClient2) GetReplicaSetClient() k8sclient.ReplicaSetClient {
 	return &mockReplicaSetInfo2{}
 }
 
@@ -571,7 +571,7 @@ func TestPodStore_addPodOwnersAndPodName(t *testing.T) {
 
 type mockPodClient struct{}
 
-func (m *mockPodClient) ListPods() ([]corev1.Pod, error) {
+func (*mockPodClient) ListPods() ([]corev1.Pod, error) {
 	pod := getBaseTestPodInfo()
 	podList := []corev1.Pod{*pod}
 	return podList, nil

--- a/receiver/awscontainerinsightreceiver/internal/stores/servicestore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/servicestore_test.go
@@ -16,7 +16,7 @@ import (
 
 type mockEndpoint struct{}
 
-func (m *mockEndpoint) PodKeyToServiceNames() map[string][]string {
+func (*mockEndpoint) PodKeyToServiceNames() map[string][]string {
 	return map[string][]string{
 		"namespace:default,podName:test-pod": {"test-service"},
 	}

--- a/receiver/awscontainerinsightreceiver/receiver_test.go
+++ b/receiver/awscontainerinsightreceiver/receiver_test.go
@@ -19,23 +19,23 @@ import (
 // Mock cadvisor
 type mockCadvisor struct{}
 
-func (c *mockCadvisor) GetMetrics() []pmetric.Metrics {
+func (*mockCadvisor) GetMetrics() []pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	return []pmetric.Metrics{md}
 }
 
-func (c *mockCadvisor) Shutdown() error {
+func (*mockCadvisor) Shutdown() error {
 	return nil
 }
 
 // Mock k8sapiserver
 type mockK8sAPIServer struct{}
 
-func (m *mockK8sAPIServer) Shutdown() error {
+func (*mockK8sAPIServer) Shutdown() error {
 	return nil
 }
 
-func (m *mockK8sAPIServer) GetMetrics() []pmetric.Metrics {
+func (*mockK8sAPIServer) GetMetrics() []pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	return []pmetric.Metrics{md}
 }

--- a/receiver/awsecscontainermetricsreceiver/receiver_test.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver_test.go
@@ -93,7 +93,7 @@ func TestCollectDataFromEndpointWithConsumerError(t *testing.T) {
 
 type invalidFakeClient struct{}
 
-func (f invalidFakeClient) GetResponse(_ string) ([]byte, error) {
+func (invalidFakeClient) GetResponse(string) ([]byte, error) {
 	return nil, errors.New("intentional error")
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
@@ -141,6 +141,6 @@ func parseLog(data []byte) (log cWLog, control bool, _ error) {
 }
 
 // Type of the serialized messages.
-func (u *Unmarshaler) Type() string {
+func (*Unmarshaler) Type() string {
 	return TypeStr
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
@@ -165,12 +165,12 @@ func (u Unmarshaler) UnmarshalMetrics(record []byte) (pmetric.Metrics, error) {
 }
 
 // isValid validates that the cWMetric has been unmarshalled correctly.
-func (u Unmarshaler) isValid(metric cWMetric) bool {
+func (Unmarshaler) isValid(metric cWMetric) bool {
 	return metric.MetricName != "" && metric.Namespace != "" && metric.Unit != "" && metric.Value.isSet
 }
 
 // Type of the serialized messages.
-func (u Unmarshaler) Type() string {
+func (Unmarshaler) Type() string {
 	return TypeStr
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
@@ -40,6 +40,6 @@ func (u *NopLogsUnmarshaler) UnmarshalLogs([]byte) (plog.Logs, error) {
 }
 
 // Type of the serialized messages.
-func (u *NopLogsUnmarshaler) Type() string {
+func (*NopLogsUnmarshaler) Type() string {
 	return typeStr
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
@@ -42,6 +42,6 @@ func (u *NopMetricsUnmarshaler) UnmarshalMetrics([]byte) (pmetric.Metrics, error
 }
 
 // Type of the serialized messages.
-func (u *NopMetricsUnmarshaler) Type() string {
+func (*NopMetricsUnmarshaler) Type() string {
 	return typeStr
 }

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -36,7 +36,7 @@ func (rc *logsRecordConsumer) ConsumeLogs(_ context.Context, logs plog.Logs) err
 	return nil
 }
 
-func (rc *logsRecordConsumer) Capabilities() consumer.Capabilities {
+func (*logsRecordConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -35,7 +35,7 @@ func (rc *metricsRecordConsumer) ConsumeMetrics(_ context.Context, metrics pmetr
 	return nil
 }
 
-func (rc *metricsRecordConsumer) Capabilities() consumer.Capabilities {
+func (*metricsRecordConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -246,7 +246,7 @@ func (fmr *firehoseReceiver) validate(r *http.Request) (int, error) {
 }
 
 // getCommonAttributes unmarshalls the common attributes from the request header
-func (fmr *firehoseReceiver) getCommonAttributes(r *http.Request) (map[string]string, error) {
+func (*firehoseReceiver) getCommonAttributes(r *http.Request) (map[string]string, error) {
 	attributes := make(map[string]string)
 	if commonAttributes := r.Header.Get(headerFirehoseCommonAttributes); commonAttributes != "" {
 		var fca firehoseCommonAttributes

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -312,11 +312,11 @@ type plogUnmarshalerExtension struct {
 	logs plog.Logs
 }
 
-func (e plogUnmarshalerExtension) Start(context.Context, component.Host) error {
+func (plogUnmarshalerExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e plogUnmarshalerExtension) Shutdown(context.Context) error {
+func (plogUnmarshalerExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -328,11 +328,11 @@ type pmetricUnmarshalerExtension struct {
 	metrics pmetric.Metrics
 }
 
-func (e pmetricUnmarshalerExtension) Start(context.Context, component.Host) error {
+func (pmetricUnmarshalerExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e pmetricUnmarshalerExtension) Shutdown(context.Context) error {
+func (pmetricUnmarshalerExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/receiver/awss3receiver/notifications_test.go
+++ b/receiver/awss3receiver/notifications_test.go
@@ -45,15 +45,15 @@ type hostWithCustomCapabilityRegistry struct {
 	extension *mockCustomCapabilityRegistry
 }
 
-func (h hostWithCustomCapabilityRegistry) Start(context.Context, component.Host) error {
+func (hostWithCustomCapabilityRegistry) Start(context.Context, component.Host) error {
 	panic("unsupported")
 }
 
-func (h hostWithCustomCapabilityRegistry) Shutdown(context.Context) error {
+func (hostWithCustomCapabilityRegistry) Shutdown(context.Context) error {
 	panic("unsupported")
 }
 
-func (h hostWithCustomCapabilityRegistry) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+func (hostWithCustomCapabilityRegistry) GetFactory(component.Kind, component.Type) component.Factory {
 	panic("unsupported")
 }
 
@@ -73,7 +73,7 @@ func (m *mockCustomCapabilityRegistry) Register(_ string, _ ...opampcustommessag
 	return m, nil
 }
 
-func (m *mockCustomCapabilityRegistry) Message() <-chan *protobufs.CustomMessage {
+func (*mockCustomCapabilityRegistry) Message() <-chan *protobufs.CustomMessage {
 	panic("unsupported")
 }
 

--- a/receiver/awss3receiver/receiver_test.go
+++ b/receiver/awss3receiver/receiver_test.go
@@ -75,11 +75,11 @@ func (h hostWithExtensions) GetExtensions() map[component.ID]component.Component
 
 type nonEncodingExtension struct{}
 
-func (e nonEncodingExtension) Start(_ context.Context, _ component.Host) error {
+func (nonEncodingExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e nonEncodingExtension) Shutdown(_ context.Context) error {
+func (nonEncodingExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -89,11 +89,11 @@ type unmarshalExtension struct {
 	log    plog.Logs
 }
 
-func (e unmarshalExtension) Start(_ context.Context, _ component.Host) error {
+func (unmarshalExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (e unmarshalExtension) Shutdown(_ context.Context) error {
+func (unmarshalExtension) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/receiver/awss3receiver/s3reader_test.go
+++ b/receiver/awss3receiver/s3reader_test.go
@@ -321,11 +321,11 @@ type mockNotifier struct {
 	messages []statusNotification
 }
 
-func (m *mockNotifier) Start(_ context.Context, _ component.Host) error {
+func (*mockNotifier) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (m *mockNotifier) Shutdown(_ context.Context) error {
+func (*mockNotifier) Shutdown(context.Context) error {
 	return nil
 }
 

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -385,7 +385,7 @@ func (m *mockNetError) Timeout() bool {
 	return m.timeout
 }
 
-func (m *mockNetError) Temporary() bool {
+func (*mockNetError) Temporary() bool {
 	return false
 }
 
@@ -417,7 +417,7 @@ func (m *mockSocketConn) Read(b []byte) (int, error) {
 	return copied, m.expectedError
 }
 
-func (m *mockSocketConn) Close() error { return nil }
+func (*mockSocketConn) Close() error { return nil }
 
 func createAndOptionallyStartPoller(
 	t *testing.T,

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -229,11 +229,11 @@ type mockPoller struct {
 	closeErr error
 }
 
-func (m *mockPoller) SegmentsChan() <-chan udppoller.RawSegment {
+func (*mockPoller) SegmentsChan() <-chan udppoller.RawSegment {
 	return make(chan udppoller.RawSegment, 1)
 }
 
-func (m *mockPoller) Start(_ context.Context) {}
+func (*mockPoller) Start(context.Context) {}
 
 func (m *mockPoller) Close() error {
 	if m.closeErr != nil {
@@ -246,7 +246,7 @@ type mockProxy struct {
 	closeErr error
 }
 
-func (m *mockProxy) ListenAndServe() error {
+func (*mockProxy) ListenAndServe() error {
 	return errors.New("returning from ListenAndServe() always errors out")
 }
 

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -43,7 +43,7 @@ func NewFactory() receiver.Factory {
 		receiver.WithLogs(f.createLogsReceiver, metadata.LogsStability))
 }
 
-func (f *blobReceiverFactory) createDefaultConfig() component.Config {
+func (*blobReceiverFactory) createDefaultConfig() component.Config {
 	return &Config{
 		Logs:           LogsConfig{ContainerName: logsContainerName},
 		Traces:         TracesConfig{ContainerName: tracesContainerName},
@@ -116,7 +116,7 @@ func (f *blobReceiverFactory) getReceiver(
 	return r.Unwrap(), err
 }
 
-func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logger) (blobEventHandler, error) {
+func (*blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logger) (blobEventHandler, error) {
 	var bc blobClient
 	var err error
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -24,7 +24,7 @@ import (
 
 type mockHubWrapper struct{}
 
-func (m mockHubWrapper) GetRuntimeInformation(_ context.Context) (*eventhub.HubRuntimeInformation, error) {
+func (mockHubWrapper) GetRuntimeInformation(context.Context) (*eventhub.HubRuntimeInformation, error) {
 	return &eventhub.HubRuntimeInformation{
 		Path:           "foo",
 		CreatedAt:      time.Now(),
@@ -33,13 +33,13 @@ func (m mockHubWrapper) GetRuntimeInformation(_ context.Context) (*eventhub.HubR
 	}, nil
 }
 
-func (m mockHubWrapper) Receive(ctx context.Context, _ string, _ eventhub.Handler, _ ...eventhub.ReceiveOption) (listerHandleWrapper, error) {
+func (mockHubWrapper) Receive(ctx context.Context, _ string, _ eventhub.Handler, _ ...eventhub.ReceiveOption) (listerHandleWrapper, error) {
 	return &mockListenerHandleWrapper{
 		ctx: ctx,
 	}, nil
 }
 
-func (m mockHubWrapper) Close(_ context.Context) error {
+func (mockHubWrapper) Close(context.Context) error {
 	return nil
 }
 
@@ -51,7 +51,7 @@ func (m *mockListenerHandleWrapper) Done() <-chan struct{} {
 	return m.ctx.Done()
 }
 
-func (m mockListenerHandleWrapper) Err() error {
+func (mockListenerHandleWrapper) Err() error {
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (m *mockDataConsumer) setNextTracesConsumer(nextTracesConsumer consumer.Tra
 	m.nextTracesConsumer = nextTracesConsumer
 }
 
-func (m *mockDataConsumer) setNextMetricsConsumer(_ consumer.Metrics) {}
+func (*mockDataConsumer) setNextMetricsConsumer(consumer.Metrics) {}
 
 func (m *mockDataConsumer) consume(ctx context.Context, event *eventhub.Event) error {
 	logsContext := m.obsrecv.StartLogsOp(ctx)

--- a/receiver/azureeventhubreceiver/rawlogs_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/rawlogs_unmarshaler.go
@@ -22,7 +22,7 @@ func newRawLogsUnmarshaler(logger *zap.Logger) eventLogsUnmarshaler {
 	}
 }
 
-func (r rawLogsUnmarshaler) UnmarshalLogs(event *eventhub.Event) (plog.Logs, error) {
+func (rawLogsUnmarshaler) UnmarshalLogs(event *eventhub.Event) (plog.Logs, error) {
 	l := plog.NewLogs()
 	lr := l.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 	slice := lr.Body().SetEmptyBytes()

--- a/receiver/carbonreceiver/internal/transport/server_test.go
+++ b/receiver/carbonreceiver/internal/transport/server_test.go
@@ -106,14 +106,14 @@ type mockReporter struct {
 	wgMetricsProcessed sync.WaitGroup
 }
 
-func (m *mockReporter) OnDataReceived(ctx context.Context) context.Context {
+func (*mockReporter) OnDataReceived(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (m *mockReporter) OnTranslationError(context.Context, error) {}
+func (*mockReporter) OnTranslationError(context.Context, error) {}
 
 func (m *mockReporter) OnMetricsProcessed(context.Context, int, error) {
 	m.wgMetricsProcessed.Done()
 }
 
-func (m *mockReporter) OnDebugf(string, ...any) {}
+func (*mockReporter) OnDebugf(string, ...any) {}

--- a/receiver/carbonreceiver/protocol/plaintext_parser.go
+++ b/receiver/carbonreceiver/protocol/plaintext_parser.go
@@ -17,7 +17,7 @@ var _ ParserConfig = (*PlaintextConfig)(nil)
 
 // BuildParser creates a new Parser instance that receives plaintext
 // Carbon data.
-func (p *PlaintextConfig) BuildParser() (Parser, error) {
+func (*PlaintextConfig) BuildParser() (Parser, error) {
 	pathParser := &PlaintextPathParser{}
 	return NewParser(pathParser)
 }
@@ -37,7 +37,7 @@ type PlaintextPathParser struct{}
 //
 // tag is of the form "key=val", where key can contain any char except ";!^=" and
 // val can contain any char except ";~".
-func (p *PlaintextPathParser) ParsePath(path string, parsedPath *ParsedPath) error {
+func (*PlaintextPathParser) ParsePath(path string, parsedPath *ParsedPath) error {
 	parts := strings.SplitN(path, ";", 2)
 	if len(parts) < 1 || parts[0] == "" {
 		return fmt.Errorf("empty metric name extracted from path [%s]", path)

--- a/receiver/carbonreceiver/receiver_test.go
+++ b/receiver/carbonreceiver/receiver_test.go
@@ -248,7 +248,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/couchdbreceiver/metrics.go
+++ b/receiver/couchdbreceiver/metrics.go
@@ -167,7 +167,7 @@ func getValueFromBody(keys []string, body map[string]any) (any, error) {
 	return currentValue, nil
 }
 
-func (c *couchdbScraper) parseInt(value any) (int64, error) {
+func (*couchdbScraper) parseInt(value any) (int64, error) {
 	switch i := value.(type) {
 	case int64:
 		return i, nil
@@ -177,7 +177,7 @@ func (c *couchdbScraper) parseInt(value any) (int64, error) {
 	return 0, errors.New("could not parse value as int")
 }
 
-func (c *couchdbScraper) parseFloat(value any) (float64, error) {
+func (*couchdbScraper) parseFloat(value any) (float64, error) {
 	if f, ok := value.(float64); ok {
 		return f, nil
 	}

--- a/receiver/datadogreceiver/internal/translator/series.go
+++ b/receiver/datadogreceiver/internal/translator/series.go
@@ -28,7 +28,7 @@ type SeriesList struct {
 	Series []datadogV1.Series `json:"series"`
 }
 
-func (mt *MetricsTranslator) HandleSeriesV2Payload(req *http.Request) (mp []*gogen.MetricPayload_MetricSeries, err error) {
+func (*MetricsTranslator) HandleSeriesV2Payload(req *http.Request) (mp []*gogen.MetricPayload_MetricSeries, err error) {
 	buf := GetBuffer()
 	defer PutBuffer(buf)
 	if _, err := io.Copy(buf, req.Body); err != nil {

--- a/receiver/datadogreceiver/internal/translator/sketches.go
+++ b/receiver/datadogreceiver/internal/translator/sketches.go
@@ -51,7 +51,7 @@ const (
 )
 
 // Unmarshal the sketch payload, which contains the underlying Dogsketch structure used for the translation
-func (mt *MetricsTranslator) HandleSketchesPayload(req *http.Request) (sp []gogen.SketchPayload_Sketch, err error) {
+func (*MetricsTranslator) HandleSketchesPayload(req *http.Request) (sp []gogen.SketchPayload_Sketch, err error) {
 	buf := GetBuffer()
 	defer PutBuffer(buf)
 	if _, err := io.Copy(buf, req.Body); err != nil {

--- a/receiver/datadogreceiver/internal/translator/stats_translator.go
+++ b/receiver/datadogreceiver/internal/translator/stats_translator.go
@@ -83,7 +83,7 @@ func (st *StatsTranslator) processStats(in *pb.ClientStatsPayload, lang, tracerV
 	return in
 }
 
-func (st *StatsTranslator) normalizeStatsGroup(b *pb.ClientGroupedStats, lang string) {
+func (*StatsTranslator) normalizeStatsGroup(b *pb.ClientGroupedStats, lang string) {
 	b.Name, _ = normalizeutil.NormalizeName(b.Name)
 	b.Service, _ = normalizeutil.NormalizeService(b.Service, lang)
 	if b.Resource == "" {

--- a/receiver/dockerstatsreceiver/integration_test.go
+++ b/receiver/dockerstatsreceiver/integration_test.go
@@ -163,7 +163,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -24,12 +24,12 @@ func NewFactory() receiver.Factory {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return createDefaultConfig()
 }
 
@@ -44,7 +44,7 @@ func createDefaultConfig() *FileLogConfig {
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*FileLogConfig).BaseConfig
 }
 
@@ -58,6 +58,6 @@ type FileLogConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*FileLogConfig).InputConfig)
 }

--- a/receiver/fluentforwardreceiver/internal/ack_test.go
+++ b/receiver/fluentforwardreceiver/internal/ack_test.go
@@ -55,6 +55,6 @@ func (lw *limitedWriter) Write(p []byte) (n int, err error) {
 }
 
 // Close closes the writer.
-func (lw *limitedWriter) Close() error {
+func (*limitedWriter) Close() error {
 	return nil
 }

--- a/receiver/fluentforwardreceiver/timeext.go
+++ b/receiver/fluentforwardreceiver/timeext.go
@@ -21,7 +21,7 @@ func (*eventTimeExt) ExtensionType() int8 {
 	return 0x00
 }
 
-func (e *eventTimeExt) Len() int {
+func (*eventTimeExt) Len() int {
 	return 8
 }
 

--- a/receiver/githubreceiver/internal/scraper/githubscraper/factory.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/factory.go
@@ -24,7 +24,7 @@ const (
 
 type Factory struct{}
 
-func (f *Factory) CreateDefaultConfig() internal.Config {
+func (*Factory) CreateDefaultConfig() internal.Config {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Timeout = defaultHTTPTimeout
 	return &Config{
@@ -33,7 +33,7 @@ func (f *Factory) CreateDefaultConfig() internal.Config {
 	}
 }
 
-func (f *Factory) CreateMetricsScraper(
+func (*Factory) CreateMetricsScraper(
 	_ context.Context,
 	params receiver.Settings,
 	cfg internal.Config,

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers.go
@@ -22,7 +22,7 @@ const (
 	defaultReturnItems = 100
 )
 
-func (ghs *githubScraper) getRepos(
+func (*githubScraper) getRepos(
 	ctx context.Context,
 	client graphql.Client,
 	searchQuery string,

--- a/receiver/githubreceiver/trace_event_handling.go
+++ b/receiver/githubreceiver/trace_event_handling.go
@@ -173,7 +173,7 @@ func (gtr *githubTracesReceiver) createRootSpan(
 
 // createParentSpan creates a parent span based on the provided event, associated
 // with the deterministic traceID.
-func (gtr *githubTracesReceiver) createParentSpan(
+func (*githubTracesReceiver) createParentSpan(
 	resourceSpans ptrace.ResourceSpans,
 	event *github.WorkflowJobEvent,
 	traceID pcommon.TraceID,
@@ -288,7 +288,7 @@ func newUniqueSteps(steps []*github.TaskStep) []string {
 
 // createStepSpan creates a span with a deterministic spandID for the provided
 // step.
-func (gtr *githubTracesReceiver) createStepSpan(
+func (*githubTracesReceiver) createStepSpan(
 	resourceSpans ptrace.ResourceSpans,
 	traceID pcommon.TraceID,
 	parentSpanID pcommon.SpanID,
@@ -361,7 +361,7 @@ func newStepSpanID(runID int64, runAttempt int, jobName, stepName string, number
 
 // createJobQueueSpan creates a span for the job queue based on the provided
 // event by using the delta between the job created and completed times.
-func (gtr *githubTracesReceiver) createJobQueueSpan(
+func (*githubTracesReceiver) createJobQueueSpan(
 	resourceSpans ptrace.ResourceSpans,
 	event *github.WorkflowJobEvent,
 	traceID pcommon.TraceID,

--- a/receiver/githubreceiver/trace_receiver.go
+++ b/receiver/githubreceiver/trace_receiver.go
@@ -188,7 +188,7 @@ func (gtr *githubTracesReceiver) handleReq(w http.ResponseWriter, req *http.Requ
 }
 
 // Simple healthcheck endpoint.
-func (gtr *githubTracesReceiver) handleHealthCheck(w http.ResponseWriter, _ *http.Request) {
+func (*githubTracesReceiver) handleHealthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 

--- a/receiver/gitlabreceiver/model.go
+++ b/receiver/gitlabreceiver/model.go
@@ -47,16 +47,16 @@ func (p *glPipeline) setSpanData(span ptrace.Span) error {
 }
 
 // the glPipeline doesn't have a parent span ID, bc it's the root span
-func (p *glPipeline) setSpanIDs(span ptrace.Span, spanID pcommon.SpanID) error {
+func (*glPipeline) setSpanIDs(span ptrace.Span, spanID pcommon.SpanID) error {
 	span.SetSpanID(spanID)
 	return nil
 }
 
-func (p *glPipeline) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
+func (*glPipeline) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 
-func (p *glPipeline) setAttributes(_ ptrace.Span) error {
+func (*glPipeline) setAttributes(_ ptrace.Span) error {
 	// ToDo in next PR: set semconv attributes
 	return nil
 }
@@ -99,11 +99,11 @@ func (s *glPipelineStage) setSpanIDs(span ptrace.Span, parentSpanID pcommon.Span
 	return nil
 }
 
-func (s *glPipelineStage) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
+func (*glPipelineStage) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 
-func (s *glPipelineStage) setAttributes(_ ptrace.Span) error {
+func (*glPipelineStage) setAttributes(ptrace.Span) error {
 	// ToDo in next PR: set semconv attributes
 	return nil
 }
@@ -171,11 +171,11 @@ func (j *glPipelineJob) setSpanIDs(span ptrace.Span, parentSpanID pcommon.SpanID
 	return nil
 }
 
-func (j *glPipelineJob) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
+func (*glPipelineJob) setTimeStamps(span ptrace.Span, startTime, endTime string) error {
 	return setSpanTimeStamps(span, startTime, endTime)
 }
 
-func (j *glPipelineJob) setAttributes(_ ptrace.Span) error {
+func (*glPipelineJob) setAttributes(ptrace.Span) error {
 	// ToDo in next PR: set semconv attributes
 	return nil
 }

--- a/receiver/gitlabreceiver/traces_event_handling.go
+++ b/receiver/gitlabreceiver/traces_event_handling.go
@@ -113,7 +113,7 @@ func (gtr *gitlabTracesReceiver) processJobSpans(r ptrace.ResourceSpans, p *glPi
 	return nil
 }
 
-func (gtr *gitlabTracesReceiver) createSpan(resourceSpans ptrace.ResourceSpans, e GitlabEvent, traceID pcommon.TraceID, spanID pcommon.SpanID) error {
+func (*gitlabTracesReceiver) createSpan(resourceSpans ptrace.ResourceSpans, e GitlabEvent, traceID pcommon.TraceID, spanID pcommon.SpanID) error {
 	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
 	span := scopeSpans.Spans().AppendEmpty()
 
@@ -243,7 +243,7 @@ func (gtr *gitlabTracesReceiver) newStages(pipeline *glPipeline) (map[string]*gl
 }
 
 // setStageTime determines stage start/finish times by finding the earliest start and latest finish time
-func (gtr *gitlabTracesReceiver) setStageTime(stage *glPipelineStage, job glPipelineJob) error {
+func (*gitlabTracesReceiver) setStageTime(stage *glPipelineStage, job glPipelineJob) error {
 	// Handle start time
 	if stage.StartedAt == "" {
 		stage.StartedAt = job.StartedAt

--- a/receiver/googlecloudpubsubreceiver/factory.go
+++ b/receiver/googlecloudpubsubreceiver/factory.go
@@ -37,7 +37,7 @@ type pubsubReceiverFactory struct {
 	receivers map[*Config]*pubsubReceiver
 }
 
-func (factory *pubsubReceiverFactory) CreateDefaultConfig() component.Config {
+func (*pubsubReceiverFactory) CreateDefaultConfig() component.Config {
 	return &Config{}
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
@@ -21,19 +21,19 @@ func NewNopItemFilterResolver() ItemFilterResolver {
 	}
 }
 
-func (f *nopItemCardinalityFilter) Filter(sourceItems []*Item) []*Item {
+func (*nopItemCardinalityFilter) Filter(sourceItems []*Item) []*Item {
 	return sourceItems
 }
 
-func (f *nopItemCardinalityFilter) Shutdown() error {
+func (*nopItemCardinalityFilter) Shutdown() error {
 	return nil
 }
 
-func (f *nopItemCardinalityFilter) TotalLimit() int {
+func (*nopItemCardinalityFilter) TotalLimit() int {
 	return 0
 }
 
-func (f *nopItemCardinalityFilter) LimitByTimestamp() int {
+func (*nopItemCardinalityFilter) LimitByTimestamp() int {
 	return 0
 }
 
@@ -41,6 +41,6 @@ func (r *nopItemFilterResolver) Resolve(string) (ItemFilter, error) {
 	return r.nopFilter, nil
 }
 
-func (r *nopItemFilterResolver) Shutdown() error {
+func (*nopItemFilterResolver) Shutdown() error {
 	return nil
 }

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
@@ -21,7 +21,7 @@ type mockFilter struct {
 	mock.Mock
 }
 
-func (f *mockFilter) Filter(source []*filter.Item) []*filter.Item {
+func (*mockFilter) Filter(source []*filter.Item) []*filter.Item {
 	return source
 }
 
@@ -30,11 +30,11 @@ func (f *mockFilter) Shutdown() error {
 	return args.Error(0)
 }
 
-func (f *mockFilter) TotalLimit() int {
+func (*mockFilter) TotalLimit() int {
 	return 0
 }
 
-func (f *mockFilter) LimitByTimestamp() int {
+func (*mockFilter) LimitByTimestamp() int {
 	return 0
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -22,7 +22,7 @@ type mockReader struct {
 	mock.Mock
 }
 
-func (r *mockReader) Name() string {
+func (*mockReader) Name() string {
 	return "mockReader"
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
@@ -20,7 +20,7 @@ type mockCompositeReader struct {
 	mock.Mock
 }
 
-func (r *mockCompositeReader) Name() string {
+func (*mockCompositeReader) Name() string {
 	return "mockCompositeReader"
 }
 
@@ -29,7 +29,7 @@ func (r *mockCompositeReader) Read(ctx context.Context) ([]*metadata.MetricsData
 	return args.Get(0).([]*metadata.MetricsDataPoint), args.Error(1)
 }
 
-func (r *mockCompositeReader) Shutdown() {
+func (*mockCompositeReader) Shutdown() {
 	// Do nothing
 }
 

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -28,7 +28,7 @@ type mockCompositeReader struct {
 	mock.Mock
 }
 
-func (r *mockCompositeReader) Name() string {
+func (*mockCompositeReader) Name() string {
 	return "mockCompositeReader"
 }
 
@@ -37,7 +37,7 @@ func (r *mockCompositeReader) Read(ctx context.Context) ([]*metadata.MetricsData
 	return args.Get(0).([]*metadata.MetricsDataPoint), args.Error(1)
 }
 
-func (r *mockCompositeReader) Shutdown() {
+func (*mockCompositeReader) Shutdown() {
 	// Do nothing
 }
 
@@ -51,7 +51,7 @@ func newMetricsBuilder(throwErrorOnShutdown bool) metadata.MetricsBuilder {
 	}
 }
 
-func (b *metricsBuilder) Build([]*metadata.MetricsDataPoint) (pmetric.Metrics, error) {
+func (*metricsBuilder) Build([]*metadata.MetricsDataPoint) (pmetric.Metrics, error) {
 	return pmetric.NewMetrics(), nil
 }
 

--- a/receiver/haproxyreceiver/scraper.go
+++ b/receiver/haproxyreceiver/scraper.go
@@ -256,7 +256,7 @@ func (s *haproxyScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	return s.mb.Emit(), nil
 }
 
-func (s *haproxyScraper) readStats(buf []byte) ([]map[string]string, error) {
+func (*haproxyScraper) readStats(buf []byte) ([]map[string]string, error) {
 	reader := csv.NewReader(bytes.NewReader(bytes.TrimSpace(buf)))
 	headers, err := reader.Read()
 	if err != nil {

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -221,7 +221,7 @@ type notifyingSink struct {
 	ch              chan int
 }
 
-func (s *notifyingSink) Capabilities() consumer.Capabilities {
+func (*notifyingSink) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -37,7 +37,7 @@ func (s *cpuScraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization 
 	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Iowait, cpuUtilization.CPU, metadata.AttributeStateWait)
 }
 
-func (s *cpuScraper) getCPUInfo() ([]cpuInfo, error) {
+func (*cpuScraper) getCPUInfo() ([]cpuInfo, error) {
 	var cpuInfos []cpuInfo
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -27,7 +27,7 @@ func (s *cpuScraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization 
 	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
 }
 
-func (s *cpuScraper) getCPUInfo() ([]cpuInfo, error) {
+func (*cpuScraper) getCPUInfo() ([]cpuInfo, error) {
 	var cpuInfos []cpuInfo
 	return cpuInfos, nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
@@ -34,5 +34,5 @@ func (s *filesystemsScraper) recordFileSystemUsageMetric(now pcommon.Timestamp, 
 
 const systemSpecificMetricsLen = 0
 
-func (s *filesystemsScraper) recordSystemSpecificMetrics(_ pcommon.Timestamp, _ []*deviceUsage) {
+func (*filesystemsScraper) recordSystemSpecificMetrics(pcommon.Timestamp, []*deviceUsage) {
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -22,5 +22,5 @@ func (s *memoryScraper) recordMemoryUtilizationMetric(now pcommon.Timestamp, mem
 	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Free)/float64(memInfo.Total), metadata.AttributeStateFree)
 }
 
-func (s *memoryScraper) recordSystemSpecificMetrics(_ pcommon.Timestamp, _ *mem.VirtualMemoryStat) {
+func (*memoryScraper) recordSystemSpecificMetrics(pcommon.Timestamp, *mem.VirtualMemoryStat) {
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
@@ -27,6 +27,6 @@ var allTCPStates = []string{
 	"TIME_WAIT",
 }
 
-func (s *networkScraper) recordNetworkConntrackMetrics(context.Context) error {
+func (*networkScraper) recordNetworkConntrackMetrics(context.Context) error {
 	return nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/nfs_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/nfs_scraper.go
@@ -27,11 +27,11 @@ func newNfsScraper(_ context.Context, settings scraper.Settings, cfg *Config) *n
 	return &nfsScraper{settings: settings, config: cfg}
 }
 
-func (s *nfsScraper) start(_ context.Context, _ component.Host) error {
+func (s *nfsScraper) start(context.Context, component.Host) error {
 	s.mb = metadata.NewMetricsBuilder(s.config.MetricsBuilderConfig, s.settings)
 	return nil
 }
 
-func (s *nfsScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
+func (*nfsScraper) scrape(context.Context) (pmetric.Metrics, error) {
 	return pmetric.NewMetrics(), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
@@ -14,6 +14,6 @@ const (
 	enableProcessesCreated = false
 )
 
-func (s *processesScraper) getProcessesMetadata(context.Context) (processesMetadata, error) {
+func (*processesScraper) getProcessesMetadata(context.Context) (processesMetadata, error) {
 	return processesMetadata{}, nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -177,7 +177,7 @@ var fakeProcessesData = []proc{
 
 type errProcess struct{}
 
-func (e errProcess) Status() ([]string, error) {
+func (errProcess) Status() ([]string, error) {
 	return []string{""}, errors.New("errProcess")
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/get_process_handle_count_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/get_process_handle_count_others.go
@@ -14,6 +14,6 @@ const handleCountMetricsLen = 0
 
 var ErrHandlesPlatformSupport = errors.New("process handle collection is only supported on Windows")
 
-func (p *wrappedProcessHandle) GetProcessHandleCountWithContext(_ context.Context) (int64, error) {
+func (*wrappedProcessHandle) GetProcessHandleCountWithContext(context.Context) (int64, error) {
 	return 0, ErrHandlesPlatformSupport
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -419,7 +419,7 @@ type processHandlesMock struct {
 	handles []*processHandleMock
 }
 
-func (p *processHandlesMock) Pid(int) int32 {
+func (*processHandlesMock) Pid(int) int32 {
 	return 1
 }
 
@@ -1239,7 +1239,7 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 
 type ProcessReadError struct{}
 
-func (m *ProcessReadError) Error() string {
+func (*ProcessReadError) Error() string {
 	return "unable to read data"
 }
 

--- a/receiver/iisreceiver/scraper_test.go
+++ b/receiver/iisreceiver/scraper_test.go
@@ -183,17 +183,17 @@ func newMockWatcherFactorFromPath(watchErr error, value float64) func(string) (w
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (mpc *mockPerfCounter) ScrapeRawValue(_ *int64) (bool, error) {
+func (*mockPerfCounter) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 
 // ScrapeRawValues implements winperfcounters.PerfCounterWatcher.
-func (mpc *mockPerfCounter) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
+func (*mockPerfCounter) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
 	panic("unimplemented")
 }
 
 // Path
-func (mpc *mockPerfCounter) Path() string {
+func (*mockPerfCounter) Path() string {
 	return ""
 }
 
@@ -203,10 +203,10 @@ func (mpc *mockPerfCounter) ScrapeData() ([]winperfcounters.CounterValue, error)
 }
 
 // Close
-func (mpc *mockPerfCounter) Close() error {
+func (*mockPerfCounter) Close() error {
 	return nil
 }
 
-func (mpc *mockPerfCounter) Reset() error {
+func (*mockPerfCounter) Reset() error {
 	return nil
 }

--- a/receiver/influxdbreceiver/receiver.go
+++ b/receiver/influxdbreceiver/receiver.go
@@ -204,6 +204,6 @@ func (r *metricsReceiver) handleWrite(w http.ResponseWriter, req *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (r *metricsReceiver) handlePing(w http.ResponseWriter, _ *http.Request) {
+func (*metricsReceiver) handlePing(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -93,7 +93,7 @@ type mockConsumer struct {
 	lastMetricsConsumed pmetric.Metrics
 }
 
-func (m *mockConsumer) Capabilities() consumer.Capabilities {
+func (*mockConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -155,7 +155,7 @@ type agentHandler struct {
 }
 
 // EmitZipkinBatch is unsupported agent's
-func (h *agentHandler) EmitZipkinBatch(context.Context, []*zipkincore.Span) (err error) {
+func (*agentHandler) EmitZipkinBatch(context.Context, []*zipkincore.Span) (err error) {
 	panic("unsupported receiver")
 }
 
@@ -264,7 +264,7 @@ func (jr *jReceiver) buildProcessor(address string, cfg ServerConfigUDP, factory
 	return processor, nil
 }
 
-func (jr *jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpError) {
+func (*jReceiver) decodeThriftHTTPBody(r *http.Request) (*jaeger.Batch, *httpError) {
 	bodyBytes, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {

--- a/receiver/journaldreceiver/config.go
+++ b/receiver/journaldreceiver/config.go
@@ -29,12 +29,12 @@ func createDefaultConfig() component.Config {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*JournaldConfig).BaseConfig
 }
 
@@ -48,6 +48,6 @@ type JournaldConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*JournaldConfig).InputConfig)
 }

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -19,6 +19,6 @@ func newFactoryAdapter() receiver.Factory {
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return createDefaultConfig()
 }

--- a/receiver/k8sclusterreceiver/factory_test.go
+++ b/receiver/k8sclusterreceiver/factory_test.go
@@ -108,7 +108,7 @@ func newNopHostWithExporters() component.Host {
 	return &nopHostWithExporters{Host: newNopHost()}
 }
 
-func (n *nopHostWithExporters) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
+func (*nopHostWithExporters) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
 	return map[pipeline.Signal]map[component.ID]component.Component{
 		pipeline.SignalMetrics: {
 			component.MustNewIDWithName("nop", "withoutmetadata"): mockExporter{},

--- a/receiver/k8sclusterreceiver/mock_exporter_test.go
+++ b/receiver/k8sclusterreceiver/mock_exporter_test.go
@@ -14,11 +14,11 @@ import (
 
 type mockExporter struct{}
 
-func (m mockExporter) Start(context.Context, component.Host) error {
+func (mockExporter) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (m mockExporter) Shutdown(context.Context) error {
+func (mockExporter) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -28,15 +28,15 @@ type mockExporterWithK8sMetadata struct {
 	*consumertest.MetricsSink
 }
 
-func (m mockExporterWithK8sMetadata) Start(context.Context, component.Host) error {
+func (mockExporterWithK8sMetadata) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (m mockExporterWithK8sMetadata) Shutdown(context.Context) error {
+func (mockExporterWithK8sMetadata) Shutdown(context.Context) error {
 	return nil
 }
 
-func (m mockExporterWithK8sMetadata) ConsumeMetadata([]*metadata.MetadataUpdate) error {
+func (mockExporterWithK8sMetadata) ConsumeMetadata([]*metadata.MetadataUpdate) error {
 	consumeMetadataInvocation()
 	return nil
 }

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -34,7 +34,7 @@ type nopHost struct {
 	component.Host
 }
 
-func (nh *nopHost) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
+func (*nopHost) GetExporters() map[pipeline.Signal]map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/k8seventsreceiver/receiver.go
+++ b/receiver/k8seventsreceiver/receiver.go
@@ -118,7 +118,7 @@ func (kr *k8seventsReceiver) handleEvent(ev *corev1.Event) {
 
 // startWatchingNamespace creates an informer and starts
 // watching a specific namespace for the events.
-func (kr *k8seventsReceiver) startWatchingNamespace(
+func (*k8seventsReceiver) startWatchingNamespace(
 	clientset k8s.Interface,
 	handlers cache.ResourceEventHandlerFuncs,
 	ns string,

--- a/receiver/k8slogreceiver/receiver.go
+++ b/receiver/k8slogreceiver/receiver.go
@@ -13,18 +13,18 @@ import (
 
 type k8slogReceiver struct{}
 
-func (k *k8slogReceiver) Start(_ context.Context, _ component.Host) error {
+func (*k8slogReceiver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (k *k8slogReceiver) Shutdown(_ context.Context) error {
+func (*k8slogReceiver) Shutdown(context.Context) error {
 	return nil
 }
 
 func newReceiver(
-	_ receiver.Settings,
-	_ *Config,
-	_ consumer.Logs,
+	receiver.Settings,
+	*Config,
+	consumer.Logs,
 ) (receiver.Logs, error) {
 	return &k8slogReceiver{}, nil
 }

--- a/receiver/k8slogreceiver/runtime_api_config.go
+++ b/receiver/k8slogreceiver/runtime_api_config.go
@@ -74,15 +74,15 @@ type criConfig struct {
 	ContainerdState string `mapstructure:"containerd_state"`
 }
 
-func (c *criConfig) Validate() error {
+func (*criConfig) Validate() error {
 	return nil
 }
 
-func (c *criConfig) Type() string {
+func (*criConfig) Type() string {
 	return "cri"
 }
 
-func (c *criConfig) NewClient(logger *zap.Logger, hostRoot string) (any, error) {
+func (*criConfig) NewClient(logger *zap.Logger, hostRoot string) (any, error) {
 	_ = logger
 	_ = hostRoot
 	// TODO implement me
@@ -105,15 +105,15 @@ type dockerConfig struct {
 	ContainerdAddr string `mapstructure:"containerd_addr"`
 }
 
-func (c *dockerConfig) Validate() error {
+func (*dockerConfig) Validate() error {
 	return nil
 }
 
-func (c *dockerConfig) Type() string {
+func (*dockerConfig) Type() string {
 	return "docker"
 }
 
-func (c *dockerConfig) NewClient(logger *zap.Logger, hostRoot string) (any, error) {
+func (*dockerConfig) NewClient(logger *zap.Logger, hostRoot string) (any, error) {
 	_ = logger
 	_ = hostRoot
 	// TODO implement me

--- a/receiver/k8sobjectsreceiver/mock_discovery_client_test.go
+++ b/receiver/k8sobjectsreceiver/mock_discovery_client_test.go
@@ -13,7 +13,7 @@ type mockDiscovery struct {
 	fakeDiscovery.FakeDiscovery
 }
 
-func (c *mockDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+func (*mockDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return []*metav1.APIResourceList{
 		{
 			GroupVersion: "v1",

--- a/receiver/k8sobjectsreceiver/mock_log_consumer_test.go
+++ b/receiver/k8sobjectsreceiver/mock_log_consumer_test.go
@@ -24,7 +24,7 @@ func newMockLogConsumer() *mockLogConsumer {
 	}
 }
 
-func (m *mockLogConsumer) Capabilities() consumer.Capabilities {
+func (*mockLogConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{
 		MutatesData: false,
 	}

--- a/receiver/kafkareceiver/internal/unmarshaler/jaeger_unmarshaler.go
+++ b/receiver/kafkareceiver/internal/unmarshaler/jaeger_unmarshaler.go
@@ -20,7 +20,7 @@ var (
 
 type JaegerProtoSpanUnmarshaler struct{}
 
-func (j JaegerProtoSpanUnmarshaler) UnmarshalTraces(bytes []byte) (ptrace.Traces, error) {
+func (JaegerProtoSpanUnmarshaler) UnmarshalTraces(bytes []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := span.Unmarshal(bytes)
 	if err != nil {
@@ -31,7 +31,7 @@ func (j JaegerProtoSpanUnmarshaler) UnmarshalTraces(bytes []byte) (ptrace.Traces
 
 type JaegerJSONSpanUnmarshaler struct{}
 
-func (j JaegerJSONSpanUnmarshaler) UnmarshalTraces(data []byte) (ptrace.Traces, error) {
+func (JaegerJSONSpanUnmarshaler) UnmarshalTraces(data []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := jsonpb.Unmarshal(bytes.NewReader(data), span)
 	if err != nil {

--- a/receiver/kafkareceiver/internal/unmarshaler/raw_unmarshaler.go
+++ b/receiver/kafkareceiver/internal/unmarshaler/raw_unmarshaler.go
@@ -11,7 +11,7 @@ var _ plog.Unmarshaler = RawLogsUnmarshaler{}
 
 type RawLogsUnmarshaler struct{}
 
-func (r RawLogsUnmarshaler) UnmarshalLogs(buf []byte) (plog.Logs, error) {
+func (RawLogsUnmarshaler) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	l := plog.NewLogs()
 	l.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetEmptyBytes().FromRaw(buf)
 	return l, nil

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -176,7 +176,7 @@ func (h *logsHandler) endObsReport(ctx context.Context, n int, err error) {
 	h.obsrecv.EndLogsOp(ctx, h.encoding, n, err)
 }
 
-func (h *logsHandler) getResources(data plog.Logs) iter.Seq[pcommon.Resource] {
+func (*logsHandler) getResources(data plog.Logs) iter.Seq[pcommon.Resource] {
 	return func(yield func(pcommon.Resource) bool) {
 		for _, rm := range data.ResourceLogs().All() {
 			if !yield(rm.Resource()) {
@@ -186,7 +186,7 @@ func (h *logsHandler) getResources(data plog.Logs) iter.Seq[pcommon.Resource] {
 	}
 }
 
-func (h *logsHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
+func (*logsHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
 	return telBldr.KafkaReceiverUnmarshalFailedLogRecords
 }
 
@@ -217,7 +217,7 @@ func (h *metricsHandler) endObsReport(ctx context.Context, n int, err error) {
 	h.obsrecv.EndMetricsOp(ctx, h.encoding, n, err)
 }
 
-func (h *metricsHandler) getResources(data pmetric.Metrics) iter.Seq[pcommon.Resource] {
+func (*metricsHandler) getResources(data pmetric.Metrics) iter.Seq[pcommon.Resource] {
 	return func(yield func(pcommon.Resource) bool) {
 		for _, rm := range data.ResourceMetrics().All() {
 			if !yield(rm.Resource()) {
@@ -227,7 +227,7 @@ func (h *metricsHandler) getResources(data pmetric.Metrics) iter.Seq[pcommon.Res
 	}
 }
 
-func (h *metricsHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
+func (*metricsHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
 	return telBldr.KafkaReceiverUnmarshalFailedMetricPoints
 }
 
@@ -258,7 +258,7 @@ func (h *tracesHandler) endObsReport(ctx context.Context, n int, err error) {
 	h.obsrecv.EndTracesOp(ctx, h.encoding, n, err)
 }
 
-func (h *tracesHandler) getResources(data ptrace.Traces) iter.Seq[pcommon.Resource] {
+func (*tracesHandler) getResources(data ptrace.Traces) iter.Seq[pcommon.Resource] {
 	return func(yield func(pcommon.Resource) bool) {
 		for _, rm := range data.ResourceSpans().All() {
 			if !yield(rm.Resource()) {
@@ -268,7 +268,7 @@ func (h *tracesHandler) getResources(data ptrace.Traces) iter.Seq[pcommon.Resour
 	}
 }
 
-func (h *tracesHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
+func (*tracesHandler) getUnmarshalFailureCounter(telBldr *metadata.TelemetryBuilder) metric.Int64Counter {
 	return telBldr.KafkaReceiverUnmarshalFailedSpans
 }
 

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -810,7 +810,7 @@ type statusReporterHost struct {
 	report func(*componentstatus.Event)
 }
 
-func (h *statusReporterHost) GetExtensions() map[component.ID]component.Component {
+func (*statusReporterHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_provider_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_provider_test.go
@@ -17,7 +17,7 @@ type testRestClient struct {
 	invalidJSON bool
 }
 
-func (f testRestClient) StatsSummary() ([]byte, error) {
+func (testRestClient) StatsSummary() ([]byte, error) {
 	return []byte{}, nil
 }
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -18,11 +18,11 @@ import (
 
 type fakeRestClient struct{}
 
-func (f fakeRestClient) StatsSummary() ([]byte, error) {
+func (fakeRestClient) StatsSummary() ([]byte, error) {
 	return os.ReadFile("../../testdata/stats-summary.json")
 }
 
-func (f fakeRestClient) Pods() ([]byte, error) {
+func (fakeRestClient) Pods() ([]byte, error) {
 	return os.ReadFile("../../testdata/pods.json")
 }
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/rest_client_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/rest_client_test.go
@@ -23,6 +23,6 @@ var _ kube.Client = (*fakeClient)(nil)
 
 type fakeClient struct{}
 
-func (f *fakeClient) Get(path string) ([]byte, error) {
+func (*fakeClient) Get(path string) ([]byte, error) {
 	return []byte(path), nil
 }

--- a/receiver/libhoneyreceiver/receiver_test.go
+++ b/receiver/libhoneyreceiver/receiver_test.go
@@ -471,6 +471,6 @@ func (tc *testConsumer) ConsumeTraces(ctx context.Context, traces ptrace.Traces)
 	return tc.tracesConsumer.ConsumeTraces(ctx, traces)
 }
 
-func (tc *testConsumer) Capabilities() consumer.Capabilities {
+func (*testConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }

--- a/receiver/memcachedreceiver/client_mock_test.go
+++ b/receiver/memcachedreceiver/client_mock_test.go
@@ -15,7 +15,7 @@ type fakeClient struct{}
 
 var _ client = (*fakeClient)(nil)
 
-func (c *fakeClient) Stats() (map[net.Addr]memcache.Stats, error) {
+func (*fakeClient) Stats() (map[net.Addr]memcache.Stats, error) {
 	bytes, err := os.ReadFile("./testdata/fake_stats.json")
 	if err != nil {
 		return nil, err

--- a/receiver/mongodbatlasreceiver/events_test.go
+++ b/receiver/mongodbatlasreceiver/events_test.go
@@ -208,7 +208,7 @@ func (mec *mockEventsClient) setupGetOrganization() {
 	}, nil)
 }
 
-func (mec *mockEventsClient) loadTestEvents(t *testing.T, filename string) []*mongodbatlas.Event {
+func (*mockEventsClient) loadTestEvents(t *testing.T, filename string) []*mongodbatlas.Event {
 	testEvents := filepath.Join("testdata", "events", "sample-payloads", filename)
 	eventBytes, err := os.ReadFile(testEvents)
 	require.NoError(t, err)
@@ -244,6 +244,6 @@ func (mec *mockEventsClient) GetOrganizationEvents(ctx context.Context, oID stri
 	return args.Get(0).([]*mongodbatlas.Event), args.Bool(1), args.Error(2)
 }
 
-func (mec *mockEventsClient) Shutdown() error {
+func (*mockEventsClient) Shutdown() error {
 	return nil
 }

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -202,11 +202,11 @@ func readFile(fname string) (map[string]string, error) {
 	return stats, nil
 }
 
-func (c *mockClient) Connect() error {
+func (*mockClient) Connect() error {
 	return nil
 }
 
-func (c *mockClient) getVersion() (*version.Version, error) {
+func (*mockClient) getVersion() (*version.Version, error) {
 	version, _ := version.NewVersion("8.0.27")
 	return version, nil
 }
@@ -489,6 +489,6 @@ func (c *mockClient) getQuerySamples(uint64) ([]querySample, error) {
 	return samples, nil
 }
 
-func (c *mockClient) Close() error {
+func (*mockClient) Close() error {
 	return nil
 }

--- a/receiver/namedpipereceiver/namedpipe.go
+++ b/receiver/namedpipereceiver/namedpipe.go
@@ -21,12 +21,12 @@ func NewFactory() receiver.Factory {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return createDefaultConfig()
 }
 
@@ -46,7 +46,7 @@ func createDefaultConfig() *NamedPipeConfig {
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*NamedPipeConfig).BaseConfig
 }
 
@@ -60,6 +60,6 @@ type NamedPipeConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*NamedPipeConfig).InputConfig)
 }

--- a/receiver/netflowreceiver/producer_test.go
+++ b/receiver/netflowreceiver/producer_test.go
@@ -153,13 +153,13 @@ func TestProduceRaw(t *testing.T) {
 // This panicProducer replaces the ProtoProducer, to simulate it producing a panic
 type panicProducer struct{}
 
-func (m *panicProducer) Produce(_ any, _ *producer.ProduceArgs) ([]producer.ProducerMessage, error) {
+func (*panicProducer) Produce(any, *producer.ProduceArgs) ([]producer.ProducerMessage, error) {
 	panic("producer panic!")
 }
 
-func (m *panicProducer) Close() {}
+func (*panicProducer) Close() {}
 
-func (m *panicProducer) Commit(_ []producer.ProducerMessage) {}
+func (*panicProducer) Commit([]producer.ProducerMessage) {}
 
 func TestProducerPanic(t *testing.T) {
 	// Create a mock logger that can capture logged messages

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -175,21 +175,21 @@ func (c *nsxClient) doRequest(ctx context.Context, path string) ([]byte, error) 
 	}
 }
 
-func (c *nsxClient) nodeStatusEndpoint(class nodeClass, nodeID string) string {
+func (*nsxClient) nodeStatusEndpoint(class nodeClass, nodeID string) string {
 	if class == transportClass {
 		return fmt.Sprintf("/api/v1/transport-nodes/%s/status", nodeID)
 	}
 	return fmt.Sprintf("/api/v1/cluster/nodes/%s/status", nodeID)
 }
 
-func (c *nsxClient) interfacesEndpoint(class nodeClass, nodeID string) string {
+func (*nsxClient) interfacesEndpoint(class nodeClass, nodeID string) string {
 	if class == transportClass {
 		return fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces", nodeID)
 	}
 	return fmt.Sprintf("/api/v1/cluster/nodes/%s/network/interfaces", nodeID)
 }
 
-func (c *nsxClient) interfaceStatusEndpoint(class nodeClass, nodeID, interfaceID string) string {
+func (*nsxClient) interfaceStatusEndpoint(class nodeClass, nodeID, interfaceID string) string {
 	if class == transportClass {
 		return fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces/%s/stats", nodeID, interfaceID)
 	}

--- a/receiver/opencensusreceiver/config.go
+++ b/receiver/opencensusreceiver/config.go
@@ -37,6 +37,6 @@ func (cfg *Config) buildOptions() []ocOption {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/receiver/opencensusreceiver/internal/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/internal/octrace/opencensus.go
@@ -53,7 +53,7 @@ var _ agenttracepb.TraceServiceServer = (*Receiver)(nil)
 var errUnimplemented = errors.New("unimplemented")
 
 // Config handles configuration messages.
-func (ocr *Receiver) Config(agenttracepb.TraceService_ConfigServer) error {
+func (*Receiver) Config(agenttracepb.TraceService_ConfigServer) error {
 	// TODO: Implement when we define the config receiver/sender.
 	return errUnimplemented
 }

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -895,7 +895,7 @@ func (esc *errOrSinkConsumer) SetConsumeError(err error) {
 	esc.consumeError = err
 }
 
-func (esc *errOrSinkConsumer) Capabilities() consumer.Capabilities {
+func (*errOrSinkConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -943,7 +943,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/oracledbreceiver/scraper.go
+++ b/receiver/oracledbreceiver/scraper.go
@@ -798,7 +798,7 @@ func (s *oracleScraper) getChildAddressToPlanMap(ctx context.Context, hits []que
 	return childAddressToPlanMap
 }
 
-func (s *oracleScraper) getTopNMetricNames() []string {
+func (*oracleScraper) getTopNMetricNames() []string {
 	return []string{
 		elapsedTimeMetric, queryExecutionMetric, cpuTimeMetric, applicationWaitTimeMetric,
 		concurrencyWaitTimeMetric, userIoWaitTimeMetric, clusterWaitTimeMetric, rowsProcessedMetric, bufferGetsMetric,

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -134,7 +134,7 @@ func newUnhealthyTestChannel(t *testing.T) *unhealthyTestChannel {
 	return &unhealthyTestChannel{t: t}
 }
 
-func (u unhealthyTestChannel) onConsume(ctx context.Context) error {
+func (unhealthyTestChannel) onConsume(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/receiver/otelarrowreceiver/internal/testconsumer/blocking_consumer.go
+++ b/receiver/otelarrowreceiver/internal/testconsumer/blocking_consumer.go
@@ -41,6 +41,6 @@ func (bc *BlockingConsumer) Unblock() {
 	close(bc.block)
 }
 
-func (bc *BlockingConsumer) Capabilities() consumer.Capabilities {
+func (*BlockingConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -508,7 +508,7 @@ func (esc *errOrSinkConsumer) SetConsumeError(err error) {
 	esc.consumeError = err
 }
 
-func (esc *errOrSinkConsumer) Capabilities() consumer.Capabilities {
+func (*errOrSinkConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -88,14 +88,14 @@ func (c mockPodmanClient) stats(context.Context, url.Values) ([]containerStats, 
 	return report.Stats, nil
 }
 
-func (c mockPodmanClient) ping(context.Context) error {
+func (mockPodmanClient) ping(context.Context) error {
 	return nil
 }
 
-func (c mockPodmanClient) list(context.Context, url.Values) ([]container, error) {
+func (mockPodmanClient) list(context.Context, url.Values) ([]container, error) {
 	return []container{{ID: "c1", Image: "localimage"}}, nil
 }
 
-func (c mockPodmanClient) events(context.Context, url.Values) (<-chan event, <-chan error) {
+func (mockPodmanClient) events(context.Context, url.Values) (<-chan event, <-chan error) {
 	return nil, nil
 }

--- a/receiver/postgresqlreceiver/client_factory.go
+++ b/receiver/postgresqlreceiver/client_factory.go
@@ -51,7 +51,7 @@ func (d *defaultClientFactory) getClient(database string) (client, error) {
 	return &postgreSQLClient{client: db, closeFn: db.Close}, nil
 }
 
-func (d *defaultClientFactory) close() error {
+func (*defaultClientFactory) close() error {
 	return nil
 }
 

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -677,7 +677,7 @@ func (p *postgreSQLScraper) retrieveDatabaseSize(
 	r.Unlock()
 }
 
-func (p *postgreSQLScraper) retrieveBackends(
+func (*postgreSQLScraper) retrieveBackends(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	client client,

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -512,17 +512,17 @@ type (
 )
 
 // explainQuery implements client.
-func (m *mockClient) explainQuery(string, string, *zap.Logger) (string, error) {
+func (*mockClient) explainQuery(string, string, *zap.Logger) (string, error) {
 	panic("unimplemented")
 }
 
 // getTopQuery implements client.
-func (m *mockClient) getTopQuery(context.Context, int64, *zap.Logger) ([]map[string]any, error) {
+func (*mockClient) getTopQuery(context.Context, int64, *zap.Logger) ([]map[string]any, error) {
 	panic("unimplemented")
 }
 
 // close implements postgreSQLClientFactory.
-func (m mockSimpleClientFactory) close() error {
+func (mockSimpleClientFactory) close() error {
 	return nil
 }
 
@@ -535,7 +535,7 @@ func (m mockSimpleClientFactory) getClient(string) (client, error) {
 }
 
 // getQuerySamples implements client.
-func (m *mockClient) getQuerySamples(context.Context, int64, float64, *zap.Logger) ([]map[string]any, float64, error) {
+func (*mockClient) getQuerySamples(context.Context, int64, float64, *zap.Logger) ([]map[string]any, float64, error) {
 	panic("this should not be invoked")
 }
 

--- a/receiver/pprofreceiver/factory.go
+++ b/receiver/pprofreceiver/factory.go
@@ -30,20 +30,20 @@ func createDefaultConfig() component.Config {
 }
 
 func createProfilesReceiver(
-	_ context.Context,
-	_ receiver.Settings,
-	_ component.Config,
-	_ xconsumer.Profiles,
+	context.Context,
+	receiver.Settings,
+	component.Config,
+	xconsumer.Profiles,
 ) (xreceiver.Profiles, error) {
 	return &rcvr{}, errors.New("not implemented")
 }
 
 type rcvr struct{}
 
-func (p rcvr) Start(_ context.Context, _ component.Host) error {
+func (rcvr) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (p rcvr) Shutdown(_ context.Context) error {
+func (rcvr) Shutdown(context.Context) error {
 	return nil
 }

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -26,9 +26,9 @@ func (tmc testMetadataStore) GetMetadata(familyName string) (scrape.MetricMetada
 	return lookup, ok
 }
 
-func (tmc testMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
+func (testMetadataStore) ListMetadata() []scrape.MetricMetadata { return nil }
 
-func (tmc testMetadataStore) SizeMetadata() int { return 0 }
+func (testMetadataStore) SizeMetadata() int { return 0 }
 
 func (tmc testMetadataStore) LengthMetadata() int {
 	return len(tmc)

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -390,7 +390,7 @@ func (t *transaction) setCreationTimestamp(ls labels.Labels, atMs, ctMs int64) (
 	return storage.SeriesRef(seriesRef), nil
 }
 
-func (t *transaction) SetOptions(_ *storage.AppendOptions) {
+func (*transaction) SetOptions(_ *storage.AppendOptions) {
 	// TODO: implement this func
 }
 
@@ -559,11 +559,11 @@ func (t *transaction) Commit() error {
 	return err
 }
 
-func (t *transaction) Rollback() error {
+func (*transaction) Rollback() error {
 	return nil
 }
 
-func (t *transaction) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+func (*transaction) UpdateMetadata(_ storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
 	// TODO: implement this func
 	return 0, nil
 }

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -2058,7 +2058,7 @@ func (ea *errorAdjuster) AdjustMetrics(pmetric.Metrics) error {
 
 type nopAdjuster struct{}
 
-func (n *nopAdjuster) AdjustMetrics(_ pmetric.Metrics) error {
+func (*nopAdjuster) AdjustMetrics(_ pmetric.Metrics) error {
 	return nil
 }
 

--- a/receiver/prometheusremotewritereceiver/config.go
+++ b/receiver/prometheusremotewritereceiver/config.go
@@ -16,6 +16,6 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -203,7 +203,7 @@ func (prw *prometheusRemoteWriteReceiver) handlePRW(w http.ResponseWriter, req *
 // parseProto parses the content-type header and returns the version of the remote-write protocol.
 // We can't expect that senders of remote-write v1 will add the "proto=" parameter since it was not
 // a requirement in v1. So, if the parameter is not found, we assume v1.
-func (prw *prometheusRemoteWriteReceiver) parseProto(contentType string) (promconfig.RemoteWriteProtoMsg, error) {
+func (*prometheusRemoteWriteReceiver) parseProto(contentType string) (promconfig.RemoteWriteProtoMsg, error) {
 	contentType = strings.TrimSpace(contentType)
 
 	parts := strings.Split(contentType, ";")
@@ -713,7 +713,7 @@ func (prw *prometheusRemoteWriteReceiver) extractScopeInfo(ls labels.Labels) (st
 }
 
 // addNHCBDatapoint converts a single Native Histogram Custom Buckets (NHCB) to OpenTelemetry histogram datapoints
-func (prw *prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram writev2.Histogram, ls labels.Labels, createdTimestamp int64, stats *promremote.WriteResponseStats) {
+func (*prometheusRemoteWriteReceiver) addNHCBDatapoint(datapoints pmetric.HistogramDataPointSlice, histogram writev2.Histogram, ls labels.Labels, createdTimestamp int64, stats *promremote.WriteResponseStats) {
 	if len(histogram.CustomValues) == 0 {
 		return
 	}

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -1394,7 +1394,7 @@ func TestTranslateV2(t *testing.T) {
 type nonMutatingConsumer struct{}
 
 // Capabilities returns the base consumer capabilities.
-func (bc nonMutatingConsumer) Capabilities() consumer.Capabilities {
+func (nonMutatingConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/receiver/pulsarreceiver/config.go
+++ b/receiver/pulsarreceiver/config.go
@@ -65,7 +65,7 @@ type OAuth2 struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }
 

--- a/receiver/pulsarreceiver/factory_test.go
+++ b/receiver/pulsarreceiver/factory_test.go
@@ -182,26 +182,26 @@ type customMetricsUnmarshaler struct{}
 
 type customLogsUnmarshaler struct{}
 
-func (c customTracesUnmarshaler) Unmarshal([]byte) (ptrace.Traces, error) {
+func (customTracesUnmarshaler) Unmarshal([]byte) (ptrace.Traces, error) {
 	panic("implement me")
 }
 
-func (c customTracesUnmarshaler) Encoding() string {
+func (customTracesUnmarshaler) Encoding() string {
 	return "custom"
 }
 
-func (c customMetricsUnmarshaler) Unmarshal([]byte) (pmetric.Metrics, error) {
+func (customMetricsUnmarshaler) Unmarshal([]byte) (pmetric.Metrics, error) {
 	panic("implement me")
 }
 
-func (c customMetricsUnmarshaler) Encoding() string {
+func (customMetricsUnmarshaler) Encoding() string {
 	return "custom"
 }
 
-func (c customLogsUnmarshaler) Unmarshal([]byte) (plog.Logs, error) {
+func (customLogsUnmarshaler) Unmarshal([]byte) (plog.Logs, error) {
 	panic("implement me")
 }
 
-func (c customLogsUnmarshaler) Encoding() string {
+func (customLogsUnmarshaler) Encoding() string {
 	return "custom"
 }

--- a/receiver/pulsarreceiver/jaeger_unmarshaler.go
+++ b/receiver/pulsarreceiver/jaeger_unmarshaler.go
@@ -18,7 +18,7 @@ type jaegerProtoSpanUnmarshaler struct{}
 
 var _ TracesUnmarshaler = (*jaegerProtoSpanUnmarshaler)(nil)
 
-func (j jaegerProtoSpanUnmarshaler) Unmarshal(bytes []byte) (ptrace.Traces, error) {
+func (jaegerProtoSpanUnmarshaler) Unmarshal(bytes []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := span.Unmarshal(bytes)
 	if err != nil {
@@ -27,7 +27,7 @@ func (j jaegerProtoSpanUnmarshaler) Unmarshal(bytes []byte) (ptrace.Traces, erro
 	return jaegerSpanToTraces(span)
 }
 
-func (j jaegerProtoSpanUnmarshaler) Encoding() string {
+func (jaegerProtoSpanUnmarshaler) Encoding() string {
 	return "jaeger_proto"
 }
 
@@ -35,7 +35,7 @@ type jaegerJSONSpanUnmarshaler struct{}
 
 var _ TracesUnmarshaler = (*jaegerJSONSpanUnmarshaler)(nil)
 
-func (j jaegerJSONSpanUnmarshaler) Unmarshal(data []byte) (ptrace.Traces, error) {
+func (jaegerJSONSpanUnmarshaler) Unmarshal(data []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
 	err := jsonpb.Unmarshal(bytes.NewReader(data), span)
 	if err != nil {
@@ -44,7 +44,7 @@ func (j jaegerJSONSpanUnmarshaler) Unmarshal(data []byte) (ptrace.Traces, error)
 	return jaegerSpanToTraces(span)
 }
 
-func (j jaegerJSONSpanUnmarshaler) Encoding() string {
+func (jaegerJSONSpanUnmarshaler) Encoding() string {
 	return "jaeger_json"
 }
 

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -672,7 +672,7 @@ type reportingHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *reportingHost) GetExtensions() map[component.ID]component.Component {
+func (*reportingHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/receivercreator/receiver_test.go
+++ b/receiver/receivercreator/receiver_test.go
@@ -36,21 +36,21 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 type mockObserver struct{}
 
-func (m *mockObserver) Start(_ context.Context, _ component.Host) error {
+func (*mockObserver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (m *mockObserver) Shutdown(_ context.Context) error {
+func (*mockObserver) Shutdown(context.Context) error {
 	return nil
 }
 
 var _ extension.Extension = (*mockObserver)(nil)
 
-func (m *mockObserver) ListAndWatch(notify observer.Notify) {
+func (*mockObserver) ListAndWatch(notify observer.Notify) {
 	notify.OnAdd([]observer.Endpoint{portEndpoint})
 }
 
-func (m *mockObserver) Unsubscribe(_ observer.Notify) {}
+func (*mockObserver) Unsubscribe(observer.Notify) {}
 
 var _ observer.Observable = (*mockObserver)(nil)
 

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -117,13 +117,13 @@ func (run *receiverRunner) start(
 }
 
 // shutdown the given receiver.
-func (run *receiverRunner) shutdown(rcvr component.Component) error {
+func (*receiverRunner) shutdown(rcvr component.Component) error {
 	return rcvr.Shutdown(context.Background())
 }
 
 // loadRuntimeReceiverConfig loads the given receiverTemplate merged with config values
 // that may have been discovered at runtime.
-func (run *receiverRunner) loadRuntimeReceiverConfig(
+func (*receiverRunner) loadRuntimeReceiverConfig(
 	factory rcvr.Factory,
 	receiver receiverConfig,
 	discoveredConfig userConfigMap,

--- a/receiver/redisreceiver/client.go
+++ b/receiver/redisreceiver/client.go
@@ -35,7 +35,7 @@ func newRedisClient(options *redis.Options) client {
 }
 
 // Redis strings are CRLF delimited.
-func (c *redisClient) delimiter() string {
+func (*redisClient) delimiter() string {
 	return "\r\n"
 }
 

--- a/receiver/redisreceiver/client_test.go
+++ b/receiver/redisreceiver/client_test.go
@@ -21,7 +21,7 @@ func newFakeClient() *fakeClient {
 	return &fakeClient{}
 }
 
-func (c fakeClient) delimiter() string {
+func (fakeClient) delimiter() string {
 	if runtime.GOOS == "windows" {
 		return "\r\n"
 	}

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -157,7 +157,7 @@ func (rs *redisScraper) recordKeyspaceMetrics(ts pcommon.Timestamp, inf info) {
 
 // getRedisVersion retrieves version string from 'redis_version' Redis info key-value pairs
 // e.g. "redis_version:5.0.7"
-func (rs *redisScraper) getRedisVersion(inf info) string {
+func (*redisScraper) getRedisVersion(inf info) string {
 	if str, ok := inf["redis_version"]; ok {
 		return str
 	}

--- a/receiver/saphanareceiver/client.go
+++ b/receiver/saphanareceiver/client.go
@@ -79,7 +79,7 @@ type sapHanaConnectionFactory interface {
 
 type defaultConnectionFactory struct{}
 
-func (f *defaultConnectionFactory) getConnection(c driver.Connector) dbWrapper {
+func (*defaultConnectionFactory) getConnection(c driver.Connector) dbWrapper {
 	wrapper := standardDBWrapper{db: sql.OpenDB((c))}
 	return &wrapper
 }

--- a/receiver/saphanareceiver/client_test.go
+++ b/receiver/saphanareceiver/client_test.go
@@ -36,7 +36,7 @@ func (m *testResultWrapper) Scan(dest ...any) error {
 	return nil
 }
 
-func (m *testResultWrapper) Close() error {
+func (*testResultWrapper) Close() error {
 	return nil
 }
 

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -407,7 +407,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -941,11 +941,11 @@ type badReqBody struct{}
 
 var _ io.ReadCloser = (*badReqBody)(nil)
 
-func (b badReqBody) Read(_ []byte) (n int, err error) {
+func (badReqBody) Read([]byte) (n int, err error) {
 	return 0, errors.New("badReqBody: can't read it")
 }
 
-func (b badReqBody) Close() error {
+func (badReqBody) Close() error {
 	return nil
 }
 
@@ -1068,7 +1068,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/skywalkingreceiver/sw_dummy_clr_service.go
+++ b/receiver/skywalkingreceiver/sw_dummy_clr_service.go
@@ -14,6 +14,6 @@ type clrService struct {
 	agent.UnimplementedCLRMetricReportServiceServer
 }
 
-func (c *clrService) Collect(_ context.Context, _ *agent.CLRMetricCollection) (*common.Commands, error) {
+func (*clrService) Collect(context.Context, *agent.CLRMetricCollection) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }

--- a/receiver/skywalkingreceiver/sw_dummy_event_service.go
+++ b/receiver/skywalkingreceiver/sw_dummy_event_service.go
@@ -11,6 +11,6 @@ type eventService struct {
 	event.UnimplementedEventServiceServer
 }
 
-func (e *eventService) Collect(_ event.EventService_CollectServer) error {
+func (*eventService) Collect(event.EventService_CollectServer) error {
 	return nil
 }

--- a/receiver/skywalkingreceiver/sw_dummy_meter_service.go
+++ b/receiver/skywalkingreceiver/sw_dummy_meter_service.go
@@ -11,10 +11,10 @@ type meterService struct {
 	meter.UnimplementedMeterReportServiceServer
 }
 
-func (m *meterService) Collect(_ meter.MeterReportService_CollectServer) error {
+func (*meterService) Collect(meter.MeterReportService_CollectServer) error {
 	return nil
 }
 
-func (m *meterService) CollectBatch(_ meter.MeterReportService_CollectBatchServer) error {
+func (*meterService) CollectBatch(meter.MeterReportService_CollectBatchServer) error {
 	return nil
 }

--- a/receiver/skywalkingreceiver/sw_dummy_response_service.go
+++ b/receiver/skywalkingreceiver/sw_dummy_response_service.go
@@ -24,34 +24,34 @@ type dummyReportService struct {
 }
 
 // for sw InstanceProperties
-func (d *dummyReportService) ReportInstanceProperties(_ context.Context, _ *management.InstanceProperties) (*common.Commands, error) {
+func (*dummyReportService) ReportInstanceProperties(context.Context, *management.InstanceProperties) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }
 
 // for sw InstancePingPkg
-func (d *dummyReportService) KeepAlive(_ context.Context, _ *management.InstancePingPkg) (*common.Commands, error) {
+func (*dummyReportService) KeepAlive(context.Context, *management.InstancePingPkg) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }
 
 // for sw JVMMetric
-func (d *dummyReportService) Collect(_ context.Context, _ *agent.JVMMetricCollection) (*common.Commands, error) {
+func (*dummyReportService) Collect(context.Context, *agent.JVMMetricCollection) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }
 
 // for sw agent cds
-func (d *dummyReportService) FetchConfigurations(_ context.Context, _ *v3c.ConfigurationSyncRequest) (*common.Commands, error) {
+func (*dummyReportService) FetchConfigurations(context.Context, *v3c.ConfigurationSyncRequest) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }
 
 // for sw profile
-func (d *dummyReportService) GetProfileTaskCommands(_ context.Context, _ *profile.ProfileTaskCommandQuery) (*common.Commands, error) {
+func (*dummyReportService) GetProfileTaskCommands(context.Context, *profile.ProfileTaskCommandQuery) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }
 
-func (d *dummyReportService) CollectSnapshot(_ profile.ProfileTask_CollectSnapshotServer) error {
+func (*dummyReportService) CollectSnapshot(profile.ProfileTask_CollectSnapshotServer) error {
 	return nil
 }
 
-func (d *dummyReportService) ReportTaskFinish(_ context.Context, _ *profile.ProfileTaskFinishReport) (*common.Commands, error) {
+func (*dummyReportService) ReportTaskFinish(context.Context, *profile.ProfileTaskFinishReport) (*common.Commands, error) {
 	return &common.Commands{}, nil
 }

--- a/receiver/snmpreceiver/client.go
+++ b/receiver/snmpreceiver/client.go
@@ -372,7 +372,7 @@ func (c *snmpClient) convertSnmpPDUToSnmpData(pdu gosnmp.SnmpPDU) snmpData {
 // This is a convenience function to make working with SnmpPDU's easier - it
 // reduces the need for type assertions. A int64 is convenient, as SNMP can
 // return int32, uint32, and int64.
-func (c *snmpClient) toInt64(name string, value any) (int64, error) {
+func (*snmpClient) toInt64(name string, value any) (int64, error) {
 	switch value := value.(type) { // shadow
 	case uint:
 		return int64(value), nil
@@ -405,7 +405,7 @@ func (c *snmpClient) toInt64(name string, value any) (int64, error) {
 // This is a convenience function to make working with SnmpPDU's easier - it
 // reduces the need for type assertions. A float64 is convenient, as SNMP can
 // return float32 and float64.
-func (c *snmpClient) toFloat64(name string, value any) (float64, error) {
+func (*snmpClient) toFloat64(name string, value any) (float64, error) {
 	switch value := value.(type) { // shadow
 	case float32:
 		return float64(value), nil

--- a/receiver/snmpreceiver/scraper.go
+++ b/receiver/snmpreceiver/scraper.go
@@ -150,7 +150,7 @@ func (s *snmpScraper) scrapeIndexedMetrics(
 
 // scalarDataToMetric will take one piece of SNMP scalar data and turn it into a datapoint for
 // either a new or existing metric with attributes based on the related configs
-func (s *snmpScraper) scalarDataToMetric(
+func (*snmpScraper) scalarDataToMetric(
 	data snmpData,
 	metricHelper *otelMetricHelper,
 	configHelper *configHelper,

--- a/receiver/solacereceiver/messaging_service_test.go
+++ b/receiver/solacereceiver/messaging_service_test.go
@@ -682,23 +682,23 @@ func (c *connMock) Close() error {
 	return nil
 }
 
-func (c *connMock) LocalAddr() net.Addr {
+func (*connMock) LocalAddr() net.Addr {
 	return nil
 }
 
-func (c *connMock) RemoteAddr() net.Addr {
+func (*connMock) RemoteAddr() net.Addr {
 	return nil
 }
 
-func (c *connMock) SetDeadline(_ time.Time) error {
+func (*connMock) SetDeadline(_ time.Time) error {
 	return nil
 }
 
-func (c *connMock) SetReadDeadline(_ time.Time) error {
+func (*connMock) SetReadDeadline(_ time.Time) error {
 	return nil
 }
 
-func (c *connMock) SetWriteDeadline(_ time.Time) error {
+func (*connMock) SetWriteDeadline(_ time.Time) error {
 	return nil
 }
 

--- a/receiver/solacereceiver/unmarshaller_egress.go
+++ b/receiver/solacereceiver/unmarshaller_egress.go
@@ -40,7 +40,7 @@ func (u *brokerTraceEgressUnmarshallerV1) unmarshal(message *inboundMessage) (pt
 
 // unmarshalToSpanData will consume an solaceMessage and unmarshal it into a SpanData.
 // Returns an error if one occurred.
-func (u *brokerTraceEgressUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*egress_v1.SpanData, error) {
+func (*brokerTraceEgressUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*egress_v1.SpanData, error) {
 	data := message.GetData()
 	if len(data) == 0 {
 		return nil, errEmptyPayload
@@ -65,7 +65,7 @@ func (u *brokerTraceEgressUnmarshallerV1) populateTraces(spanData *egress_v1.Spa
 	}
 }
 
-func (u *brokerTraceEgressUnmarshallerV1) mapResourceSpanAttributes(spanData *egress_v1.SpanData, attrMap pcommon.Map) {
+func (*brokerTraceEgressUnmarshallerV1) mapResourceSpanAttributes(spanData *egress_v1.SpanData, attrMap pcommon.Map) {
 	setResourceSpanAttributes(attrMap, spanData.RouterName, spanData.SolosVersion, spanData.MessageVpnName)
 }
 
@@ -101,7 +101,7 @@ func (u *brokerTraceEgressUnmarshallerV1) mapEgressSpan(spanData *egress_v1.Span
 	}
 }
 
-func (u *brokerTraceEgressUnmarshallerV1) mapEgressSpanCommon(spanData *egress_v1.SpanData_EgressSpan, clientSpan ptrace.Span) {
+func (*brokerTraceEgressUnmarshallerV1) mapEgressSpanCommon(spanData *egress_v1.SpanData_EgressSpan, clientSpan ptrace.Span) {
 	var traceID [16]byte
 	copy(traceID[:16], spanData.TraceId)
 	clientSpan.SetTraceID(traceID)

--- a/receiver/solacereceiver/unmarshaller_move.go
+++ b/receiver/solacereceiver/unmarshaller_move.go
@@ -37,7 +37,7 @@ func (u *brokerTraceMoveUnmarshallerV1) unmarshal(message *inboundMessage) (ptra
 
 // unmarshalToSpanData will consume an solaceMessage and unmarshal it into a SpanData.
 // Returns an error if one occurred.
-func (u *brokerTraceMoveUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*move_v1.SpanData, error) {
+func (*brokerTraceMoveUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*move_v1.SpanData, error) {
 	data := message.GetData()
 	if len(data) == 0 {
 		return nil, errEmptyPayload
@@ -65,11 +65,11 @@ func (u *brokerTraceMoveUnmarshallerV1) populateTraces(spanData *move_v1.SpanDat
 	u.mapClientSpanData(spanData, clientSpan)
 }
 
-func (u *brokerTraceMoveUnmarshallerV1) mapResourceSpanAttributes(spanData *move_v1.SpanData, attrMap pcommon.Map) {
+func (*brokerTraceMoveUnmarshallerV1) mapResourceSpanAttributes(spanData *move_v1.SpanData, attrMap pcommon.Map) {
 	setResourceSpanAttributes(attrMap, spanData.RouterName, spanData.SolosVersion, spanData.MessageVpnName)
 }
 
-func (u *brokerTraceMoveUnmarshallerV1) mapMoveSpanTracingInfo(spanData *move_v1.SpanData, span ptrace.Span) {
+func (*brokerTraceMoveUnmarshallerV1) mapMoveSpanTracingInfo(spanData *move_v1.SpanData, span ptrace.Span) {
 	// hard coded to internal span
 	// SPAN_KIND_CONSUMER == 1
 	span.SetKind(ptrace.SpanKindInternal)

--- a/receiver/solacereceiver/unmarshaller_receive.go
+++ b/receiver/solacereceiver/unmarshaller_receive.go
@@ -41,7 +41,7 @@ func (u *brokerTraceReceiveUnmarshallerV1) unmarshal(message *inboundMessage) (p
 
 // unmarshalToSpanData will consume an solaceMessage and unmarshal it into a SpanData.
 // Returns an error if one occurred.
-func (u *brokerTraceReceiveUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*receive_v1.SpanData, error) {
+func (*brokerTraceReceiveUnmarshallerV1) unmarshalToSpanData(message *inboundMessage) (*receive_v1.SpanData, error) {
 	data := message.GetData()
 	if len(data) == 0 {
 		return nil, errEmptyPayload
@@ -71,11 +71,11 @@ func (u *brokerTraceReceiveUnmarshallerV1) populateTraces(spanData *receive_v1.S
 	u.mapEvents(spanData, clientSpan)
 }
 
-func (u *brokerTraceReceiveUnmarshallerV1) mapResourceSpanAttributes(spanData *receive_v1.SpanData, attrMap pcommon.Map) {
+func (*brokerTraceReceiveUnmarshallerV1) mapResourceSpanAttributes(spanData *receive_v1.SpanData, attrMap pcommon.Map) {
 	setResourceSpanAttributes(attrMap, spanData.RouterName, spanData.SolosVersion, spanData.MessageVpnName)
 }
 
-func (u *brokerTraceReceiveUnmarshallerV1) mapClientSpanData(spanData *receive_v1.SpanData, clientSpan ptrace.Span) {
+func (*brokerTraceReceiveUnmarshallerV1) mapClientSpanData(spanData *receive_v1.SpanData, clientSpan ptrace.Span) {
 	// Set client span name
 	if spanData.Topic != "" {
 		clientSpan.SetName(spanData.Topic + " receive")
@@ -344,7 +344,7 @@ func (u *brokerTraceReceiveUnmarshallerV1) rgmidToString(rgmid []byte) string {
 
 // unmarshalBaggage will unmarshal a baggage string
 // See spec https://github.com/open-telemetry/opentelemetry-go/blob/v1.11.1/baggage/baggage.go
-func (u *brokerTraceReceiveUnmarshallerV1) unmarshalBaggage(toMap pcommon.Map, baggageString string) error {
+func (*brokerTraceReceiveUnmarshallerV1) unmarshalBaggage(toMap pcommon.Map, baggageString string) error {
 	const (
 		baggageValuePrefix    = "messaging.solace.message.baggage."
 		baggageMetadataPrefix = "messaging.solace.message.baggage_metadata."

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -206,7 +206,7 @@ func (r *splunkReceiver) processSuccessResponseWithAck(resp http.ResponseWriter,
 	return r.processSuccessResponse(resp, []byte(fmt.Sprintf(responseOKWithAckID, ackID)))
 }
 
-func (r *splunkReceiver) processSuccessResponse(resp http.ResponseWriter, bodyContent []byte) error {
+func (*splunkReceiver) processSuccessResponse(resp http.ResponseWriter, bodyContent []byte) error {
 	resp.Header().Set(httpContentTypeHeader, httpJSONTypeHeader)
 	resp.WriteHeader(http.StatusOK)
 	_, err := resp.Write(bodyContent)
@@ -343,7 +343,7 @@ func (r *splunkReceiver) handleRawReq(resp http.ResponseWriter, req *http.Reques
 	}
 }
 
-func (r *splunkReceiver) extractChannel(req *http.Request) (string, bool) {
+func (*splunkReceiver) extractChannel(req *http.Request) (string, bool) {
 	// check header
 	for k, v := range req.Header {
 		if strings.EqualFold(k, splunk.HTTPSplunkChannelHeader) {
@@ -360,7 +360,7 @@ func (r *splunkReceiver) extractChannel(req *http.Request) (string, bool) {
 	return "", false
 }
 
-func (r *splunkReceiver) validateChannelHeader(channelID string) error {
+func (*splunkReceiver) validateChannelHeader(channelID string) error {
 	if channelID == "" {
 		return errors.New(responseErrDataChannelMissing)
 	}
@@ -535,7 +535,7 @@ func (r *splunkReceiver) failRequest(
 	}
 }
 
-func (r *splunkReceiver) handleHealthReq(writer http.ResponseWriter, _ *http.Request) {
+func (*splunkReceiver) handleHealthReq(writer http.ResponseWriter, _ *http.Request) {
 	writer.Header().Add("Content-Type", "application/json")
 	writer.WriteHeader(http.StatusOK)
 	_, _ = writer.Write([]byte(responseHecHealthy))

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -890,11 +890,11 @@ type badReqBody struct{}
 
 var _ io.ReadCloser = (*badReqBody)(nil)
 
-func (b badReqBody) Read(_ []byte) (n int, err error) {
+func (badReqBody) Read([]byte) (n int, err error) {
 	return 0, errors.New("badReqBody: can't read it")
 }
 
-func (b badReqBody) Close() error {
+func (badReqBody) Close() error {
 	return nil
 }
 
@@ -2046,11 +2046,11 @@ type mockAckExtension struct {
 	processEvent func(partitionID string) (ackID uint64)
 }
 
-func (ae *mockAckExtension) Start(context.Context, component.Host) error {
+func (*mockAckExtension) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (ae *mockAckExtension) Shutdown(context.Context) error {
+func (*mockAckExtension) Shutdown(context.Context) error {
 	return nil
 }
 
@@ -2072,7 +2072,7 @@ type nopHost struct {
 	reportFunc func(event *componentstatus.Event)
 }
 
-func (nh *nopHost) GetExtensions() map[component.ID]component.Component {
+func (*nopHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 

--- a/receiver/sqlserverreceiver/config_others.go
+++ b/receiver/sqlserverreceiver/config_others.go
@@ -5,6 +5,6 @@
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 
-func (cfg *Config) validateInstanceAndComputerName() error {
+func (*Config) validateInstanceAndComputerName() error {
 	return nil
 }

--- a/receiver/sqlserverreceiver/scraper_windows_test.go
+++ b/receiver/sqlserverreceiver/scraper_windows_test.go
@@ -29,18 +29,18 @@ type mockPerfCounterWatcher struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (_m *mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
+func (*mockPerfCounterWatcher) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 
 // ScrapeRawValues implements winperfcounters.PerfCounterWatcher.
-func (_m *mockPerfCounterWatcher) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
+func (*mockPerfCounterWatcher) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
 	panic("unimplemented")
 }
 
 // Close provides a mock function with given fields:
-func (_m *mockPerfCounterWatcher) Close() error {
-	ret := _m.Called()
+func (w *mockPerfCounterWatcher) Close() error {
+	ret := w.Called()
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
@@ -53,8 +53,8 @@ func (_m *mockPerfCounterWatcher) Close() error {
 }
 
 // Path provides a mock function with given fields:
-func (_m *mockPerfCounterWatcher) Path() string {
-	ret := _m.Called()
+func (w *mockPerfCounterWatcher) Path() string {
+	ret := w.Called()
 
 	var r0 string
 	if rf, ok := ret.Get(0).(func() string); ok {
@@ -67,8 +67,8 @@ func (_m *mockPerfCounterWatcher) Path() string {
 }
 
 // ScrapeData provides a mock function with given fields:
-func (_m *mockPerfCounterWatcher) ScrapeData() ([]winperfcounters.CounterValue, error) {
-	ret := _m.Called()
+func (w *mockPerfCounterWatcher) ScrapeData() ([]winperfcounters.CounterValue, error) {
+	ret := w.Called()
 
 	var r0 []winperfcounters.CounterValue
 	if rf, ok := ret.Get(0).(func() []winperfcounters.CounterValue); ok {
@@ -87,7 +87,7 @@ func (_m *mockPerfCounterWatcher) ScrapeData() ([]winperfcounters.CounterValue, 
 	return r0, r1
 }
 
-func (_m *mockPerfCounterWatcher) Reset() error {
+func (*mockPerfCounterWatcher) Reset() error {
 	return nil
 }
 

--- a/receiver/statsdreceiver/internal/transport/mock_reporter.go
+++ b/receiver/statsdreceiver/internal/transport/mock_reporter.go
@@ -22,7 +22,7 @@ func NewMockReporter(expectedOnMetricsProcessedCalls int) *MockReporter {
 	return &m
 }
 
-func (m *MockReporter) OnDebugf(string, ...any) {
+func (*MockReporter) OnDebugf(string, ...any) {
 }
 
 // WaitAllOnMetricsProcessedCalls blocks until the number of expected calls

--- a/receiver/statsdreceiver/internal/transport/packet_server.go
+++ b/receiver/statsdreceiver/internal/transport/packet_server.go
@@ -55,7 +55,7 @@ func (u *packetServer) ListenAndServe(
 }
 
 // handlePacket is helper that parses the buffer and split it line by line to be parsed upstream.
-func (u *packetServer) handlePacket(
+func (*packetServer) handlePacket(
 	numBytes int,
 	data []byte,
 	addr net.Addr,

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -178,6 +178,6 @@ func (r *statsdReceiver) Shutdown(context.Context) error {
 	return err
 }
 
-func (r *statsdReceiver) Flush(ctx context.Context, metrics pmetric.Metrics, nextConsumer consumer.Metrics) error {
+func (*statsdReceiver) Flush(ctx context.Context, metrics pmetric.Metrics, nextConsumer consumer.Metrics) error {
 	return nextConsumer.ConsumeMetrics(ctx, metrics)
 }

--- a/receiver/stefreceiver/config.go
+++ b/receiver/stefreceiver/config.go
@@ -18,6 +18,6 @@ type Config struct {
 	_ struct{}
 }
 
-func (c *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -27,12 +27,12 @@ func NewFactory() receiver.Factory {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return &SysLogConfig{
 		BaseConfig: adapter.BaseConfig{
 			Operators:      []operator.Config{},
@@ -43,7 +43,7 @@ func (f ReceiverType) CreateDefaultConfig() component.Config {
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*SysLogConfig).BaseConfig
 }
 
@@ -57,7 +57,7 @@ type SysLogConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*SysLogConfig).InputConfig)
 }
 

--- a/receiver/systemdreceiver/receiver.go
+++ b/receiver/systemdreceiver/receiver.go
@@ -10,10 +10,10 @@ import (
 
 type systemdReceiver struct{}
 
-func (s systemdReceiver) Start(context.Context, component.Host) error {
+func (systemdReceiver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (s systemdReceiver) Shutdown(context.Context) error {
+func (systemdReceiver) Shutdown(context.Context) error {
 	return nil
 }

--- a/receiver/tcpcheckreceiver/scraper.go
+++ b/receiver/tcpcheckreceiver/scraper.go
@@ -46,7 +46,7 @@ func getConnectionState(tcpConfig *confignet.TCPAddrConfig) (tcpConnectionState,
 	return state, nil
 }
 
-func (s *scraper) errorListener(ctx context.Context, eQueue <-chan error, eOut chan<- *scrapererror.ScrapeErrors) {
+func (*scraper) errorListener(ctx context.Context, eQueue <-chan error, eOut chan<- *scrapererror.ScrapeErrors) {
 	errs := &scrapererror.ScrapeErrors{}
 
 	for {

--- a/receiver/tcplogreceiver/tcp.go
+++ b/receiver/tcplogreceiver/tcp.go
@@ -23,12 +23,12 @@ func NewFactory() receiver.Factory {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return &TCPLogConfig{
 		BaseConfig: adapter.BaseConfig{
 			Operators: []operator.Config{},
@@ -38,7 +38,7 @@ func (f ReceiverType) CreateDefaultConfig() component.Config {
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*TCPLogConfig).BaseConfig
 }
 
@@ -52,6 +52,6 @@ type TCPLogConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*TCPLogConfig).InputConfig)
 }

--- a/receiver/udplogreceiver/udp.go
+++ b/receiver/udplogreceiver/udp.go
@@ -23,12 +23,12 @@ func NewFactory() receiver.Factory {
 type ReceiverType struct{}
 
 // Type is the receiver type
-func (f ReceiverType) Type() component.Type {
+func (ReceiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f ReceiverType) CreateDefaultConfig() component.Config {
+func (ReceiverType) CreateDefaultConfig() component.Config {
 	return &UDPLogConfig{
 		BaseConfig: adapter.BaseConfig{
 			Operators: []operator.Config{},
@@ -38,7 +38,7 @@ func (f ReceiverType) CreateDefaultConfig() component.Config {
 }
 
 // BaseConfig gets the base config from config, for now
-func (f ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (ReceiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*UDPLogConfig).BaseConfig
 }
 
@@ -52,6 +52,6 @@ type UDPLogConfig struct {
 }
 
 // InputConfig unmarshals the input operator
-func (f ReceiverType) InputConfig(cfg component.Config) operator.Config {
+func (ReceiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*UDPLogConfig).InputConfig)
 }

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -380,7 +380,7 @@ const (
 )
 
 // getLabelsForQueryType returns the appropriate labels for each query type
-func (vc *vcenterClient) getLabelsForQueryType(queryType vSANQueryType) []string {
+func (*vcenterClient) getLabelsForQueryType(queryType vSANQueryType) []string {
 	switch queryType {
 	case vSANQueryTypeClusters:
 		return []string{
@@ -603,7 +603,7 @@ func (vc *vcenterClient) convertVSANValueToMetricDetails(
 }
 
 // uuidFromEntityRefID returns the UUID portion of the EntityRefId
-func (vc *vcenterClient) uuidFromEntityRefID(id string) (string, error) {
+func (*vcenterClient) uuidFromEntityRefID(id string) (string, error) {
 	colonIndex := strings.Index(id, ":")
 	if colonIndex != -1 {
 		uuid := id[colonIndex+1:]

--- a/receiver/wavefrontreceiver/wavefront_parser.go
+++ b/receiver/wavefrontreceiver/wavefront_parser.go
@@ -116,7 +116,7 @@ func (wp *wavefrontParser) Parse(line string) (pmetric.Metric, error) {
 	return metric, nil
 }
 
-func (wp *wavefrontParser) injectCollectDLabels(
+func (*wavefrontParser) injectCollectDLabels(
 	metricName string,
 	attributes pcommon.Map,
 ) string {

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -212,7 +212,7 @@ func (er *eventReceiver) handleReq(w http.ResponseWriter, r *http.Request, _ htt
 }
 
 // Simple healthcheck endpoint.
-func (er *eventReceiver) handleHealthCheck(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+func (*eventReceiver) handleHealthCheck(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -26,21 +26,21 @@ type receiverType struct{}
 var _ adapter.LogReceiverType = (*receiverType)(nil)
 
 // Type is the receiver type
-func (f receiverType) Type() component.Type {
+func (receiverType) Type() component.Type {
 	return metadata.Type
 }
 
 // CreateDefaultConfig creates a config with type and version
-func (f receiverType) CreateDefaultConfig() component.Config {
+func (receiverType) CreateDefaultConfig() component.Config {
 	return createDefaultConfig()
 }
 
 // BaseConfig gets the base config from config, for now
-func (f receiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
+func (receiverType) BaseConfig(cfg component.Config) adapter.BaseConfig {
 	return cfg.(*WindowsLogConfig).BaseConfig
 }
 
 // InputConfig unmarshals the input operator
-func (f receiverType) InputConfig(cfg component.Config) operator.Config {
+func (receiverType) InputConfig(cfg component.Config) operator.Config {
 	return operator.NewConfig(&cfg.(*WindowsLogConfig).InputConfig)
 }

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -38,12 +38,12 @@ type mockPerfCounter struct {
 }
 
 // ScrapeRawValue implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounter) ScrapeRawValue(*int64) (bool, error) {
+func (*mockPerfCounter) ScrapeRawValue(*int64) (bool, error) {
 	panic("unimplemented")
 }
 
 // ScrapeRawValues implements winperfcounters.PerfCounterWatcher.
-func (w *mockPerfCounter) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
+func (*mockPerfCounter) ScrapeRawValues() ([]winperfcounters.RawCounterValue, error) {
 	panic("unimplemented")
 }
 

--- a/receiver/windowsservicereceiver/config.go
+++ b/receiver/windowsservicereceiver/config.go
@@ -20,6 +20,6 @@ type Config struct {
 }
 
 // Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/receiver/windowsservicereceiver/factory.go
+++ b/receiver/windowsservicereceiver/factory.go
@@ -44,10 +44,10 @@ func newMetricsReceiver(*Config, consumer.Metrics) *windowsServiceReceiver {
 
 type windowsServiceReceiver struct{}
 
-func (r *windowsServiceReceiver) Start(context.Context, component.Host) error {
+func (*windowsServiceReceiver) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (r *windowsServiceReceiver) Shutdown(context.Context) error {
+func (*windowsServiceReceiver) Shutdown(context.Context) error {
 	return nil
 }

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -33,12 +33,12 @@ func newWindowsServiceScraper(settings receiver.Settings, _ *Config) windowsServ
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) start(context.Context, component.Host) (err error) {
+func (*windowsServiceScraper) start(context.Context, component.Host) (err error) {
 	return nil
 }
 
 //nolint:unused
-func (ws *windowsServiceScraper) shutdown(context.Context) (err error) {
+func (*windowsServiceScraper) shutdown(context.Context) (err error) {
 	return nil
 }
 

--- a/receiver/windowsservicereceiver/winapi.go
+++ b/receiver/windowsservicereceiver/winapi.go
@@ -38,17 +38,17 @@ func scmConnect() (*serviceManager, error) {
 }
 
 //nolint:unused
-func (sm *serviceManager) disconnect() error {
+func (*serviceManager) disconnect() error {
 	return nil
 }
 
 //nolint:unused
-func (sm *serviceManager) listServices() ([]string, error) {
+func (*serviceManager) listServices() ([]string, error) {
 	var s []string
 	return s, nil
 }
 
 //nolint:unused
-func (sm *serviceManager) openService() (*mgr.Service, error) {
+func (*serviceManager) openService() (*mgr.Service, error) {
 	return nil, nil
 }

--- a/receiver/windowsservicereceiver/winservice.go
+++ b/receiver/windowsservicereceiver/winservice.go
@@ -29,11 +29,11 @@ func getService(mgr *serviceManager, sname string) (*winService, error) {
 }
 
 //nolint:unused
-func (w *winService) getStatus() error {
+func (*winService) getStatus() error {
 	return nil
 }
 
 //nolint:unused
-func (w *winService) getConfig() error {
+func (*winService) getConfig() error {
 	return nil
 }

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -23,6 +23,6 @@ type Config struct {
 var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
-func (cfg *Config) Validate() error {
+func (*Config) Validate() error {
 	return nil
 }

--- a/testbed/correctnesstests/metrics/metrics_test_harness.go
+++ b/testbed/correctnesstests/metrics/metrics_test_harness.go
@@ -50,7 +50,7 @@ func newTestHarness(
 	}
 }
 
-func (h *testHarness) Capabilities() consumer.Capabilities {
+func (*testHarness) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/testbed/dataconnectors/routing.go
+++ b/testbed/dataconnectors/routing.go
@@ -17,7 +17,7 @@ func NewRoutingDataConnector(receiverDataType string) *RoutingDataConnector {
 	return &RoutingDataConnector{DataConnectorBase: testbed.DataConnectorBase{ReceiverDataType: receiverDataType}}
 }
 
-func (rc *RoutingDataConnector) GenConfigYAMLStr() string {
+func (*RoutingDataConnector) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return `
   routing:
@@ -27,7 +27,7 @@ func (rc *RoutingDataConnector) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (rc *RoutingDataConnector) ProtocolName() string {
+func (*RoutingDataConnector) ProtocolName() string {
 	return "routing"
 }
 

--- a/testbed/dataconnectors/spanmetrics.go
+++ b/testbed/dataconnectors/spanmetrics.go
@@ -17,14 +17,14 @@ func NewSpanMetricDataConnector(receiverDataType string) *SpanMetricDataConnecto
 	return &SpanMetricDataConnector{DataConnectorBase: testbed.DataConnectorBase{ReceiverDataType: receiverDataType}}
 }
 
-func (smc *SpanMetricDataConnector) GenConfigYAMLStr() string {
+func (*SpanMetricDataConnector) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return `
   spanmetrics:`
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (smc *SpanMetricDataConnector) ProtocolName() string {
+func (*SpanMetricDataConnector) ProtocolName() string {
 	return "spanmetrics"
 }
 

--- a/testbed/datareceivers/carbon.go
+++ b/testbed/datareceivers/carbon.go
@@ -63,6 +63,6 @@ func (cr *CarbonDataReceiver) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (cr *CarbonDataReceiver) ProtocolName() string {
+func (*CarbonDataReceiver) ProtocolName() string {
 	return "carbon"
 }

--- a/testbed/datareceivers/datadog.go
+++ b/testbed/datareceivers/datadog.go
@@ -45,7 +45,7 @@ func (dd *datadogDataReceiver) Stop() error {
 	return dd.receiver.Shutdown(context.Background())
 }
 
-func (dd *datadogDataReceiver) GenConfigYAMLStr() string {
+func (*datadogDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return `
   datadog:
@@ -53,6 +53,6 @@ func (dd *datadogDataReceiver) GenConfigYAMLStr() string {
     `
 }
 
-func (dd *datadogDataReceiver) ProtocolName() string {
+func (*datadogDataReceiver) ProtocolName() string {
 	return "datadog"
 }

--- a/testbed/datareceivers/jaeger.go
+++ b/testbed/datareceivers/jaeger.go
@@ -61,6 +61,6 @@ func (jr *jaegerDataReceiver) GenConfigYAMLStr() string {
       insecure: true`, jr.Port)
 }
 
-func (jr *jaegerDataReceiver) ProtocolName() string {
+func (*jaegerDataReceiver) ProtocolName() string {
 	return "otlp/jaeger"
 }

--- a/testbed/datareceivers/opencensus.go
+++ b/testbed/datareceivers/opencensus.go
@@ -65,6 +65,6 @@ func (or *ocDataReceiver) GenConfigYAMLStr() string {
       insecure: true`, or.Port)
 }
 
-func (or *ocDataReceiver) ProtocolName() string {
+func (*ocDataReceiver) ProtocolName() string {
 	return "opencensus"
 }

--- a/testbed/datareceivers/prometheus.go
+++ b/testbed/datareceivers/prometheus.go
@@ -72,6 +72,6 @@ func (dr *prometheusDataReceiver) GenConfigYAMLStr() string {
 	return fmt.Sprintf(format, dr.Port)
 }
 
-func (dr *prometheusDataReceiver) ProtocolName() string {
+func (*prometheusDataReceiver) ProtocolName() string {
 	return "prometheus"
 }

--- a/testbed/datareceivers/signalfx.go
+++ b/testbed/datareceivers/signalfx.go
@@ -65,6 +65,6 @@ func (sr *SFxMetricsDataReceiver) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (sr *SFxMetricsDataReceiver) ProtocolName() string {
+func (*SFxMetricsDataReceiver) ProtocolName() string {
 	return "signalfx"
 }

--- a/testbed/datareceivers/splunk.go
+++ b/testbed/datareceivers/splunk.go
@@ -64,6 +64,6 @@ func (sr *SplunkHECDataReceiver) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (sr *SplunkHECDataReceiver) ProtocolName() string {
+func (*SplunkHECDataReceiver) ProtocolName() string {
 	return "splunk_hec"
 }

--- a/testbed/datareceivers/stef.go
+++ b/testbed/datareceivers/stef.go
@@ -65,6 +65,6 @@ func (sr *StefDataReceiver) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (sr *StefDataReceiver) ProtocolName() string {
+func (*StefDataReceiver) ProtocolName() string {
 	return "stef"
 }

--- a/testbed/datareceivers/syslog.go
+++ b/testbed/datareceivers/syslog.go
@@ -67,6 +67,6 @@ func (cr *SyslogDataReceiver) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (cr *SyslogDataReceiver) ProtocolName() string {
+func (*SyslogDataReceiver) ProtocolName() string {
 	return "tcp"
 }

--- a/testbed/datareceivers/zipkin.go
+++ b/testbed/datareceivers/zipkin.go
@@ -55,6 +55,6 @@ func (zr *zipkinDataReceiver) GenConfigYAMLStr() string {
     format: json`, zr.Port)
 }
 
-func (zr *zipkinDataReceiver) ProtocolName() string {
+func (*zipkinDataReceiver) ProtocolName() string {
 	return "zipkin"
 }

--- a/testbed/datasenders/carbon.go
+++ b/testbed/datasenders/carbon.go
@@ -70,6 +70,6 @@ func (cs *CarbonDataSender) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (cs *CarbonDataSender) ProtocolName() string {
+func (*CarbonDataSender) ProtocolName() string {
 	return "carbon"
 }

--- a/testbed/datasenders/datadog_agent_exporter.go
+++ b/testbed/datasenders/datadog_agent_exporter.go
@@ -56,6 +56,6 @@ func (dd *datadogDataSender) GenConfigYAMLStr() string {
     endpoint: %s`, dd.GetEndpoint())
 }
 
-func (dd *datadogDataSender) ProtocolName() string {
+func (*datadogDataSender) ProtocolName() string {
 	return "datadog"
 }

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -64,11 +64,11 @@ func NewFluentLogsForwarder(t *testing.T, port int) *FluentLogsForwarder {
 	return f
 }
 
-func (f *FluentLogsForwarder) Capabilities() consumer.Capabilities {
+func (*FluentLogsForwarder) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (f *FluentLogsForwarder) Start() error {
+func (*FluentLogsForwarder) Start() error {
 	return nil
 }
 
@@ -96,7 +96,7 @@ func (f *FluentLogsForwarder) ConsumeLogs(_ context.Context, logs plog.Logs) err
 	return nil
 }
 
-func (f *FluentLogsForwarder) convertLogToMap(lr plog.LogRecord) map[string]string {
+func (*FluentLogsForwarder) convertLogToMap(lr plog.LogRecord) map[string]string {
 	out := map[string]string{}
 
 	if lr.Body().Type() == pcommon.ValueTypeStr {
@@ -121,7 +121,7 @@ func (f *FluentLogsForwarder) convertLogToMap(lr plog.LogRecord) map[string]stri
 	return out
 }
 
-func (f *FluentLogsForwarder) convertLogToJSON(lr plog.LogRecord) []byte {
+func (*FluentLogsForwarder) convertLogToJSON(lr plog.LogRecord) []byte {
 	rec := map[string]string{
 		"time": time.Unix(0, int64(lr.Timestamp())).Format("02/01/2006:15:04:05Z"),
 	}
@@ -158,6 +158,6 @@ func (f *FluentLogsForwarder) GenConfigYAMLStr() string {
     endpoint: 127.0.0.1:%d`, f.Port)
 }
 
-func (f *FluentLogsForwarder) ProtocolName() string {
+func (*FluentLogsForwarder) ProtocolName() string {
 	return "fluentforward"
 }

--- a/testbed/datasenders/jaeger.go
+++ b/testbed/datasenders/jaeger.go
@@ -68,7 +68,7 @@ func (je *jaegerGRPCDataSender) GenConfigYAMLStr() string {
         endpoint: "%s"`, je.GetEndpoint())
 }
 
-func (je *jaegerGRPCDataSender) ProtocolName() string {
+func (*jaegerGRPCDataSender) ProtocolName() string {
 	return "jaeger"
 }
 

--- a/testbed/datasenders/k8s.go
+++ b/testbed/datasenders/k8s.go
@@ -70,11 +70,11 @@ func NewFileLogK8sWriter(config string) *FileLogK8sWriter {
 	return f
 }
 
-func (f *FileLogK8sWriter) Capabilities() consumer.Capabilities {
+func (*FileLogK8sWriter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (f *FileLogK8sWriter) Start() error {
+func (*FileLogK8sWriter) Start() error {
 	return nil
 }
 
@@ -93,7 +93,7 @@ func (f *FileLogK8sWriter) ConsumeLogs(_ context.Context, logs plog.Logs) error 
 	return nil
 }
 
-func (f *FileLogK8sWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
+func (*FileLogK8sWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 	sb := strings.Builder{}
 
 	// Timestamp
@@ -140,11 +140,11 @@ func (f *FileLogK8sWriter) GenConfigYAMLStr() string {
 	return fmt.Sprintf(f.config, f.file.Name())
 }
 
-func (f *FileLogK8sWriter) ProtocolName() string {
+func (*FileLogK8sWriter) ProtocolName() string {
 	return "filelog"
 }
 
-func (f *FileLogK8sWriter) GetEndpoint() net.Addr {
+func (*FileLogK8sWriter) GetEndpoint() net.Addr {
 	return nil
 }
 

--- a/testbed/datasenders/opencensus.go
+++ b/testbed/datasenders/opencensus.go
@@ -36,7 +36,7 @@ func (ods *ocDataSender) GenConfigYAMLStr() string {
     endpoint: "%s"`, ods.GetEndpoint())
 }
 
-func (ods *ocDataSender) ProtocolName() string {
+func (*ocDataSender) ProtocolName() string {
 	return "opencensus"
 }
 

--- a/testbed/datasenders/prometheus.go
+++ b/testbed/datasenders/prometheus.go
@@ -63,6 +63,6 @@ func (pds *prometheusDataSender) GenConfigYAMLStr() string {
 	return fmt.Sprintf(format, pds.GetEndpoint())
 }
 
-func (pds *prometheusDataSender) ProtocolName() string {
+func (*prometheusDataSender) ProtocolName() string {
 	return "prometheus"
 }

--- a/testbed/datasenders/signalfx.go
+++ b/testbed/datasenders/signalfx.go
@@ -70,6 +70,6 @@ func (sf *SFxMetricsDataSender) GenConfigYAMLStr() string {
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.
-func (sf *SFxMetricsDataSender) ProtocolName() string {
+func (*SFxMetricsDataSender) ProtocolName() string {
 	return "signalfx"
 }

--- a/testbed/datasenders/stanza.go
+++ b/testbed/datasenders/stanza.go
@@ -54,11 +54,11 @@ func (f *FileLogWriter) WithStorage(storage string) *FileLogWriter {
 	return f
 }
 
-func (f *FileLogWriter) Capabilities() consumer.Capabilities {
+func (*FileLogWriter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (f *FileLogWriter) Start() error {
+func (*FileLogWriter) Start() error {
 	return nil
 }
 
@@ -77,7 +77,7 @@ func (f *FileLogWriter) ConsumeLogs(_ context.Context, logs plog.Logs) error {
 	return nil
 }
 
-func (f *FileLogWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
+func (*FileLogWriter) convertLogToTextLine(lr plog.LogRecord) []byte {
 	sb := strings.Builder{}
 
 	// Timestamp
@@ -137,11 +137,11 @@ func (f *FileLogWriter) GenConfigYAMLStr() string {
 `, f.file.Name(), f.retry, f.storage)
 }
 
-func (f *FileLogWriter) ProtocolName() string {
+func (*FileLogWriter) ProtocolName() string {
 	return "filelog"
 }
 
-func (f *FileLogWriter) GetEndpoint() net.Addr {
+func (*FileLogWriter) GetEndpoint() net.Addr {
 	return nil
 }
 

--- a/testbed/datasenders/stef.go
+++ b/testbed/datasenders/stef.go
@@ -59,6 +59,6 @@ func (sds *stefDataSender) GenConfigYAMLStr() string {
 	return fmt.Sprintf(format, sds.GetEndpoint())
 }
 
-func (sds *stefDataSender) ProtocolName() string {
+func (*stefDataSender) ProtocolName() string {
 	return "stef"
 }

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -51,7 +51,7 @@ func (f *SyslogWriter) GetEndpoint() net.Addr {
 	return addr
 }
 
-func (f *SyslogWriter) Capabilities() consumer.Capabilities {
+func (*SyslogWriter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -125,9 +125,9 @@ func (f *SyslogWriter) SendCheck() error {
 	return nil
 }
 
-func (f *SyslogWriter) Flush() {
+func (*SyslogWriter) Flush() {
 }
 
-func (f *SyslogWriter) ProtocolName() string {
+func (*SyslogWriter) ProtocolName() string {
 	return "syslog"
 }

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -52,7 +52,7 @@ func (f *TCPUDPWriter) GetEndpoint() net.Addr {
 	return addr
 }
 
-func (f *TCPUDPWriter) Capabilities() consumer.Capabilities {
+func (*TCPUDPWriter) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -118,7 +118,7 @@ func (f *TCPUDPWriter) SendCheck() error {
 	return nil
 }
 
-func (f *TCPUDPWriter) Flush() {
+func (*TCPUDPWriter) Flush() {
 }
 
 func (f *TCPUDPWriter) ProtocolName() string {

--- a/testbed/datasenders/zipkin.go
+++ b/testbed/datasenders/zipkin.go
@@ -59,6 +59,6 @@ func (zs *zipkinDataSender) GenConfigYAMLStr() string {
     endpoint: %s`, zs.GetEndpoint())
 }
 
-func (zs *zipkinDataSender) ProtocolName() string {
+func (*zipkinDataSender) ProtocolName() string {
 	return "zipkin"
 }

--- a/testbed/testbed/data_providers.go
+++ b/testbed/testbed/data_providers.go
@@ -223,7 +223,7 @@ func (dp *goldenDataProvider) GenerateMetrics() (pmetric.Metrics, bool) {
 	return pdm, false
 }
 
-func (dp *goldenDataProvider) GenerateLogs() (plog.Logs, bool) {
+func (*goldenDataProvider) GenerateLogs() (plog.Logs, bool) {
 	return plog.NewLogs(), true
 }
 

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -109,15 +109,15 @@ func (ipp *inProcessCollector) Stop() (stopped bool, err error) {
 	return stopped, err
 }
 
-func (ipp *inProcessCollector) WatchResourceConsumption() error {
+func (*inProcessCollector) WatchResourceConsumption() error {
 	return nil
 }
 
-func (ipp *inProcessCollector) GetProcessMon() *process.Process {
+func (*inProcessCollector) GetProcessMon() *process.Process {
 	return nil
 }
 
-func (ipp *inProcessCollector) GetTotalConsumption() *ResourceConsumption {
+func (*inProcessCollector) GetTotalConsumption() *ResourceConsumption {
 	return &ResourceConsumption{
 		CPUPercentAvg:   0,
 		CPUPercentMax:   0,
@@ -128,6 +128,6 @@ func (ipp *inProcessCollector) GetTotalConsumption() *ResourceConsumption {
 	}
 }
 
-func (ipp *inProcessCollector) GetResourceConsumption() string {
+func (*inProcessCollector) GetResourceConsumption() string {
 	return ""
 }

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -191,7 +191,7 @@ type MockTraceConsumer struct {
 	backend          *MockBackend
 }
 
-func (tc *MockTraceConsumer) Capabilities() consumer.Capabilities {
+func (*MockTraceConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -243,7 +243,7 @@ type MockMetricConsumer struct {
 	backend            *MockBackend
 }
 
-func (mc *MockMetricConsumer) Capabilities() consumer.Capabilities {
+func (*MockMetricConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
@@ -275,7 +275,7 @@ type MockLogConsumer struct {
 	backend               *MockBackend
 }
 
-func (lc *MockLogConsumer) Capabilities() consumer.Capabilities {
+func (*MockLogConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -72,7 +72,7 @@ func (dsb *DataSenderBase) GetEndpoint() net.Addr {
 	return addr
 }
 
-func (dsb *DataSenderBase) Flush() {
+func (*DataSenderBase) Flush() {
 	// Exporter interface does not support Flush, so nothing to do.
 }
 
@@ -103,7 +103,7 @@ func (ods *otlpHTTPDataSender) GenConfigYAMLStr() string {
         endpoint: "%s"`, ods.GetEndpoint())
 }
 
-func (ods *otlpHTTPDataSender) ProtocolName() string {
+func (*otlpHTTPDataSender) ProtocolName() string {
 	return "otlp"
 }
 
@@ -234,7 +234,7 @@ func (ods *otlpDataSender) GenConfigYAMLStr() string {
         endpoint: "%s"`, ods.GetEndpoint())
 }
 
-func (ods *otlpDataSender) ProtocolName() string {
+func (*otlpDataSender) ProtocolName() string {
 	return "otlp"
 }
 

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -47,7 +47,7 @@ func (v *LogPresentValidator) Validate(tc *TestCase) {
 	}
 }
 
-func (v *LogPresentValidator) RecordResults(tc *TestCase) {
+func (*LogPresentValidator) RecordResults(tc *TestCase) {
 	var result string
 	if tc.t.Failed() {
 		result = "FAIL"
@@ -71,7 +71,7 @@ type PerfTestValidator struct {
 	IncludeLimitsInReport bool
 }
 
-func (v *PerfTestValidator) Validate(tc *TestCase) {
+func (*PerfTestValidator) Validate(tc *TestCase) {
 	if assert.Equal(tc.t,
 		int64(tc.LoadGenerator.DataItemsSent()),
 		int64(tc.MockBackend.DataItemsReceived()),
@@ -617,7 +617,7 @@ func (c *CorrectnessLogTestValidator) Validate(tc *TestCase) {
 	}
 }
 
-func (c *CorrectnessLogTestValidator) RecordResults(tc *TestCase) {
+func (*CorrectnessLogTestValidator) RecordResults(tc *TestCase) {
 	rc := tc.agentProc.GetTotalConsumption()
 
 	var result string


### PR DESCRIPTION
#### Description

Enables and fixes [unused-receiver](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#unused-receiver) rule from revive.

This deletes receivers names when they are unused in the method they are called. 
This also apply the same logic when all of the parameters are named '_'
