### PR TITLE
[telemetrygen] allow --child-spans=0

### DIFF
--- a/cmd/telemetrygen/pkg/traces/traces.go
+++ b/cmd/telemetrygen/pkg/traces/traces.go
@@ -142,7 +142,7 @@ func run(c *Config, logger *zap.Logger) error {
 		wg.Add(1)
 		w := worker{
 			numTraces:        c.NumTraces,
-			numChildSpans:    int(math.Max(1, float64(c.NumChildSpans))),
+			numChildSpans:    int(math.Max(0, float64(c.NumChildSpans))),
 			propagateContext: c.PropagateContext,
 			statusCode:       statusCode,
 			limitPerSecond:   limit,

--- a/cmd/telemetrygen/pkg/traces/worker.go
+++ b/cmd/telemetrygen/pkg/traces/worker.go
@@ -75,7 +75,7 @@ func (w worker) simulateTraces(telemetryAttributes []attribute.KeyValue) {
 			// simulates getting a request from a client
 			childCtx = otel.GetTextMapPropagator().Extract(childCtx, header)
 		}
-		var endTimestamp trace.SpanEventOption
+		endTimestamp := trace.WithTimestamp(spanEnd)
 
 		for j := 0; j < w.numChildSpans; j++ {
 			if err := limiter.Wait(context.Background()); err != nil {

--- a/cmd/telemetrygen/pkg/traces/worker_test.go
+++ b/cmd/telemetrygen/pkg/traces/worker_test.go
@@ -366,9 +366,9 @@ func configWithNoAttributes(qty int, statusCode string) *Config {
 			WorkerCount:         1,
 			TelemetryAttributes: nil,
 		},
-		NumTraces:  qty,
+		NumTraces:     qty,
 		NumChildSpans: 1,
-		StatusCode: statusCode,
+		StatusCode:    statusCode,
 	}
 }
 
@@ -378,9 +378,9 @@ func configWithOneAttribute(qty int, statusCode string) *Config {
 			WorkerCount:         1,
 			TelemetryAttributes: common.KeyValue{telemetryAttrKeyOne: telemetryAttrValueOne},
 		},
-		NumTraces:  qty,
+		NumTraces:     qty,
 		NumChildSpans: 1,
-		StatusCode: statusCode,
+		StatusCode:    statusCode,
 	}
 }
 
@@ -391,8 +391,8 @@ func configWithMultipleAttributes(qty int, statusCode string) *Config {
 			WorkerCount:         1,
 			TelemetryAttributes: kvs,
 		},
-		NumTraces:  qty,
+		NumTraces:     qty,
 		NumChildSpans: 1,
-		StatusCode: statusCode,
+		StatusCode:    statusCode,
 	}
 }

--- a/cmd/telemetrygen/pkg/traces/worker_test.go
+++ b/cmd/telemetrygen/pkg/traces/worker_test.go
@@ -47,7 +47,7 @@ func TestFixedNumberOfTraces(t *testing.T) {
 	require.NoError(t, run(cfg, zap.NewNop()))
 
 	// verify
-	assert.Len(t, syncer.spans, 2) // each trace has two spans
+	assert.Len(t, syncer.spans, 1) // each trace has two spans
 }
 
 func TestNumberOfSpans(t *testing.T) {
@@ -90,6 +90,7 @@ func TestRateOfSpans(t *testing.T) {
 			TotalDuration: time.Second / 2,
 			WorkerCount:   1,
 		},
+		NumChildSpans: 1,
 	}
 
 	// sanity check
@@ -366,6 +367,7 @@ func configWithNoAttributes(qty int, statusCode string) *Config {
 			TelemetryAttributes: nil,
 		},
 		NumTraces:  qty,
+		NumChildSpans: 1,
 		StatusCode: statusCode,
 	}
 }
@@ -377,6 +379,7 @@ func configWithOneAttribute(qty int, statusCode string) *Config {
 			TelemetryAttributes: common.KeyValue{telemetryAttrKeyOne: telemetryAttrValueOne},
 		},
 		NumTraces:  qty,
+		NumChildSpans: 1,
 		StatusCode: statusCode,
 	}
 }
@@ -389,6 +392,7 @@ func configWithMultipleAttributes(qty int, statusCode string) *Config {
 			TelemetryAttributes: kvs,
 		},
 		NumTraces:  qty,
+		NumChildSpans: 1,
 		StatusCode: statusCode,
 	}
 }


### PR DESCRIPTION
I don't get why I'm not allowed to send a trace with just the root span.

