### PR TITLE
test(prometheusremotewrite/wal): fix Test_WALTelemetry by checking if  the metric exists instead of the actual value

### DIFF
--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -433,8 +433,6 @@ func TestWALLag_Telemetry(t *testing.T) {
 	// Wait for lag recording to happen (longer than lagRecordFrequency)
 	time.Sleep(5 * cfg.WAL.LagRecordFrequency)
 
-	metadatatest.AssertEqualExporterPrometheusremotewriteWalLag(t, tel,
-		[]metricdata.DataPoint[int64]{{Value: 0}},
-		metricdatatest.IgnoreTimestamp())
+	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_lag")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes Test_WALTelemetry test by checking if the metric exists instead of the actual value. Managed to reproduced the flakyness by running 

```
go test -v -failfast  -run  TestWALLag_Telemetry  -count=10000 -race -timeout=30m
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41354

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

No Changelog is needed in my opinion

<!--Please delete paragraphs that you did not use before submitting.-->
