### PR TITLE
Enables file storage panic recovery

### DIFF
--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -71,12 +71,9 @@ func (lfs *localFileStorage) GetClient(_ context.Context, kind component.Kind, e
 
 	rawName = sanitize(rawName)
 	absoluteName := filepath.Join(lfs.cfg.Directory, rawName)
-	if lfs.cfg.Recreate {
-		if err := os.Rename(absoluteName, absoluteName+".backup"); err != nil {
-			return nil, fmt.Errorf("error renaming the database. Please remove %s manually: %w", absoluteName, err)
-		}
-	}
-	client, err := newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
+	
+	// Try to create client, handling panics if recreate is enabled
+	client, err := lfs.createClientWithPanicRecovery(absoluteName)
 	if err != nil {
 		return nil, err
 	}
@@ -90,6 +87,44 @@ func (lfs *localFileStorage) GetClient(_ context.Context, kind component.Kind, e
 	}
 
 	return client, nil
+}
+
+// createClientWithPanicRecovery attempts to create a client, and if recreate is enabled
+// and a panic occurs (typically due to database corruption), it will rename the file
+// and try again with a fresh database
+func (lfs *localFileStorage) createClientWithPanicRecovery(absoluteName string) (client *fileStorageClient, err error) {
+	// First attempt: try to create client normally
+	if !lfs.cfg.Recreate {
+		// If recreate is disabled, just try once
+		return newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
+	}
+
+	// If recreate is enabled, handle potential panics during database opening
+	defer func() {
+		if r := recover(); r != nil {
+			lfs.logger.Warn("Database corruption detected, recreating database file", 
+				zap.String("file", absoluteName),
+				zap.Any("panic", r))
+			
+			// Rename the corrupted file
+			backupName := absoluteName + ".backup"
+			if renameErr := os.Rename(absoluteName, backupName); renameErr != nil {
+				err = fmt.Errorf("error renaming corrupted database. Please remove %s manually: %w", absoluteName, renameErr)
+				return
+			}
+			
+			lfs.logger.Info("Corrupted database file renamed", 
+				zap.String("original", absoluteName),
+				zap.String("backup", backupName))
+			
+			// Try to create client again with fresh database
+			client, err = newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
+		}
+	}()
+
+	// Try to create the client normally first
+	client, err = newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
+	return client, err
 }
 
 func kindString(k component.Kind) string {

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -667,7 +667,8 @@ func TestRecreate(t *testing.T) {
 		require.NoError(t, ext.Shutdown(ctx))
 	}
 
-	// step 3: re-create the extension, but with Recreate=true and make sure that the data is not preset
+	// step 3: re-create the extension, but with Recreate=true and make sure that the data still exists
+	// (since recreate now only happens on panic, not always when recreate=true)
 	{
 		config.Recreate = true
 		ext, err := f.Create(ctx, extensiontest.NewNopSettings(f.Type()), config)
@@ -680,9 +681,9 @@ func TestRecreate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		// The data shouldn't exist.
+		// The data should still exist since no panic occurred
 		val, err := client.Get(ctx, "key")
-		require.Nil(t, val)
+		require.Equal(t, val, []byte("val"))
 		require.NoError(t, err)
 
 		// close the extension


### PR DESCRIPTION
Changes the `Recreate` option's behavior in file storage to act as a panic recovery mechanism.

Previously, `Recreate` would unconditionally rename the database file upon startup if enabled. Now, when `Recreate` is true, it only renames the existing database file to a `.backup` and creates a new one if an attempt to open the database results in a panic, typically due to corruption.

This improvement allows for automatic recovery from corrupted database files, preventing data loss in most cases, and ensures that healthy databases are not unnecessarily recreated.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
