### PR TITLE
[extension/solarwindsapmsettingsextension] Fixed the obsolete go path

### DIFF
--- a/extension/solarwindsapmsettingsextension/extension.go
+++ b/extension/solarwindsapmsettingsextension/extension.go
@@ -14,7 +14,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/solarwindscloud/apm-proto/go/collectorpb"
+	"github.com/solarwinds/apm-proto/go/collectorpb"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/extension"

--- a/extension/solarwindsapmsettingsextension/extension_test.go
+++ b/extension/solarwindsapmsettingsextension/extension_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/solarwindscloud/apm-proto/go/collectorpb"
-	"github.com/solarwindscloud/apm-proto/go/collectorpb/mocks"
+	"github.com/solarwinds/apm-proto/go/collectorpb"
+	"github.com/solarwinds/apm-proto/go/collectorpb/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"

--- a/extension/solarwindsapmsettingsextension/go.mod
+++ b/extension/solarwindsapmsettingsextension/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/solarwindscloud/apm-proto v1.0.9
+	github.com/solarwinds/apm-proto v1.0.9
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.36.0
 	go.opentelemetry.io/collector/component/componenttest v0.130.0
@@ -38,7 +38,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/apm-proto/go/collectorpb v0.0.0-20240613003450-632ba12aefa9 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.36.0 // indirect

--- a/extension/solarwindsapmsettingsextension/go.sum
+++ b/extension/solarwindsapmsettingsextension/go.sum
@@ -61,10 +61,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/solarwinds/apm-proto/go/collectorpb v0.0.0-20240613003450-632ba12aefa9 h1:G0VJS2ZTib9Y+SWiDkY+F6ePywOQtQBDnS9hlXiXKfE=
-github.com/solarwinds/apm-proto/go/collectorpb v0.0.0-20240613003450-632ba12aefa9/go.mod h1:s+WnRtCbTo+e8S9ytEO/WBlf1N0kXdqgtMhEdi4Ir3g=
-github.com/solarwindscloud/apm-proto v1.0.9 h1:HknUExNfxH67ybDIhBu2jaqJtJJ2/5nIuLsRWqsj1Zk=
-github.com/solarwindscloud/apm-proto v1.0.9/go.mod h1:PIMzXc8HpB0ryT4Oci4pUz8F0m1X7Q/hVXkQE4jGv6Y=
+github.com/solarwinds/apm-proto v1.0.9 h1:6s1YYLINX9CTocE/A9ocUKIv43rZZ4X9OHbCUFpWrKg=
+github.com/solarwinds/apm-proto v1.0.9/go.mod h1:CN4fCYBnxyOJlBV0CYNXLz6lzNH8SCfNqcCBbpai76c=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
apm-proto v1.0.9 has a change in the go path which breaks the update pipeline of opentelemetry-collector-contrib.
The path changed 
from 
`github.com/solarwindscloud/apm-proto/go/collectorpb` 
to 
`github.com/solarwinds/apm-proto/go/collectorpb`

Updated the path to resolve the bug.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
[Fixes](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41298)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
After updating the path, it passed the `make test` command

<!--Please delete paragraphs that you did not use before submitting.-->
