### PR TITLE
[chore] do not run cron jobs on forks, they create noise

### DIFF
--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   check-jmx-metrics-version:
+    if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     runs-on: ubuntu-24.04
     outputs:
       latest-version: ${{ steps.check-jmx-metrics-version.outputs.latest-version }}
@@ -55,6 +56,7 @@ jobs:
       contents: write # required for pushing changes
     runs-on: ubuntu-24.04
     if: |
+      github.repository == 'open-telemetry/opentelemetry-collector-contrib' &&
       needs.check-jmx-metrics-version.outputs.already-added != 'true' &&
       needs.check-jmx-metrics-version.outputs.already-opened != 'true'
     needs:
@@ -128,6 +130,7 @@ jobs:
 
   check-jmx-scraper-version:
     runs-on: ubuntu-24.04
+    if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     outputs:
       latest-version: ${{ steps.check-jmx-scraper-version.outputs.latest-version }}
       already-added: ${{ steps.check-jmx-scraper-version.outputs.already-added }}
@@ -171,6 +174,7 @@ jobs:
       contents: write # required for pushing changes
     runs-on: ubuntu-24.04
     if: |
+      github.repository == 'open-telemetry/opentelemetry-collector-contrib' &&
       needs.check-jmx-scraper-version.outputs.already-added != 'true' &&
       needs.check-jmx-scraper-version.outputs.already-opened != 'true'
     needs:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   fossa:
     runs-on: ubuntu-latest
+    if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
A small annoyance that on forks, these jobs fail. See https://github.com/atoulme/opentelemetry-collector-contrib/actions/runs/16700654026 and https://github.com/atoulme/opentelemetry-collector-contrib/actions/runs/16700645277 for example.