### PR TITLE
[chore] Fix artifacts overwritten in flakytests-generate-issues on Windows

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -130,6 +130,9 @@ jobs:
           fi
   flakytests-generate-issues:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        os: [windows-2022, windows-2025]
     runs-on: ubuntu-24.04
     needs: [windows-unittest-matrix]
     permissions:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
-          pattern: test-results-windows-*
+          pattern: test-results-windows-${{ matrix.os }}-*
           path: ./internal/tools/testresults/
       - name: Install Tools
         if: steps.go-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fix https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/1063

The issue is that the artifacts with the test results exist for Windows 2022 and 2025 when we download the artifacts with the test results there is a race to write the files and occasionally that can end up with a corrupt XML on disk. Separating the download of 2022 and 2025 fixes the issue.