### PR TITLE
[receiver/googlecloudpubsubreceiver] Add observed timestamp when using raw text encoding

### DIFF
--- a/.chloggen/pubsub-add-observed-at-timestamp.yaml
+++ b/.chloggen/pubsub-add-observed-at-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudpubsubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Sets the observed timestamp when using raw text encoding
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/pubsub-add-observed-at-timestamp.yaml
+++ b/.chloggen/pubsub-add-observed-at-timestamp.yaml
@@ -10,7 +10,7 @@ component: googlecloudpubsubreceiver
 note: Sets the observed timestamp when using raw text encoding
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [41800]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -229,6 +229,8 @@ func (unmarshalLogStrings) UnmarshalLogs(data []byte) (plog.Logs, error) {
 	lr := ills.LogRecords().AppendEmpty()
 
 	lr.Body().SetStr(string(data))
+	lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
 	return out, nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When using the raw text encoding the observed timestamp was not being set

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Setup a local pub sub emulator and outputted to a file. Validated that there was no observed timestamp before the change, and then it did exist after the change.