### PR TITLE
[connector/spanmetrics] Fix Exemplar counts out of control when not set MaxPerDataPoint

### DIFF
--- a/.chloggen/fix-spanmetrics-examplers.yaml
+++ b/.chloggen/fix-spanmetrics-examplers.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a default maximum number of exemplars within the metric export interval.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41679]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  1. If the user manually sets max_per_data_point, there will be no impact.
+  2. If the user does not set max_per_data_point, the default value will take effect, with max_per_data_point = 5.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -122,6 +122,7 @@ The following settings can be optionally configured:
 - `metric_timestamp_cache_size` (default `1000`): Only relevant for delta temporality span metrics. Controls the size of the cache used to keep track of a metric's TimestampUnixNano the last time it was flushed. When a metric is evicted from the cache, its next data point will indicate a "reset" in the series. Downstream components converting from delta to cumulative, like `prometheusexporter`, may handle these resets by setting cumulative counters back to 0.
 - `exemplars`:  Use to configure how to attach exemplars to metrics.
   - `enabled` (default: `false`): enabling will add spans as Exemplars to all metrics. Exemplars are only kept for one flush interval.rom the cache, its next data point will indicate a "reset" in the series. Downstream components converting from delta to cumulative, like `prometheusexporter`, may handle these resets by setting cumulative counters back to 0.
+  - `max_per_data_point` (default: `5`): The maximum number of exemplars to attach to a single metric data point.
 - `events`: Use to configure the events metric.
   - `enabled`: (default: `false`): enabling will add the events metric.
   - `dimensions`: (mandatory if `enabled`) the list of the span's event attributes to add as dimensions to the `traces.span.metrics.events` metric, which will be included _on top of_ the common and configured `dimensions` for span attributes and resource attributes.
@@ -163,7 +164,6 @@ connectors:
     exemplars:
       enabled: true
     exclude_dimensions: ['status.code']
