### PR TITLE
[chore] Wait 30 minutes before retrying, do it at most once

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -45,9 +45,9 @@ jobs:
       - name: Gets packages from links with retries
         uses: nick-fields/retry@v3
         with:  
-          retry_wait_seconds: 500
+          retry_wait_seconds: 1800
           timeout_minutes: 120
-          max_attempts: 3
+          max_attempts: 2
           retry_on: error 
           command: |
             cd opentelemetry-collector-contrib


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://proxy.golang.org/ says:

> Note that if someone requested the version before the tag was pushed, it may take up to 30 minutes for the mirror's cache to expire and fresh data about the version to become available. If the version is still not available after 30 minutes, please [file an issue](https://golang.org/issue/new?title=proxy.golang.org%3A+).

So I propose we bump this to 30 minutes, and that we try at most once more, and file an issue in golang/go if it fails after that.
