### PR TITLE
[connector/routing] Add support for IsRootSpan function

### DIFF
--- a/.chloggen/register-is-root-span-ottl-func.yaml
+++ b/.chloggen/register-is-root-span-ottl-func.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/routing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for the `IsRootSpan` OTTL function.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41462]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/internal/common/functions.go
+++ b/connector/routingconnector/internal/common/functions.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
@@ -16,7 +17,7 @@ func createRouteFunction[K any](ottl.FunctionContext, ottl.Arguments) (ottl.Expr
 	}, nil
 }
 
-func Functions[K any]() map[string]ottl.Factory[K] {
+func StandardFunctions[K any]() map[string]ottl.Factory[K] {
 	// standard converters do not transform data, so we can safely use them
 	funcs := ottlfuncs.StandardConverters[K]()
 
@@ -28,6 +29,15 @@ func Functions[K any]() map[string]ottl.Factory[K] {
 
 	route := ottl.NewFactory("route", nil, createRouteFunction[K])
 	funcs[route.Name()] = route
+
+	return funcs
+}
+
+func SpanFunctions() map[string]ottl.Factory[ottlspan.TransformContext] {
+	funcs := StandardFunctions[ottlspan.TransformContext]()
+
+	isRootSpan := ottlfuncs.NewIsRootSpanFactory()
+	funcs[isRootSpan.Name()] = isRootSpan
 
 	return funcs
 }

--- a/connector/routingconnector/internal/common/functions_test.go
+++ b/connector/routingconnector/internal/common/functions_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+)
+
+func TestStandardFunctions(t *testing.T) {
+	assertStandardFunctions(t, StandardFunctions[any]())
+}
+
+func TestSpanFunctions(t *testing.T) {
+	funcs := SpanFunctions()
+	assertStandardFunctions(t, funcs)
+
+	isRouteFuncName := ottlfuncs.NewIsRootSpanFactory().Name()
+	val, ok := funcs[isRouteFuncName]
+
+	require.True(t, ok)
+	require.NotNil(t, val)
+	require.Equal(t, isRouteFuncName, val.Name())
+}
+
+func assertStandardFunctions[K any](t *testing.T, funcs map[string]ottl.Factory[K]) {
+	expectedFunctions := slices.AppendSeq([]string{
+		ottlfuncs.NewDeleteKeyFactory[any]().Name(),
+		ottlfuncs.NewDeleteMatchingKeysFactory[any]().Name(),
+		"route",
+	}, maps.Keys(ottlfuncs.StandardConverters[K]()))
+
+	for _, fn := range expectedFunctions {
+		val, ok := funcs[fn]
+		require.True(t, ok, "Function %s not found in standard functions", fn)
+		require.NotNil(t, val, "Function %s should not be nil", fn)
+		require.Equal(t, fn, val.Name(), "Function name mismatch for %s", fn)
+	}
+}

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -437,9 +437,9 @@ func TestLogsConnectorDetailed(t *testing.T) {
 
 	// IsMap and IsString are just candidate for Standard Converter Function to prevent any unknown regressions for this component
 	isBodyString := `IsString(body) == true`
-	require.Contains(t, common.Functions[ottllog.TransformContext](), "IsString")
+	require.Contains(t, common.StandardFunctions[ottllog.TransformContext](), "IsString")
 	isBodyMap := `IsMap(body) == true`
-	require.Contains(t, common.Functions[ottllog.TransformContext](), "IsMap")
+	require.Contains(t, common.StandardFunctions[ottllog.TransformContext](), "IsMap")
 
 	isScopeCFromLowerContext := `instrumentation_scope.name == "scopeC"`
 	isScopeDFromLowerContext := `instrumentation_scope.name == "scopeD"`

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -453,9 +453,9 @@ func TestMetricsConnectorDetailed(t *testing.T) {
 
 	// IsMap and IsString are just candidate for Standard Converter Function to prevent any unknown regressions for this component
 	isResourceString := `IsString(attributes["resourceName"]) == true`
-	require.Contains(t, common.Functions[ottlresource.TransformContext](), "IsString")
+	require.Contains(t, common.StandardFunctions[ottlresource.TransformContext](), "IsString")
 	isAttributesMap := `IsMap(attributes) == true`
-	require.Contains(t, common.Functions[ottlresource.TransformContext](), "IsMap")
+	require.Contains(t, common.StandardFunctions[ottlresource.TransformContext](), "IsMap")
 
 	isMetricE := `name == "metricE"`
 	isMetricF := `name == "metricF"`

--- a/connector/routingconnector/router.go
+++ b/connector/routingconnector/router.go
@@ -102,7 +102,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	var errs error
 	if buildResource {
 		parser, err := ottlresource.NewParser(
-			common.Functions[ottlresource.TransformContext](),
+			common.StandardFunctions[ottlresource.TransformContext](),
 			settings,
 		)
 		if err == nil {
@@ -113,7 +113,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildSpan {
 		parser, err := ottlspan.NewParser(
-			common.Functions[ottlspan.TransformContext](),
+			common.SpanFunctions(),
 			settings,
 		)
 		if err == nil {
@@ -124,7 +124,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildMetric {
 		parser, err := ottlmetric.NewParser(
-			common.Functions[ottlmetric.TransformContext](),
+			common.StandardFunctions[ottlmetric.TransformContext](),
 			settings,
 		)
 		if err == nil {
@@ -135,7 +135,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildDataPoint {
 		parser, err := ottldatapoint.NewParser(
-			common.Functions[ottldatapoint.TransformContext](),
+			common.StandardFunctions[ottldatapoint.TransformContext](),
 			settings,
 		)
 		if err == nil {
@@ -146,7 +146,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildLog {
 		parser, err := ottllog.NewParser(
-			common.Functions[ottllog.TransformContext](),
+			common.StandardFunctions[ottllog.TransformContext](),
 			settings,
 		)
 		if err == nil {

--- a/connector/routingconnector/traces_test.go
+++ b/connector/routingconnector/traces_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/common"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/ptraceutiltest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
 )
 
 func TestTracesRegisterConsumersForValidRoute(t *testing.T) {
@@ -411,9 +410,9 @@ func TestTracesConnectorDetailed(t *testing.T) {
 
 	// IsMap and IsString are just candidate for Standard Converter Function to prevent any unknown regressions for this component
 	isResourceString := `IsString(attributes["resourceName"]) == true`
-	require.Contains(t, common.Functions[ottlresource.TransformContext](), "IsString")
+	require.Contains(t, common.SpanFunctions(), "IsString")
 	isAttributesMap := `IsMap(attributes) == true`
-	require.Contains(t, common.Functions[ottlresource.TransformContext](), "IsMap")
+	require.Contains(t, common.SpanFunctions(), "IsMap")
 
 	isSpanE := `name == "spanE"`
 	isSpanF := `name == "spanF"`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added the missing `IsRootSpan` OTTL function to the routing connector's span context conditions.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41462

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests
