### PR TITLE
[exporter/tinybird] default logs' Timestamp value to ObservedTimestamp when Timestamp is not set

### DIFF
--- a/.chloggen/fix_41397-fallback-to-observed-timestamp.yaml
+++ b/.chloggen/fix_41397-fallback-to-observed-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tinybirdexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Default logs' Timestamp value to ObservedTimestamp when Timestamp is not set
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41447]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/tinybirdexporter/internal/logs.go
+++ b/exporter/tinybirdexporter/internal/logs.go
@@ -46,6 +46,12 @@ func ConvertLogs(ld plog.Logs, encoder Encoder) error {
 			scopeAttributes := convertAttributes(scope.Attributes())
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				log := sl.LogRecords().At(k)
+
+				timestamp := log.Timestamp()
+				if timestamp == 0 {
+					timestamp = log.ObservedTimestamp()
+				}
+
 				logEntry := logSignal{
 					ResourceSchemaURL:  resourceSchemaURL,
 					ResourceAttributes: resourceAttributes,
@@ -54,7 +60,7 @@ func ConvertLogs(ld plog.Logs, encoder Encoder) error {
 					ScopeVersion:       scopeVersion,
 					ScopeSchemaURL:     scopeSchemaURL,
 					ScopeAttributes:    scopeAttributes,
-					Timestamp:          log.Timestamp().AsTime().Format(time.RFC3339Nano),
+					Timestamp:          timestamp.AsTime().Format(time.RFC3339Nano),
 					SeverityText:       log.SeverityText(),
 					SeverityNumber:     int32(log.SeverityNumber()),
 					LogAttributes:      convertAttributes(log.Attributes()),


### PR DESCRIPTION
#### Description

In some cases (like using Rust OTel SDK), the Timestamp value for the logs signal was not correctly set. That caused log entries to be set to the start timestamp epoch, which is not the desired behavior. For that reason, we are defaulting the Timestamp value to the ObservedTimestamp value, so we ensure there is always a valid value set.

#### Link to tracking issue
Fixes #41397