### PR TITLE
[pkg/stanza] feat: add support for batch processing in most operators

### DIFF
--- a/.chloggen/batching-operators.yaml
+++ b/.chloggen/batching-operators.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for batch processing in most operators
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39575]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following operators now support batching: `add`, `assign_keys`, `copy`, `flatten`, `move`,
+  `regex_replace`, `remove`, `retain`, `unquote` `json_parser`, `json_array_parser`, `key_value_parser`,
+  `regex_parser`, `scope_name`, `severity`, `timestamp`, `trace_parser`, `uri_parser`.
+
+  The following operators do not support batching yet: `container`, `csv_parser`, `filter`,
+  `recombine`, `router`, `syslog`.
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/README.md
+++ b/pkg/stanza/README.md
@@ -77,6 +77,38 @@ The planned schedule for this feature gate is the following:
 - Introduce as `Alpha` (disabled by default) in v0.122.0
 - Move to `Beta` (enabled by default) after transform operators support batching and after all receivers that are selected to support batching support it
 
+Here's the summary of current support for batching in Stanza operators:
+
+Operators that support batching:
+
+- `add`
+- `assign_keys`
+- `copy`
+- `flatten`
+- `json_array_parser`
+- `json_parser`
+- `key_value_parser`
+- `move`
+- `regex_parser`
+- `regex_replace`
+- `remove`
+- `retain`
+- `scope_name`
+- `severity`
+- `timestamp`
+- `trace_parser`
+- `unquote`
+- `uri_parser`
+
+Operators that do not support batching:
+
+- `container`
+- `csv_parser`
+- `filter`
+- `recombine`
+- `router`
+- `syslog`
+
 ### FAQ
 
 Q: Why don't we make every parser and transform operator into a distinct OpenTelemetry processor?

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -299,11 +299,10 @@ func TestTransformerProcessWithValid(t *testing.T) {
 	output.AssertCalled(t, "Process", mock.Anything, mock.Anything)
 }
 
-// This test documents the current behavior where the operators split batches,
+// TestTransformerSplitsBatches documents that if a transformer operator uses the `TransformerOperator`'s `ProcessBatchWith` method,
+// the batch is split into individual entries,
 // as described in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39575.
-// After that issue is resolved, this test should be renamed to “TestTransformerProcessBatchDoesNotSplitBatches`
-// and updated to prove that batches are not split.
-func TestTransformerProcessBatchSplitsBatches(t *testing.T) {
+func TestTransformerSplitsBatches(t *testing.T) {
 	output := &testutil.Operator{}
 	output.On("ID").Return("test-output")
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
@@ -341,6 +340,44 @@ func TestTransformerProcessBatchSplitsBatches(t *testing.T) {
 	output.AssertCalled(t, "Process", ctx, testEntry2)
 	output.AssertCalled(t, "Process", ctx, testEntry3)
 	output.AssertNumberOfCalls(t, "Process", 3)
+}
+
+// TestTransformerDoesNotSplitBatches documents that if a transformer operator uses the `TransformerOperator`'s `ProcessBatchWithTransform` method,
+// the batch of entries is NOT split into individual entries, which is more performant and preferred way to process entries by operators.
+func TestTransformerDoesNotSplitBatches(t *testing.T) {
+	output := &testutil.Operator{}
+	output.On("ID").Return("test-output")
+	output.On("ProcessBatch", mock.Anything, mock.Anything).Return(nil)
+
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	transformer := TransformerOperator{
+		OnError: SendOnError,
+		WriterOperator: WriterOperator{
+			BasicOperator: BasicOperator{
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
+			},
+			OutputOperators: []operator.Operator{output},
+			OutputIDs:       []string{"test-output"},
+		},
+	}
+
+	ctx := context.Background()
+	testEntry := entry.New()
+	testEntry2 := entry.New()
+	testEntry3 := entry.New()
+	testEntries := []*entry.Entry{testEntry, testEntry2, testEntry3}
+	transform := func(_ *entry.Entry) error {
+		return nil
+	}
+
+	err := transformer.ProcessBatchWithTransform(ctx, testEntries, transform)
+	require.NoError(t, err)
+	// This proves that the batch was not split.
+	output.AssertCalled(t, "ProcessBatch", ctx, testEntries)
+	output.AssertNumberOfCalls(t, "ProcessBatch", 1)
 }
 
 func TestTransformerIf(t *testing.T) {

--- a/pkg/stanza/operator/helper/writer.go
+++ b/pkg/stanza/operator/helper/writer.go
@@ -130,3 +130,5 @@ func (*WriterOperator) findOperator(operators []operator.Operator, operatorID st
 	}
 	return nil, false
 }
+
+type WriteFunction = func(context.Context, *entry.Entry) error

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -71,7 +71,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.TransformerOperator.ProcessBatchWith(ctx, entries, p.Process)
 }
 
 // Process will parse an entry of Container logs
@@ -117,14 +117,14 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 
 		if format == containerdFormat {
 			// parse the message
-			err = p.ParseWith(ctx, entry, p.parseContainerd)
+			err = p.ParseWith(ctx, entry, p.parseContainerd, p.Write)
 			if err != nil {
 				return fmt.Errorf("failed to parse containerd log: %w", err)
 			}
 			p.timeLayout = goTimeLayout
 		} else {
 			// parse the message
-			err = p.ParseWith(ctx, entry, p.parseCRIO)
+			err = p.ParseWith(ctx, entry, p.parseCRIO, p.Write)
 			if err != nil {
 				return fmt.Errorf("failed to parse crio log: %w", err)
 			}

--- a/pkg/stanza/operator/parser/csv/parser.go
+++ b/pkg/stanza/operator/parser/csv/parser.go
@@ -28,7 +28,7 @@ type Parser struct {
 type parseFunc func(any) (any, error)
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.TransformerOperator.ProcessBatchWith(ctx, entries, p.Process)
 }
 
 // Process will parse an entry for csv.

--- a/pkg/stanza/operator/parser/json/parser.go
+++ b/pkg/stanza/operator/parser/json/parser.go
@@ -22,7 +22,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWith(ctx, entries, p.parse)
 }
 
 // Process will parse an entry for JSON.

--- a/pkg/stanza/operator/parser/jsonarray/parser.go
+++ b/pkg/stanza/operator/parser/jsonarray/parser.go
@@ -22,7 +22,7 @@ type Parser struct {
 type parseFunc func(any) (any, error)
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWith(ctx, entries, p.parse)
 }
 
 // Process will parse an entry for json array.

--- a/pkg/stanza/operator/parser/keyvalue/parser.go
+++ b/pkg/stanza/operator/parser/keyvalue/parser.go
@@ -20,7 +20,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWith(ctx, entries, p.parse)
 }
 
 // Process will parse an entry for key value pairs.

--- a/pkg/stanza/operator/parser/regex/parser.go
+++ b/pkg/stanza/operator/parser/regex/parser.go
@@ -27,7 +27,7 @@ func (p *Parser) Stop() error {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWith(ctx, entries, p.parse)
 }
 
 // Process will parse an entry for regex.

--- a/pkg/stanza/operator/parser/scope/parser.go
+++ b/pkg/stanza/operator/parser/scope/parser.go
@@ -17,7 +17,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWithTransform(ctx, entries, p.Parse)
 }
 
 // Process will parse logger name from an entry.

--- a/pkg/stanza/operator/parser/severity/parser.go
+++ b/pkg/stanza/operator/parser/severity/parser.go
@@ -17,7 +17,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWithTransform(ctx, entries, p.Parse)
 }
 
 // Process will parse severity from an entry.

--- a/pkg/stanza/operator/parser/syslog/parser.go
+++ b/pkg/stanza/operator/parser/syslog/parser.go
@@ -38,7 +38,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.TransformerOperator.ProcessBatchWith(ctx, entries, p.Process)
 }
 
 // Process will parse an entry field as syslog.

