### PR TITLE
[chore][receiver/tlscheck] Remove excessive "Peer Certificates" log

### DIFF
--- a/receiver/tlscheckreceiver/scraper.go
+++ b/receiver/tlscheckreceiver/scraper.go
@@ -124,7 +124,7 @@ func (s *scraper) scrapeEndpoint(endpoint string, metrics *pmetric.Metrics, wg *
 		return
 	}
 
-	s.settings.Logger.Info("Peer Certificates", zap.Int("certificates_count", len(state.PeerCertificates)))
+	s.settings.Logger.Debug("Peer Certificates", zap.Int("certificates_count", len(state.PeerCertificates)))
 	if len(state.PeerCertificates) == 0 {
 		err := fmt.Errorf("no TLS certificates found for endpoint: %s. Verify the endpoint serves TLS certificates", endpoint)
 		s.settings.Logger.Error(err.Error(), zap.String("endpoint", endpoint))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Switch "Peer Certificates" log line from Info to Debug level to reduce excessive logging during `tlscheckreceiver` scrape loop