### PR TITLE
[chore]: fix contextcheck for exporters

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/factory.go
+++ b/exporter/alibabacloudlogserviceexporter/factory.go
@@ -30,25 +30,25 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesExporter(
-	_ context.Context,
+	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	return newTracesExporter(set, cfg)
+	return newTracesExporter(ctx, set, cfg)
 }
 
 func createMetricsExporter(
-	_ context.Context,
+	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,
 ) (exp exporter.Metrics, err error) {
-	return newMetricsExporter(set, cfg)
+	return newMetricsExporter(ctx, set, cfg)
 }
 
 func createLogsExporter(
-	_ context.Context,
+	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config,
 ) (exp exporter.Logs, err error) {
-	return newLogsExporter(set, cfg)
+	return newLogsExporter(ctx, set, cfg)
 }

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter.go
@@ -14,7 +14,7 @@ import (
 )
 
 // newLogsExporter return a new LogService logs exporter.
-func newLogsExporter(set exporter.Settings, cfg component.Config) (exporter.Logs, error) {
+func newLogsExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Logs, error) {
 	l := &logServiceLogsSender{
 		logger: set.Logger,
 	}
@@ -25,7 +25,7 @@ func newLogsExporter(set exporter.Settings, cfg component.Config) (exporter.Logs
 	}
 
 	return exporterhelper.NewLogs(
-		context.TODO(),
+		ctx,
 		set,
 		cfg,
 		l.pushLogsData)

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -42,7 +42,7 @@ func createSimpleLogData(numberOfLogs int) plog.Logs {
 }
 
 func TestNewLogsExporter(t *testing.T) {
-	got, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), &Config{
+	got, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{
 		Endpoint: "us-west-1.log.aliyuncs.com",
 		Project:  "demo-project",
 		Logstore: "demo-logstore",
@@ -57,7 +57,7 @@ func TestNewLogsExporter(t *testing.T) {
 }
 
 func TestSTSTokenExporter(t *testing.T) {
-	got, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), &Config{
+	got, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{
 		Endpoint:      "us-west-1.log.aliyuncs.com",
 		Project:       "demo-project",
 		Logstore:      "demo-logstore",
@@ -68,7 +68,7 @@ func TestSTSTokenExporter(t *testing.T) {
 }
 
 func TestNewFailsWithEmptyLogsExporterName(t *testing.T) {
-	got, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), &Config{})
+	got, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{})
 	assert.Error(t, err)
 	require.Nil(t, got)
 }

--- a/exporter/alibabacloudlogserviceexporter/metrics_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/metrics_exporter.go
@@ -14,7 +14,7 @@ import (
 )
 
 // newMetricsExporter return a new LogService metrics exporter.
-func newMetricsExporter(set exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
+func newMetricsExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
 	l := &logServiceMetricsSender{
 		logger: set.Logger,
 	}
@@ -25,7 +25,7 @@ func newMetricsExporter(set exporter.Settings, cfg component.Config) (exporter.M
 	}
 
 	return exporterhelper.NewMetrics(
-		context.TODO(),
+		ctx,
 		set,
 		cfg,
 		l.pushMetricsData)

--- a/exporter/alibabacloudlogserviceexporter/metrics_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/metrics_exporter_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewMetricsExporter(t *testing.T) {
-	got, err := newMetricsExporter(exportertest.NewNopSettings(metadata.Type), &Config{
+	got, err := newMetricsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{
 		Endpoint: "us-west-1.log.aliyuncs.com",
 		Project:  "demo-project",
 		Logstore: "demo-logstore",
@@ -30,7 +30,7 @@ func TestNewMetricsExporter(t *testing.T) {
 }
 
 func TestNewFailsWithEmptyMetricsExporterName(t *testing.T) {
-	got, err := newMetricsExporter(exportertest.NewNopSettings(metadata.Type), &Config{})
+	got, err := newMetricsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{})
 	assert.Error(t, err)
 	require.Nil(t, got)
 }

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter.go
@@ -14,7 +14,7 @@ import (
 )
 
 // newTracesExporter return a new LogService trace exporter.
-func newTracesExporter(set exporter.Settings, cfg component.Config) (exporter.Traces, error) {
+func newTracesExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	l := &logServiceTraceSender{
 		logger: set.Logger,
 	}
@@ -25,7 +25,7 @@ func newTracesExporter(set exporter.Settings, cfg component.Config) (exporter.Tr
 	}
 
 	return exporterhelper.NewTraces(
-		context.TODO(),
+		ctx,
 		set,
 		cfg,
 		l.pushTraceData)

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewTracesExporter(t *testing.T) {
-	got, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), &Config{
+	got, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{
 		Endpoint: "cn-hangzhou.log.aliyuncs.com",
 		Project:  "demo-project",
 		Logstore: "demo-logstore",
@@ -36,7 +36,7 @@ func TestNewTracesExporter(t *testing.T) {
 }
 
 func TestNewFailsWithEmptyTracesExporterName(t *testing.T) {
-	got, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), &Config{})
+	got, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), &Config{})
 	assert.Error(t, err)
 	require.Nil(t, got)
 }

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -44,7 +44,7 @@ func newTracesExporter(ctx context.Context, cfg *Config, set exporter.Settings, 
 		opts = append(opts, telemetry.WithLogger(set.Logger))
 		sender = registry.Register(set.ID, cfg.TelemetryConfig, xrayClient, opts...)
 	}
-	return exporterhelper.NewTraces(context.Background(), set, cfg,
+	return exporterhelper.NewTraces(ctx, set, cfg,
 		func(ctx context.Context, td ptrace.Traces) error {
 			var err error
 			logger.Debug("TracesExporter", typeLog, nameLog, zap.Int("#spans", td.SpanCount()))

--- a/exporter/azuredataexplorerexporter/adx_exporter.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter.go
@@ -49,7 +49,7 @@ func (e *adxDataProducer) metricsDataPusher(ctx context.Context, metrics pmetric
 		metricsBuffer[idx] = adxMetricJSONString
 	}
 	if len(metricsBuffer) != 0 {
-		if err := e.ingestData(metricsBuffer); err != nil {
+		if err := e.ingestData(ctx, metricsBuffer); err != nil {
 			return err
 		}
 	}
@@ -58,17 +58,17 @@ func (e *adxDataProducer) metricsDataPusher(ctx context.Context, metrics pmetric
 	return nil
 }
 
-func (e *adxDataProducer) ingestData(b []string) error {
+func (e *adxDataProducer) ingestData(ctx context.Context, b []string) error {
 	ingestReader := strings.NewReader(strings.Join(b, nextline))
 
-	if _, err := e.ingestor.FromReader(context.Background(), ingestReader, e.ingestOptions...); err != nil {
+	if _, err := e.ingestor.FromReader(ctx, ingestReader, e.ingestOptions...); err != nil {
 		e.logger.Error("Error performing managed data ingestion.", zap.Error(err))
 		return err
 	}
 	return nil
 }
 
-func (e *adxDataProducer) logsDataPusher(_ context.Context, logData plog.Logs) error {
+func (e *adxDataProducer) logsDataPusher(ctx context.Context, logData plog.Logs) error {
 	resourceLogs := logData.ResourceLogs()
 	var logsBuffer []string
 	for i := 0; i < resourceLogs.Len(); i++ {
@@ -89,14 +89,14 @@ func (e *adxDataProducer) logsDataPusher(_ context.Context, logData plog.Logs) e
 		}
 	}
 	if len(logsBuffer) != 0 {
-		if err := e.ingestData(logsBuffer); err != nil {
+		if err := e.ingestData(ctx, logsBuffer); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (e *adxDataProducer) tracesDataPusher(_ context.Context, traceData ptrace.Traces) error {
+func (e *adxDataProducer) tracesDataPusher(ctx context.Context, traceData ptrace.Traces) error {
 	resourceSpans := traceData.ResourceSpans()
 	var spanBuffer []string
 	for i := 0; i < resourceSpans.Len(); i++ {
@@ -117,7 +117,7 @@ func (e *adxDataProducer) tracesDataPusher(_ context.Context, traceData ptrace.T
 		}
 	}
 	if len(spanBuffer) != 0 {
-		if err := e.ingestData(spanBuffer); err != nil {
+		if err := e.ingestData(ctx, spanBuffer); err != nil {
 			return err
 		}
 	}

--- a/exporter/cassandraexporter/exporter_logs.go
+++ b/exporter/cassandraexporter/exporter_logs.go
@@ -28,8 +28,7 @@ func newLogsExporter(logger *zap.Logger, cfg *Config) *logsExporter {
 	return &logsExporter{logger: logger, cfg: cfg}
 }
 
-func initializeLogKernel(cfg *Config) error {
-	ctx := context.Background()
+func initializeLogKernel(ctx context.Context, cfg *Config) error {
 	cluster, err := newCluster(cfg)
 	if err != nil {
 		return err
@@ -76,7 +75,7 @@ func newCluster(cfg *Config) (*gocql.ClusterConfig, error) {
 	return cluster, nil
 }
 
-func (e *logsExporter) Start(_ context.Context, _ component.Host) error {
+func (e *logsExporter) Start(ctx context.Context, _ component.Host) error {
 	cluster, err := newCluster(e.cfg)
 	if err != nil {
 		return err
@@ -91,7 +90,7 @@ func (e *logsExporter) Start(_ context.Context, _ component.Host) error {
 		return err
 	}
 	e.client = session
-	initializeErr := initializeLogKernel(e.cfg)
+	initializeErr := initializeLogKernel(ctx, e.cfg)
 	return initializeErr
 }
 

--- a/exporter/cassandraexporter/exporter_traces.go
+++ b/exporter/cassandraexporter/exporter_traces.go
@@ -26,8 +26,7 @@ func newTracesExporter(logger *zap.Logger, cfg *Config) *tracesExporter {
 	return &tracesExporter{logger: logger, cfg: cfg}
 }
 
-func initializeTraceKernel(cfg *Config) error {
-	ctx := context.Background()
+func initializeTraceKernel(ctx context.Context, cfg *Config) error {
 	cluster, err := newCluster(cfg)
 	if err != nil {
 		return err
@@ -79,7 +78,7 @@ func parseCreateDatabaseSQL(cfg *Config) string {
 	return fmt.Sprintf(createDatabaseSQL, cfg.Keyspace, cfg.Replication.Class, cfg.Replication.ReplicationFactor)
 }
 
-func (e *tracesExporter) Start(_ context.Context, _ component.Host) error {
+func (e *tracesExporter) Start(ctx context.Context, _ component.Host) error {
 	cluster, err := newCluster(e.cfg)
 	if err != nil {
 		return err
@@ -94,7 +93,7 @@ func (e *tracesExporter) Start(_ context.Context, _ component.Host) error {
 		return err
 	}
 	e.client = session
-	initializeErr := initializeTraceKernel(e.cfg)
+	initializeErr := initializeTraceKernel(ctx, e.cfg)
 	return initializeErr
 }
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -80,7 +80,7 @@ func buildExporterResilienceOptions(options []exporterhelper.Option, cfg *Config
 
 func createTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	c := cfg.(*Config)
-	exp, err := newTracesExporter(params, cfg)
+	exp, err := newTracesExporter(ctx, params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing traces exporter: %w", err)
 	}
@@ -102,7 +102,7 @@ func createTracesExporter(ctx context.Context, params exporter.Settings, cfg com
 
 func createLogsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
 	c := cfg.(*Config)
-	exporter, err := newLogsExporter(params, cfg)
+	exporter, err := newLogsExporter(ctx, params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing logs exporter: %w", err)
 	}
@@ -124,7 +124,7 @@ func createLogsExporter(ctx context.Context, params exporter.Settings, cfg compo
 
 func createMetricsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
 	c := cfg.(*Config)
-	exporter, err := newMetricsExporter(params, cfg)
+	exporter, err := newMetricsExporter(ctx, params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing metrics exporter: %w", err)
 	}

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -42,7 +42,7 @@ type loadBalancer struct {
 }
 
 // Create new load balancer
-func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory componentFactory, telemetry *metadata.TelemetryBuilder) (*loadBalancer, error) {
+func newLoadBalancer(ctx context.Context, logger *zap.Logger, cfg component.Config, factory componentFactory, telemetry *metadata.TelemetryBuilder) (*loadBalancer, error) {
 	oCfg := cfg.(*Config)
 
 	count := 0
@@ -97,6 +97,7 @@ func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory component
 			return nil, err
 		}
 		res, err = newK8sResolver(
+			ctx,
 			clt,
 			k8sLogger,
 			oCfg.Resolver.K8sSvc.Service,
@@ -114,6 +115,7 @@ func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory component
 		awsCloudMapLogger := logger.With(zap.String("resolver", "aws_cloud_map"))
 		var err error
 		res, err = newCloudMapResolver(
+			ctx,
 			awsCloudMapLogger,
 			&oCfg.Resolver.AWSCloudMap.NamespaceName,
 			&oCfg.Resolver.AWSCloudMap.ServiceName,

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -26,7 +26,7 @@ func TestNewLoadBalancerNoResolver(t *testing.T) {
 	cfg := &Config{}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	require.Nil(t, p)
@@ -43,7 +43,7 @@ func TestNewLoadBalancerInvalidStaticResolver(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	require.Nil(t, p)
@@ -62,7 +62,7 @@ func TestNewLoadBalancerInvalidDNSResolver(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	require.Nil(t, p)
@@ -81,7 +81,7 @@ func TestNewLoadBalancerInvalidK8sResolver(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	assert.Nil(t, p)
@@ -93,7 +93,7 @@ func TestLoadBalancerStart(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := simpleConfig()
 
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 	p.res = &mockResolver{}
@@ -117,7 +117,7 @@ func TestWithDNSResolver(t *testing.T) {
 		},
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -140,7 +140,7 @@ func TestWithDNSResolverNoEndpoints(t *testing.T) {
 		},
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -169,7 +169,7 @@ func TestMultipleResolvers(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	assert.Nil(t, p)
@@ -181,7 +181,7 @@ func TestStartFailureStaticResolver(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := simpleConfig()
 
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -202,7 +202,7 @@ func TestStartFailureStaticResolver(t *testing.T) {
 func TestLoadBalancerShutdown(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
-	p, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), cfg)
+	p, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), cfg)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -221,7 +221,7 @@ func TestOnBackendChanges(t *testing.T) {
 		return newNopMockExporter(), nil
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -245,7 +245,7 @@ func TestRemoveExtraExporters(t *testing.T) {
 		return newNopMockExporter(), nil
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -279,7 +279,7 @@ func TestAddMissingExporters(t *testing.T) {
 		return exporterFactory.CreateTraces(ctx, exportertest.NewNopSettings(exporterFactory.Type()), &oCfg)
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, fn, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, fn, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -314,7 +314,7 @@ func TestFailedToAddMissingExporters(t *testing.T) {
 		return exporterFactory.CreateTraces(ctx, exportertest.NewNopSettings(metadata.Type), &oCfg)
 	}
 
-	p, err := newLoadBalancer(ts.Logger, cfg, fn, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, fn, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -380,7 +380,7 @@ func TestFailedExporterInRing(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
-	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -424,7 +424,7 @@ func TestNewLoadBalancerInvalidNamespaceAwsResolver(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	assert.Nil(t, p)
@@ -444,7 +444,7 @@ func TestNewLoadBalancerInvalidServiceAwsResolver(t *testing.T) {
 	}
 
 	// test
-	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	p, err := newLoadBalancer(context.Background(), ts.Logger, cfg, nil, tb)
 
 	// verify
 	assert.Nil(t, p)

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -35,7 +35,7 @@ type logExporterImp struct {
 }
 
 // Create new logs exporter
-func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExporterImp, error) {
+func newLogsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (*logExporterImp, error) {
 	telemetry, err := metadata.NewTelemetryBuilder(params.TelemetrySettings)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 		return exporterFactory.CreateLogs(ctx, oParams, &oCfg)
 	}
 
-	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)
+	lb, err := newLoadBalancer(ctx, params.Logger, cfg, cfFunc, telemetry)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -47,7 +47,7 @@ func TestNewLogsExporter(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			// test
-			_, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), tt.config)
+			_, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), tt.config)
 
 			// verify
 			require.Equal(t, tt.err, err)
@@ -65,7 +65,7 @@ func TestLogExporterStart(t *testing.T) {
 		{
 			"ok",
 			func() *logExporterImp {
-				p, _ := newLogsExporter(exportertest.NewNopSettings(metadata.Type), simpleConfig())
+				p, _ := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), simpleConfig())
 				return p
 			}(),
 			nil,
@@ -74,9 +74,9 @@ func TestLogExporterStart(t *testing.T) {
 			"error",
 			func() *logExporterImp {
 				// prepare
-				lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
+				lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), nil, tb)
 				require.NoError(t, err)
-				p, _ := newLogsExporter(exportertest.NewNopSettings(metadata.Type), simpleConfig())
+				p, _ := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), simpleConfig())
 
 				lb.res = &mockResolver{
 					onStart: func(context.Context) error {
@@ -106,7 +106,7 @@ func TestLogExporterStart(t *testing.T) {
 }
 
 func TestLogExporterShutdown(t *testing.T) {
-	p, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), simpleConfig())
+	p, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -123,11 +123,11 @@ func TestConsumeLogs(t *testing.T) {
 		return newNopMockLogsExporter(), nil
 	}
 
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(ts, simpleConfig())
+	p, err := newLogsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -160,11 +160,11 @@ func TestConsumeLogsUnexpectedExporterType(t *testing.T) {
 	}
 	ts, tb := getTelemetryAssets(t)
 
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(ts, simpleConfig())
+	p, err := newLogsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -199,11 +199,11 @@ func TestLogBatchWithTwoTraces(t *testing.T) {
 		return newMockLogsExporter(sink.ConsumeLogs), nil
 	}
 
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(ts, simpleConfig())
+	p, err := newLogsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -272,11 +272,11 @@ func TestLogsWithoutTraceID(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockLogsExporter(sink.ConsumeLogs), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(ts, simpleConfig())
+	p, err := newLogsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -314,11 +314,11 @@ func TestConsumeLogs_ConcurrentResolverChange(t *testing.T) {
 		}
 		return te, nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(ts, simpleConfig())
+	p, err := newLogsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -406,11 +406,11 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockLogsExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), cfg)
+	p, err := newLogsExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), cfg)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -37,7 +37,7 @@ type metricExporterImp struct {
 	telemetry  *metadata.TelemetryBuilder
 }
 
-func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metricExporterImp, error) {
+func newMetricsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (*metricExporterImp, error) {
 	telemetry, err := metadata.NewTelemetryBuilder(params.TelemetrySettings)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 		return exporterFactory.CreateMetrics(ctx, oParams, &oCfg)
 	}
 
-	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)
+	lb, err := newLoadBalancer(ctx, params.Logger, cfg, cfFunc, telemetry)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -91,7 +91,7 @@ func TestNewMetricsExporter(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			// test
-			_, err := newMetricsExporter(ts, tt.config)
+			_, err := newMetricsExporter(context.Background(), ts, tt.config)
 
 			// verify
 			require.Equal(t, tt.err, err)
@@ -109,7 +109,7 @@ func TestMetricsExporterStart(t *testing.T) {
 		{
 			"ok",
 			func() *metricExporterImp {
-				p, _ := newMetricsExporter(ts, serviceBasedRoutingConfig())
+				p, _ := newMetricsExporter(context.Background(), ts, serviceBasedRoutingConfig())
 				return p
 			}(),
 			nil,
@@ -117,10 +117,10 @@ func TestMetricsExporterStart(t *testing.T) {
 		{
 			"error",
 			func() *metricExporterImp {
-				lb, err := newLoadBalancer(ts.Logger, serviceBasedRoutingConfig(), nil, tb)
+				lb, err := newLoadBalancer(context.Background(), ts.Logger, serviceBasedRoutingConfig(), nil, tb)
 				require.NoError(t, err)
 
-				p, _ := newMetricsExporter(ts, serviceBasedRoutingConfig())
+				p, _ := newMetricsExporter(context.Background(), ts, serviceBasedRoutingConfig())
 
 				lb.res = &mockResolver{
 					onStart: func(context.Context) error {
@@ -151,7 +151,7 @@ func TestMetricsExporterStart(t *testing.T) {
 
 func TestMetricsExporterShutdown(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
-	p, err := newMetricsExporter(ts, serviceBasedRoutingConfig())
+	p, err := newMetricsExporter(context.Background(), ts, serviceBasedRoutingConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestConsumeMetrics_SingleEndpoint(t *testing.T) {
 				RoutingKey: tc.routingKey,
 			}
 
-			p, err := newMetricsExporter(createSettings, config)
+			p, err := newMetricsExporter(context.Background(), createSettings, config)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 
@@ -354,7 +354,7 @@ func TestConsumeMetrics_SingleEndpoint(t *testing.T) {
 				return newMockMetricsExporter(sink.ConsumeMetrics), nil
 			}
 
-			lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+			lb, err := newLoadBalancer(context.Background(), ts.Logger, config, componentFactory, tb)
 			require.NoError(t, err)
 			require.NotNil(t, lb)
 
@@ -448,7 +448,7 @@ func TestConsumeMetrics_TripleEndpoint(t *testing.T) {
 				RoutingKey: tc.routingKey,
 			}
 
-			p, err := newMetricsExporter(createSettings, config)
+			p, err := newMetricsExporter(context.Background(), createSettings, config)
 			require.NoError(t, err)
 			require.NotNil(t, p)
 
@@ -473,7 +473,7 @@ func TestConsumeMetrics_TripleEndpoint(t *testing.T) {
 				return nil, errors.New("invalid endpoint")
 			}
 
-			lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+			lb, err := newLoadBalancer(context.Background(), ts.Logger, config, componentFactory, tb)
 			require.NoError(t, err)
 			require.NotNil(t, lb)
 
@@ -551,11 +551,11 @@ func TestConsumeMetrics_ConcurrentResolverChange(t *testing.T) {
 		}
 		return te, nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newMetricsExporter(ts, simpleConfig())
+	p, err := newMetricsExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -593,11 +593,11 @@ func TestConsumeMetricsExporterNoEndpoint(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newMetricsExporter(ts, endpoint2Config())
+	p, err := newMetricsExporter(context.Background(), ts, endpoint2Config())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -628,11 +628,11 @@ func TestConsumeMetricsUnexpectedExporterType(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newMetricsExporter(ts, serviceBasedRoutingConfig())
+	p, err := newMetricsExporter(context.Background(), ts, serviceBasedRoutingConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -667,11 +667,11 @@ func TestBatchWithTwoMetrics(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockMetricsExporter(sink.ConsumeMetrics), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newMetricsExporter(ts, serviceBasedRoutingConfig())
+	p, err := newMetricsExporter(context.Background(), ts, serviceBasedRoutingConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -752,11 +752,11 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newMetricsExporter(ts, cfg)
+	p, err := newMetricsExporter(context.Background(), ts, cfg)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -904,11 +904,11 @@ func benchConsumeMetrics(b *testing.B, routingKey string, endpointsCount, rmCoun
 		RoutingKey: routingKey,
 	}
 
-	lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, config, componentFactory, tb)
 	require.NotNil(b, lb)
 	require.NoError(b, err)
 
-	p, err := newMetricsExporter(ts, config)
+	p, err := newMetricsExporter(context.Background(), ts, config)
 	require.NotNil(b, p)
 	require.NoError(b, err)
 

--- a/exporter/loadbalancingexporter/resolver_k8s.go
+++ b/exporter/loadbalancingexporter/resolver_k8s.go
@@ -71,7 +71,8 @@ type k8sResolver struct {
 	telemetry *metadata.TelemetryBuilder
 }
 
-func newK8sResolver(clt kubernetes.Interface,
+func newK8sResolver(ctx context.Context,
+	clt kubernetes.Interface,
 	logger *zap.Logger,
 	service string,
 	ports []int32,
@@ -106,12 +107,12 @@ func newK8sResolver(clt kubernetes.Interface,
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = epsSelector
 			options.TimeoutSeconds = ptr.To[int64](int64(timeout.Seconds()))
-			return clt.CoreV1().Endpoints(namespace).List(context.Background(), options)
+			return clt.CoreV1().Endpoints(namespace).List(ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = epsSelector
 			options.TimeoutSeconds = ptr.To[int64](int64(timeout.Seconds()))
-			return clt.CoreV1().Endpoints(namespace).Watch(context.Background(), options)
+			return clt.CoreV1().Endpoints(namespace).Watch(ctx, options)
 		},
 	}
 

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -67,7 +67,7 @@ func TestK8sResolve(t *testing.T) {
 
 		cl := fake.NewClientset(endpoint)
 		_, tb := getTelemetryAssets(t)
-		res, err := newK8sResolver(cl, zap.NewNop(), service, ports, defaultListWatchTimeout, returnHostnames, tb)
+		res, err := newK8sResolver(context.Background(), cl, zap.NewNop(), service, ports, defaultListWatchTimeout, returnHostnames, tb)
 		require.NoError(t, err)
 
 		require.NoError(t, res.start(context.Background()))
@@ -309,7 +309,7 @@ func Test_newK8sResolver(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, tb := getTelemetryAssets(t)
-			got, err := newK8sResolver(fake.NewClientset(), tt.args.logger, tt.args.service, tt.args.ports, defaultListWatchTimeout, false, tb)
+			got, err := newK8sResolver(context.Background(), fake.NewClientset(), tt.args.logger, tt.args.service, tt.args.ports, defaultListWatchTimeout, false, tb)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 			} else {

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -45,7 +45,7 @@ type traceExporterImp struct {
 }
 
 // Create new traces exporter
-func newTracesExporter(params exporter.Settings, cfg component.Config) (*traceExporterImp, error) {
+func newTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (*traceExporterImp, error) {
 	telemetry, err := metadata.NewTelemetryBuilder(params.TelemetrySettings)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func newTracesExporter(params exporter.Settings, cfg component.Config) (*traceEx
 		return exporterFactory.CreateTraces(ctx, oParams, &oCfg)
 	}
 
-	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)
+	lb, err := newLoadBalancer(ctx, params.Logger, cfg, cfFunc, telemetry)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -48,7 +48,7 @@ func TestNewTracesExporter(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			// test
-			_, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), tt.config)
+			_, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), tt.config)
 
 			// verify
 			require.Equal(t, tt.err, err)
@@ -65,7 +65,7 @@ func TestTracesExporterStart(t *testing.T) {
 		{
 			"ok",
 			func() *traceExporterImp {
-				p, _ := newTracesExporter(exportertest.NewNopSettings(metadata.Type), simpleConfig())
+				p, _ := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), simpleConfig())
 				return p
 			}(),
 			nil,
@@ -74,8 +74,8 @@ func TestTracesExporterStart(t *testing.T) {
 			"error",
 			func() *traceExporterImp {
 				ts, tb := getTelemetryAssets(t)
-				lb, _ := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
-				p, _ := newTracesExporter(ts, simpleConfig())
+				lb, _ := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), nil, tb)
+				p, _ := newTracesExporter(context.Background(), ts, simpleConfig())
 
 				lb.res = &mockResolver{
 					onStart: func(context.Context) error {
@@ -105,7 +105,7 @@ func TestTracesExporterStart(t *testing.T) {
 }
 
 func TestTracesExporterShutdown(t *testing.T) {
-	p, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), simpleConfig())
+	p, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -121,11 +121,11 @@ func TestConsumeTraces(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, simpleConfig())
+	p, err := newTracesExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 	assert.Equal(t, traceIDRouting, p.routingKey)
@@ -169,11 +169,11 @@ func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 		}
 		return te, nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, simpleConfig())
+	p, err := newTracesExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 	assert.Equal(t, traceIDRouting, p.routingKey)
@@ -212,11 +212,11 @@ func TestConsumeTracesServiceBased(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, serviceBasedRoutingConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, serviceBasedRoutingConfig())
+	p, err := newTracesExporter(context.Background(), ts, serviceBasedRoutingConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 	assert.Equal(t, svcRouting, p.routingKey)
@@ -439,11 +439,11 @@ func TestConsumeTracesExporterNoEndpoint(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, simpleConfig())
+	p, err := newTracesExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -474,11 +474,11 @@ func TestConsumeTracesUnexpectedExporterType(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, simpleConfig())
+	p, err := newTracesExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -512,11 +512,11 @@ func TestBatchWithTwoTraces(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockTracesExporter(sink.ConsumeTraces), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, simpleConfig(), componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, simpleConfig())
+	p, err := newTracesExporter(context.Background(), ts, simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -640,11 +640,11 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
-	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, cfg, componentFactory, tb)
 	require.NotNil(t, lb)
 	require.NoError(t, err)
 
-	p, err := newTracesExporter(ts, cfg)
+	p, err := newTracesExporter(context.Background(), ts, cfg)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
@@ -744,11 +744,11 @@ func benchConsumeTraces(b *testing.B, endpointsCount, tracesCount int) {
 		},
 	}
 
-	lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+	lb, err := newLoadBalancer(context.Background(), ts.Logger, config, componentFactory, tb)
 	require.NotNil(b, lb)
 	require.NoError(b, err)
 
-	p, err := newTracesExporter(exportertest.NewNopSettings(metadata.Type), config)
+	p, err := newTracesExporter(context.Background(), exportertest.NewNopSettings(metadata.Type), config)
 	require.NotNil(b, p)
 	require.NoError(b, err)
 

--- a/exporter/logzioexporter/exporter.go
+++ b/exporter/logzioexporter/exporter.go
@@ -58,7 +58,7 @@ func newLogzioExporter(cfg *Config, params exporter.Settings) (*logzioExporter, 
 	}, nil
 }
 
-func newLogzioTracesExporter(config *Config, set exporter.Settings) (exporter.Traces, error) {
+func newLogzioTracesExporter(ctx context.Context, config *Config, set exporter.Settings) (exporter.Traces, error) {
 	exporter, err := newLogzioExporter(config, set)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func newLogzioTracesExporter(config *Config, set exporter.Settings) (exporter.Tr
 	}
 	config.checkAndWarnDeprecatedOptions(exporter.logger)
 	return exporterhelper.NewTraces(
-		context.Background(),
+		ctx,
 		set,
 		config,
 		exporter.pushTraceData,
@@ -81,7 +81,7 @@ func newLogzioTracesExporter(config *Config, set exporter.Settings) (exporter.Tr
 	)
 }
 
-func newLogzioLogsExporter(config *Config, set exporter.Settings) (exporter.Logs, error) {
+func newLogzioLogsExporter(ctx context.Context, config *Config, set exporter.Settings) (exporter.Logs, error) {
 	exporter, err := newLogzioExporter(config, set)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func newLogzioLogsExporter(config *Config, set exporter.Settings) (exporter.Logs
 	}
 	config.checkAndWarnDeprecatedOptions(exporter.logger)
 	return exporterhelper.NewLogs(
-		context.TODO(),
+		ctx,
 		set,
 		config,
 		exporter.pushLogData,

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -197,7 +197,7 @@ func TestExportErrors(tester *testing.T) {
 
 func TestNullTracesExporterConfig(tester *testing.T) {
 	params := exportertest.NewNopSettings(metadata.Type)
-	_, err := newLogzioTracesExporter(nil, params)
+	_, err := newLogzioTracesExporter(context.Background(), nil, params)
 	assert.Error(tester, err, "Null exporter config should produce error")
 }
 

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -73,12 +73,12 @@ func generateEndpoint(cfg *Config, dataType string) (string, error) {
 	}
 }
 
-func createTracesExporter(_ context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
+func createTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	exporterConfig := cfg.(*Config)
-	return newLogzioTracesExporter(exporterConfig, params)
+	return newLogzioTracesExporter(ctx, exporterConfig, params)
 }
 
-func createLogsExporter(_ context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
+func createLogsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
 	exporterConfig := cfg.(*Config)
-	return newLogzioLogsExporter(exporterConfig, params)
+	return newLogzioLogsExporter(ctx, exporterConfig, params)
 }

--- a/exporter/otelarrowexporter/otelarrow.go
+++ b/exporter/otelarrowexporter/otelarrow.go
@@ -135,7 +135,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 
 	if !e.config.Arrow.Disabled {
 		// Note this sets static outgoing context for all future stream requests.
-		ctx := e.enhanceContext(context.Background())
+		ctx = e.enhanceContext(ctx)
 
 		var perRPCCreds credentials.PerRPCCredentials
 		if e.config.Auth.HasValue() {

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -135,7 +135,7 @@ func newPRWTelemetry(set exporter.Settings, endpointURL *url.URL) (prwTelemetry,
 }
 
 // newPRWExporter initializes a new prwExporter instance and sets fields accordingly.
-func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
+func newPRWExporter(ctx context.Context, cfg *Config, set exporter.Settings) (*prwExporter, error) {
 	sanitizedLabels, err := validateAndSanitizeExternalLabels(cfg)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,7 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 	}
 
 	// Set the desired number of consumers as a metric for the exporter.
-	telemetry.setNumberConsumer(context.Background(), int64(concurrency))
+	telemetry.setNumberConsumer(ctx, int64(concurrency))
 
 	prwe := &prwExporter{
 		endpointURL:         endpointURL,

--- a/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
@@ -117,7 +117,7 @@ func Test_PushMetricsConcurrent(t *testing.T) {
 
 	assert.NotNil(t, cfg)
 	set := exportertest.NewNopSettings(metadata.Type)
-	prwe, nErr := newPRWExporter(cfg, set)
+	prwe, nErr := newPRWExporter(context.Background(), cfg, set)
 
 	require.NoError(t, nErr)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -124,7 +124,7 @@ func Test_NewPRWExporter(t *testing.T) {
 			cfg.Namespace = tt.namespace
 			cfg.RemoteWriteQueue.NumConsumers = 1
 			cfg.RemoteWriteProtoMsg = config.RemoteWriteProtoMsgV1
-			prwe, err := newPRWExporter(cfg, tt.set)
+			prwe, err := newPRWExporter(context.Background(), cfg, tt.set)
 
 			if tt.returnErrorOnCreate {
 				assert.Error(t, err)
@@ -215,7 +215,7 @@ func Test_Start(t *testing.T) {
 			cfg.ClientConfig = tt.clientSettings
 			cfg.RemoteWriteProtoMsg = config.RemoteWriteProtoMsgV1
 
-			prwe, err := newPRWExporter(cfg, tt.set)
+			prwe, err := newPRWExporter(context.Background(), cfg, tt.set)
 			assert.NoError(t, err)
 			assert.NotNil(t, prwe)
 
@@ -375,7 +375,7 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 	set := exportertest.NewNopSettings(metadata.Type)
 	set.BuildInfo = buildInfo
 	// after this, instantiate a CortexExporter with the current HTTP client and endpoint set to passed in endpoint
-	prwe, err := newPRWExporter(cfg, set)
+	prwe, err := newPRWExporter(context.Background(), cfg, set)
 	if err != nil {
 		return err
 	}
@@ -781,7 +781,7 @@ func Test_PushMetrics(t *testing.T) {
 						Version:     "1.0",
 					}
 
-					prwe, nErr := newPRWExporter(cfg, set)
+					prwe, nErr := newPRWExporter(context.Background(), cfg, set)
 
 					require.NoError(t, nErr)
 					ctx, cancel := context.WithCancel(context.Background())
@@ -984,7 +984,7 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		Version:     "1.0",
 	}
 
-	prwe, perr := newPRWExporter(cfg, set)
+	prwe, perr := newPRWExporter(context.Background(), cfg, set)
 	assert.NoError(t, perr)
 
 	nopHost := componenttest.NewNopHost()
@@ -1062,7 +1062,7 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	// 4. Finally, ensure that the bytes that were uploaded to the
 	// Prometheus Remote Write endpoint are exactly as were saved in the WAL.
 	// Read from that same WAL, export to the RWExporter server.
-	prwe2, err := newPRWExporter(cfg, set)
+	prwe2, err := newPRWExporter(context.Background(), cfg, set)
 	assert.NoError(t, err)
 	require.NoError(t, prwe2.Start(ctx, nopHost))
 	t.Cleanup(func() {
@@ -1353,7 +1353,7 @@ func benchmarkPushMetrics(b *testing.B, numMetrics, numConsumers int) {
 		BackOffConfig:     retrySettings,
 		TargetInfo:        &TargetInfo{Enabled: true},
 	}
-	exporter, err := newPRWExporter(cfg, set)
+	exporter, err := newPRWExporter(context.Background(), cfg, set)
 	require.NoError(b, err)
 
 	var metrics []pmetric.Metrics

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -61,7 +61,7 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings,
 		set.Logger.Warn("`remote_write_queue.num_consumers` will be used to configure processing parallelism, rather than request parallelism in a future release. This may cause out-of-order issues unless you take action. Please migrate to using `max_batch_request_parallelism` to keep the your existing behavior.")
 	}
 
-	prwe, err := newPRWExporter(prwCfg, set)
+	prwe, err := newPRWExporter(ctx, prwCfg, set)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -211,7 +211,7 @@ func TestExportWithWALEnabled(t *testing.T) {
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig
 
-	prwe, err := newPRWExporter(cfg, set)
+	prwe, err := newPRWExporter(context.Background(), cfg, set)
 	assert.NoError(t, err)
 	assert.NotNil(t, prwe)
 	err = prwe.Start(context.Background(), componenttest.NewNopHost())
@@ -257,7 +257,7 @@ func TestWALWrite_Telemetry(t *testing.T) {
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig
 
-	prw, err := newPRWExporter(cfg, set)
+	prw, err := newPRWExporter(context.Background(), cfg, set)
 	require.NotNil(t, prw)
 	require.NoError(t, err)
 
@@ -329,7 +329,7 @@ func TestWALRead_Telemetry(t *testing.T) {
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig
 
-	prw, err := newPRWExporter(cfg, set)
+	prw, err := newPRWExporter(context.Background(), cfg, set)
 	require.NotNil(t, prw)
 	require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func TestWALLag_Telemetry(t *testing.T) {
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig
 
-	prw, err := newPRWExporter(cfg, set)
+	prw, err := newPRWExporter(context.Background(), cfg, set)
 	require.NotNil(t, prw)
 	require.NoError(t, err)
 

--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -55,14 +55,14 @@ func newSAPMExporter(cfg *Config, params exporter.Settings) (sapmExporter, error
 	}, err
 }
 
-func newSAPMTracesExporter(cfg *Config, set exporter.Settings) (exporter.Traces, error) {
+func newSAPMTracesExporter(ctx context.Context, cfg *Config, set exporter.Settings) (exporter.Traces, error) {
 	se, err := newSAPMExporter(cfg, set)
 	if err != nil {
 		return nil, err
 	}
 
 	te, err := exporterhelper.NewTraces(
-		context.TODO(),
+		ctx,
 		set,
 		cfg,
 		se.pushTraceData,

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -40,7 +40,7 @@ func TestCreateTraces(t *testing.T) {
 	}
 	params := exportertest.NewNopSettings(metadata.Type)
 
-	te, err := newSAPMTracesExporter(cfg, params)
+	te, err := newSAPMTracesExporter(context.Background(), cfg, params)
 	assert.NoError(t, err)
 	assert.NotNil(t, te, "failed to create trace exporter")
 

--- a/exporter/sapmexporter/factory.go
+++ b/exporter/sapmexporter/factory.go
@@ -40,10 +40,10 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesExporter(
-	_ context.Context,
+	ctx context.Context,
 	params exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
 	eCfg := cfg.(*Config)
-	return newSAPMTracesExporter(eCfg, params)
+	return newSAPMTracesExporter(ctx, eCfg, params)
 }

--- a/exporter/sentryexporter/factory.go
+++ b/exporter/sentryexporter/factory.go
@@ -29,7 +29,7 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesExporter(
-	_ context.Context,
+	ctx context.Context,
 	params exporter.Settings,
 	config component.Config,
 ) (exporter.Traces, error) {
@@ -39,6 +39,6 @@ func createTracesExporter(
 	}
 
 	// Create exporter based on sentry config.
-	exp, err := createSentryExporter(sentryConfig, params)
+	exp, err := createSentryExporter(ctx, sentryConfig, params)
 	return exp, err
 }

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -478,7 +478,7 @@ func generateEventID() sentry.EventID {
 }
 
 // createSentryExporter returns a new Sentry Exporter.
-func createSentryExporter(config *Config, set exporter.Settings) (exporter.Traces, error) {
+func createSentryExporter(ctx context.Context, config *Config, set exporter.Settings) (exporter.Traces, error) {
 	transport := newSentryTransport()
 
 	clientOptions := sentry.ClientOptions{
@@ -498,7 +498,7 @@ func createSentryExporter(config *Config, set exporter.Settings) (exporter.Trace
 	}
 
 	return exporterhelper.NewTraces(
-		context.TODO(),
+		ctx,
 		set,
 		config,
 		s.pushTraceData,

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -154,7 +154,7 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 			IdleConnTimeout:     se.config.DimensionClient.IdleConnTimeout,
 			Timeout:             se.config.DimensionClient.Timeout,
 		})
-	dimClient.Start()
+	dimClient.Start(ctx)
 
 	var hms *hostmetadata.Syncer
 	if se.config.SyncHostMetadata {

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1419,7 +1419,7 @@ func TestConsumeMetadata(t *testing.T) {
 					MetricsConverter:  *converter,
 					ExcludeProperties: tt.excludeProperties,
 				})
-			dimClient.Start()
+			dimClient.Start(context.Background())
 
 			se := &signalfxExporter{
 				dimClient: dimClient,
@@ -1782,7 +1782,7 @@ func TestTLSAPIConnection(t *testing.T) {
 					MetricsConverter: *converter,
 					APITLSConfig:     apiTLSCfg,
 				})
-			dimClient.Start()
+			dimClient.Start(context.Background())
 			defer func() { dimClient.Shutdown() }()
 
 			se := &signalfxExporter{

--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -121,12 +121,11 @@ func NewDimensionClient(options DimensionClientOptions) *DimensionClient {
 }
 
 // Start the client's processing queue
-func (dc *DimensionClient) Start() {
-	var ctx context.Context
+func (dc *DimensionClient) Start(ctx context.Context) {
 	// The dimension client is started during the exporter's startup functionality.
 	// The collector spec states that for long-running operations, components should
 	// use the background context, rather than the passed in context.
-	ctx, dc.cancel = context.WithCancel(context.Background())
+	ctx, dc.cancel = context.WithCancel(ctx)
 	go dc.processQueue(ctx)
 }
 

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -4,6 +4,7 @@
 package dimensions
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -116,7 +117,7 @@ func setupTestClientServer(t *testing.T) (*DimensionClient, *testServer) {
 			SendDelay:   100 * time.Millisecond,
 			MaxBuffered: 10,
 		})
-	client.Start()
+	client.Start(context.Background())
 
 	return client, ts
 }

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -627,9 +627,9 @@ func (c *client) start(ctx context.Context, host component.Host) (err error) {
 	}
 	url, _ := c.config.getURL()
 	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(c.config, c.buildInfo), c.logger}
-	c.heartbeater = newHeartbeater(c.config, c.buildInfo, getPushLogFn(c), c.meter)
+	c.heartbeater = newHeartbeater(ctx, c.config, c.buildInfo, getPushLogFn(c), c.meter)
 	if c.config.Heartbeat.Startup {
-		if err := c.heartbeater.sendHeartbeat(c.config, c.buildInfo, getPushLogFn(c)); err != nil {
+		if err := c.heartbeater.sendHeartbeat(ctx, c.config, c.buildInfo, getPushLogFn(c)); err != nil {
 			return fmt.Errorf("%s: heartbeat on startup failed: %w", c.exporterName, err)
 		}
 	}

--- a/exporter/splunkhecexporter/heartbeat.go
+++ b/exporter/splunkhecexporter/heartbeat.go
@@ -35,7 +35,7 @@ func getMetricsName(overrides map[string]string, metricName string) string {
 	return metricName
 }
 
-func newHeartbeater(config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error, meter metric.Meter) *heartbeater {
+func newHeartbeater(ctx context.Context, config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error, meter metric.Meter) *heartbeater {
 	interval := config.Heartbeat.Interval
 	if interval == 0 {
 		return nil
@@ -82,7 +82,7 @@ func newHeartbeater(config *Config, buildInfo component.BuildInfo, pushLogFn fun
 			case <-hbter.hbDoneChan:
 				return
 			case <-ticker.C:
-				err := hbter.sendHeartbeat(config, buildInfo, pushLogFn)
+				err := hbter.sendHeartbeat(ctx, config, buildInfo, pushLogFn)
 				if config.Telemetry.Enabled {
 					observe(heartbeatsSent, heartbeatsFailed, attrs, err)
 				}
@@ -96,8 +96,8 @@ func (h *heartbeater) shutdown() {
 	close(h.hbDoneChan)
 }
 
-func (*heartbeater) sendHeartbeat(config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error) error {
-	return pushLogFn(context.Background(), generateHeartbeatLog(config.HecToOtelAttrs, buildInfo))
+func (*heartbeater) sendHeartbeat(ctx context.Context, config *Config, buildInfo component.BuildInfo, pushLogFn func(ctx context.Context, ld plog.Logs) error) error {
+	return pushLogFn(ctx, generateHeartbeatLog(config.HecToOtelAttrs, buildInfo))
 }
 
 // there is only use case for open census metrics recording for now. Extend to use open telemetry in the future.

--- a/exporter/splunkhecexporter/heartbeat_test.go
+++ b/exporter/splunkhecexporter/heartbeat_test.go
@@ -41,7 +41,7 @@ func createTestConfig(metricsOverrides map[string]string, enableMetrics bool) *C
 
 func initHeartbeater(t *testing.T, metricsOverrides map[string]string, enableMetrics bool, consumeFn func(ctx context.Context, ld plog.Logs) error, mp *sdkmetric.MeterProvider) {
 	config := createTestConfig(metricsOverrides, enableMetrics)
-	hbter := newHeartbeater(config, component.NewDefaultBuildInfo(), consumeFn, mp.Meter("test"))
+	hbter := newHeartbeater(context.Background(), config, component.NewDefaultBuildInfo(), consumeFn, mp.Meter("test"))
 	t.Cleanup(func() {
 		hbter.shutdown()
 	})
@@ -85,7 +85,7 @@ func getAttributes(reader *sdkmetric.ManualReader, name string) ([]attribute.Set
 func Test_newHeartbeater_disabled(t *testing.T) {
 	config := createTestConfig(map[string]string{}, false)
 	config.Heartbeat.Interval = 0
-	hb := newHeartbeater(config, component.NewDefaultBuildInfo(), func(_ context.Context, _ plog.Logs) error {
+	hb := newHeartbeater(context.Background(), config, component.NewDefaultBuildInfo(), func(_ context.Context, _ plog.Logs) error {
 		return nil
 	}, metricnoop.NewMeterProvider().Meter("test"))
 	assert.Nil(t, hb)


### PR DESCRIPTION
#### Description

Fixes [contextcheck](https://golangci-lint.run/usage/linters/#contextcheck) issues for exporter.

Golangci-lint cannot be configured yet for this