### PR TITLE
Missing RISC-V binaries

### DIFF
--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -7,8 +7,9 @@ files=(
     bin/otelcontribcol_darwin_arm64
     bin/otelcontribcol_darwin_amd64
     bin/otelcontribcol_linux_arm64
-    bin/otelcontribcol_linux_ppc64le
     bin/otelcontribcol_linux_amd64
+    bin/otelcontribcol_linux_ppc64le
+    bin/otelcontribcol_linux_riscv64
     bin/otelcontribcol_linux_s390x
     bin/otelcontribcol_windows_amd64.exe
     # skip. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10113

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -47,9 +47,10 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
       - name: Build binaries
         run: |
-          GOOS=linux GOARCH=ppc64le make telemetrygen
           GOOS=linux GOARCH=arm64 make telemetrygen
           GOOS=linux GOARCH=amd64 make telemetrygen
+          GOOS=linux GOARCH=ppc64le make telemetrygen
+          GOOS=linux GOARCH=riscv64 make telemetrygen
           GOOS=linux GOARCH=s390x make telemetrygen
           cp bin/telemetrygen_* cmd/telemetrygen/
       - name: Build telemetrygen
@@ -58,7 +59,7 @@ jobs:
           context: cmd/telemetrygen
           push: false
           tags: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:dev
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64
 
   publish-latest:
     runs-on: ubuntu-24.04
@@ -92,9 +93,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build binaries
         run: |
-          GOOS=linux GOARCH=ppc64le make telemetrygen
           GOOS=linux GOARCH=arm64 make telemetrygen
           GOOS=linux GOARCH=amd64 make telemetrygen
+          GOOS=linux GOARCH=ppc64le make telemetrygen
+          GOOS=linux GOARCH=riscv64 make telemetrygen
           GOOS=linux GOARCH=s390x make telemetrygen
           cp bin/telemetrygen_* cmd/telemetrygen/
       - name: Push telemetrygen to Github packages
@@ -140,9 +142,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build binaries
         run: |
-          GOOS=linux GOARCH=ppc64le make telemetrygen
           GOOS=linux GOARCH=arm64 make telemetrygen
           GOOS=linux GOARCH=amd64 make telemetrygen
+          GOOS=linux GOARCH=ppc64le make telemetrygen
+          GOOS=linux GOARCH=riscv64 make telemetrygen
           GOOS=linux GOARCH=s390x make telemetrygen
           cp bin/telemetrygen_* cmd/telemetrygen/
       - name: Push telemetrygen to Github packages
@@ -151,4 +154,4 @@ jobs:
           context: cmd/telemetrygen
           push: true
           tags: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:${{ steps.github_tag.outputs.tag }}
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/riscv64


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixing missing RV64 binaries in all `telemetrygen` builds.

https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/16519577066/job/46718138001

```
 > [linux/riscv64 stage-1 2/2] COPY ./telemetrygen_linux_riscv64 /telemetrygen:
------
Dockerfile:14
--------------------
  12 |     
  13 |     COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
  14 | >>> COPY ./telemetrygen_${TARGETOS}_${TARGETARCH} /telemetrygen
  15 |     
  16 |     ENTRYPOINT ["/telemetrygen"]
--------------------
ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref ikt1je4gm752tfkb1zrp2v4rl::z7me4ry27x9ebwq1r91c1abm7: "/telemetrygen_linux_riscv64": not found
Reference
  builder-59792c0a-eec9-45ba-add9-60d89801f9b1/builder-59792c0a-eec9-45ba-add9-60d89801f9b10/u3bzkxsj62z7vspt89y8cgwym
Check build summary support
  Build summary supported!
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref ikt1je4gm752tfkb1zrp2v4rl::z7me4ry27x9ebwq1r91c1abm7: "/telemetrygen_linux_riscv64": not found
```

Suppresses #41558