--- a/pkg/stanza/operator/parser/time/parser.go
+++ b/pkg/stanza/operator/parser/time/parser.go
@@ -17,7 +17,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWithTransform(ctx, entries, p.Parse)
 }
 
 // Process will parse time from an entry.

--- a/pkg/stanza/operator/parser/trace/parser.go
+++ b/pkg/stanza/operator/parser/trace/parser.go
@@ -17,7 +17,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWithTransform(ctx, entries, p.Parse)
 }
 
 // Process will parse traces from an entry.

--- a/pkg/stanza/operator/parser/uri/parser.go
+++ b/pkg/stanza/operator/parser/uri/parser.go
@@ -33,7 +33,7 @@ type Parser struct {
 }
 
 func (p *Parser) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return p.ProcessBatchWith(ctx, entries, p.Process)
+	return p.ProcessBatchWith(ctx, entries, p.parse)
 }
 
 // Process will parse an entry.

--- a/pkg/stanza/operator/transformer/add/transformer.go
+++ b/pkg/stanza/operator/transformer/add/transformer.go
@@ -25,7 +25,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a add transformation.

--- a/pkg/stanza/operator/transformer/assignkeys/transformer.go
+++ b/pkg/stanza/operator/transformer/assignkeys/transformer.go
@@ -18,7 +18,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with AssignKeys transformation.

--- a/pkg/stanza/operator/transformer/copy/transformer.go
+++ b/pkg/stanza/operator/transformer/copy/transformer.go
@@ -19,7 +19,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a copy transformation.

--- a/pkg/stanza/operator/transformer/flatten/transformer.go
+++ b/pkg/stanza/operator/transformer/flatten/transformer.go
@@ -24,7 +24,7 @@ type Transformer[T interface {
 }
 
 func (t *Transformer[T]) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a flatten transformation.

--- a/pkg/stanza/operator/transformer/move/transformer.go
+++ b/pkg/stanza/operator/transformer/move/transformer.go
@@ -19,7 +19,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a move transformation.

--- a/pkg/stanza/operator/transformer/regexreplace/transformer.go
+++ b/pkg/stanza/operator/transformer/regexreplace/transformer.go
@@ -21,7 +21,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.replace)
 }
 
 func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {

--- a/pkg/stanza/operator/transformer/remove/transformer.go
+++ b/pkg/stanza/operator/transformer/remove/transformer.go
@@ -18,7 +18,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a remove transformation.

--- a/pkg/stanza/operator/transformer/retain/transformer.go
+++ b/pkg/stanza/operator/transformer/retain/transformer.go
@@ -20,7 +20,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.Transform)
 }
 
 // Process will process an entry with a retain transformation.

--- a/pkg/stanza/operator/transformer/unquote/transformer.go
+++ b/pkg/stanza/operator/transformer/unquote/transformer.go
@@ -19,7 +19,7 @@ type Transformer struct {
 }
 
 func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) error {
-	return t.ProcessBatchWith(ctx, entries, t.Process)
+	return t.ProcessBatchWithTransform(ctx, entries, t.unquote)
 }
 
 // Process will unquote a string


### PR DESCRIPTION
#### Description

Implements batch processing for most of Stanza operators, leaving out those where it is a nontrivial amount of work. Those should be worked on separately, to make the changesets smaller and easier to review.

The operators that now support batching can be used with the `stanza.synchronousLogEmitter` feature gate without a performance degradation.

#### Link to tracking issue

- Partially resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39575

#### Testing

Added a unit test verifying that operators that use the `ProcessBatchWithTransform` function support batching.

Manually tested all the operators.

#### Documentation

Whether an operator supports batching or not should in principle not be a concern to users. This may only be a concern because it affects the performance of the collector when the feature gate `stanza.synchronousLogEmitter` is used. I have updated the documentation section on this feature gate to list the operators that support and do not support batching.

Ultimately, when all operators support batching, this feature gate can be removed and with it the documentation on batching support in the operators.