### PR TITLE
[receiver/prometheusreceiver] copy back the static config objects to retain the custom labels after reloading

### DIFF
--- a/.chloggen/fix_prometheusreceiver_labels-dropped-static-config.yaml
+++ b/.chloggen/fix_prometheusreceiver_labels-dropped-static-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a bug where static configuration labels were dropped when using the Prometheus receiver. Previously, labels defined in the static config were not being applied to the metrics."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41727]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -8,13 +8,16 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
 	"github.com/goccy/go-yaml"
 	commonconfig "github.com/prometheus/common/config"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
 
@@ -144,6 +147,40 @@ func (cfg *PromConfig) Validate() error {
 	return nil
 }
 
+// copyStaticConfig copies static service discovery configs from src to dst to assure that labels in StaticConfig are retained.
+func copyStaticConfig(dst *PromConfig, src any) {
+	// only deal with PromConfig
+	srcCfg, ok := src.(*PromConfig)
+	if !ok {
+		return
+	}
+
+	// Job name -> static config list
+	// The static configs are grouped by job name, so that we can
+	// copy them over to the destination config.
+	srcCfgMap := make(map[string][]*targetgroup.Group, len(srcCfg.ScrapeConfigs))
+	for _, srcSC := range srcCfg.ScrapeConfigs {
+		for _, srcSDC := range srcSC.ServiceDiscoveryConfigs {
+			if sc, ok := srcSDC.(discovery.StaticConfig); ok {
+				srcCfgMap[srcSC.JobName] = append(srcCfgMap[srcSC.JobName], sc...)
+			}
+		}
+	}
+
+	for _, dstSC := range dst.ScrapeConfigs {
+		if len(srcCfgMap[dstSC.JobName]) == 0 {
+			continue
+		}
+
+		dstSC.ServiceDiscoveryConfigs = slices.DeleteFunc(dstSC.ServiceDiscoveryConfigs, func(cfg discovery.Config) bool {
+			// Remove all static configs for this job name.
+			_, ok := cfg.(discovery.StaticConfig)
+			return ok
+		})
+		dstSC.ServiceDiscoveryConfigs = append(dstSC.ServiceDiscoveryConfigs, discovery.StaticConfig(srcCfgMap[dstSC.JobName]))
+	}
+}
+
 func reloadPromConfig(dst *PromConfig, src any) error {
 	yamlOut, err := yaml.MarshalWithOptions(
 		src,
@@ -159,6 +196,7 @@ func reloadPromConfig(dst *PromConfig, src any) error {
 	if err != nil {
 		return fmt.Errorf("prometheus receiver: failed to unmarshal yaml to prometheus config object: %w", err)
 	}
+	copyStaticConfig((*PromConfig)(newCfg), src)
 	*dst = PromConfig(*newCfg)
 	return nil
 }

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -4,6 +4,7 @@
 package prometheusreceiver
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,9 +12,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	promConfig "github.com/prometheus/common/config"
 	promModel "github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/http"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -477,4 +483,87 @@ scrape_configs:
 			tt.checkFn(t, dst)
 		})
 	}
+}
+
+func TestReloadPromConfigStaticConfigsWithLabels(t *testing.T) {
+	createGroup := func(idxArr ...int) *targetgroup.Group {
+		g := &targetgroup.Group{}
+		g.Labels = promModel.LabelSet{}
+		for _, idx := range idxArr {
+			g.Targets = append(g.Targets, promModel.LabelSet{
+				promModel.AddressLabel:                    promModel.LabelValue(fmt.Sprint("localhost:", 8080+idx)),
+				promModel.LabelName(fmt.Sprint("k", idx)): promModel.LabelValue(fmt.Sprint("v", idx)),
+			})
+			g.Labels[promModel.LabelName(fmt.Sprint("label", idx))] = promModel.LabelValue(fmt.Sprint("value", idx))
+		}
+		return g
+	}
+	create := func() *PromConfig {
+		return &PromConfig{
+			ScrapeConfigs: []*promconfig.ScrapeConfig{
+				{
+					JobName: "test_job",
+					ServiceDiscoveryConfigs: discovery.Configs{
+						&http.SDConfig{
+							URL:             "http://localhost:8080",
+							RefreshInterval: promModel.Duration(time.Second) * 5,
+							HTTPClientConfig: promConfig.HTTPClientConfig{
+								TLSConfig: promConfig.TLSConfig{
+									InsecureSkipVerify: true,
+								},
+							},
+						},
+						discovery.StaticConfig{
+							createGroup(1),
+						},
+						&file.SDConfig{
+							Files: []string{"targets.json"},
+						},
+						discovery.StaticConfig{
+							createGroup(2),
+						},
+						discovery.StaticConfig{
+							createGroup(3, 4),
+							createGroup(5, 6),
+						},
+					},
+				},
+				{
+					JobName: "another_job",
+					ServiceDiscoveryConfigs: discovery.Configs{
+						discovery.StaticConfig{
+							createGroup(10),
+						},
+						&file.SDConfig{
+							Files: []string{"another_targets.json"},
+						},
+					},
+				},
+			},
+		}
+	}
+	promConfig := create()
+	assert.NoError(t, promConfig.Reload())
+
+	for _, sc := range promConfig.ScrapeConfigs {
+		for _, sd := range sc.ServiceDiscoveryConfigs {
+			sc, ok := sd.(discovery.StaticConfig)
+			if !ok {
+				continue
+			}
+			for _, tg := range sc {
+				for _, target := range tg.Targets {
+					// Ensure that the targets have the expected labels.
+					assert.NotEmpty(t, target[promModel.AddressLabel])
+					assert.Greater(t, len(target), 1, "target should have more than just address label")
+				}
+				assert.NotEmpty(t, tg.Labels, "target group should have labels")
+			}
+		}
+	}
+
+	data1, _ := yaml.Marshal(promConfig)
+	assert.NoError(t, promConfig.Reload())
+	data2, _ := yaml.Marshal(promConfig)
+	assert.Equal(t, string(data1), string(data2), "Reload should not change the config")
 }


### PR DESCRIPTION
#### Description

This PR fixes the issue #41727 by copying back the StaticConfig objects after reloading.

#### Link to tracking issue
Fixes #41727 

#### Testing

A unit test is added for this fix.

#### Documentation

No changes in the documentation.
