### PR TITLE
[Documentation Fix] EC2 resourcedetection processor doco bug

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/ec2/documentation.md
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/documentation.md
@@ -16,4 +16,4 @@
 | host.id | The host.id | Any Str | true |
 | host.image.id | The host image id | Any Str | true |
 | host.name | The hostname | Any Str | true |
-| host.type | The host id | Any Str | true |
+| host.type | The host instance type | Any Str | true |

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.yaml
@@ -36,7 +36,7 @@ resource_attributes:
     type: string
     enabled: true
   host.type:
-    description: The host id
+    description: The host instance type
     type: string
     enabled: true
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Just noticed a duplicate value under the host.type field in the resourcedetection processor for ec2. After doing a little digging this seems to refer to the ec2 instance type rather than the instance id.

<!--Describe the documentation added.-->
#### Documentation
Updated yaml that seem to generate the readme for resourcedetection/ec2 processor

<!--Please delete paragraphs that you did not use before submitting.-->
