### PR TITLE
datadogsemanticsprocessor: Add mapping for DataDog Source Code integration

### DIFF
--- a/.chloggen/rm_mapping_for_source_code_integration.yaml
+++ b/.chloggen/rm_mapping_for_source_code_integration.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'datadogsemanticsprocessor'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Add mapping for Datadog source code integration through VCS attributes' 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41716]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: maps `vcs.ref.head.revision` to `git.commit.sha` and `vcs.repository.url.full` to `git.repository_url` with stripped protocol
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/datadogsemanticsprocessor/processor.go
+++ b/processor/datadogsemanticsprocessor/processor.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 )
 
 func (tp *tracesProcessor) insertAttrIfMissingOrShouldOverride(sattr pcommon.Map, key string, value any) (err error) {
@@ -74,6 +75,22 @@ func (tp *tracesProcessor) processTraces(ctx context.Context, td ptrace.Traces) 
 				return ptrace.Traces{}, err
 			}
 
+			// Map VCS (version control system) attributes for source code integration at resource level
+			if vcsRevision, ok := rattr.Get(string(semconv.VCSRefHeadRevisionKey)); ok {
+				err = tp.insertAttrIfMissingOrShouldOverride(rattr, "git.commit.sha", vcsRevision.AsString())
+				if err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+			if vcsRepoURL, ok := rattr.Get(string(semconv.VCSRepositoryURLFullKey)); ok {
+				// Strip protocol from repository URL as required by Datadog
+				cleanURL := stripProtocolFromURL(vcsRepoURL.AsString())
+				err = tp.insertAttrIfMissingOrShouldOverride(rattr, "git.repository_url", cleanURL)
+				if err != nil {
+					return ptrace.Traces{}, err
+				}
+			}
+
 			libspans := rspan.ScopeSpans().At(j)
 			for k := 0; k < libspans.Spans().Len(); k++ {
 				otelspan := libspans.Spans().At(k)
@@ -96,6 +113,23 @@ func (tp *tracesProcessor) processTraces(ctx context.Context, td ptrace.Traces) 
 				if err != nil {
 					return ptrace.Traces{}, err
 				}
+
+				// Map VCS (version control system) attributes for source code integration
+				if vcsRevision, ok := sattr.Get(string(semconv.VCSRefHeadRevisionKey)); ok {
+					err = tp.insertAttrIfMissingOrShouldOverride(sattr, "git.commit.sha", vcsRevision.AsString())
+					if err != nil {
+						return ptrace.Traces{}, err
+					}
+				}
+				if vcsRepoURL, ok := sattr.Get(string(semconv.VCSRepositoryURLFullKey)); ok {
+					// Strip protocol from repository URL as required by Datadog
+					cleanURL := stripProtocolFromURL(vcsRepoURL.AsString())
+					err = tp.insertAttrIfMissingOrShouldOverride(sattr, "git.repository_url", cleanURL)
+					if err != nil {
+						return ptrace.Traces{}, err
+					}
+				}
+
 				metaMap := make(map[string]string)
 				code := traceutil.GetOTelStatusCode(otelspan)
 				if code != 0 {
@@ -171,6 +205,17 @@ func status2Error(status ptrace.Status, events ptrace.SpanEventSlice, metaMap ma
 		}
 	}
 	return 1
+}
+
+func stripProtocolFromURL(rawURL string) string {
+	// Try to parse as URL first
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		// If parsing fails, return the original string
+		return rawURL
+	}
+
+	return strings.TrimPrefix(rawURL, parsedURL.Scheme+"://")
 }
 
 // TODO remove once Status2Error is imported from datadog-agent

--- a/processor/datadogsemanticsprocessor/processor_test.go
+++ b/processor/datadogsemanticsprocessor/processor_test.go
@@ -405,6 +405,192 @@ func TestBasicTranslation(t *testing.T) {
 				assertKeyInAttributesMatchesValue(t, sattr, "datadog.error.stack", "specified-error-stack")
 			},
 		},
