### PR TITLE
[exporter/elasticsearch] Change default flush::interval and batcher::flush_timeout to 10s

### DIFF
--- a/.chloggen/elasticsearchexporter_flush-10s.yaml
+++ b/.chloggen/elasticsearchexporter_flush-10s.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change default flush::interval and batcher::flush_timeout to 10s
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41726]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -98,7 +98,7 @@ The Elasticsearch exporter supports the [common `batcher` settings](https://gith
   - `sizer` (default=items): Unit of `min_size` and `max_size`. Currently supports only "items", in the future will also support "bytes".
   - `min_size` (default=5000): Minimum batch size to be exported to Elasticsearch, measured in units according to `batcher::sizer`.
   - `max_size` (default=0): Maximum batch size to be exported to Elasticsearch, measured in units according to `batcher::sizer`. To limit bulk request size, configure `flush::bytes` instead. :warning: It is recommended to keep `max_size` as 0 as a non-zero value may lead to broken metrics grouping and indexing rejections.
-  - `flush_timeout` (default=30s): Maximum time of the oldest item spent inside the batcher buffer, aka "max age of batcher buffer". A batcher flush will happen regardless of the size of content in batcher buffer.
+  - `flush_timeout` (default=10s): Maximum time of the oldest item spent inside the batcher buffer, aka "max age of batcher buffer". A batcher flush will happen regardless of the size of content in batcher buffer.
 
 By default, the exporter will perform its own buffering and batching, as configured through the
 `flush` config, and `batcher` will be unused. By setting `batcher::enabled` to either `true` or
@@ -309,7 +309,7 @@ The behaviour of this bulk indexing can be configured with the following setting
 - `num_workers` (default=runtime.NumCPU()): Number of workers publishing bulk requests concurrently. Note this is not applicable if `batcher::enabled` is `true` or `false`.
 - `flush`: Event bulk indexer buffer flush settings
   - `bytes` (default=5000000): Write buffer flush size limit before compression. A bulk request will be sent immediately when its buffer exceeds this limit. This value should be much lower than [Elasticsearch's `http.max_content_length`](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#http-settings) config to avoid HTTP 413 Entity Too Large error. It is recommended to keep this value under 5MB.
-  - `interval` (default=30s): Write buffer flush time limit.
+  - `interval` (default=10s): Write buffer flush time limit.
 - `retry`: Elasticsearch bulk request retry settings
   - `enabled` (default=true): Enable/Disable request retry on error. Failed requests are retried with exponential backoff.
   - `max_requests` (DEPRECATED, use retry::max_retries instead): Number of HTTP request retries including the initial attempt. If used, `retry::max_retries` will be set to `max_requests - 1`.

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -100,7 +100,7 @@ func TestConfig(t *testing.T) {
 				},
 				Flush: FlushSettings{
 					Bytes:    10485760,
-					Interval: 30 * time.Second,
+					Interval: 10 * time.Second,
 				},
 				Retry: RetrySettings{
 					Enabled:         true,
@@ -119,7 +119,7 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					FlushTimeout: 30 * time.Second,
+					FlushTimeout: 10 * time.Second,
 					Sizer:        exporterhelper.RequestSizerTypeItems,
 					MinSize:      defaultBatcherMinSizeItems,
 				},
@@ -176,7 +176,7 @@ func TestConfig(t *testing.T) {
 				},
 				Flush: FlushSettings{
 					Bytes:    10485760,
-					Interval: 30 * time.Second,
+					Interval: 10 * time.Second,
 				},
 				Retry: RetrySettings{
 					Enabled:         true,
@@ -195,7 +195,7 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					FlushTimeout: 30 * time.Second,
+					FlushTimeout: 10 * time.Second,
 					Sizer:        exporterhelper.RequestSizerTypeItems,
 					MinSize:      defaultBatcherMinSizeItems,
 				},
@@ -252,7 +252,7 @@ func TestConfig(t *testing.T) {
 				},
 				Flush: FlushSettings{
 					Bytes:    10485760,
-					Interval: 30 * time.Second,
+					Interval: 10 * time.Second,
 				},
 				Retry: RetrySettings{
 					Enabled:         true,
@@ -271,7 +271,7 @@ func TestConfig(t *testing.T) {
 					DateFormat:      "%Y.%m.%d",
 				},
 				Batcher: BatcherConfig{
-					FlushTimeout: 30 * time.Second,
+					FlushTimeout: 10 * time.Second,
 					Sizer:        exporterhelper.RequestSizerTypeItems,
 					MinSize:      defaultBatcherMinSizeItems,
 				},

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -84,13 +84,13 @@ func createDefaultConfig() component.Config {
 		},
 		IncludeSourceOnError: nil,
 		Batcher: BatcherConfig{
-			FlushTimeout: 30 * time.Second,
+			FlushTimeout: 10 * time.Second,
 			Sizer:        exporterhelper.RequestSizerTypeItems,
 			MinSize:      defaultBatcherMinSizeItems,
 		},
 		Flush: FlushSettings{
 			Bytes:    5e+6,
-			Interval: 30 * time.Second,
+			Interval: 10 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Breaking change: change default `flush::interval` and `batcher::flush_timeout` to 10s

