### PR TITLE
[chore] Promote edmocosta to maintainer

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -17,7 +17,6 @@ assigneeGroups:
     # - crobert-1 (On leave, back August 5th)
     - dashpole
     - dehaansa
-    - edmocosta
     - mwear
     - fatsheep9146
     # Maintainers
@@ -26,6 +25,7 @@ assigneeGroups:
     - bogdandrutu
     - codeboten
     - dmitryax
+    - edmocosta
     - evan-bradley
     - MovieStoreGuy
     - mx-psi

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Bogdan Drutu](https://github.com/bogdandrutu), Snowflake
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
+- [Edmo Vamerlatti Costa](https://github.com/edmocosta), Elastic
 - [Evan Bradley](https://github.com/evan-bradley), Dynatrace
 - [Pablo Baeyens](https://github.com/mx-psi), DataDog
 - [Sean Marciniak](https://github.com/MovieStoreGuy), Splunk
@@ -89,7 +90,6 @@ For more information about the maintainer role, see the [community repository](h
 - [Christos Markou](https://github.com/ChrsMark), Elastic (On leave)
 - [Curtis Robert](https://github.com/crobert-1), Splunk
 - [David Ashpole](https://github.com/dashpole), Google
-- [Edmo Vamerlatti Costa](https://github.com/edmocosta), Elastic
 - [Matt Wear](https://github.com/mwear), Lightstep
 - [Sam DeHaan](https://github.com/dehaansa), Grafana Labs
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba


### PR DESCRIPTION
@edmocosta has been a very active approver in Collector Contrib, showing great judgement and dedication to the project. He continues to lead the future of OTTL and other Contrib components.

PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Aedmocosta+
PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3Aedmocosta+
Issues created: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+author%3Aedmocosta+
Issues commented: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+commenter%3Aedmocosta+
Commits: https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?author=edmocosta&since=2023-05-31&until=now

For these reasons we'd like to promote @edmocosta to Maintainer.