### PR TITLE
[exporter/coralogixexporter] Add trace id to partial success log message

### DIFF
--- a/.chloggen/41544.yaml
+++ b/.chloggen/41544.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Print trace IDs in partial success response in the log message
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41544]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -64,23 +64,29 @@ func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) e
 
 	partialSuccess := resp.PartialSuccess()
 	if partialSuccess.ErrorMessage() != "" || partialSuccess.RejectedDataPoints() != 0 {
-		var metricNames []string
-		rss := md.ResourceMetrics()
-		for i := 0; i < rss.Len(); i++ {
-			rm := rss.At(i)
-			sm := rm.ScopeMetrics()
-			for j := 0; j < sm.Len(); j++ {
-				metrics := sm.At(j).Metrics()
-				for k := 0; k < metrics.Len(); k++ {
-					metricNames = append(metricNames, metrics.At(k).Name())
+		logFields := []zap.Field{
+			zap.String("message", partialSuccess.ErrorMessage()),
+			zap.Int64("rejected_data_points", partialSuccess.RejectedDataPoints()),
+		}
+
+		if e.settings.Logger.Level() == zap.DebugLevel {
+			var metricNames []string
+			rss := md.ResourceMetrics()
+			for i := 0; i < rss.Len(); i++ {
+				rm := rss.At(i)
+				sm := rm.ScopeMetrics()
+				for j := 0; j < sm.Len(); j++ {
+					metrics := sm.At(j).Metrics()
+					for k := 0; k < metrics.Len(); k++ {
+						metricNames = append(metricNames, metrics.At(k).Name())
+					}
 				}
 			}
+			logFields = append(logFields, zap.Strings("metric_names", metricNames))
 		}
 
 		e.settings.Logger.Error("Partial success response from Coralogix",
-			zap.String("message", partialSuccess.ErrorMessage()),
-			zap.Int64("rejected_data_points", partialSuccess.RejectedDataPoints()),
-			zap.Strings("metric_names", metricNames),
+			logFields...,
 		)
 	}
 

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -377,7 +377,7 @@ func TestMetricsExporter_PushMetrics_PartialSuccess(t *testing.T) {
 	partialSuccess.SetRejectedDataPoints(1)
 	mockSrv.partialSuccess = &partialSuccess
 
-	core, observed := observer.New(zapcore.ErrorLevel)
+	core, observed := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 	exp.settings.Logger = logger
 

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -64,9 +64,34 @@ func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error
 
 	partialSuccess := resp.PartialSuccess()
 	if partialSuccess.ErrorMessage() != "" || partialSuccess.RejectedSpans() != 0 {
-		e.settings.Logger.Error("Partial success response from Coralogix",
+		logFields := []zap.Field{
 			zap.String("message", partialSuccess.ErrorMessage()),
 			zap.Int64("rejected_spans", partialSuccess.RejectedSpans()),
+		}
+
+		if e.settings.Logger.Level() == zap.DebugLevel {
+			// We need to deduplicate the trace IDs because the same trace ID
+			// can be sent multiple times
+			traceIDSet := make(map[string]struct{})
+			rss := td.ResourceSpans()
+			for i := 0; i < rss.Len(); i++ {
+				ss := rss.At(i).ScopeSpans()
+				for j := 0; j < ss.Len(); j++ {
+					spans := ss.At(j).Spans()
+					for k := 0; k < spans.Len(); k++ {
+						traceIDSet[spans.At(k).TraceID().String()] = struct{}{}
+					}
+				}
+			}
+			traceIDs := make([]string, 0, len(traceIDSet))
+			for traceID := range traceIDSet {
+				traceIDs = append(traceIDs, traceID)
+			}
+			logFields = append(logFields, zap.Strings("trace_ids", traceIDs))
+		}
+
+		e.settings.Logger.Error("Partial success response from Coralogix",
+			logFields...,
 		)
 	}
 

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -5,6 +5,7 @@ package coralogixexporter
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -93,7 +94,6 @@ func TestTracesExporter_Start(t *testing.T) {
 	assert.NotNil(t, exp.traceExporter)
 	assert.Contains(t, exp.config.Traces.Headers, "Authorization")
 
-	// Test shutdown
 	err = exp.shutdown(context.Background())
 	require.NoError(t, err)
 }
@@ -129,7 +129,6 @@ func TestTracesExporter_PushTraces(t *testing.T) {
 	exp, err := newTracesExporter(cfg, exportertest.NewNopSettings(exportertest.NopType))
 	require.NoError(t, err)
 
-	// Initialize the exporter by calling start
 	err = exp.start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 	defer func() {
@@ -137,7 +136,6 @@ func TestTracesExporter_PushTraces(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	// Create test traces
 	traces := ptrace.NewTraces()
 	resourceSpans := traces.ResourceSpans()
 	rs := resourceSpans.AppendEmpty()
@@ -261,6 +259,12 @@ func startMockOtlpTracesServer(tb testing.TB) (endpoint string, stopFn func(), s
 	}, srv
 }
 
+func getTraceID(s string) [16]byte {
+	var id [16]byte
+	copy(id[:], s)
+	return id
+}
+
 func TestTracesExporter_PushTraces_PartialSuccess(t *testing.T) {
 	endpoint, stopFn, mockSrv := startMockOtlpTracesServer(t)
 	defer stopFn()
@@ -297,15 +301,23 @@ func TestTracesExporter_PushTraces_PartialSuccess(t *testing.T) {
 
 	span1 := scopeSpans.Spans().AppendEmpty()
 	span1.SetName("span1")
+	traceID1 := getTraceID("traceid1")
+	span1.SetTraceID(traceID1)
 	span2 := scopeSpans.Spans().AppendEmpty()
 	span2.SetName("span2")
+	traceID2 := getTraceID("traceid2")
+	span2.SetTraceID(traceID2)
+	// Add another span with duplicate trace ID
+	span3 := scopeSpans.Spans().AppendEmpty()
+	span3.SetName("span3")
+	span3.SetTraceID(traceID1) // Duplicate trace ID
 
 	partialSuccess := ptraceotlp.NewExportPartialSuccess()
 	partialSuccess.SetErrorMessage("some spans were rejected")
 	partialSuccess.SetRejectedSpans(1)
 	mockSrv.partialSuccess = &partialSuccess
 
-	core, observed := observer.New(zapcore.ErrorLevel)
+	core, observed := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 	exp.settings.Logger = logger
 
@@ -314,15 +326,32 @@ func TestTracesExporter_PushTraces_PartialSuccess(t *testing.T) {
 
 	entries := observed.All()
 	found := false
-	for _, entry := range entries {
-		if entry.Message == "Partial success response from Coralogix" &&
-			entry.Level == zapcore.ErrorLevel &&
-			entry.ContextMap()["message"] == "some spans were rejected" &&
-			entry.ContextMap()["rejected_spans"] == int64(1) {
-			found = true
-		}
+	expectedTraceIDs := []string{
+		hex.EncodeToString(traceID1[:]),
+		hex.EncodeToString(traceID2[:]),
 	}
-	assert.True(t, found, "Expected partial success log with correct fields")
+	for _, entry := range entries {
+		if entry.Message != "Partial success response from Coralogix" ||
+			entry.Level != zapcore.ErrorLevel ||
+			entry.ContextMap()["message"] != "some spans were rejected" ||
+			entry.ContextMap()["rejected_spans"] != int64(1) {
+			continue
+		}
+
+		traceIDs, ok := entry.ContextMap()["trace_ids"].([]any)
+		assert.True(t, ok, "trace_ids should be a slice")
+		assert.Len(t, traceIDs, 2, "Should have exactly 2 trace IDs after deduplication")
+
+		seenIDs := make(map[string]bool)
+		for _, id := range traceIDs {
+			actualID := id.(string)
+			assert.False(t, seenIDs[actualID], "Duplicate trace ID found in log message")
+			seenIDs[actualID] = true
+			assert.Contains(t, expectedTraceIDs, actualID, "Logged trace ID should be in expected trace IDs")
+		}
+		found = true
+	}
+	assert.True(t, found, "Expected partial success log with correct fields and trace IDs")
 }
 
 func BenchmarkTracesExporter_PushTraces(b *testing.B) {
@@ -344,7 +373,8 @@ func BenchmarkTracesExporter_PushTraces(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to create traces exporter: %v", err)
 	}
-	if err := exp.start(context.Background(), componenttest.NewNopHost()); err != nil {
+	err = exp.start(context.Background(), componenttest.NewNopHost())
+	if err != nil {
 		b.Fatalf("failed to start traces exporter: %v", err)
 	}
 	defer func() {
@@ -368,7 +398,7 @@ func BenchmarkTracesExporter_PushTraces(b *testing.B) {
 				ss := rs.ScopeSpans().AppendEmpty()
 				for j := 0; j < numTraces; j++ {
 					span := ss.Spans().AppendEmpty()
-					span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+					span.SetTraceID(getTraceID(fmt.Sprintf("trace%d", j)))
 					span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 					span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 					span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
@@ -421,7 +451,7 @@ func TestTracesExporter_PushTraces_Performance(t *testing.T) {
 		for i := 0; i < spanCount; i++ {
 			span := ss.Spans().AppendEmpty()
 			span.SetName(fmt.Sprintf("test_span_%d", i))
-			span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, byte(i % 256)})
+			span.SetTraceID(getTraceID(fmt.Sprintf("trace%d", i)))
 			span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, byte(i % 256)})
 			span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 			span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
@@ -452,7 +482,7 @@ func TestTracesExporter_PushTraces_Performance(t *testing.T) {
 		for i := 0; i < spanCount; i++ {
 			span := ss.Spans().AppendEmpty()
 			span.SetName(fmt.Sprintf("test_span_%d", i))
-			span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, byte(i % 256)})
+			span.SetTraceID(getTraceID(fmt.Sprintf("trace%d", i)))
 			span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, byte(i % 256)})
 			span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 			span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))
@@ -478,12 +508,12 @@ func TestTracesExporter_PushTraces_Performance(t *testing.T) {
 			testSs := testRs.ScopeSpans().AppendEmpty()
 			testSpan := testSs.Spans().AppendEmpty()
 			testSpan.SetName("test-span")
+			testSpan.SetTraceID(getTraceID("test-trace"))
 
 			errPush := exp.pushTraces(context.Background(), testTraces)
 			return errPush == nil
 		}, 3*time.Second, 100*time.Millisecond, "Rate limit should reset within 3 seconds")
 
-		// It's 1 because the last push is successful
 		require.Equal(t, 1, mockSrv.recvCount)
 		mockSrv.recvCount = 0
 
@@ -492,11 +522,11 @@ func TestTracesExporter_PushTraces_Performance(t *testing.T) {
 		rs.Resource().Attributes().PutStr("service.name", "test-service")
 		ss := rs.ScopeSpans().AppendEmpty()
 
-		spanCount := 3000 // Under the threshold again
+		spanCount := 3000
 		for i := 0; i < spanCount; i++ {
 			span := ss.Spans().AppendEmpty()
 			span.SetName(fmt.Sprintf("test_span_%d", i))
-			span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, byte(i % 256)})
+			span.SetTraceID(getTraceID(fmt.Sprintf("trace%d", i)))
 			span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, byte(i % 256)})
 			span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 			span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Now().Add(time.Second)))


### PR DESCRIPTION
#### Description
Add trace ID to partial success log message.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41544

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added some unit tests
- Manual test: start an OTEL Collector with the exporter and send some data using `telemetrygen`. After that, verified the data is in the Coralogix backend.