+		{
+			name:                          "VCS attributes mapping - span level",
+			overrideIncomingDatadogFields: false,
+			in: []testutil.OTLPResourceSpan{
+				{
+					LibName:    "libname",
+					LibVersion: "1.2",
+					Attributes: map[string]any{
+						"service.name":                "test-service",
+						"deployment.environment.name": "test-env",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:  [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+							SpanID:   [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+							ParentID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+							Kind:     ptrace.SpanKindServer,
+							Attributes: map[string]any{
+								"operation.name":          "test-operation",
+								"vcs.ref.head.revision":   "9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc",
+								"vcs.repository.url.full": "https://github.com/opentelemetry/opentelemetry-collector-contrib",
+							},
+						},
+					},
+				},
+			},
+			fn: func(out *ptrace.Traces) {
+				span := out.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
+				sattr := span.Attributes()
+				assertKeyInAttributesMatchesValue(t, sattr, "git.commit.sha", "9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc")
+				assertKeyInAttributesMatchesValue(t, sattr, "git.repository_url", "github.com/opentelemetry/opentelemetry-collector-contrib")
+				// Verify original VCS attributes are still present
+				assertKeyInAttributesMatchesValue(t, sattr, "vcs.ref.head.revision", "9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc")
+				assertKeyInAttributesMatchesValue(t, sattr, "vcs.repository.url.full", "https://github.com/opentelemetry/opentelemetry-collector-contrib")
+			},
+		},
+		{
+			name:                          "VCS attributes mapping - resource level",
+			overrideIncomingDatadogFields: false,
+			in: []testutil.OTLPResourceSpan{
+				{
+					LibName:    "libname",
+					LibVersion: "1.2",
+					Attributes: map[string]any{
+						"service.name":                "test-service",
+						"deployment.environment.name": "test-env",
+						"vcs.ref.head.revision":       "abc123def456",
+						"vcs.repository.url.full":     "https://gitlab.com/my-org/my-project",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:  [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+							SpanID:   [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+							ParentID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+							Kind:     ptrace.SpanKindServer,
+							Attributes: map[string]any{
+								"operation.name": "test-operation",
+							},
+						},
+					},
+				},
+			},
+			fn: func(out *ptrace.Traces) {
+				rs := out.ResourceSpans().At(0)
+				rattr := rs.Resource().Attributes()
+				assertKeyInAttributesMatchesValue(t, rattr, "git.commit.sha", "abc123def456")
+				assertKeyInAttributesMatchesValue(t, rattr, "git.repository_url", "gitlab.com/my-org/my-project")
+				// Verify original VCS attributes are still present
+				assertKeyInAttributesMatchesValue(t, rattr, "vcs.ref.head.revision", "abc123def456")
+				assertKeyInAttributesMatchesValue(t, rattr, "vcs.repository.url.full", "https://gitlab.com/my-org/my-project")
+			},
+		},
+		{
+			name:                          "VCS attributes mapping - both levels",
+			overrideIncomingDatadogFields: false,
+			in: []testutil.OTLPResourceSpan{
+				{
+					LibName:    "libname",
+					LibVersion: "1.2",
+					Attributes: map[string]any{
+						"service.name":                "test-service",
+						"deployment.environment.name": "test-env",
+						"vcs.ref.head.revision":       "resource-level-commit",
+						"vcs.repository.url.full":     "https://github.com/resource-repo",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:  [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+							SpanID:   [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+							ParentID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+							Kind:     ptrace.SpanKindServer,
+							Attributes: map[string]any{
+								"operation.name":          "test-operation",
+								"vcs.ref.head.revision":   "span-level-commit",
+								"vcs.repository.url.full": "https://github.com/span-repo",
+							},
+						},
+					},
+				},
+			},
+			fn: func(out *ptrace.Traces) {
+				rs := out.ResourceSpans().At(0)
+				rattr := rs.Resource().Attributes()
+				// Resource level mappings
+				assertKeyInAttributesMatchesValue(t, rattr, "git.commit.sha", "resource-level-commit")
+				assertKeyInAttributesMatchesValue(t, rattr, "git.repository_url", "github.com/resource-repo")
+
+				span := rs.ScopeSpans().At(0).Spans().At(0)
+				sattr := span.Attributes()
+				// Span level mappings
+				assertKeyInAttributesMatchesValue(t, sattr, "git.commit.sha", "span-level-commit")
+				assertKeyInAttributesMatchesValue(t, sattr, "git.repository_url", "github.com/span-repo")
+			},
+		},
+		{
+			name:                          "VCS attributes mapping with override",
+			overrideIncomingDatadogFields: true,
+			in: []testutil.OTLPResourceSpan{
+				{
+					LibName:    "libname",
+					LibVersion: "1.2",
+					Attributes: map[string]any{
+						"service.name":                "test-service",
+						"deployment.environment.name": "test-env",
+						"vcs.ref.head.revision":       "new-commit",
+						"vcs.repository.url.full":     "https://github.com/new-repo",
+						"git.commit.sha":              "old-commit",
+						"git.repository_url":          "github.com/old-repo",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:  [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+							SpanID:   [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+							ParentID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+							Kind:     ptrace.SpanKindServer,
+							Attributes: map[string]any{
+								"operation.name": "test-operation",
+							},
+						},
+					},
+				},
+			},
+			fn: func(out *ptrace.Traces) {
+				rs := out.ResourceSpans().At(0)
+				rattr := rs.Resource().Attributes()
+				// Should override existing Datadog attributes with new VCS values
+				assertKeyInAttributesMatchesValue(t, rattr, "git.commit.sha", "new-commit")
+				assertKeyInAttributesMatchesValue(t, rattr, "git.repository_url", "github.com/new-repo")
+			},
+		},
+		{
+			name:                          "VCS attributes mapping without override",
+			overrideIncomingDatadogFields: false,
+			in: []testutil.OTLPResourceSpan{
+				{
+					LibName:    "libname",
+					LibVersion: "1.2",
+					Attributes: map[string]any{
+						"service.name":                "test-service",
+						"deployment.environment.name": "test-env",
+						"vcs.ref.head.revision":       "new-commit",
+						"vcs.repository.url.full":     "https://github.com/new-repo",
+						"git.commit.sha":              "existing-commit",
+						"git.repository_url":          "github.com/existing-repo",
+					},
+					Spans: []*testutil.OTLPSpan{
+						{
+							TraceID:  [16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+							SpanID:   [8]byte{0, 1, 2, 3, 4, 5, 6, 7},
+							ParentID: [8]byte{0, 0, 0, 0, 0, 0, 0, 1},
+							Kind:     ptrace.SpanKindServer,
+							Attributes: map[string]any{
+								"operation.name": "test-operation",
+							},
+						},
+					},
+				},
+			},
+			fn: func(out *ptrace.Traces) {
+				rs := out.ResourceSpans().At(0)
+				rattr := rs.Resource().Attributes()
+				// Should preserve existing Datadog attributes when override is false
+				assertKeyInAttributesMatchesValue(t, rattr, "git.commit.sha", "existing-commit")
+				assertKeyInAttributesMatchesValue(t, rattr, "git.repository_url", "github.com/existing-repo")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Datadog allows APM SourceCode Integration via tags: `git.commit.sha` and `git.repository_url`. See here https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=githubsaasonprem#configure-telemetry-tagging

Those tags are not semconv. Recently otel added specs for VCS attributes such that:
- `git.commit.sha` could map to [`vcs.ref.head.revision`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/vcs/#vcs-ref-head-revision)
- `git.repository_url` could map to [`vcs.repository.url.full`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/vcs/#vcs-repository-url-full) with stripped scheme.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added some unit tests.