### PR TITLE
[chore] fix install-tools missing

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -136,4 +136,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          make install-tools
           ./.tools/issuegenerator -path ./internal/tools/testresults/

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -167,4 +167,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          make install-tools
           ./.tools/issuegenerator -path ./internal/tools/testresults/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -693,4 +693,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          make install-tools
           ./.tools/issuegenerator -path ./internal/tools/testresults/

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -37,7 +37,6 @@ jobs:
           cache-dependency-path: "**/*.sum"
 
       - name: Install tools
-        if: github.repository == 'open-telemetry/opentelemetry-collector-contrib' && steps.go-setup.outputs.cache-hit != 'true'
         run: |
           make install-tools
 


### PR DESCRIPTION
#41709 broke the build because it doesn't cache the .tools folder - we need to `make install-tools` in some builds.