-    dimensions_cache_size: 1000
     aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    
     metrics_flush_interval: 15s
     metrics_expiration: 5m

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -106,7 +106,7 @@ type HistogramConfig struct {
 
 type ExemplarsConfig struct {
 	Enabled         bool `mapstructure:"enabled"`
-	MaxPerDataPoint *int `mapstructure:"max_per_data_point"`
+	MaxPerDataPoint int  `mapstructure:"max_per_data_point"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -165,6 +165,10 @@ func (c Config) Validate() error {
 
 	if c.AggregationCardinalityLimit < 0 {
 		return fmt.Errorf("invalid aggregation_cardinality_limit: %v, the limit should be positive", c.AggregationCardinalityLimit)
+	}
+
+	if c.Exemplars.Enabled && c.Exemplars.MaxPerDataPoint < 0 {
+		return fmt.Errorf("invalid max_per_data_point: %v, the value should be positive", c.Exemplars.MaxPerDataPoint)
 	}
 
 	return nil

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -28,24 +28,27 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	defaultMethod := http.MethodGet
-	defaultMaxPerDatapoint := 5
 	customTimestampCacheSize := 123
 	tests := []struct {
+		name            string
 		id              component.ID
 		expected        component.Config
 		errorMessage    string
 		extraAssertions func(config *Config)
 	}{
 		{
+			name:     "default",
 			id:       component.NewIDWithName(metadata.Type, "default"),
 			expected: createDefaultConfig(),
 		},
 		{
+			name:     "default_explicit_histogram",
 			id:       component.NewIDWithName(metadata.Type, "default_explicit_histogram"),
 			expected: createDefaultConfig(),
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "full"),
+			name: "full",
+			id:   component.NewIDWithName(metadata.Type, "full"),
 			expected: &Config{
 				AggregationTemporality: delta,
 				Dimensions: []Dimension{
@@ -56,7 +59,8 @@ func TestLoadConfig(t *testing.T) {
 				ResourceMetricsCacheSize: 1600,
 				MetricsFlushInterval:     30 * time.Second,
 				Exemplars: ExemplarsConfig{
-					Enabled: true,
+					Enabled:         true,
+					MaxPerDataPoint: defaultMaxPerDatapoint,
 				},
 				Histogram: HistogramConfig{
 					Unit: metrics.Seconds,
@@ -71,12 +75,16 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "exponential_histogram"),
+			name: "exponential_histogram",
+			id:   component.NewIDWithName(metadata.Type, "exponential_histogram"),
 			expected: &Config{
 				Namespace:                DefaultNamespace,
 				AggregationTemporality:   cumulative,
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
+				Exemplars: ExemplarsConfig{
+					MaxPerDataPoint: defaultMaxPerDatapoint,
+				},
 				Histogram: HistogramConfig{
 					Unit: metrics.Milliseconds,
 					Exponential: &ExponentialHistogramConfig{
@@ -86,80 +94,99 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			name:         "exponential_and_explicit_histogram",
 			id:           component.NewIDWithName(metadata.Type, "exponential_and_explicit_histogram"),
 			errorMessage: "use either `explicit` or `exponential` buckets histogram",
 		},
 		{
+			name:         "invalid_histogram_unit",
 			id:           component.NewIDWithName(metadata.Type, "invalid_histogram_unit"),
 			errorMessage: "unknown Unit \"h\"",
 		},
 		{
+			name:         "invalid_metrics_expiration",
 			id:           component.NewIDWithName(metadata.Type, "invalid_metrics_expiration"),
 			errorMessage: "the duration should be positive",
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "exemplars_enabled"),
+			name: "exemplars_enabled",
+			id:   component.NewIDWithName(metadata.Type, "exemplars_enabled"),
 			expected: &Config{
 				AggregationTemporality:   "AGGREGATION_TEMPORALITY_CUMULATIVE",
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
 				Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
-				Exemplars:                ExemplarsConfig{Enabled: true},
+				Exemplars:                ExemplarsConfig{Enabled: true, MaxPerDataPoint: defaultMaxPerDatapoint},
 				Namespace:                DefaultNamespace,
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "exemplars_enabled_with_max_per_datapoint"),
+			name: "exemplars_enabled_with_max_per_datapoint",
+			id:   component.NewIDWithName(metadata.Type, "exemplars_enabled_with_max_per_datapoint"),
 			expected: &Config{
 				AggregationTemporality:   "AGGREGATION_TEMPORALITY_CUMULATIVE",
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
 				Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
-				Exemplars:                ExemplarsConfig{Enabled: true, MaxPerDataPoint: &defaultMaxPerDatapoint},
+				Exemplars:                ExemplarsConfig{Enabled: true, MaxPerDataPoint: 10},
 				Namespace:                DefaultNamespace,
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "resource_metrics_key_attributes"),
+			name: "resource_metrics_key_attributes",
+			id:   component.NewIDWithName(metadata.Type, "resource_metrics_key_attributes"),
 			expected: &Config{
 				AggregationTemporality:       "AGGREGATION_TEMPORALITY_CUMULATIVE",
 				ResourceMetricsCacheSize:     defaultResourceMetricsCacheSize,
 				ResourceMetricsKeyAttributes: []string{"service.name", "telemetry.sdk.language", "telemetry.sdk.name"},
 				MetricsFlushInterval:         60 * time.Second,
-				Histogram:                    HistogramConfig{Disable: false, Unit: defaultUnit},
-				Namespace:                    DefaultNamespace,
+				Exemplars: ExemplarsConfig{
+					MaxPerDataPoint: defaultMaxPerDatapoint,
+				},
+				Histogram: HistogramConfig{Disable: false, Unit: defaultUnit},
+				Namespace: DefaultNamespace,
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "custom_delta_timestamp_cache_size"),
+			name: "custom_delta_timestamp_cache_size",
+			id:   component.NewIDWithName(metadata.Type, "custom_delta_timestamp_cache_size"),
 			expected: &Config{
 				AggregationTemporality:   "AGGREGATION_TEMPORALITY_DELTA",
 				TimestampCacheSize:       &customTimestampCacheSize,
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
-				Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
-				Namespace:                DefaultNamespace,
+				Exemplars: ExemplarsConfig{
+					MaxPerDataPoint: defaultMaxPerDatapoint,
+				},
+				Histogram: HistogramConfig{Disable: false, Unit: defaultUnit},
+				Namespace: DefaultNamespace,
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "default_delta_timestamp_cache_size"),
+			name: "default_delta_timestamp_cache_size",
+			id:   component.NewIDWithName(metadata.Type, "default_delta_timestamp_cache_size"),
 			expected: &Config{
 				AggregationTemporality:   "AGGREGATION_TEMPORALITY_DELTA",
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
-				Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
-				Namespace:                DefaultNamespace,
+				Exemplars: ExemplarsConfig{
+					MaxPerDataPoint: defaultMaxPerDatapoint,
+				},
+				Histogram: HistogramConfig{Disable: false, Unit: defaultUnit},
+				Namespace: DefaultNamespace,
 			},
 			extraAssertions: func(config *Config) {
 				assert.Equal(t, defaultDeltaTimestampCacheSize, config.GetDeltaTimestampCacheSize())
 			},
 		},
 		{
+			name:         "invalid_delta_timestamp_cache_size",
 			id:           component.NewIDWithName(metadata.Type, "invalid_delta_timestamp_cache_size"),
 			errorMessage: "invalid delta timestamp cache size: 0, the maximum number of the items in the cache should be positive",
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "separate_calls_and_duration_dimensions"),
+			name: "separate_calls_and_duration_dimensions",
+			id:   component.NewIDWithName(metadata.Type, "separate_calls_and_duration_dimensions"),
 			expected: &Config{
 				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
 				Histogram:              HistogramConfig{Disable: false, Unit: defaultUnit, Dimensions: []Dimension{{Name: "http.status_code", Default: (*string)(nil)}}},
@@ -171,13 +198,16 @@ func TestLoadConfig(t *testing.T) {
 				},
 				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
 				MetricsFlushInterval:     60 * time.Second,
-				Namespace:                DefaultNamespace,
+				Exemplars: ExemplarsConfig{
+					MaxPerDataPoint: defaultMaxPerDatapoint,
+				},
+				Namespace: DefaultNamespace,
 			},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.id.String(), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -46,6 +46,8 @@ const (
 
 	// https://github.com/open-telemetry/opentelemetry-go/blob/3ae002c3caf3e44387f0554dfcbbde2c5aab7909/sdk/metric/internal/aggregate/limit.go#L11C36-L11C50
 	overflowKey = "otel.metric.overflow"
+
+	defaultMaxPerDatapoint = 5
 )
 
 type connectorImp struct {

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -416,7 +416,8 @@ func disabledExemplarsConfig() ExemplarsConfig {
 
 func enabledExemplarsConfig() ExemplarsConfig {
 	return ExemplarsConfig{
-		Enabled: true,
+		Enabled:         true,
+		MaxPerDataPoint: defaultMaxPerDatapoint,
 	}
 }
 
@@ -1405,7 +1406,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		{
 			name:   "initialize histogram with no config provided",
 			config: Config{},
-			want:   metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsMs, nil, 0),
+			want:   metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsMs, 0, 0),
 		},
 		{
 			name: "Disable histogram",
@@ -1423,7 +1424,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					Unit: metrics.Milliseconds,
 				},
 			},
-			want: metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsMs, nil, 0),
+			want: metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsMs, 0, 0),
 		},
 		{
 			name: "initialize explicit histogram with default bounds (seconds)",
@@ -1432,7 +1433,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					Unit: metrics.Seconds,
 				},
 			},
-			want: metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsSeconds, nil, 0),
+			want: metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsSeconds, 0, 0),
 		},
 		{
 			name: "initialize explicit histogram with bounds (seconds)",
@@ -1447,7 +1448,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					},
 				},
 			},
-			want: metrics.NewExplicitHistogramMetrics([]float64{0.1, 1}, nil, 0),
+			want: metrics.NewExplicitHistogramMetrics([]float64{0.1, 1}, 0, 0),
 		},
 		{
 			name: "initialize explicit histogram with bounds (ms)",
@@ -1462,7 +1463,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					},
 				},
 			},
-			want: metrics.NewExplicitHistogramMetrics([]float64{100, 1000}, nil, 0),
+			want: metrics.NewExplicitHistogramMetrics([]float64{100, 1000}, 0, 0),
 		},
 		{
 			name: "initialize exponential histogram",
@@ -1474,7 +1475,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					},
 				},
 			},
-			want: metrics.NewExponentialHistogramMetrics(10, nil, 0),
+			want: metrics.NewExponentialHistogramMetrics(10, 0, 0),
 		},
 		{
 			name: "initialize exponential histogram with default max buckets count",
@@ -1484,7 +1485,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 					Exponential: &ExponentialHistogramConfig{},
 				},
 			},
-			want: metrics.NewExponentialHistogramMetrics(structure.DefaultMaxSize, nil, 0),
+			want: metrics.NewExponentialHistogramMetrics(structure.DefaultMaxSize, 0, 0),
 		},
 	}
 	for _, tt := range tests {

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -52,6 +52,9 @@ func createDefaultConfig() component.Config {
 		Histogram:                   HistogramConfig{Disable: false, Unit: defaultUnit},
 		Namespace:                   DefaultNamespace,
 		AggregationCardinalityLimit: 0,
+		Exemplars: ExemplarsConfig{
+			MaxPerDataPoint: defaultMaxPerDatapoint,
+		},
 	}
 }
 

--- a/connector/spanmetricsconnector/internal/metrics/metrics.go
+++ b/connector/spanmetricsconnector/internal/metrics/metrics.go
@@ -30,14 +30,14 @@ type Histogram interface {
 type explicitHistogramMetrics struct {
 	metrics          map[Key]*explicitHistogram
 	bounds           []float64
-	maxExemplarCount *int
+	maxExemplarCount int
 	cardinalityLimit int
 }
 
 type exponentialHistogramMetrics struct {
 	metrics          map[Key]*exponentialHistogram
 	maxSize          int32
-	maxExemplarCount *int
+	maxExemplarCount int
 	cardinalityLimit int
 }
 
@@ -51,7 +51,7 @@ type explicitHistogram struct {
 
 	bounds []float64
 
-	maxExemplarCount *int
+	maxExemplarCount int
 
 	startTimestamp pcommon.Timestamp
 }
@@ -62,14 +62,14 @@ type exponentialHistogram struct {
 
 	histogram *structure.Histogram[float64]
 
-	maxExemplarCount *int
+	maxExemplarCount int
 
 	startTimestamp pcommon.Timestamp
 }
 
 type BuildAttributesFun func() pcommon.Map
 
-func NewExponentialHistogramMetrics(maxSize int32, maxExemplarCount *int, cardinalityLimit int) HistogramMetrics {
+func NewExponentialHistogramMetrics(maxSize int32, maxExemplarCount, cardinalityLimit int) HistogramMetrics {
 	return &exponentialHistogramMetrics{
 		metrics:          make(map[Key]*exponentialHistogram),
 		maxSize:          maxSize,
@@ -78,7 +78,7 @@ func NewExponentialHistogramMetrics(maxSize int32, maxExemplarCount *int, cardin
 	}
 }
 
-func NewExplicitHistogramMetrics(bounds []float64, maxExemplarCount *int, cardinalityLimit int) HistogramMetrics {
+func NewExplicitHistogramMetrics(bounds []float64, maxExemplarCount, cardinalityLimit int) HistogramMetrics {
 	return &explicitHistogramMetrics{
 		metrics:          make(map[Key]*explicitHistogram),
 		bounds:           bounds,
@@ -270,7 +270,7 @@ func (h *explicitHistogram) Observe(value float64) {
 }
 
 func (h *explicitHistogram) AddExemplar(traceID pcommon.TraceID, spanID pcommon.SpanID, value float64) {
-	if h.maxExemplarCount != nil && h.exemplars.Len() >= *h.maxExemplarCount {
+	if h.exemplars.Len() >= h.maxExemplarCount {
 		return
 	}
 	e := h.exemplars.AppendEmpty()
@@ -284,7 +284,7 @@ func (h *exponentialHistogram) Observe(value float64) {
 }
 
 func (h *exponentialHistogram) AddExemplar(traceID pcommon.TraceID, spanID pcommon.SpanID, value float64) {
-	if h.maxExemplarCount != nil && h.exemplars.Len() >= *h.maxExemplarCount {
+	if h.exemplars.Len() >= h.maxExemplarCount {
 		return
 	}
 	e := h.exemplars.AppendEmpty()
@@ -298,7 +298,7 @@ type Sum struct {
 	count      uint64
 
 	exemplars        pmetric.ExemplarSlice
-	maxExemplarCount *int
+	maxExemplarCount int
 
 	startTimestamp pcommon.Timestamp
 	// isFirst is used to track if this datapoint is new to the Sum. This
@@ -312,7 +312,7 @@ func (s *Sum) Add(value uint64) {
 	s.count += value
 }
 
-func NewSumMetrics(maxExemplarCount *int, cardinalityLimit int) SumMetrics {
+func NewSumMetrics(maxExemplarCount, cardinalityLimit int) SumMetrics {
 	return SumMetrics{
 		metrics:          make(map[Key]*Sum),
 		maxExemplarCount: maxExemplarCount,
@@ -322,7 +322,7 @@ func NewSumMetrics(maxExemplarCount *int, cardinalityLimit int) SumMetrics {
 
 type SumMetrics struct {
 	metrics          map[Key]*Sum
-	maxExemplarCount *int
+	maxExemplarCount int
 	cardinalityLimit int
 }
 
@@ -366,7 +366,7 @@ func (m *SumMetrics) GetOrCreate(key Key, attributesFun BuildAttributesFun, star
 }
 
 func (s *Sum) AddExemplar(traceID pcommon.TraceID, spanID pcommon.SpanID, value float64) {
-	if s.maxExemplarCount != nil && s.exemplars.Len() >= *s.maxExemplarCount {
+	if s.exemplars.Len() >= s.maxExemplarCount {
 		return
 	}
 	e := s.exemplars.AppendEmpty()

--- a/connector/spanmetricsconnector/internal/metrics/metrics_test.go
+++ b/connector/spanmetricsconnector/internal/metrics/metrics_test.go
@@ -113,9 +113,9 @@ func TestSum_AddExemplar(t *testing.T) {
 		want  int
 	}{
 		{
-			name:  "Sum Metric - No exemplars configured",
-			input: Sum{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: &maxCount},
-			want:  1,
+			name:  "Sum Metric - set maxExemplarCount zero",
+			input: Sum{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: 0},
+			want:  0,
 		},
 		{
 			name: "Sum Metric - With exemplars length less than configured max count",
@@ -128,7 +128,7 @@ func TestSum_AddExemplar(t *testing.T) {
 
 				return Sum{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 2,
@@ -152,7 +152,7 @@ func TestSum_AddExemplar(t *testing.T) {
 
 				return Sum{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 3,
@@ -174,9 +174,9 @@ func TestExplicitHistogram_AddExemplar(t *testing.T) {
 		want  int
 	}{
 		{
-			name:  "Explicit Histogram - No exemplars configured",
-			input: explicitHistogram{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: &maxCount},
-			want:  1,
+			name:  "Explicit Histogram - set maxExemplarCount zero",
+			input: explicitHistogram{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: 0},
+			want:  0,
 		},
 		{
 			name: "Explicit Histogram - With exemplars length less than configured max count",
@@ -189,7 +189,7 @@ func TestExplicitHistogram_AddExemplar(t *testing.T) {
 
 				return explicitHistogram{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 2,
@@ -213,7 +213,7 @@ func TestExplicitHistogram_AddExemplar(t *testing.T) {
 
 				return explicitHistogram{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 3,
@@ -235,9 +235,9 @@ func TestExponentialHistogram_AddExemplar(t *testing.T) {
 		want  int
 	}{
 		{
-			name:  "Exponential Histogram - No exemplars configured",
-			input: exponentialHistogram{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: &maxCount},
-			want:  1,
+			name:  "Exponential Histogram - set maxExemplarCount zero",
+			input: exponentialHistogram{exemplars: pmetric.NewExemplarSlice(), maxExemplarCount: 0},
+			want:  0,
 		},
 		{
 			name: "Exponential Histogram - With exemplars length less than configured max count",
@@ -250,7 +250,7 @@ func TestExponentialHistogram_AddExemplar(t *testing.T) {
 
 				return exponentialHistogram{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 2,
@@ -274,7 +274,7 @@ func TestExponentialHistogram_AddExemplar(t *testing.T) {
 
 				return exponentialHistogram{
 					exemplars:        exs,
-					maxExemplarCount: &maxCount,
+					maxExemplarCount: maxCount,
 				}
 			}(),
 			want: 3,

--- a/connector/spanmetricsconnector/testdata/config.yaml
+++ b/connector/spanmetricsconnector/testdata/config.yaml
@@ -69,7 +69,7 @@ spanmetrics/exemplars_enabled:
 spanmetrics/exemplars_enabled_with_max_per_datapoint:
   exemplars:
     enabled: true
-    max_per_data_point: 5
+    max_per_data_point: 10
 
 # resource metrics key attributes filter
 spanmetrics/resource_metrics_key_attributes:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds a default maximum number of exemplars within the metric export interval.

Currently, spanmetrics does not have a default maximum exemplar count. If users omit this configuration, the exemplar count can grow indefinitely, potentially leading to out-of-memory (OOM) errors.

### User Impact

1. If the user manually sets `max_per_data_point`, there will be no impact.
2. If the user does not set `max_per_data_point`, the default value will take effect, with `max_per_data_point = 5`.
