### PR TITLE
[s3exporter] Fix duplicate slash

### DIFF
--- a/.chloggen/fix_s3-path-join.yaml
+++ b/.chloggen/fix_s3-path-join.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awss3exporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes S3 path joining in the AWS S3 exporter to ensure correct partitioning and prefix handling."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41675]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -5,6 +5,7 @@ package upload // import "github.com/open-telemetry/opentelemetry-collector-cont
 
 import (
 	"math/rand/v2"
+	"path"
 	"strconv"
 	"time"
 
@@ -44,7 +45,7 @@ type PartitionKeyBuilder struct {
 }
 
 func (pki *PartitionKeyBuilder) Build(ts time.Time, overridePrefix string) string {
-	return pki.bucketKeyPrefix(ts, overridePrefix) + "/" + pki.fileName()
+	return path.Join(pki.bucketKeyPrefix(ts, overridePrefix), pki.fileName())
 }
 
 func (pki *PartitionKeyBuilder) bucketKeyPrefix(ts time.Time, overridePrefix string) string {

--- a/exporter/awss3exporter/internal/upload/partition_test.go
+++ b/exporter/awss3exporter/internal/upload/partition_test.go
@@ -27,7 +27,32 @@ func TestPartitionKeyInputsNewPartitionKey(t *testing.T) {
 					return "fixed"
 				},
 			},
-			expect:         "/_fixed",
+			expect:         "_fixed",
+			overridePrefix: "",
+		},
+		{
+			name: "fixed key with prefix",
+			inputs: &PartitionKeyBuilder{
+				PartitionPrefix: "telemetry",
+				UniqueKeyFunc: func() string {
+					return "fixed"
+				},
+			},
+			expect:         "telemetry/_fixed",
+			overridePrefix: "",
+		},
+		{
+			name: "empty partition",
+			inputs: &PartitionKeyBuilder{
+				PartitionPrefix: "telemetry/foo",
+				PartitionFormat: "",
+				FilePrefix:      "signal-output-",
+				FileFormat:      "metrics",
+				UniqueKeyFunc: func() string {
+					return "fixed"
+				},
+			},
+			expect:         "telemetry/foo/signal-output-_fixed.metrics",
 			overridePrefix: "",
 		},
 		{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
If the `s3_partition_format` is empty, the resulting S3 path includes double slashes.

Eg: `<prefix>//<output_file>`

This PR uses `Path.join` instead of manual concatenation to avoid double slashes.

I should note that in this PR, I changed the `empty values` test so the expected value _does not_ have a `/` prefix. I feel like this is the more accurate/intended behavior as we wouldn't want to prepend a slash to to the key. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
(unfiled)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added new tests
- Local testing with localstack/sample configs

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
