### PR TITLE
Add support to SanitizeDBStatement OTTL function

### DIFF
--- a/.chloggen/41519.yaml
+++ b/.chloggen/41519.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for sanitizing SQL statements in OTTL with a new function `SanitizeDBStatement`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41519]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -507,6 +507,7 @@ Available Converters:
 - [ParseXML](#parsexml)
 - [ProfileID](#profileid)
 - [RemoveXML](#removexml)
+- [SanitizeDBStatement](#sanitizedbstatement)
 - [Second](#second)
 - [Seconds](#seconds)
 - [SHA1](#sha1)
@@ -1897,6 +1898,28 @@ Delete all comments
 Delete text from nodes that contain the word "sensitive"
 
 - `RemoveXML(log.body, "//*[contains(text(), 'sensitive')]")`
+
+### SanitizeDBStatement
+
+`SanitizeDBStatement(target)`
+
+The `SanitizeDBStatement` Converter takes a SQL statement string and returns a sanitized version with literals replaced by placeholders.
+
+`target` is a string containing a SQL statement. If `target` is not a string or is empty, the function returns an error.
+
+The function performs the following sanitization:
+- Replaces numeric literals with `?`
+- Replaces string literals with `?`
+- Preserves SQL keywords, identifiers, and operators
+- Preserves comments
+- Normalizes whitespace
+- Handles special cases like `IN` clauses and hex numbers
+
+Examples:
+
+- `SanitizeDBStatement("SELECT * FROM users WHERE id = 123")` returns `SELECT * FROM users WHERE id = ?`
+- `SanitizeDBStatement("INSERT INTO users (name, age) VALUES ('John', 30)")` returns `INSERT INTO users (name, age) VALUES (?, ?)`
+- `SanitizeDBStatement("SELECT * FROM users WHERE status IN (1, 2, 3)")` returns `SELECT * FROM users WHERE status IN (?)`
 
 ### Second
 

--- a/pkg/ottl/ottlfuncs/func_sanitize_db_statement.go
+++ b/pkg/ottl/ottlfuncs/func_sanitize_db_statement.go
@@ -1,0 +1,358 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"unicode"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type SanitizeDBStatementArguments[K any] struct {
+	Target ottl.StringGetter[K]
+}
+
+func NewSanitizeDBStatementFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("SanitizeDBStatement", &SanitizeDBStatementArguments[K]{}, createSanitizeDBStatementFunction[K])
+}
+
+func createSanitizeDBStatementFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*SanitizeDBStatementArguments[K])
+	if !ok {
+		return nil, errors.New("SanitizeDBStatementFactory args must be of type *SanitizeDBStatementArguments[K]")
+	}
+
+	return sanitizeDBStatement(args.Target), nil
+}
+
+type tokenType int
+
+const (
+	tokenUnknown tokenType = iota
+	tokenWhitespace
+	tokenIdentifier
+	tokenNumber
+	tokenString
+	tokenOperator
+	tokenPunctuation
+	tokenComment
+	tokenKeyword
+)
+
+type token struct {
+	typ   tokenType
+	value string
+}
+
+type sqlLexer struct {
+	input string
+	pos   int
+	start int
+}
+
+func (l *sqlLexer) next() rune {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	r := rune(l.input[l.pos])
+	l.pos++
+	return r
+}
+
+func (l *sqlLexer) peek() rune {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	return rune(l.input[l.pos])
+}
+
+func (l *sqlLexer) backup() {
+	if l.pos > 0 {
+		l.pos--
+	}
+}
+
+func (l *sqlLexer) emit(typ tokenType) token {
+	tok := token{typ: typ, value: l.input[l.start:l.pos]}
+	l.start = l.pos
+	return tok
+}
+
+func (l *sqlLexer) skipWhitespace() token {
+	for l.pos < len(l.input) {
+		r := l.next()
+		if !unicode.IsSpace(r) {
+			l.backup()
+			break
+		}
+	}
+	return l.emit(tokenWhitespace)
+}
+
+func isHexDigit(r rune) bool {
+	return unicode.IsDigit(r) || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+}
+
+func (l *sqlLexer) scanNumber() token {
+	// Handle 0x prefix for hex numbers
+	if l.peek() == 'x' && l.input[l.start] == '0' {
+		l.next() // consume 'x'
+		hasHexDigit := false
+		for {
+			r := l.next()
+			if r == 0 {
+				break
+			}
+			if !isHexDigit(r) {
+				l.backup()
+				break
+			}
+			hasHexDigit = true
+		}
+		if hasHexDigit {
+			return l.emit(tokenNumber)
+		}
+		// Not a valid hex number, reset position
+		l.pos = l.start
+	}
+
+	// Handle regular numbers including scientific notation
+	for {
+		r := l.next()
+		if r == 0 {
+			break
+		}
+		if r == '.' || r == 'e' || r == 'E' || r == '-' || r == '+' || unicode.IsDigit(r) {
+			continue
+		}
+		l.backup()
+		break
+	}
+	return l.emit(tokenNumber)
+}
+
+func (l *sqlLexer) scanString() token {
+	quote := rune(l.input[l.start])
+	if quote == '$' {
+		// Handle dollar quoted strings
+		l.next() // consume first $
+		l.next() // consume second $
+		for {
+			r := l.next()
+			if r == 0 {
+				break
+			}
+			if r == '$' && l.peek() == '$' {
+				l.next() // consume second $
+				break
+			}
+		}
+		return l.emit(tokenString)
+	}
+
+	escaped := false
+	for {
+		r := l.next()
+		if r == 0 {
+			break
+		}
+		if r == quote && !escaped {
+			if l.peek() == quote {
+				l.next() // consume repeated quote
+				escaped = false
+				continue
+			}
+			break
+		}
+		if r == '\\' {
+			escaped = !escaped
+		} else {
+			escaped = false
+		}
+	}
+	return l.emit(tokenString)
+}
+
+func (l *sqlLexer) scanIdentifier() token {
+	for {
+		r := l.next()
+		if r == 0 {
+			break
+		}
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			l.backup()
+			break
+		}
+	}
+	return l.emit(tokenIdentifier)
+}
+
+func (l *sqlLexer) scanComment() token {
+	if l.peek() == '*' {
+		l.next() // consume *
+		for {
+			r := l.next()
+			if r == 0 {
+				break
+			}
+			if r == '*' && l.peek() == '/' {
+				l.next() // consume /
+				break
+			}
+		}
+	} else {
+		// Single line comment
+		for {
+			r := l.next()
+			if r == 0 || r == '\n' {
+				break
+			}
+		}
+	}
+	return l.emit(tokenComment)
+}
+
+func (l *sqlLexer) nextToken() token {
+	if l.pos >= len(l.input) {
+		return token{typ: tokenUnknown}
+	}
+
+	r := l.next()
+	if r == 0 {
+		return token{typ: tokenUnknown}
+	}
+
+	if unicode.IsSpace(r) {
+		return l.skipWhitespace()
+	}
+
+	if unicode.IsDigit(r) || (r == '-' || r == '+') && unicode.IsDigit(l.peek()) {
+		return l.scanNumber()
+	}
+
+	if r == '\'' || r == '"' || (r == '$' && l.peek() == '$') {
+		return l.scanString()
+	}
+
+	if r == '/' && (l.peek() == '*' || l.peek() == '/') {
+		return l.scanComment()
+	}
+
+	if unicode.IsLetter(r) || r == '_' {
+		return l.scanIdentifier()
+	}
+
+	l.pos = l.start + 1
+	return l.emit(tokenPunctuation)
+}
+
+type sqlParser struct {
+	lexer      *sqlLexer
+	operation  string
+	parenLevel int
+	inValues   bool
+	inIN       bool
+}
+
+func (p *sqlParser) parseToken(tok token) string {
+	if p.inValues {
+		if tok.typ == tokenPunctuation && tok.value == ")" {
+			p.inValues = false
+			p.parenLevel--
+			return ")"
+		}
+		return ""
+	}
+
+	switch tok.typ {
+	case tokenWhitespace:
+		return " "
+	case tokenNumber:
+		return "?"
+	case tokenString:
+		if p.operation == "" {
+			upper := strings.ToUpper(tok.value)
+			if isRedisCommand(upper) {
+				p.operation = upper
+				return tok.value
+			}
+		}
+		return "?"
+	case tokenComment:
+		return tok.value
+	case tokenIdentifier:
+		upper := strings.ToUpper(tok.value)
+
+		if p.operation == "" {
+			if isRedisCommand(upper) {
+				p.operation = upper
+				return tok.value
+			}
+		}
+
+		switch upper {
+		case "SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "MERGE":
+			p.operation = upper
+		case "IN":
+			p.inIN = true
+		}
+		return tok.value
+	case tokenPunctuation:
+		switch tok.value {
+		case "(":
+			p.parenLevel++
+			if p.inIN {
+				p.inValues = true
+				p.inIN = false
+				return "(?"
+			}
+		case ")":
+			p.parenLevel--
+		}
+		return tok.value
+	default:
+		return tok.value
+	}
+}
+
+func isRedisCommand(cmd string) bool {
+	switch cmd {
+	case "SET", "GET", "HSET", "ZADD", "ZRANGEBYSCORE", "MULTI", "EXEC":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeDBStatement[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		str, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		if str == "" {
+			return str, nil
+		}
+
+		lexer := &sqlLexer{input: str}
+		parser := &sqlParser{lexer: lexer}
+		var result strings.Builder
+
+		for {
+			tok := lexer.nextToken()
+			if tok.typ == tokenUnknown {
+				break
+			}
+			result.WriteString(parser.parseToken(tok))
+		}
+
+		normalized := strings.Join(strings.Fields(result.String()), " ")
+
+		return normalized, nil
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_sanitize_db_statement_test.go
+++ b/pkg/ottl/ottlfuncs/func_sanitize_db_statement_test.go
@@ -1,0 +1,199 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStringGetter struct {
+	val string
+}
+
+func (g testStringGetter) Get(context.Context, any) (string, error) {
+	return g.val, nil
+}
+
+func Test_sanitizeDBStatement(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple select with number",
+			input:    "SELECT * FROM users WHERE id = 123",
+			expected: "SELECT * FROM users WHERE id = ?",
+		},
+		{
+			name:     "select with string literal",
+			input:    "SELECT * FROM users WHERE name = 'john'",
+			expected: "SELECT * FROM users WHERE name = ?",
+		},
+		{
+			name:     "select with hex number",
+			input:    "SELECT * FROM users WHERE flag = 0xFF",
+			expected: "SELECT * FROM users WHERE flag = ?",
+		},
+		{
+			name:     "select with IN clause",
+			input:    "SELECT * FROM users WHERE id IN (1, 2, 3)",
+			expected: "SELECT * FROM users WHERE id IN (?)",
+		},
+		{
+			name:     "select with multiple spaces",
+			input:    "SELECT   *   FROM   users",
+			expected: "SELECT * FROM users",
+		},
+		{
+			name:     "select with dollar quoted string",
+			input:    "SELECT * FROM users WHERE name = $$john$$",
+			expected: "SELECT * FROM users WHERE name = ?",
+		},
+		{
+			name:     "select with double quoted string",
+			input:    "SELECT * FROM users WHERE name = \"john\"",
+			expected: "SELECT * FROM users WHERE name = ?",
+		},
+		{
+			name:     "select with double and single quoted string",
+			input:    "SELECT * FROM users WHERE name = 'john' AND city = \"london\"",
+			expected: "SELECT * FROM users WHERE name = ? AND city = ?",
+		},
+		{
+			name:     "select with escaped single quotes",
+			input:    "SELECT * FROM users WHERE name = 'O''Connor'",
+			expected: "SELECT * FROM users WHERE name = ?",
+		},
+		{
+			name:     "select with multiple conditions",
+			input:    "SELECT * FROM users WHERE age > 21 AND balance = 100.50 AND name = 'john'",
+			expected: "SELECT * FROM users WHERE age > ? AND balance = ? AND name = ?",
+		},
+		{
+			name:     "select with subquery in IN clause",
+			input:    "SELECT * FROM users WHERE department_id IN (SELECT id FROM departments WHERE budget > 1000000) AND salary > 50000",
+			expected: "SELECT * FROM users WHERE department_id IN (?) AND salary > ?",
+		},
+		{
+			name:     "select with nested subqueries",
+			input:    "SELECT * FROM employees WHERE salary > (SELECT AVG(salary) FROM employees WHERE department_id = (SELECT id FROM departments WHERE name = 'Engineering'))",
+			expected: "SELECT * FROM employees WHERE salary > (SELECT AVG(salary) FROM employees WHERE department_id = (SELECT id FROM departments WHERE name = ?))",
+		},
+		{
+			name:     "redis select",
+			input:    "HSET map password \"secret\"",
+			expected: "HSET map password ?",
+		},
+		{
+			name:     "redis set",
+			input:    "SET mykey \"myvalue\"",
+			expected: "SET mykey ?",
+		},
+		{
+			name:     "redis get",
+			input:    "GET mykey",
+			expected: "GET mykey",
+		},
+		{
+			name:     "redis hset",
+			input:    "HSET myhash field1 \"value1\" field2 \"value2\"",
+			expected: "HSET myhash field1 ? field2 ?",
+		},
+		{
+			name:     "redis zadd",
+			input:    "ZADD myset 1.0 \"member1\" 2.0 \"member2\"",
+			expected: "ZADD myset ? ? ? ?",
+		},
+		{
+			name:     "redis zrangebyscore",
+			input:    "ZRANGEBYSCORE myset 1.0 2.0",
+			expected: "ZRANGEBYSCORE myset ? ?",
+		},
+		{
+			name:     "redis with hex number",
+			input:    "SET mykey 0xFF",
+			expected: "SET mykey ?",
+		},
+		{
+			name:     "redis with dollar string",
+			input:    "SET mykey $$myvalue$$",
+			expected: "SET mykey ?",
+		},
+		{
+			name:     "redis with multiple commands",
+			input:    "MULTI\nSET key1 \"value1\"\nSET key2 \"value2\"\nEXEC",
+			expected: "MULTI SET key1 ? SET key2 ? EXEC",
+		},
+		{
+			name:     "redis with empty value",
+			input:    "SET mykey \"\"",
+			expected: "SET mykey ?",
+		},
+		{
+			name:     "redis with special characters",
+			input:    "SET my:key \"value with spaces\"",
+			expected: "SET my:key ?",
+		},
+		{
+			name:     "redis with multiple spaces",
+			input:    "SET    mykey    \"myvalue\"   ",
+			expected: "SET mykey ?",
+		},
+		{
+			name:     "redis with comment",
+			input:    "SET mykey \"myvalue\" -- this is a comment",
+			expected: "SET mykey ? -- this is a comment",
+		},
+		{
+			name:     "redis with multiline comment",
+			input:    "SET mykey /* comment */ \"myvalue\"",
+			expected: "SET mykey /* comment */ ?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			function := sanitizeDBStatement[any](testStringGetter{val: tt.input})
+
+			result, err := function(context.Background(), nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_sanitizeDBStatement_error(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{
+			name:        "empty string",
+			input:       "",
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			function := sanitizeDBStatement[any](testStringGetter{val: tt.input})
+
+			result, err := function(context.Background(), nil)
+			if tt.expectedErr != "" {
+				assert.EqualError(t, err, tt.expectedErr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, result)
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -22,6 +22,7 @@ func StandardFuncs[K any]() map[string]ottl.Factory[K] {
 		NewReplaceAllPatternsFactory[K](),
 		NewReplaceMatchFactory[K](),
 		NewReplacePatternFactory[K](),
+		NewSanitizeDBStatementFactory[K](),
 		NewSetFactory[K](),
 		NewTruncateAllFactory[K](),
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add support to `SanitizeDBStatement` OTTL function.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41519

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added unit tests
- Tested with this config:
```yaml
receivers:
  otlp:
    protocols:
      grpc:
      http:

exporters:
  debug:
    verbosity: detailed

processors:
  transform:
    error_mode: ignore
    trace_statements:
      - context: span
        conditions:
          - span.attributes["db.statement"] != nil
        statements:
          - set(span.attributes["db.statement"], SanitizeDBStatement(span.attributes["db.statement"]))

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [transform]
      exporters: [debug]  
```
