### PR TITLE
[chore] [receiver/hostmetrics] Update documentation to remove Mac exclusion for `disk` and `cpu`

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -41,8 +41,8 @@ The available scrapers are:
 
 | Scraper      | Supported OSs                | Description                                            |
 | ------------ | ---------------------------- | ------------------------------------------------------ |
-| [cpu]        | All except Mac<sup>[1]</sup> | CPU utilization metrics                                |
-| [disk]       | All except Mac<sup>[1]</sup> | Disk I/O metrics                                       |
+| [cpu]        | All                          | CPU utilization metrics                                |
+| [disk]       | All                          | Disk I/O metrics                                       |
 | [load]       | All                          | CPU load metrics                                       |
 | [filesystem] | All                          | File System utilization metrics                        |
 | [memory]     | All                          | Memory utilization metrics                             |
@@ -64,8 +64,6 @@ The available scrapers are:
 [system]: ./internal/scraper/systemscraper/documentation.md
 
 ### Notes
-
-<sup>[1]</sup> Not supported on Mac when compiled without cgo which is the default.
 
 Several scrapers support additional configuration:
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Previously, the `disk` and `cpu` scrapers would error on `darwin` runtime due to the metrics not being supported without CGO. This changed in a `gopsutil` update to [use `purego` for loading Mac shared objects instead of CGO bindings](https://github.com/shirou/gopsutil/pull/1702). These now work as expected on `darwin`, and nothing restricts these receivers from working.

This PR removes the declaration in the documentation that these scrapers are unsupported on Mac.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #33393 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
The tests aren't disabled for `darwin` as far as I can tell, so unless I'm mistaken the tests for these scrapers have been running anyway.

<!--Describe the documentation added.-->
#### Documentation
This is a documentation PR. :smiley: 

<!--Please delete paragraphs that you did not use before submitting.-->
