### PR TITLE
[chore][exporter/kafka]Fix incorrect queue batch setting for metrics and traces

### DIFF
--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -88,7 +88,7 @@ func createTracesExporter(
 		exp.exportData,
 		exporterhelperOptions(
 			oCfg,
-			exporterhelper.NewLogsQueueBatchSettings(),
+			exporterhelper.NewTracesQueueBatchSettings(),
 			exp.Start, exp.Close,
 		)...,
 	)
@@ -108,7 +108,7 @@ func createMetricsExporter(
 		exp.exportData,
 		exporterhelperOptions(
 			oCfg,
-			exporterhelper.NewLogsQueueBatchSettings(),
+			exporterhelper.NewMetricsQueueBatchSettings(),
 			exp.Start, exp.Close,
 		)...,
 	)

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/xexporter"
+	"go.opentelemetry.io/collector/pdata/testdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
@@ -77,6 +80,9 @@ func TestCreateMetricExporter(t *testing.T) {
 				// Disabling broker check
 				conf.Metadata.Full = false
 				conf.IncludeMetadataKeys = []string{"k1", "k2"}
+				conf.QueueBatchConfig.Batch = configoptional.Some(exporterhelper.BatchConfig{
+					Sizer: exporterhelper.RequestSizerTypeBytes,
+				})
 			}),
 			err: nil,
 		},
@@ -101,6 +107,7 @@ func TestCreateMetricExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+			assert.NoError(t, exporter.ConsumeMetrics(context.Background(), testdata.GenerateMetrics(2)))
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
 	}
@@ -148,6 +155,9 @@ func TestCreateLogExporter(t *testing.T) {
 				// Disabling broker check
 				conf.Metadata.Full = false
 				conf.IncludeMetadataKeys = []string{"k1", "k2"}
+				conf.QueueBatchConfig.Batch = configoptional.Some(exporterhelper.BatchConfig{
+					Sizer: exporterhelper.RequestSizerTypeBytes,
+				})
 			}),
 			err: nil,
 		},
@@ -172,6 +182,7 @@ func TestCreateLogExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+			assert.NoError(t, exporter.ConsumeLogs(context.Background(), testdata.GenerateLogs(2)))
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
 	}
@@ -217,6 +228,9 @@ func TestCreateTraceExporter(t *testing.T) {
 				// Disabling broker check
 				conf.Metadata.Full = false
 				conf.IncludeMetadataKeys = []string{"k1", "k2"}
+				conf.QueueBatchConfig.Batch = configoptional.Some(exporterhelper.BatchConfig{
+					Sizer: exporterhelper.RequestSizerTypeBytes,
+				})
 			}),
 			err: nil,
 		},
@@ -241,6 +255,7 @@ func TestCreateTraceExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+			assert.NoError(t, exporter.ConsumeTraces(context.Background(), testdata.GenerateTraces(2)))
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
 	}
@@ -288,6 +303,9 @@ func TestCreateProfileExporter(t *testing.T) {
 				// Disabling broker check
 				conf.Metadata.Full = false
 				conf.IncludeMetadataKeys = []string{"k1", "k2"}
+				conf.QueueBatchConfig.Batch = configoptional.Some(exporterhelper.BatchConfig{
+					Sizer: exporterhelper.RequestSizerTypeBytes,
+				})
 			}),
 			err: nil,
 		},
@@ -312,6 +330,7 @@ func TestCreateProfileExporter(t *testing.T) {
 			}
 			assert.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
+			assert.NoError(t, exporter.ConsumeProfiles(context.Background(), testdata.GenerateProfiles(2)))
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
 	}

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/client v1.37.1-0.20250801020258-8b73477b9810
 	go.opentelemetry.io/collector/component v1.37.1-0.20250801020258-8b73477b9810
 	go.opentelemetry.io/collector/component/componenttest v0.131.1-0.20250801020258-8b73477b9810
+	go.opentelemetry.io/collector/config/configoptional v0.131.1-0.20250801020258-8b73477b9810
 	go.opentelemetry.io/collector/config/configretry v1.37.1-0.20250801020258-8b73477b9810
 	go.opentelemetry.io/collector/confmap v1.37.1-0.20250801020258-8b73477b9810
 	go.opentelemetry.io/collector/confmap/xconfmap v0.131.1-0.20250801020258-8b73477b9810
@@ -106,7 +107,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.37.1-0.20250801020258-8b73477b9810 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.37.1-0.20250801020258-8b73477b9810 // indirect
-	go.opentelemetry.io/collector/config/configoptional v0.131.1-0.20250801020258-8b73477b9810 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.37.1-0.20250801020258-8b73477b9810 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.131.1-0.20250801020258-8b73477b9810 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.131.1-0.20250801020258-8b73477b9810 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41776 introduced a bug where incorrect queue batch settings were used for metrics and traces. This would result in panic due to the incorrect encoding defined in the incorrect queue batch settings when the `sending_queue#batch` is used with sizers that require the encoding (ex: bytes sizer). The PR updates the test cases to catch this too.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41775

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated test cases.

<!--Describe the documentation added.-->
#### Documentation

Not required.

<!--Please delete paragraphs that you did not use before submitting.-->
