### PR TITLE
[exporter/bmchelix] Add rate and percentage metric computation

### DIFF
--- a/.chloggen/bmchelixexporter_support_percent_and_rate_metric_derivation.yaml
+++ b/.chloggen/bmchelixexporter_support_percent_and_rate_metric_derivation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement 
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bmchelixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support .percent and .rate metric derivation for ratio and counter metrics respectively"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41611]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -159,7 +159,6 @@ func (mp *MetricsProducer) createHelixMetrics(metric pmetric.Metric, resourceAtt
 			}
 
 			helixMetrics = append(helixMetrics, *metricPayload)
-
 		}
 	case pmetric.MetricTypeGauge:
 		sliceLen := metric.Gauge().DataPoints().Len()

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -436,7 +436,7 @@ func addPercentageVariants(metrics []BMCHelixOMMetric) []BMCHelixOMMetric {
 	for _, m := range metrics {
 		final = append(final, m)
 
-		unit := strings.ToLower(m.Labels["unit"])
+		unit := m.Labels["unit"]
 		if unit != "1" {
 			continue // Not a ratio
 		}

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -197,7 +197,7 @@ func (mp *MetricsProducer) createHelixMetrics(metric pmetric.Metric, resourceAtt
 // and computes the rate metric from the counter metric if required.
 func (mp *MetricsProducer) addRateVariants(helixMetrics []BMCHelixOMMetric) []BMCHelixOMMetric {
 	for i, metric := range helixMetrics {
-		requiresRate := metric.Labels["bmchelix.requiresRateMetric"] == "true"
+		requiresRate := metric.Labels[rateMetricFlag] == "true"
 		if !requiresRate {
 			continue
 		}
@@ -208,7 +208,7 @@ func (mp *MetricsProducer) addRateVariants(helixMetrics []BMCHelixOMMetric) []BM
 		}
 
 		// Remove the 'bmchelix.requiresRateMetric' label
-		delete(helixMetrics[i].Labels, "bmchelix.requiresRateMetric")
+		delete(helixMetrics[i].Labels, rateMetricFlag)
 	}
 	return helixMetrics
 }

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -55,7 +55,7 @@ var coreAttributes = map[string]struct{}{
 	"entityId":               {},
 }
 
-var rateMetricFlag = "bmchelix.requiresRateMetric"
+const rateMetricFlag = "bmchelix.requiresRateMetric"
 
 // ProduceHelixPayload takes the OpenTelemetry metrics and converts them into the BMC Helix Operations Management metric format
 func (mp *MetricsProducer) ProduceHelixPayload(metrics pmetric.Metrics) ([]BMCHelixOMMetric, error) {
@@ -503,8 +503,8 @@ func (mp *MetricsProducer) computeRateMetricFromCounter(metric BMCHelixOMMetric)
 
 	deltaValue := sample.Value - prev.Value
 	if deltaValue < 0 {
-		mp.logger.Debug("Negative delta value, skipping rate calculation", zap.String("key", key), zap.Float64("deltaValue", deltaValue))
-		return nil
+		mp.logger.Debug("Negative delta value, resetting to zero", zap.String("key", key), zap.Float64("deltaValue", deltaValue))
+		deltaValue = 0 // Avoid negative rates
 	}
 
 	deltaTime := float64(sample.Timestamp-prev.Timestamp) / 1000.0 // ms to sec

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go
@@ -29,14 +29,14 @@ type BMCHelixOMSample struct {
 
 // MetricsProducer is responsible for converting OpenTelemetry metrics into BMC Helix Operations Management metrics
 type MetricsProducer struct {
-	logger          *zap.Logger
+	logger           *zap.Logger
 	previousCounters map[string]BMCHelixOMSample
 }
 
 // NewMetricsProducer creates a new MetricsProducer
 func NewMetricsProducer(logger *zap.Logger) *MetricsProducer {
 	return &MetricsProducer{
-		logger: logger,
+		logger:           logger,
 		previousCounters: make(map[string]BMCHelixOMSample),
 	}
 }
@@ -479,10 +479,10 @@ func (mp *MetricsProducer) computeRateMetricFromCounter(metric BMCHelixOMMetric)
 	deltaValue := sample.Value - prev.Value
 	if deltaValue < 0 {
 		mp.logger.Debug("Negative delta value, skipping rate calculation", zap.String("key", key), zap.Float64("deltaValue", deltaValue))
-    	return nil
+		return nil
 	}
 
-	deltaTime := float64(sample.Timestamp - prev.Timestamp) / 1000.0 // ms to sec
+	deltaTime := float64(sample.Timestamp-prev.Timestamp) / 1000.0 // ms to sec
 
 	if deltaTime <= 0 {
 		mp.logger.Debug("Zero or negative delta time, skipping rate calculation", zap.String("key", key), zap.Float64("deltaTime", deltaTime))
@@ -496,8 +496,8 @@ func (mp *MetricsProducer) computeRateMetricFromCounter(metric BMCHelixOMMetric)
 	for k, v := range metric.Labels {
 		rateLabels[k] = v
 	}
-	rateLabels["metricName"] = rateLabels["metricName"] + ".rate"
-	rateLabels["unit"] = rateLabels["unit"] + ".per_second"
+	rateLabels["metricName"] += ".rate"
+	rateLabels["unit"] += ".per_second"
 
 	return &BMCHelixOMMetric{
 		Labels:  rateLabels,

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -414,11 +414,11 @@ func TestAddRateVariants(t *testing.T) {
 
 	// Create a base counter metric
 	originalLabels := map[string]string{
-		"metricName":                  "hw.network.io",
-		"unit":                        "By",
-		"entityId":                    "OTEL:host:network:eth0",
-		"hostname":                    "host",
-		"source":                      "OTEL",
+		"metricName":   "hw.network.io",
+		"unit":         "By",
+		"entityId":     "OTEL:host:network:eth0",
+		"hostname":     "host",
+		"source":       "OTEL",
 		rateMetricFlag: "true",
 	}
 

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -419,7 +419,7 @@ func TestAddRateVariants(t *testing.T) {
 		"entityId":                    "OTEL:host:network:eth0",
 		"hostname":                    "host",
 		"source":                      "OTEL",
-		"bmchelix.requiresRateMetric": "true",
+		rateMetricFlag: "true",
 	}
 
 	t1 := time.Now().UnixMilli()
@@ -444,7 +444,7 @@ func TestAddRateVariants(t *testing.T) {
 
 	// Original metric should remain unchanged except the flag
 	orig := metrics[0]
-	_, exists := orig.Labels["bmchelix.requiresRateMetric"]
+	_, exists := orig.Labels[rateMetricFlag]
 	assert.False(t, exists, "Temporary label should be removed after processing")
 
 	// Check the added rate metric

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -300,11 +300,12 @@ func TestComputeRateMetricFromCounter(t *testing.T) {
 	}
 
 	// First sample: initial counter datapoint
+	now := time.Now()
 	first := BMCHelixOMMetric{
 		Labels: labels,
 		Samples: []BMCHelixOMSample{{
 			Value:     5000,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: now.UnixMilli(),
 		}},
 	}
 
@@ -312,13 +313,13 @@ func TestComputeRateMetricFromCounter(t *testing.T) {
 	assert.Nil(t, producer.computeRateMetricFromCounter(first), "First datapoint should not yield a rate metric")
 
 	// Simulate a second datapoint after a short delay (simulate time passage)
-	time.Sleep(20 * time.Millisecond)
+	next := now.Add(100 * time.Millisecond)
 
 	second := BMCHelixOMMetric{
 		Labels: labels,
 		Samples: []BMCHelixOMSample{{
 			Value:     8000,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: next.UnixMilli(),
 		}},
 	}
 

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -414,11 +414,11 @@ func TestAddRateVariants(t *testing.T) {
 
 	// Create a base counter metric
 	originalLabels := map[string]string{
-		"metricName":                   "hw.network.io",
-		"unit":                         "By",
-		"entityId":                     "OTEL:host:network:eth0",
-		"hostname":                     "host",
-		"source":                       "OTEL",
+		"metricName":                  "hw.network.io",
+		"unit":                        "By",
+		"entityId":                    "OTEL:host:network:eth0",
+		"hostname":                    "host",
+		"source":                      "OTEL",
 		"bmchelix.requiresRateMetric": "true",
 	}
 

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -5,6 +5,7 @@ package operationsmanagement
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -281,4 +282,127 @@ func TestEnrichMetricNamesWithAttributes(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedLabels, actualLabels)
 		})
 	}
+}
+
+func TestComputeRateMetricFromCounter(t *testing.T) {
+	t.Parallel()
+	producer := &MetricsProducer{
+		logger:           nil,
+		previousCounters: make(map[string]BMCHelixOMSample),
+	}
+
+	labels := map[string]string{
+		"entityId":   "OTEL:host:network:eth0",
+		"metricName": "hw.network.io",
+		"unit":       "By",
+		"hostname":   "host",
+		"source":     "OTEL",
+	}
+
+	// First sample: initial counter datapoint
+	first := BMCHelixOMMetric{
+		Labels: labels,
+		Samples: []BMCHelixOMSample{{
+			Value:     5000,
+			Timestamp: time.Now().UnixMilli(),
+		}},
+	}
+
+	// First call – no rate should be returned yet
+	assert.Nil(t, producer.computeRateMetricFromCounter(first), "First datapoint should not yield a rate metric")
+
+	// Simulate a second datapoint after a short delay (simulate time passage)
+	time.Sleep(20 * time.Millisecond)
+
+	second := BMCHelixOMMetric{
+		Labels: labels,
+		Samples: []BMCHelixOMSample{{
+			Value:     8000,
+			Timestamp: time.Now().UnixMilli(),
+		}},
+	}
+
+	rateMetric := producer.computeRateMetricFromCounter(second)
+	assert.NotNil(t, rateMetric, "Expected a rate metric on second datapoint")
+
+	assert.Equal(t, "hw.network.io.rate", rateMetric.Labels["metricName"])
+	assert.Equal(t, "By.per_second", rateMetric.Labels["unit"])
+	assert.Len(t, rateMetric.Samples, 1) 
+	assert.Greater(t, rateMetric.Samples[0].Value, 0.0, "Rate should be a positive value")
+}
+
+func TestToPercentMetricName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		original     string
+		expectedName string
+	}{
+		{
+			name:         "ends with ratio",
+			original:     "hw.fan.ratio",
+			expectedName: "hw.fan.percent",
+		},
+		{
+			name:         "contains ratio mid-word",
+			original:     "some.ratio.metric.value",
+			expectedName: "some.ratio.metric.value.percent",
+		},
+		{
+			name:         "no ratio present",
+			original:     "disk.utilization",
+			expectedName: "disk.utilization.percent",
+		},
+		{
+			name:         "already ends with .percent",
+			original:     "network.bandwidth.percent",
+			expectedName: "network.bandwidth.percent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toPercentMetricName(tt.original)
+			assert.Equal(t, tt.expectedName, got)
+		})
+	}
+}
+
+func TestAddPercentageVariants(t *testing.T) {
+	t.Parallel()
+	ratioLabels := map[string]string{
+		"metricName": "hw.network.ratio",
+		"unit":       "1",
+		"entityId":   "OTEL:host:network:eth0",
+		"hostname":   "host",
+		"source":     "OTEL",
+	}
+
+	sample := BMCHelixOMSample{
+		Value:     0.82,
+		Timestamp: 1690000000000,
+	}
+
+	metrics := []BMCHelixOMMetric{
+		{
+			Labels:  ratioLabels,
+			Samples: []BMCHelixOMSample{sample},
+		},
+	}
+
+	result := addPercentageVariants(metrics)
+	assert.Len(t, result, 2, "Expected original + .percent variant")
+
+	// Original preserved
+	original := result[0]
+	assert.Equal(t, "hw.network.ratio", original.Labels["metricName"])
+	assert.Equal(t, "1", original.Labels["unit"])
+	assert.Equal(t, 0.82, original.Samples[0].Value)
+
+	// Percent variant added
+	percent := result[1]
+	assert.Equal(t, "hw.network.percent", percent.Labels["metricName"])
+	assert.Equal(t, "percent", percent.Labels["unit"])
+	assert.InDelta(t, 82.0, percent.Samples[0].Value, 0.001)
+	assert.Equal(t, sample.Timestamp, percent.Samples[0].Timestamp)
 }

--- a/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
+++ b/exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go
@@ -327,7 +327,7 @@ func TestComputeRateMetricFromCounter(t *testing.T) {
 
 	assert.Equal(t, "hw.network.io.rate", rateMetric.Labels["metricName"])
 	assert.Equal(t, "By.per_second", rateMetric.Labels["unit"])
-	assert.Len(t, rateMetric.Samples, 1) 
+	assert.Len(t, rateMetric.Samples, 1)
 	assert.Greater(t, rateMetric.Samples[0].Value, 0.0, "Rate should be a positive value")
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This pull request introduces support for `.percent` and `.rate` metric derivations in the `bmchelixexporter`. The changes enhance the functionality of the metrics producer by adding percentage variants for ratio metrics and rate metrics for counters, along with corresponding unit adjustments. Comprehensive test cases have been added to ensure the correctness of these new features.

### Enhancements to Metric Derivations:

* **Support for Percentage Variants**:
  - Added the `addPercentageVariants` function to generate `.percent` metrics for ratio metrics (unit "1"). These variants are useful for visualization and analysis. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.goR430-R535](diffhunk://#diff-5c9d35d9692f79277d9122bf02f6425f12f066b0f1304356242b0715bfdacf9fR430-R535))
  - Introduced the `toPercentMetricName` helper function to handle metric name transformations for percentage variants. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.goR430-R535](diffhunk://#diff-5c9d35d9692f79277d9122bf02f6425f12f066b0f1304356242b0715bfdacf9fR430-R535))

* **Support for Rate Metrics**:
  - Added the `addRateVariants` function to compute `.rate` metrics for counters. This calculates the rate of change per second and appends the new metrics to the payload. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.goR185-R216](diffhunk://#diff-5c9d35d9692f79277d9122bf02f6425f12f066b0f1304356242b0715bfdacf9fR185-R216))
  - Implemented the `computeRateMetricFromCounter` function to calculate rate metrics based on counter deltas and timestamps. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.goR430-R535](diffhunk://#diff-5c9d35d9692f79277d9122bf02f6425f12f066b0f1304356242b0715bfdacf9fR430-R535))
  - Introduced a `previousCounters` map in the `MetricsProducer` struct to store the last seen values for counters, enabling rate calculations. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer.goR33-R40](diffhunk://#diff-5c9d35d9692f79277d9122bf02f6425f12f066b0f1304356242b0715bfdacf9fR33-R40))

### Test Coverage:

* **New Test Cases**:
  - Added tests for `computeRateMetricFromCounter`, `toPercentMetricName`, `addPercentageVariants`, and `addRateVariants` to validate the new functionality. (`exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.go`: [exporter/bmchelixexporter/internal/operationsmanagement/metrics_producer_test.goR286-R459](diffhunk://#diff-e207bd2633bf323b83e6523cd0ba51f542e8f7008d33a654cd4b06d8d4943418R286-R459))

### Documentation:

* **Changelog Entry**:
  - Added a changelog entry to document the enhancement, specifying support for `.percent` and `.rate` metric derivations. (`.chloggen/bmchelixexporter_support_percent_and_rate_metric_derivation.yaml`: [.chloggen/bmchelixexporter_support_percent_and_rate_metric_derivation.yamlR1-R27](diffhunk://#diff-5583179d25288230b843c5a25c221895f951dcccd93bacb7f47407738fe4a847R1-R27))
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41611


<!--Describe what testing was performed and which tests were added.-->
#### Testing
<img width="2550" height="948" alt="image" src="https://github.com/user-attachments/assets/f6f23c08-596a-42ad-8e9f-a1ab8132b82f" />
