### PR TITLE
[receiver/splunk_hec] Accept dashes in metric names

### DIFF
--- a/.chloggen/accept_dashes_in_metric_names.yaml
+++ b/.chloggen/accept_dashes_in_metric_names.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Accept dashes in metric names
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41127]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -35,7 +35,7 @@ const (
 
 	// https://docs.splunk.com/Documentation/Splunk/9.2.1/Metrics/Overview#What_is_a_metric_data_point.3F
 	// metric name can contain letters, numbers, underscore, dot or colon. cannot start with number or underscore, or contain metric_name
-	metricNamePattern = `^metric_name:([A-Za-z.:][A-Za-z0-9_.:]*)$`
+	metricNamePattern = `^metric_name:([A-Za-z.:][A-Za-z0-9_.:\\-]*)$`
 )
 
 var metricNameRegexp = regexp.MustCompile(metricNamePattern)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -268,6 +268,30 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
+			name: "metric_msg_with_dashes",
+			req: func() *http.Request {
+				e := buildSplunkHecMetricsMsg("metric", 3, 4, 3)
+				delete(e.Fields, "metric_name:foo")
+				e.Fields["metric_name:name-with-dashes"] = 42
+				msgBytes, err := json.Marshal(e)
+				require.NoError(t, err)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				assertHecSuccessResponse(t, resp, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Empty(t, sink.AllLogs())
+			},
+			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, 1, sink.AllMetrics()[0].MetricCount())
+				m := sink.AllMetrics()[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+				assert.Equal(t, "name-with-dashes", m.Name())
+			},
+		},
+		{
 			name: "msg_accepted_gzipped",
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Accept dashes in metric names.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41127 
