### PR TITLE
[exporter/elasticsearch] Add metadata context to logs for failed ES reqs

### DIFF
--- a/.chloggen/41674_esexporter_logs_metadata.yaml
+++ b/.chloggen/41674_esexporter_logs_metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enhance logs with additional metadata fields for failed requests to Elasticsearch bulk API"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41674]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Metadata attributes are appended to the log fields, providing additional context for debugging failed requests to the Elasticsearch bulk API.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -429,7 +429,7 @@ func flushBulkIndexer(
 		)
 	}
 
-	fields := []zap.Field{}
+	var fields []zap.Field
 	// append metadata attributes to error log fields
 	for _, kv := range defaultMetaAttrs {
 		switch kv.Value.Type() {

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -500,6 +500,18 @@ func flushBulkIndexer(
 			zap.String("error.type", resp.Error.Type),
 			zap.String("error.reason", resp.Error.Reason),
 		}
+
+		// append metadata attributes to error log fields
+		for _, kv := range defaultMetaAttrs {
+			switch kv.Value.Type() {
+			case attribute.STRINGSLICE:
+				fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
+			default:
+				// For other types, convert to string
+				fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
+			}
+		}
+
 		if hint := getErrorHint(resp.Index, resp.Error.Type); hint != "" {
 			fields = append(fields, zap.String("hint", hint))
 		}

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -428,8 +428,20 @@ func flushBulkIndexer(
 			ctx, int64(flushed), metric.WithAttributeSet(defaultAttrsSet),
 		)
 	}
+
+	fields := []zap.Field{}
+	// append metadata attributes to error log fields
+	for _, kv := range defaultMetaAttrs {
+		switch kv.Value.Type() {
+		case attribute.STRINGSLICE:
+			fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
+		default:
+			// For other types, convert to string
+			fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
+		}
+	}
 	if err != nil {
-		logger.Error("bulk indexer flush error", zap.Error(err))
+		logger.Error("bulk indexer flush error", append(fields, zap.Error(err))...)
 		var bulkFailedErr docappender.ErrorFlushFailed
 		switch {
 		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
@@ -495,22 +507,11 @@ func flushBulkIndexer(
 			clientFailed++
 		}
 		// Log failed docs
-		fields := []zap.Field{
+		fields = append(fields,
 			zap.String("index", resp.Index),
 			zap.String("error.type", resp.Error.Type),
 			zap.String("error.reason", resp.Error.Reason),
-		}
-
-		// append metadata attributes to error log fields
-		for _, kv := range defaultMetaAttrs {
-			switch kv.Value.Type() {
-			case attribute.STRINGSLICE:
-				fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
-			default:
-				// For other types, convert to string
-				fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
-			}
-		}
+		)
 
 		if hint := getErrorHint(resp.Index, resp.Error.Type); hint != "" {
 			fields = append(fields, zap.String("hint", hint))

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -584,83 +584,122 @@ func runBulkIndexerOnce(t *testing.T, config *Config, client *elasticsearch.Clie
 }
 
 func TestSyncBulkIndexer_flushBytes(t *testing.T) {
-	var reqCnt atomic.Int64
-	cfg := Config{
-		NumWorkers:   1,
-		Flush:        FlushSettings{Interval: time.Hour, Bytes: 1},
-		MetadataKeys: []string{"x-test"},
+	tests := []struct {
+		name         string
+		responseBody string
+		wantMessage  string
+		wantFields   []zap.Field
+	}{
+		{
+			name:         "success",
+			responseBody: successResp,
+		},
+		{
+			name:         "document_error_with_metadata",
+			responseBody: `{"items":[{"create":{"_index":"foo","status":400,"error":{"type":"version_conflict_engine_exception","reason":"document already exists"}}}]}`,
+			wantMessage:  "failed to index document",
+			wantFields:   []zap.Field{zap.Strings("x-test", []string{"test"})},
+		},
 	}
-	esClient, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
-		RoundTripFunc: func(r *http.Request) (*http.Response, error) {
-			if r.URL.Path == "/_bulk" {
-				reqCnt.Add(1)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reqCnt atomic.Int64
+			cfg := Config{
+				NumWorkers:   1,
+				Flush:        FlushSettings{Interval: time.Hour, Bytes: 1},
+				MetadataKeys: []string{"x-test"},
 			}
-			return &http.Response{
-				Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
-				Body:       io.NopCloser(strings.NewReader(successResp)),
-				StatusCode: http.StatusOK,
-			}, nil
-		},
-	}})
-	require.NoError(t, err)
+			esClient, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
+				RoundTripFunc: func(r *http.Request) (*http.Response, error) {
+					if r.URL.Path == "/_bulk" {
+						reqCnt.Add(1)
+					}
+					return &http.Response{
+						Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+						Body:       io.NopCloser(strings.NewReader(tt.responseBody)),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+			}})
+			require.NoError(t, err)
 
-	ct := componenttest.NewTelemetry()
-	tb, err := metadata.NewTelemetryBuilder(
-		metadatatest.NewSettings(ct).TelemetrySettings,
-	)
-	require.NoError(t, err)
-	bi := newSyncBulkIndexer(esClient, &cfg, false, tb, zap.NewNop())
+			ct := componenttest.NewTelemetry()
+			tb, err := metadata.NewTelemetryBuilder(
+				metadatatest.NewSettings(ct).TelemetrySettings,
+			)
+			require.NoError(t, err)
 
-	info := client.Info{Metadata: client.NewMetadata(map[string][]string{"x-test": {"test"}})}
-	ctx := client.NewContext(context.Background(), info)
-	session := bi.StartSession(ctx)
-	assert.NoError(t, session.Add(ctx, "foo", "", "", strings.NewReader(`{"foo": "bar"}`), nil, docappender.ActionCreate))
-	assert.Equal(t, int64(1), reqCnt.Load()) // flush due to flush::bytes
-	assert.NoError(t, session.Flush(context.Background()))
-	session.End()
-	assert.NoError(t, bi.Close(context.Background()))
-	// Assert internal telemetry metrics
-	metadatatest.AssertEqualElasticsearchBulkRequestsCount(t, ct, []metricdata.DataPoint[int64]{
-		{
-			Value: 1, // empty session flush should be a no-op
-			Attributes: attribute.NewSet(
-				attribute.String("outcome", "success"),
-				attribute.StringSlice("x-test", []string{"test"}),
-				semconv.HTTPResponseStatusCode(http.StatusOK),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualElasticsearchDocsReceived(t, ct, []metricdata.DataPoint[int64]{
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				attribute.StringSlice("x-test", []string{"test"}),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualElasticsearchDocsProcessed(t, ct, []metricdata.DataPoint[int64]{
-		{
-			Value: 1,
-			Attributes: attribute.NewSet(
-				attribute.String("outcome", "success"),
-				attribute.StringSlice("x-test", []string{"test"}),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualElasticsearchFlushedBytes(t, ct, []metricdata.DataPoint[int64]{
-		{
-			Value: 43, // hard-coding the flush bytes since the input is fixed
-			Attributes: attribute.NewSet(
-				attribute.StringSlice("x-test", []string{"test"}),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
-	metadatatest.AssertEqualElasticsearchFlushedUncompressedBytes(t, ct, []metricdata.DataPoint[int64]{
-		{
-			Value: 43, // hard-coding the flush bytes since the input is fixed
-			Attributes: attribute.NewSet(
-				attribute.StringSlice("x-test", []string{"test"}),
-			),
-		},
-	}, metricdatatest.IgnoreTimestamp())
+			core, observed := observer.New(zap.NewAtomicLevelAt(zapcore.DebugLevel))
+			bi := newSyncBulkIndexer(esClient, &cfg, false, tb, zap.New(core))
+
+			info := client.Info{Metadata: client.NewMetadata(map[string][]string{"x-test": {"test"}})}
+			ctx := client.NewContext(context.Background(), info)
+			session := bi.StartSession(ctx)
+			assert.NoError(t, session.Add(ctx, "foo", "", "", strings.NewReader(`{"foo": "bar"}`), nil, docappender.ActionCreate))
+			assert.Equal(t, int64(1), reqCnt.Load())
+			assert.NoError(t, session.Flush(ctx))
+			session.End()
+			assert.NoError(t, bi.Close(ctx))
+
+			// Assert internal telemetry metrics
+			expectedOutcome := "success"
+			if tt.wantMessage != "" {
+				expectedOutcome = "failed_client"
+			}
+
+			metadatatest.AssertEqualElasticsearchBulkRequestsCount(t, ct, []metricdata.DataPoint[int64]{
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.String("outcome", "success"), // bulk request itself is successful
+						attribute.StringSlice("x-test", []string{"test"}),
+						semconv.HTTPResponseStatusCode(http.StatusOK),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+			metadatatest.AssertEqualElasticsearchDocsReceived(t, ct, []metricdata.DataPoint[int64]{
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.StringSlice("x-test", []string{"test"}),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+			metadatatest.AssertEqualElasticsearchDocsProcessed(t, ct, []metricdata.DataPoint[int64]{
+				{
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.String("outcome", expectedOutcome),
+						attribute.StringSlice("x-test", []string{"test"}),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+			metadatatest.AssertEqualElasticsearchFlushedBytes(t, ct, []metricdata.DataPoint[int64]{
+				{
+					Value: 43, // hard-coding the flush bytes since the input is fixed
+					Attributes: attribute.NewSet(
+						attribute.StringSlice("x-test", []string{"test"}),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+			metadatatest.AssertEqualElasticsearchFlushedUncompressedBytes(t, ct, []metricdata.DataPoint[int64]{
+				{
+					Value: 43, // hard-coding the flush bytes since the input is fixed
+					Attributes: attribute.NewSet(
+						attribute.StringSlice("x-test", []string{"test"}),
+					),
+				},
+			}, metricdatatest.IgnoreTimestamp())
+
+			// Assert logs
+			if tt.wantMessage != "" {
+				messages := observed.FilterMessage(tt.wantMessage)
+				require.Equal(t, 1, messages.Len(), "message not found; observed.All()=%v", observed.All())
+				for _, wantField := range tt.wantFields {
+					assert.Equal(t, 1, messages.FilterField(wantField).Len(), "message with field not found; observed.All()=%v", observed.All())
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### Description

+ Similar to change we did for Metrics https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41284 for enhancing them with additional metadata, This PR adds metadata attributes to the log fields, providing additional context for debugging failed requests to the Elasticsearch bulk API.

#### Testing

Unit tests are added.

#### Documentation

Already covered in https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter#metadata-keys
