### PR TITLE
[kafka/config] add support for metadata.max.age.ms in franz-go

### DIFF
--- a/.chloggen/f_kafka_franzgo_refreshinterval.yaml
+++ b/.chloggen/f_kafka_franzgo_refreshinterval.yaml
@@ -4,10 +4,10 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: franzclient
+component: internal/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add support for MetadataMaxAge through existing Metadata.RefreshInterval config option in franz-go client. This adds support for the franz-go kafkareceiver and kafkaexporter."
+note: "Allow to configure the metdata refresh interval when using the franz-go client in kafkareceiver or kafkaexporter."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [41088]
@@ -16,7 +16,7 @@ issues: [41088]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Allow to configure the metdata refresh interval when using the franz-go client in kafkareceiver and kafkaexporter.
+  The `Metadata.RefreshInterval` is set as `MetadataMaxAge` when using the  franz-go client implementation for the kafkareceiver or kafkaexporter.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/f_kafka_franzgo_refreshinterval.yaml
+++ b/.chloggen/f_kafka_franzgo_refreshinterval.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: franzclient
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for MetadataMaxAge through existing Metadata.RefreshInterval config option in franz-go client. This adds support for the franz-go kafkareceiver and kafkaexporter."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41088]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Allow to configure the metdata refresh interval when using the franz-go client in kafkareceiver and kafkaexporter.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -80,7 +80,7 @@ The following settings can be optionally configured:
   - `full` (default = true): Whether to maintain a full set of metadata. When
     disabled, the client does not make the initial request to broker at the
     startup.
-  - `refresh_interval` (default = 10m): RefreshInterval controls the frequency at which cluster metadata is refreshed in the background.
+  - `refresh_interval` (default = 10m): The refreshInterval controls the frequency at which cluster metadata is refreshed in the background.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -80,6 +80,7 @@ The following settings can be optionally configured:
   - `full` (default = true): Whether to maintain a full set of metadata. When
     disabled, the client does not make the initial request to broker at the
     startup.
+  - `refresh_interval` (default = 10m): RefreshInterval controls the frequency at which cluster metadata is refreshed in the background.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -217,6 +217,10 @@ func commonOpts(ctx context.Context, clientCfg configkafka.ClientConfig,
 	if clientCfg.ClientID != "" {
 		opts = append(opts, kgo.ClientID(clientCfg.ClientID))
 	}
+	// Reuse existing metadata refresh interval for franz-go metadataMaxAge
+	if clientCfg.Metadata.RefreshInterval > 0 {
+		opts = append(opts, kgo.MetadataMaxAge(clientCfg.Metadata.RefreshInterval))
+	}
 	return opts, nil
 }
 

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -494,7 +494,7 @@ func TestFranzClient_MetadataRefreshInterval(t *testing.T) {
 	}{
 		{
 			name: "producer",
-			setupClient: func(t *testing.T, clientConfig configkafka.ClientConfig, topic string, metadataMinAge time.Duration) {
+			setupClient: func(t *testing.T, clientConfig configkafka.ClientConfig, _ string, metadataMinAge time.Duration) {
 				tl := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
 				client, err := NewFranzSyncProducer(context.Background(), clientConfig,
 					configkafka.NewDefaultProducerConfig(), time.Second, tl,

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -540,9 +540,6 @@ func TestFranzClient_MetadataRefreshInterval(t *testing.T) {
 				t.Fatal("timed out waiting for initial metadata request")
 			}
 
-			// Wait for refresh
-			time.Sleep(metadataMaxAge + 50*time.Millisecond)
-
 			// Check for second metadata request
 			select {
 			case <-metadataReqCh:

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -481,3 +481,74 @@ func mustNewFranzConsumerGroup(t *testing.T,
 	t.Cleanup(client.Close)
 	return client
 }
+
+func TestFranzClient_MetadataRefreshInterval(t *testing.T) {
+	topic := "test-topic"
+	metadataMaxAge := 25 * time.Millisecond
+	metadataMinAge := 10 * time.Millisecond
+
+	type setupClientFunc func(t *testing.T, clientConfig configkafka.ClientConfig, topic string, metadataMinAge time.Duration)
+	tests := []struct {
+		name        string
+		setupClient setupClientFunc
+	}{
+		{
+			name: "producer",
+			setupClient: func(t *testing.T, clientConfig configkafka.ClientConfig, topic string, metadataMinAge time.Duration) {
+				tl := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+				client, err := NewFranzSyncProducer(context.Background(), clientConfig,
+					configkafka.NewDefaultProducerConfig(), time.Second, tl,
+					kgo.MetadataMinAge(metadataMinAge),
+				)
+				require.NoError(t, err)
+				t.Cleanup(client.Close)
+			},
+		},
+		{
+			name: "consumer",
+			setupClient: func(t *testing.T, clientConfig configkafka.ClientConfig, topic string, metadataMinAge time.Duration) {
+				consumeConfig := configkafka.NewDefaultConsumerConfig()
+				mustNewFranzConsumerGroup(t, clientConfig, consumeConfig, []string{topic}, kgo.MetadataMinAge(metadataMinAge))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cluster, clientConfig := kafkatest.NewCluster(t, kfake.SeedTopics(1, topic))
+			// Set the metadata refresh interval which is expected to be translated into the franz-go client's metadataMaxAge configuration
+			clientConfig.Metadata.RefreshInterval = metadataMaxAge
+
+			metadataReqCh := make(chan struct{}, 10)
+			cluster.Control(func(req kmsg.Request) (kmsg.Response, error, bool) {
+				if _, ok := req.(*kmsg.MetadataRequest); ok {
+					select {
+					case metadataReqCh <- struct{}{}:
+					default:
+					}
+				}
+				return nil, nil, false
+			})
+
+			tt.setupClient(t, clientConfig, topic, metadataMinAge)
+
+			// Wait for initial metadata request. Due to the configuration passed into franz-go client, the metadataMaxAge should be set to 25 milliseconds.
+			select {
+			case <-metadataReqCh:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for initial metadata request")
+			}
+
+			// Wait for refresh
+			time.Sleep(metadataMaxAge + 50*time.Millisecond)
+
+			// Check for second metadata request
+			select {
+			case <-metadataReqCh:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for metadata refresh")
+			}
+		})
+	}
+}

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -94,7 +94,7 @@ The following settings can be optionally configured:
   - `full` (default = true): Whether to maintain a full set of metadata. When
     disabled, the client does not make the initial request to broker at the
     startup.
-  - `refresh_interval` (default = 10m): RefreshInterval controls the frequency at which cluster metadata is refreshed in the background.
+  - `refresh_interval` (default = 10m): The refreshInterval controls the frequency at which cluster metadata is refreshed in the background.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -94,6 +94,7 @@ The following settings can be optionally configured:
   - `full` (default = true): Whether to maintain a full set of metadata. When
     disabled, the client does not make the initial request to broker at the
     startup.
+  - `refresh_interval` (default = 10m): RefreshInterval controls the frequency at which cluster metadata is refreshed in the background.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Reuse existing `Metadata.RefreshInterval` configuration for setting `franz-go` `MetadataMaxAge` config option.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
closes #41088


<!--Describe what testing was performed and which tests were added.-->
#### Testing
The PR adds unit tests 

<!--Describe the documentation added.-->
#### Documentation
kafkareceiver and kafkaexporter README files are updated to contain the config option. 
<!--Please delete paragraphs that you did not use before submitting.-->
