### PR TITLE
[tailsamplingprocessor] Add BlockOnOverFlow option

### DIFF
--- a/.chloggen/tailsamplingprocessor_block-on-overflow.yaml
+++ b/.chloggen/tailsamplingprocessor_block-on-overflow.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new option to block on num traces overflow.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41546]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -254,6 +254,9 @@ type Config struct {
 	// NumTraces is the number of traces kept on memory. Typically most of the data
 	// of a trace is released after a sampling decision is taken.
 	NumTraces uint64 `mapstructure:"num_traces"`
+	// BlockOnOverflow determines the behavior when the component's NumTraces limit is reached.
+	// If true, the component will wait for space; otherwise, old traces will be evicted to make space.
+	BlockOnOverflow bool `mapstructure:"block_on_overflow"`
 	// ExpectedNewTracesPerSec sets the expected number of new traces sending to the tail sampling processor
 	// per second. This helps with allocating data structures with closer to actual usage size.
 	ExpectedNewTracesPerSec uint64 `mapstructure:"expected_new_traces_per_sec"`

--- a/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
@@ -1,0 +1,32 @@
+package tracelimiter
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// BlockingTracesLimiter is a limiter that blocks when the number of traces exceeds the limit.
+// It is used to limit the number of traces that are processed by the processor.
+type BlockingTracesLimiter struct {
+	semaphore chan struct{}
+}
+
+func NewBlockingTracesLimiter(numTraces uint64) *BlockingTracesLimiter {
+	return &BlockingTracesLimiter{
+		semaphore: make(chan struct{}, numTraces),
+	}
+}
+
+func (l *BlockingTracesLimiter) AcceptTrace(ctx context.Context, _ pcommon.TraceID, _ time.Time) {
+	select {
+	case <-ctx.Done():
+		return
+	case l.semaphore <- struct{}{}:
+	}
+}
+
+func (l *BlockingTracesLimiter) OnDeleteTrace() {
+	<-l.semaphore
+}

--- a/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
@@ -1,4 +1,4 @@
-package tracelimiter
+package tracelimiter // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tracelimiter"
 
 import (
 	"context"

--- a/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package tracelimiter // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tracelimiter"
 
 import (

--- a/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter_test.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package tracelimiter
 
 import (

--- a/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter_test.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/blocking_traces_limiter_test.go
@@ -1,0 +1,53 @@
+package tracelimiter
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestBlockingTracesLimiter(t *testing.T) {
+	limiter := NewBlockingTracesLimiter(2)
+
+	done := make(chan struct{})
+	blocked := make(chan struct{})
+
+	// Accept first trace, should not block
+	go func() {
+		limiter.AcceptTrace(context.Background(), [16]byte{}, time.Now())
+		done <- struct{}{}
+	}()
+	<-done
+
+	// Accept second trace, should not block
+	go func() {
+		limiter.AcceptTrace(context.Background(), [16]byte{}, time.Now())
+		done <- struct{}{}
+	}()
+	<-done
+
+	// Accept third trace, should block until OnDeleteTrace is called
+	go func() {
+		limiter.AcceptTrace(context.Background(), [16]byte{}, time.Now())
+		blocked <- struct{}{}
+	}()
+
+	// Give goroutine time to potentially block
+	select {
+	case <-blocked:
+		t.Fatal("AcceptTrace should have blocked, but it did not")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked after timeout
+	}
+
+	// Now free up a slot
+	limiter.OnDeleteTrace()
+
+	// Now the blocked AcceptTrace should proceed
+	select {
+	case <-blocked:
+		// Success: unblocked as expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("AcceptTrace should have unblocked after OnDeleteTrace")
+	}
+}

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
@@ -1,0 +1,40 @@
+package tracelimiter
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type DropOldTracesLimiter struct {
+	deleteChan chan pcommon.TraceID
+	dropTrace  func(id pcommon.TraceID, time time.Time)
+}
+
+func NewDropOldTracesLimiter(numTraces uint64, dropTrace func(id pcommon.TraceID, time time.Time)) *DropOldTracesLimiter {
+	return &DropOldTracesLimiter{
+		deleteChan: make(chan pcommon.TraceID, numTraces),
+		dropTrace:  dropTrace,
+	}
+}
+
+func (l *DropOldTracesLimiter) AcceptTrace(ctx context.Context, id pcommon.TraceID, time time.Time) {
+	postDeletion := false
+	for !postDeletion {
+		select {
+		case <-ctx.Done():
+			return
+		case l.deleteChan <- id:
+			postDeletion = true
+		default:
+			toDelete := <-l.deleteChan
+			l.dropTrace(toDelete, time)
+		}
+	}
+}
+
+func (*DropOldTracesLimiter) OnDeleteTrace() {
+	// Nothing to do here, in this limiter, traces are deleted automatically
+	// when the deleteChan is full
+}

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
@@ -1,4 +1,4 @@
-package tracelimiter
+package tracelimiter // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tracelimiter"
 
 import (
 	"context"

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package tracelimiter // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tracelimiter"
 
 import (

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
@@ -16,7 +16,7 @@ func TestDropOldTracesLimiter(t *testing.T) {
 		dropped = append(dropped, id)
 	}
 
-	numTraces := 2
+	numTraces := uint64(2)
 	limiter := NewDropOldTracesLimiter(numTraces, dropTrace)
 
 	id1 := pcommon.TraceID([16]byte{1})

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package tracelimiter
 
 import (

--- a/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
+++ b/processor/tailsamplingprocessor/internal/tracelimiter/drop_old_traces_limiter_test.go
@@ -1,0 +1,47 @@
+package tracelimiter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestDropOldTracesLimiter(t *testing.T) {
+	// This test verifies that DropOldTracesLimiter drops the oldest trace when the buffer is full.
+	var dropped []pcommon.TraceID
+	dropTrace := func(id pcommon.TraceID, _ time.Time) {
+		dropped = append(dropped, id)
+	}
+
+	numTraces := 2
+	limiter := NewDropOldTracesLimiter(numTraces, dropTrace)
+
+	id1 := pcommon.TraceID([16]byte{1})
+	id2 := pcommon.TraceID([16]byte{2})
+	id3 := pcommon.TraceID([16]byte{3})
+
+	// Accept first two traces, should not drop anything
+	limiter.AcceptTrace(context.Background(), id1, time.Now())
+	limiter.AcceptTrace(context.Background(), id2, time.Now())
+	require.Empty(t, dropped, "expected no dropped traces")
+
+	// Accept third trace, should drop the oldest (id1)
+	limiter.AcceptTrace(context.Background(), id3, time.Now())
+	require.Len(t, dropped, 1, "expected 1 dropped trace")
+	require.Equal(t, id1, dropped[0], "expected dropped trace to be id1")
+
+	// Accept another trace, should drop the next oldest (id2)
+	id4 := pcommon.TraceID([16]byte{4})
+	limiter.AcceptTrace(context.Background(), id4, time.Now())
+	require.Len(t, dropped, 2, "expected 2 dropped traces")
+	require.Equal(t, id2, dropped[1], "expected dropped trace to be id2")
+
+	// Accept another trace, should drop id3
+	id5 := pcommon.TraceID([16]byte{5})
+	limiter.AcceptTrace(context.Background(), id5, time.Now())
+	require.Len(t, dropped, 3, "expected 3 dropped traces")
+	require.Equal(t, id3, dropped[2], "expected dropped trace to be id3")
+}


### PR DESCRIPTION
#### Description

When running the tailsampling processor as part of a durable collector pipeline, it's better to block trace intake than to drop old traces. This option makes it configurable to do so (default false).

#### Testing
Unit tests show the behavior of the new traceLimiter. I've also tested this change in our infrastructure at Grafana Labs and the pipeline backed up as expected until the decision timeout. This makes autoscaling of the TSP simpler to reason about, since we can confidently set an autoscaling target on in memory traces, and trust that during an ingestion spike we will slow down until the autoscaler can kick in.


