### PR TITLE
metricstarttimeprocessor: Refactor cache so its shared by strategies

### DIFF
--- a/.chloggen/refactor-resets-v2.yaml
+++ b/.chloggen/refactor-resets-v2.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: refactor datastorage cache so it can be shared across strategies
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38381]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
@@ -62,25 +62,6 @@ type SummaryInfo struct {
 	PreviousSum   float64
 }
 
-func NewNumberInfo() *NumberInfo {
-	return &NumberInfo{}
-}
-
-func NewHistogramInfo() *HistogramInfo {
-	return &HistogramInfo{}
-}
-
-func NewExponentialHistogramInfo() *ExponentialHistogramInfo {
-	eh := ExponentialHistogramInfo{}
-	eh.PositiveBuckets = pmetric.NewExponentialHistogramDataPointBuckets()
-	eh.NegativeBuckets = pmetric.NewExponentialHistogramDataPointBuckets()
-	return &eh
-}
-
-func NewSummaryDataPoint() *SummaryInfo {
-	return &SummaryInfo{}
-}
-
 type TimeseriesKey struct {
 	Name           string
 	Attributes     [16]byte

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map.go
@@ -19,10 +19,66 @@ type AttributeHash [16]byte
 type TimeseriesInfo struct {
 	Mark bool
 
-	Number               pmetric.NumberDataPoint
-	Histogram            pmetric.HistogramDataPoint
-	ExponentialHistogram pmetric.ExponentialHistogramDataPoint
-	Summary              pmetric.SummaryDataPoint
+	Number               NumberInfo
+	Histogram            HistogramInfo
+	ExponentialHistogram ExponentialHistogramInfo
+	Summary              SummaryInfo
+}
+
+type NumberInfo struct {
+	StartTime     pcommon.Timestamp
+	InitialValue  float64
+	PreviousValue float64
+}
+
+type HistogramInfo struct {
+	StartTime      pcommon.Timestamp
+	InitialCount   uint64
+	InitialSum     float64
+	PreviousCount  uint64
+	PreviousSum    float64
+	BucketCounts   []uint64
+	ExplicitBounds []float64
+}
+
+type ExponentialHistogramInfo struct {
+	StartTime         pcommon.Timestamp
+	InitialCount      uint64
+	InitialSum        float64
+	InitialZeroCount  uint64
+	PreviousCount     uint64
+	PreviousSum       float64
+	PreviousZeroCount uint64
+	Scale             int32
+	PositiveBuckets   pmetric.ExponentialHistogramDataPointBuckets
+	NegativeBuckets   pmetric.ExponentialHistogramDataPointBuckets
+}
+
+type SummaryInfo struct {
+	StartTime     pcommon.Timestamp
+	InitialCount  uint64
+	InitialSum    float64
+	PreviousCount uint64
+	PreviousSum   float64
+}
+
+func NewNumberInfo() *NumberInfo {
+	return &NumberInfo{}
+}
+
+func NewHistogramInfo() *HistogramInfo {
+	return &HistogramInfo{}
+}
+
+func NewExponentialHistogramInfo() *ExponentialHistogramInfo {
+	eh := ExponentialHistogramInfo{}
+	eh.PositiveBuckets = pmetric.NewExponentialHistogramDataPointBuckets()
+	eh.NegativeBuckets = pmetric.NewExponentialHistogramDataPointBuckets()
+	return &eh
+}
+
+func NewSummaryDataPoint() *SummaryInfo {
+	return &SummaryInfo{}
 }
 
 type TimeseriesKey struct {
@@ -92,16 +148,16 @@ func (tsm *TimeseriesMap) GC() {
 // and determines whether the metric has been reset based on the values.  It is
 // a reset if any of the bucket boundaries have changed, if any of the bucket
 // counts have decreased or if the total sum or count have decreased.
-func IsResetHistogram(h, ref pmetric.HistogramDataPoint) bool {
-	if h.Count() < ref.Count() {
+func (ref *TimeseriesInfo) IsResetHistogram(h pmetric.HistogramDataPoint) bool {
+	if h.Count() < ref.Histogram.PreviousCount {
 		return true
 	}
-	if h.Sum() < ref.Sum() {
+	if h.Sum() < ref.Histogram.PreviousSum {
 		return true
 	}
 
 	// Guard against bucket boundaries changes.
-	refBounds := ref.ExplicitBounds().AsRaw()
+	refBounds := ref.Histogram.ExplicitBounds
 	hBounds := h.ExplicitBounds().AsRaw()
 	if len(refBounds) != len(hBounds) {
 		return true
@@ -113,11 +169,11 @@ func IsResetHistogram(h, ref pmetric.HistogramDataPoint) bool {
 	}
 
 	// We need to check individual buckets to make sure the counts are all increasing.
-	if ref.BucketCounts().Len() != h.BucketCounts().Len() {
+	if len(ref.Histogram.BucketCounts) != h.BucketCounts().Len() {
 		return true
 	}
-	for i := range ref.BucketCounts().Len() {
-		if h.BucketCounts().At(i) < ref.BucketCounts().At(i) {
+	for i := range len(ref.Histogram.BucketCounts) {
+		if h.BucketCounts().At(i) < ref.Histogram.BucketCounts[i] {
 			return true
 		}
 	}
@@ -129,34 +185,37 @@ func IsResetHistogram(h, ref pmetric.HistogramDataPoint) bool {
 // has been reset based on the values.  It is a reset if any of the bucket
 // boundaries have changed, if any of the bucket counts have decreased or if the
 // total sum or count have decreased.
-func IsResetExponentialHistogram(eh, ref pmetric.ExponentialHistogramDataPoint) bool {
+func (ref *TimeseriesInfo) IsResetExponentialHistogram(eh pmetric.ExponentialHistogramDataPoint) bool {
 	// Same as the histogram implementation
-	if eh.Count() < ref.Count() {
+	if eh.Count() < ref.ExponentialHistogram.PreviousCount {
 		return true
 	}
-	if eh.Sum() < ref.Sum() {
+	if eh.Sum() < ref.ExponentialHistogram.PreviousSum {
+		return true
+	}
+	if eh.ZeroCount() < ref.ExponentialHistogram.PreviousZeroCount {
 		return true
 	}
 
 	// Guard against bucket boundaries changes.
-	if ref.Scale() != eh.Scale() {
+	if ref.ExponentialHistogram.Scale != eh.Scale() {
 		return true
 	}
 
 	// We need to check individual buckets to make sure the counts are all increasing.
-	if ref.Positive().BucketCounts().Len() != eh.Positive().BucketCounts().Len() {
+	if ref.ExponentialHistogram.PositiveBuckets.BucketCounts().Len() != eh.Positive().BucketCounts().Len() {
 		return true
 	}
-	for i := range ref.Positive().BucketCounts().Len() {
-		if eh.Positive().BucketCounts().At(i) < ref.Positive().BucketCounts().At(i) {
+	for i := range ref.ExponentialHistogram.PositiveBuckets.BucketCounts().Len() {
+		if eh.Positive().BucketCounts().At(i) < ref.ExponentialHistogram.PositiveBuckets.BucketCounts().At(i) {
 			return true
 		}
 	}
-	if ref.Negative().BucketCounts().Len() != eh.Negative().BucketCounts().Len() {
+	if ref.ExponentialHistogram.NegativeBuckets.BucketCounts().Len() != eh.Negative().BucketCounts().Len() {
 		return true
 	}
-	for i := range ref.Negative().BucketCounts().Len() {
-		if eh.Negative().BucketCounts().At(i) < ref.Negative().BucketCounts().At(i) {
+	for i := range ref.ExponentialHistogram.NegativeBuckets.BucketCounts().Len() {
+		if eh.Negative().BucketCounts().At(i) < ref.ExponentialHistogram.NegativeBuckets.BucketCounts().At(i) {
 			return true
 		}
 	}
@@ -167,15 +226,15 @@ func IsResetExponentialHistogram(eh, ref pmetric.ExponentialHistogramDataPoint) 
 // IsResetSummary compares the given summary datapoint s to ref and
 // determines whether the metric has been reset based on the values.  It is a
 // reset if the count or sum has decreased.
-func IsResetSummary(s, ref pmetric.SummaryDataPoint) bool {
-	return s.Count() < ref.Count() || s.Sum() < ref.Sum()
+func (ref *TimeseriesInfo) IsResetSummary(s pmetric.SummaryDataPoint) bool {
+	return s.Count() < ref.Summary.PreviousCount || s.Sum() < ref.Summary.PreviousSum
 }
 
 // IsResetSum compares the given number datapoint s to ref and determines
 // whether the metric has been reset based on the values.  It is a reset if the
 // value has decreased.
-func IsResetSum(s, ref pmetric.NumberDataPoint) bool {
-	return s.DoubleValue() < ref.DoubleValue()
+func (ref *TimeseriesInfo) IsResetSum(s pmetric.NumberDataPoint) bool {
+	return s.DoubleValue() < ref.Number.PreviousValue
 }
 
 func newTimeseriesMap() *TimeseriesMap {

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
@@ -126,9 +126,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -143,9 +141,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -160,10 +156,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bounds Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -179,11 +172,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
-				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -200,11 +189,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
-				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -221,11 +206,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
-				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -242,11 +223,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.PreviousCount = 10
-				tsi.Histogram.PreviousSum = 50
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
-				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -263,9 +240,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count but no change",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = *NewHistogramInfo()
-				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
-				tsi.Histogram.BucketCounts = []uint64{0, 0, 0, 0}
+				tsi.Histogram = HistogramInfo{ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{0, 0, 0, 0}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -300,9 +275,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -317,9 +290,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -334,10 +305,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
-				tsi.ExponentialHistogram.PreviousZeroCount = 10
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousZeroCount: 10, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -353,9 +321,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
@@ -372,9 +338,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
@@ -391,9 +355,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
@@ -412,9 +374,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
@@ -431,9 +391,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
@@ -450,10 +408,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Scale mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
-				tsi.ExponentialHistogram.Scale = 2
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, Scale: 2, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -469,9 +424,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 10
-				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -486,9 +439,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero values but no reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
-				tsi.ExponentialHistogram.PreviousCount = 0
-				tsi.ExponentialHistogram.PreviousSum = 0
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -521,9 +472,7 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = *NewSummaryDataPoint()
-				tsi.Summary.PreviousCount = 10
-				tsi.Summary.PreviousSum = 50
+				tsi.Summary = SummaryInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -538,9 +487,7 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = *NewSummaryDataPoint()
-				tsi.Summary.PreviousCount = 10
-				tsi.Summary.PreviousSum = 50
+				tsi.Summary = SummaryInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -555,9 +502,7 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = *NewSummaryDataPoint()
-				tsi.Summary.PreviousCount = 10
-				tsi.Summary.PreviousSum = 50
+				tsi.Summary = SummaryInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -572,9 +517,7 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = *NewSummaryDataPoint()
-				tsi.Summary.PreviousCount = 10
-				tsi.Summary.PreviousSum = 50
+				tsi.Summary = SummaryInfo{PreviousCount: 10, PreviousSum: 50}
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -607,8 +550,7 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 			name: "Double Value decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Number = *NewNumberInfo()
-				tsi.Number.PreviousValue = 10
+				tsi.Number = NumberInfo{PreviousValue: 10}
 				return tsi
 			},
 			setupS: func() pmetric.NumberDataPoint {
@@ -622,8 +564,7 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Number = *NewNumberInfo()
-				tsi.Number.PreviousValue = 10
+				tsi.Number = NumberInfo{PreviousValue: 10}
 				return tsi
 			},
 			setupS: func() pmetric.NumberDataPoint {

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
@@ -172,7 +172,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, PreviousBucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -189,7 +189,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, PreviousBucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -206,7 +206,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, PreviousBucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -223,7 +223,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{1, 2, 3, 4}}
+				tsi.Histogram = HistogramInfo{PreviousCount: 10, PreviousSum: 50, ExplicitBounds: []float64{1, 2, 3}, PreviousBucketCounts: []uint64{1, 2, 3, 4}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -240,7 +240,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count but no change",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = HistogramInfo{ExplicitBounds: []float64{1, 2, 3}, BucketCounts: []uint64{0, 0, 0, 0}}
+				tsi.Histogram = HistogramInfo{ExplicitBounds: []float64{1, 2, 3}, PreviousBucketCounts: []uint64{0, 0, 0, 0}}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -275,7 +275,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -290,7 +290,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -305,7 +305,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousZeroCount: 10, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousZeroCount: 10, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -321,8 +321,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -338,8 +338,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -355,9 +355,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
-				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -374,8 +374,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -391,8 +391,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -408,7 +408,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Scale mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, Scale: 2, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, Scale: 2, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -424,7 +424,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -439,7 +439,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero values but no reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PositiveBuckets: pmetric.NewExponentialHistogramDataPointBuckets(), NegativeBuckets: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
@@ -126,9 +126,9 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -143,9 +143,9 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -160,10 +160,10 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bounds Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -179,11 +179,11 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
-				tsi.Histogram.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -200,11 +200,11 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
-				tsi.Histogram.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -221,11 +221,11 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
-				tsi.Histogram.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -242,11 +242,11 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(10)
-				tsi.Histogram.SetSum(50)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
-				tsi.Histogram.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.PreviousCount = 10
+				tsi.Histogram.PreviousSum = 50
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -263,11 +263,9 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 			name: "Zero Bucket Count but no change",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Histogram = pmetric.NewHistogramDataPoint()
-				tsi.Histogram.SetCount(0)
-				tsi.Histogram.SetSum(0)
-				tsi.Histogram.ExplicitBounds().FromRaw([]float64{1, 2, 3})
-				tsi.Histogram.BucketCounts().FromRaw([]uint64{0, 0, 0, 0})
+				tsi.Histogram = *NewHistogramInfo()
+				tsi.Histogram.ExplicitBounds = []float64{1, 2, 3}
+				tsi.Histogram.BucketCounts = []uint64{0, 0, 0, 0}
 				return tsi
 			},
 			setupH: func() pmetric.HistogramDataPoint {
@@ -286,7 +284,7 @@ func TestTimeseriesInfo_IsResetHistogram(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tsi := tt.setupTsi()
 			h := tt.setupH()
-			assert.Equal(t, tt.expectedReset, IsResetHistogram(h, tsi.Histogram))
+			assert.Equal(t, tt.expectedReset, tsi.IsResetHistogram(h))
 		})
 	}
 }
@@ -302,9 +300,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -319,9 +317,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -333,13 +331,32 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			expectedReset: true,
 		},
 		{
+			name: "Zero Count Decreased",
+			setupTsi: func() *TimeseriesInfo {
+				tsi := &TimeseriesInfo{}
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.PreviousZeroCount = 10
+				return tsi
+			},
+			setupEh: func() pmetric.ExponentialHistogramDataPoint {
+				eh := pmetric.NewExponentialHistogramDataPoint()
+				eh.SetCount(15)
+				eh.SetSum(40)
+				eh.SetZeroCount(0)
+				return eh
+			},
+			expectedReset: true,
+		},
+		{
 			name: "Positive Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.Positive().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -355,10 +372,10 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.Negative().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -374,11 +391,11 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.Positive().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
-				tsi.ExponentialHistogram.Negative().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -395,10 +412,10 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.Positive().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.PositiveBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -414,10 +431,10 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.Negative().BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.NegativeBuckets.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -433,10 +450,10 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Scale mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
-				tsi.ExponentialHistogram.SetScale(2)
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
+				tsi.ExponentialHistogram.Scale = 2
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -452,9 +469,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(10)
-				tsi.ExponentialHistogram.SetSum(50)
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 10
+				tsi.ExponentialHistogram.PreviousSum = 50
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -469,9 +486,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero values but no reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-				tsi.ExponentialHistogram.SetCount(0)
-				tsi.ExponentialHistogram.SetSum(0)
+				tsi.ExponentialHistogram = *NewExponentialHistogramInfo()
+				tsi.ExponentialHistogram.PreviousCount = 0
+				tsi.ExponentialHistogram.PreviousSum = 0
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -488,7 +505,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tsi := tt.setupTsi()
 			eh := tt.setupEh()
-			assert.Equal(t, tt.expectedReset, IsResetExponentialHistogram(eh, tsi.ExponentialHistogram))
+			assert.Equal(t, tt.expectedReset, tsi.IsResetExponentialHistogram(eh))
 		})
 	}
 }
@@ -504,9 +521,9 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = pmetric.NewSummaryDataPoint()
-				tsi.Summary.SetCount(10)
-				tsi.Summary.SetSum(50)
+				tsi.Summary = *NewSummaryDataPoint()
+				tsi.Summary.PreviousCount = 10
+				tsi.Summary.PreviousSum = 50
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -521,9 +538,9 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = pmetric.NewSummaryDataPoint()
-				tsi.Summary.SetCount(10)
-				tsi.Summary.SetSum(50)
+				tsi.Summary = *NewSummaryDataPoint()
+				tsi.Summary.PreviousCount = 10
+				tsi.Summary.PreviousSum = 50
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -538,9 +555,9 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = pmetric.NewSummaryDataPoint()
-				tsi.Summary.SetCount(10)
-				tsi.Summary.SetSum(50)
+				tsi.Summary = *NewSummaryDataPoint()
+				tsi.Summary.PreviousCount = 10
+				tsi.Summary.PreviousSum = 50
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -555,9 +572,9 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Summary = pmetric.NewSummaryDataPoint()
-				tsi.Summary.SetCount(10)
-				tsi.Summary.SetSum(50)
+				tsi.Summary = *NewSummaryDataPoint()
+				tsi.Summary.PreviousCount = 10
+				tsi.Summary.PreviousSum = 50
 				return tsi
 			},
 			setupS: func() pmetric.SummaryDataPoint {
@@ -574,7 +591,7 @@ func TestTimeseriesInfo_IsResetSummary(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tsi := tt.setupTsi()
 			s := tt.setupS()
-			assert.Equal(t, tt.expectedReset, IsResetSummary(s, tsi.Summary))
+			assert.Equal(t, tt.expectedReset, tsi.IsResetSummary(s))
 		})
 	}
 }
@@ -590,8 +607,8 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 			name: "Double Value decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Number = pmetric.NewNumberDataPoint()
-				tsi.Number.SetDoubleValue(10)
+				tsi.Number = *NewNumberInfo()
+				tsi.Number.PreviousValue = 10
 				return tsi
 			},
 			setupS: func() pmetric.NumberDataPoint {
@@ -605,8 +622,8 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.Number = pmetric.NewNumberDataPoint()
-				tsi.Number.SetDoubleValue(10)
+				tsi.Number = *NewNumberInfo()
+				tsi.Number.PreviousValue = 10
 				return tsi
 			},
 			setupS: func() pmetric.NumberDataPoint {
@@ -622,7 +639,7 @@ func TestTimeseriesInfo_IsResetSum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tsi := tt.setupTsi()
 			s := tt.setupS()
-			assert.Equal(t, tt.expectedReset, IsResetSum(s, tsi.Number))
+			assert.Equal(t, tt.expectedReset, tsi.IsResetSum(s))
 		})
 	}
 }

--- a/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster.go
@@ -25,21 +25,15 @@ import (
 const Type = "subtract_initial_point"
 
 type Adjuster struct {
-	// referenceCache stores the initial point of each
-	// timeseries. Subsequent points are normalized against this point.
 	referenceCache *datapointstorage.Cache
-	// previousValueCache to store the previous value of each
-	// timeseries provided to the adjuster for reset detection.
-	previousValueCache *datapointstorage.Cache
-	set                component.TelemetrySettings
+	set            component.TelemetrySettings
 }
 
 // NewAdjuster returns a new Adjuster which adjust metrics' start times based on the initial received points.
 func NewAdjuster(set component.TelemetrySettings, gcInterval time.Duration) *Adjuster {
 	return &Adjuster{
-		referenceCache:     datapointstorage.NewCache(gcInterval),
-		previousValueCache: datapointstorage.NewCache(gcInterval),
-		set:                set,
+		referenceCache: datapointstorage.NewCache(gcInterval),
+		set:            set,
 	}
 }
 
@@ -60,12 +54,10 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
 		rm := metrics.ResourceMetrics().At(i)
 		attrHash := pdatautil.MapHash(rm.Resource().Attributes())
-		referenceTsm, _ := a.referenceCache.Get(attrHash)
-		previousValueTsm, _ := a.previousValueCache.Get(attrHash)
+		previousValueTsm, _ := a.referenceCache.Get(attrHash)
 
 		// The lock on the relevant timeseriesMap is held throughout the adjustment process to ensure that
 		// nothing else can modify the data used for adjustment.
-		referenceTsm.Lock()
 		previousValueTsm.Lock()
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			ilm := rm.ScopeMetrics().At(j)
@@ -73,27 +65,26 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 				metric := ilm.Metrics().At(k)
 				switch dataType := metric.Type(); dataType {
 				case pmetric.MetricTypeHistogram:
-					adjustMetricHistogram(referenceTsm, previousValueTsm, metric)
+					adjustMetricHistogram(previousValueTsm, metric)
 
 				case pmetric.MetricTypeSummary:
-					adjustMetricSummary(referenceTsm, previousValueTsm, metric)
+					adjustMetricSummary(previousValueTsm, metric)
 
 				case pmetric.MetricTypeSum:
-					adjustMetricSum(referenceTsm, previousValueTsm, metric)
+					adjustMetricSum(previousValueTsm, metric)
 
 				case pmetric.MetricTypeExponentialHistogram:
-					adjustMetricExponentialHistogram(referenceTsm, previousValueTsm, metric)
+					adjustMetricExponentialHistogram(previousValueTsm, metric)
 				}
 			}
 		}
-		referenceTsm.Unlock()
 		previousValueTsm.Unlock()
 	}
 
 	return metrics, nil
 }
 
-func adjustMetricHistogram(referenceTsm, previousValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
+func adjustMetricHistogram(referenceValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
 	histogram := metric.Histogram()
 	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only dealing with CumulativeDistributions.
@@ -107,47 +98,44 @@ func adjustMetricHistogram(referenceTsm, previousValueTsm *datapointstorage.Time
 			return false
 		}
 
-		referenceTsi, found := referenceTsm.Get(metric, currentDist.Attributes())
-		// previousTsi always exists when reference Tsi is found
-		previousTsi, _ := previousValueTsm.Get(metric, currentDist.Attributes())
+		refTsi, found := referenceValueTsm.Get(metric, currentDist.Attributes())
 		if !found {
 			// First time we see this point. Skip it and use as a reference point for the next points.
-			referenceTsi.Histogram = pmetric.NewHistogramDataPoint()
-			minimalHistogramCopyTo(currentDist, referenceTsi.Histogram)
-			// Use the timestamp of the dropped point as the start timestamp for future points.
-			referenceTsi.Histogram.SetStartTimestamp(referenceTsi.Histogram.Timestamp())
-			previousTsi.Histogram = pmetric.NewHistogramDataPoint()
-			minimalHistogramCopyTo(currentDist, previousTsi.Histogram)
+			refTsi.Histogram = *datapointstorage.NewHistogramInfo()
+			refTsi.Histogram.InitialCount, refTsi.Histogram.InitialSum = currentDist.Count(), currentDist.Sum()
+			refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = currentDist.Count(), currentDist.Sum()
+			refTsi.Histogram.StartTime = currentDist.Timestamp()
+			refTsi.Histogram.BucketCounts = currentDist.BucketCounts().AsRaw()
+			refTsi.Histogram.ExplicitBounds = currentDist.ExplicitBounds().AsRaw()
 			return true
 		}
 
 		// Adjust the datapoint based on the reference value.
-		currentDist.SetStartTimestamp(referenceTsi.Histogram.StartTimestamp())
+		currentDist.SetStartTimestamp(refTsi.Histogram.StartTime)
 		if currentDist.Flags().NoRecordedValue() {
 			return false
 		}
 
-		if datapointstorage.IsResetHistogram(currentDist, previousTsi.Histogram) {
+		if refTsi.IsResetHistogram(currentDist) {
 			// reset re-initialize everything and use the non adjusted points start time.
 			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentDist.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentDist.SetStartTimestamp(resetStartTimeStamp)
 
 			// Update the reference value with the metric point.
-			referenceTsi.Histogram = pmetric.NewHistogramDataPoint()
-			previousTsi.Histogram = pmetric.NewHistogramDataPoint()
-			referenceTsi.Histogram.SetStartTimestamp(resetStartTimeStamp)
-			currentDist.ExplicitBounds().CopyTo(referenceTsi.Histogram.ExplicitBounds())
-			referenceTsi.Histogram.BucketCounts().FromRaw(make([]uint64, currentDist.BucketCounts().Len()))
-			minimalHistogramCopyTo(currentDist, previousTsi.Histogram)
+			refTsi.Histogram.InitialCount, refTsi.Histogram.InitialSum = 0, 0
+			refTsi.Histogram.StartTime = resetStartTimeStamp
+			refTsi.Histogram.BucketCounts = make([]uint64, currentDist.BucketCounts().Len())
+			refTsi.Histogram.ExplicitBounds = currentDist.ExplicitBounds().AsRaw()
+			refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = currentDist.Count(), currentDist.Sum()
 		} else {
-			minimalHistogramCopyTo(currentDist, previousTsi.Histogram)
-			subtractHistogramDataPoint(currentDist, referenceTsi.Histogram)
+			refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = currentDist.Count(), currentDist.Sum()
+			subtractHistogramDataPoint(currentDist, refTsi.Histogram)
 		}
 		return false
 	})
 }
 
-func adjustMetricExponentialHistogram(referenceTsm, previousValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
+func adjustMetricExponentialHistogram(referenceValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
 	histogram := metric.ExponentialHistogram()
 	if histogram.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only dealing with CumulativeDistributions.
@@ -161,47 +149,46 @@ func adjustMetricExponentialHistogram(referenceTsm, previousValueTsm *datapoints
 			return false
 		}
 
-		referenceTsi, found := referenceTsm.Get(metric, currentDist.Attributes())
-		// previousTsi always exists when reference Tsi is found
-		previousTsi, _ := previousValueTsm.Get(metric, currentDist.Attributes())
+		refTsi, found := referenceValueTsm.Get(metric, currentDist.Attributes())
 		if !found {
 			// First time we see this point. Skip it and use as a reference point for the next points.
-			referenceTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-			minimalExponentialHistogramCopyTo(currentDist, referenceTsi.ExponentialHistogram)
-			// Use the timestamp of the dropped point as the start timestamp for future points.
-			referenceTsi.ExponentialHistogram.SetStartTimestamp(referenceTsi.ExponentialHistogram.Timestamp())
-			previousTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-			minimalExponentialHistogramCopyTo(currentDist, previousTsi.ExponentialHistogram)
+			ehRef := *datapointstorage.NewExponentialHistogramInfo()
+			ehRef.InitialCount, ehRef.InitialSum, ehRef.InitialZeroCount, ehRef.Scale = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount(), currentDist.Scale()
+			ehRef.PreviousCount, ehRef.PreviousSum, ehRef.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
+			ehRef.StartTime = currentDist.Timestamp()
+			ehRef.PositiveBuckets = currentDist.Positive()
+			ehRef.NegativeBuckets = currentDist.Negative()
+			refTsi.ExponentialHistogram = ehRef
 			return true
 		}
 
 		// Adjust the datapoint based on the reference value.
-		currentDist.SetStartTimestamp(referenceTsi.ExponentialHistogram.StartTimestamp())
+		currentDist.SetStartTimestamp(refTsi.ExponentialHistogram.StartTime)
 		if currentDist.Flags().NoRecordedValue() {
 			return false
 		}
 
-		if datapointstorage.IsResetExponentialHistogram(currentDist, previousTsi.ExponentialHistogram) {
+		ehRef := *datapointstorage.NewExponentialHistogramInfo()
+		if refTsi.IsResetExponentialHistogram(currentDist) {
 			// reset re-initialize everything and use the non adjusted points start time.
 			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentDist.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentDist.SetStartTimestamp(resetStartTimeStamp)
 
-			referenceTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-			previousTsi.ExponentialHistogram = pmetric.NewExponentialHistogramDataPoint()
-			referenceTsi.ExponentialHistogram.SetStartTimestamp(resetStartTimeStamp)
-			referenceTsi.ExponentialHistogram.SetScale(currentDist.Scale())
-			referenceTsi.ExponentialHistogram.Positive().BucketCounts().FromRaw(make([]uint64, currentDist.Positive().BucketCounts().Len()))
-			referenceTsi.ExponentialHistogram.Negative().BucketCounts().FromRaw(make([]uint64, currentDist.Negative().BucketCounts().Len()))
-			minimalExponentialHistogramCopyTo(currentDist, previousTsi.ExponentialHistogram)
+			ehRef.InitialCount, ehRef.InitialSum, ehRef.InitialZeroCount, ehRef.Scale = 0, 0, 0, currentDist.Scale()
+			ehRef.StartTime = resetStartTimeStamp
+			ehRef.PositiveBuckets.BucketCounts().FromRaw(make([]uint64, currentDist.Positive().BucketCounts().Len()))
+			ehRef.NegativeBuckets.BucketCounts().FromRaw(make([]uint64, currentDist.Negative().BucketCounts().Len()))
+			ehRef.PreviousCount, ehRef.PreviousSum, ehRef.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
 		} else {
-			minimalExponentialHistogramCopyTo(currentDist, previousTsi.ExponentialHistogram)
-			subtractExponentialHistogramDataPoint(currentDist, referenceTsi.ExponentialHistogram)
+			ehRef.PreviousCount, ehRef.PreviousSum, ehRef.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
+			subtractExponentialHistogramDataPoint(currentDist, refTsi.ExponentialHistogram)
 		}
+		refTsi.ExponentialHistogram = ehRef
 		return false
 	})
 }
 
-func adjustMetricSum(referenceTsm, previousValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
+func adjustMetricSum(referenceValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
 	sum := metric.Sum()
 	if sum.AggregationTemporality() != pmetric.AggregationTemporalityCumulative {
 		// Only handle cumulative temporality sums
@@ -215,44 +202,37 @@ func adjustMetricSum(referenceTsm, previousValueTsm *datapointstorage.Timeseries
 			return false
 		}
 
-		referenceTsi, found := referenceTsm.Get(metric, currentSum.Attributes())
-		// previousTsi always exists when reference Tsi is found
-		previousTsi, _ := previousValueTsm.Get(metric, currentSum.Attributes())
+		refTsi, found := referenceValueTsm.Get(metric, currentSum.Attributes())
 		if !found {
 			// First time we see this point. Skip it and use as a reference point for the next points.
-			referenceTsi.Number = pmetric.NewNumberDataPoint()
-			minimalSumCopyTo(currentSum, referenceTsi.Number)
-			// Use the timestamp of the dropped point as the start timestamp for future points.
-			referenceTsi.Number.SetStartTimestamp(referenceTsi.Number.Timestamp())
-			previousTsi.Number = pmetric.NewNumberDataPoint()
-			minimalSumCopyTo(currentSum, previousTsi.Number)
+			refTsi.Number.PreviousValue, refTsi.Number.InitialValue = currentSum.DoubleValue(), currentSum.DoubleValue()
+			refTsi.Number.StartTime = currentSum.Timestamp()
 			return true
 		}
 
 		// Adjust the datapoint based on the reference value.
-		currentSum.SetStartTimestamp(referenceTsi.Number.StartTimestamp())
+		currentSum.SetStartTimestamp(refTsi.Number.StartTime)
 		if currentSum.Flags().NoRecordedValue() {
 			return false
 		}
 
-		if datapointstorage.IsResetSum(currentSum, previousTsi.Number) {
+		if refTsi.IsResetSum(currentSum) {
 			// reset re-initialize everything and use the non adjusted points start time.
 			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentSum.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentSum.SetStartTimestamp(resetStartTimeStamp)
 
-			referenceTsi.Number = pmetric.NewNumberDataPoint()
-			previousTsi.Number = pmetric.NewNumberDataPoint()
-			referenceTsi.Number.SetStartTimestamp(resetStartTimeStamp)
-			minimalSumCopyTo(currentSum, previousTsi.Number)
+			refTsi.Number.StartTime = resetStartTimeStamp
+			refTsi.Number.InitialValue = 0
+			refTsi.Number.PreviousValue = currentSum.DoubleValue()
 		} else {
-			minimalSumCopyTo(currentSum, previousTsi.Number)
-			currentSum.SetDoubleValue(currentSum.DoubleValue() - referenceTsi.Number.DoubleValue())
+			refTsi.Number.PreviousValue = currentSum.DoubleValue()
+			currentSum.SetDoubleValue(currentSum.DoubleValue() - refTsi.Number.InitialValue)
 		}
 		return false
 	})
 }
 
-func adjustMetricSummary(referenceTsm, previousValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
+func adjustMetricSummary(referenceValueTsm *datapointstorage.TimeseriesMap, metric pmetric.Metric) {
 	metric.Summary().DataPoints().RemoveIf(func(currentSummary pmetric.SummaryDataPoint) bool {
 		pointStartTime := currentSummary.StartTimestamp()
 		if pointStartTime != 0 && pointStartTime != currentSummary.Timestamp() {
@@ -260,76 +240,73 @@ func adjustMetricSummary(referenceTsm, previousValueTsm *datapointstorage.Timese
 			return false
 		}
 
-		referenceTsi, found := referenceTsm.Get(metric, currentSummary.Attributes())
-		// previousTsi always exists when reference Tsi is found
-		previousTsi, _ := previousValueTsm.Get(metric, currentSummary.Attributes())
+		refTsi, found := referenceValueTsm.Get(metric, currentSummary.Attributes())
 		if !found {
 			// First time we see this point. Skip it and use as a reference point for the next points.
-			referenceTsi.Summary = pmetric.NewSummaryDataPoint()
-			minimalSummaryCopyTo(currentSummary, referenceTsi.Summary)
-			// Use the timestamp of the dropped point as the start timestamp for future points.
-			referenceTsi.Summary.SetStartTimestamp(referenceTsi.Summary.Timestamp())
-			previousTsi.Summary = pmetric.NewSummaryDataPoint()
-			minimalSummaryCopyTo(currentSummary, previousTsi.Summary)
+			sTsi := datapointstorage.NewSummaryDataPoint()
+			sTsi.InitialCount, sTsi.InitialSum = currentSummary.Count(), currentSummary.Sum()
+			sTsi.PreviousCount, sTsi.PreviousSum = currentSummary.Count(), currentSummary.Sum()
+			sTsi.StartTime = currentSummary.Timestamp()
+			refTsi.Summary = *sTsi
 			return true
 		}
 
 		// Adjust the datapoint based on the reference value.
-		currentSummary.SetStartTimestamp(referenceTsi.Summary.StartTimestamp())
+		currentSummary.SetStartTimestamp(refTsi.Summary.StartTime)
 		if currentSummary.Flags().NoRecordedValue() {
 			return false
 		}
 
-		if datapointstorage.IsResetSummary(currentSummary, previousTsi.Summary) {
+		sTsi := datapointstorage.NewSummaryDataPoint()
+		if refTsi.IsResetSummary(currentSummary) {
 			// reset re-initialize everything and use the non adjusted points start time.
 			resetStartTimeStamp := pcommon.NewTimestampFromTime(currentSummary.Timestamp().AsTime().Add(-1 * time.Millisecond))
 			currentSummary.SetStartTimestamp(resetStartTimeStamp)
 
-			referenceTsi.Summary = pmetric.NewSummaryDataPoint()
-			previousTsi.Summary = pmetric.NewSummaryDataPoint()
-			referenceTsi.Summary.SetStartTimestamp(resetStartTimeStamp)
-			minimalSummaryCopyTo(currentSummary, previousTsi.Summary)
+			sTsi.StartTime = resetStartTimeStamp
+			sTsi.InitialCount, sTsi.InitialSum = 0, 0
+			sTsi.PreviousCount, sTsi.PreviousSum = currentSummary.Count(), currentSummary.Sum()
 		} else {
-			currentSummary.SetStartTimestamp(referenceTsi.Summary.StartTimestamp())
-			minimalSummaryCopyTo(currentSummary, previousTsi.Summary)
-			currentSummary.SetCount(currentSummary.Count() - referenceTsi.Summary.Count())
-			currentSummary.SetSum(currentSummary.Sum() - referenceTsi.Summary.Sum())
+			sTsi.PreviousCount, sTsi.PreviousSum = currentSummary.Count(), currentSummary.Sum()
+			currentSummary.SetCount(currentSummary.Count() - refTsi.Summary.InitialCount)
+			currentSummary.SetSum(currentSummary.Sum() - refTsi.Summary.InitialSum)
 		}
+		refTsi.Summary = *sTsi
 		return false
 	})
 }
 
 // subtractHistogramDataPoint subtracts b from a.
-func subtractHistogramDataPoint(a, b pmetric.HistogramDataPoint) {
-	a.SetStartTimestamp(b.StartTimestamp())
-	a.SetCount(a.Count() - b.Count())
-	a.SetSum(a.Sum() - b.Sum())
+func subtractHistogramDataPoint(a pmetric.HistogramDataPoint, ref datapointstorage.HistogramInfo) {
+	a.SetStartTimestamp(ref.StartTime)
+	a.SetCount(a.Count() - ref.InitialCount)
+	a.SetSum(a.Sum() - ref.InitialSum)
 	aBuckets := a.BucketCounts()
-	bBuckets := b.BucketCounts()
-	if bBuckets.Len() != aBuckets.Len() {
+	bBuckets := ref.BucketCounts
+	if len(bBuckets) != aBuckets.Len() {
 		// Post reset, the reference histogram will have no buckets.
 		return
 	}
 	newBuckets := make([]uint64, aBuckets.Len())
 	for i := 0; i < aBuckets.Len(); i++ {
-		newBuckets[i] = aBuckets.At(i) - bBuckets.At(i)
+		newBuckets[i] = aBuckets.At(i) - bBuckets[i]
 	}
 	a.BucketCounts().FromRaw(newBuckets)
 }
 
 // subtractExponentialHistogramDataPoint subtracts b from a.
-func subtractExponentialHistogramDataPoint(a, b pmetric.ExponentialHistogramDataPoint) {
-	a.SetStartTimestamp(b.StartTimestamp())
-	a.SetCount(a.Count() - b.Count())
-	a.SetSum(a.Sum() - b.Sum())
-	a.SetZeroCount(a.ZeroCount() - b.ZeroCount())
-	if a.Positive().BucketCounts().Len() != b.Positive().BucketCounts().Len() ||
-		a.Negative().BucketCounts().Len() != b.Negative().BucketCounts().Len() {
+func subtractExponentialHistogramDataPoint(a pmetric.ExponentialHistogramDataPoint, ref datapointstorage.ExponentialHistogramInfo) {
+	a.SetStartTimestamp(ref.StartTime)
+	a.SetCount(a.Count() - ref.InitialCount)
+	a.SetSum(a.Sum() - ref.InitialSum)
+	a.SetZeroCount(a.ZeroCount() - ref.InitialZeroCount)
+	if a.Positive().BucketCounts().Len() != ref.PositiveBuckets.BucketCounts().Len() ||
+		a.Negative().BucketCounts().Len() != ref.NegativeBuckets.BucketCounts().Len() {
 		// Post reset, the reference histogram will have no buckets.
 		return
 	}
-	a.Positive().BucketCounts().FromRaw(subtractExponentialBuckets(a.Positive(), b.Positive()))
-	a.Negative().BucketCounts().FromRaw(subtractExponentialBuckets(a.Negative(), b.Negative()))
+	a.Positive().BucketCounts().FromRaw(subtractExponentialBuckets(a.Positive(), ref.PositiveBuckets))
+	a.Negative().BucketCounts().FromRaw(subtractExponentialBuckets(a.Negative(), ref.NegativeBuckets))
 }
 
 // subtractExponentialBuckets subtracts b from a.
@@ -346,53 +323,4 @@ func subtractExponentialBuckets(a, b pmetric.ExponentialHistogramDataPointBucket
 		}
 	}
 	return newBuckets
-}
-
-// minimalHistogramCopyTo is equivalent to a.CopyTo(b) without copying attributes or exemplars
-func minimalHistogramCopyTo(a, b pmetric.HistogramDataPoint) {
-	// Copy attributes and exemplars to temporary structures so they are not copied to b.
-	tmpAttrs := pcommon.NewMap()
-	tmpExemplars := pmetric.NewExemplarSlice()
-	a.Attributes().MoveTo(tmpAttrs)
-	a.Exemplars().MoveAndAppendTo(tmpExemplars)
-	a.CopyTo(b)
-	// Restore attributes and exemplars.
-	tmpAttrs.MoveTo(a.Attributes())
-	tmpExemplars.MoveAndAppendTo(a.Exemplars())
-}
-
-// minimalExponentialHistogramCopyTo is equivalent to a.CopyTo(b) without copying attributes or exemplars
-func minimalExponentialHistogramCopyTo(a, b pmetric.ExponentialHistogramDataPoint) {
-	// Copy attributes and exemplars to temporary structures so they are not copied to b.
-	tmpAttrs := pcommon.NewMap()
-	tmpExemplars := pmetric.NewExemplarSlice()
-	a.Attributes().MoveTo(tmpAttrs)
-	a.Exemplars().MoveAndAppendTo(tmpExemplars)
-	a.CopyTo(b)
-	// Restore attributes and exemplars.
-	tmpAttrs.MoveTo(a.Attributes())
-	tmpExemplars.MoveAndAppendTo(a.Exemplars())
-}
-
-// minimalSumCopyTo is equivalent to a.CopyTo(b) without copying attributes or exemplars
-func minimalSumCopyTo(a, b pmetric.NumberDataPoint) {
-	// Copy attributes and exemplars to temporary structures so they are not copied to b.
-	tmpAttrs := pcommon.NewMap()
-	tmpExemplars := pmetric.NewExemplarSlice()
-	a.Attributes().MoveTo(tmpAttrs)
-	a.Exemplars().MoveAndAppendTo(tmpExemplars)
-	a.CopyTo(b)
-	// Restore attributes and exemplars.
-	tmpAttrs.MoveTo(a.Attributes())
-	tmpExemplars.MoveAndAppendTo(a.Exemplars())
-}
-
-// minimalSummaryCopyTo is equivalent to a.CopyTo(b) without copying attributes or exemplars
-func minimalSummaryCopyTo(a, b pmetric.SummaryDataPoint) {
-	// Copy attributes to a temporary map so they are not copied to b.
-	tmpAttrs := pcommon.NewMap()
-	a.Attributes().MoveTo(tmpAttrs)
-	a.CopyTo(b)
-	// Restore attributes.
-	tmpAttrs.MoveTo(a.Attributes())
 }

--- a/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
@@ -905,7 +905,6 @@ func TestJobGC(t *testing.T) {
 	// ensure that at least one jobsMap.gc() completed
 	time.Sleep(gcInterval)
 	ma.referenceCache.MaybeGC()
-	ma.previousValueCache.MaybeGC()
 	time.Sleep(5 * time.Second) // Wait for the goroutine to complete.
 	// run job 1, round 2 - verify that all job 1 timeseries have been gc'd
 	testhelper.RunScript(t, ma, job1Script2, "0")

--- a/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/subtractinitial/adjuster_test.go
@@ -311,6 +311,10 @@ func TestHistogram(t *testing.T) {
 			Description: "Histogram: round 4 - instance adjusted based on round 3",
 			Metrics:     testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t4, t4, bounds0, []uint64{7, 4, 2, 12}))),
 			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t2, t4, bounds0, []uint64{7, 4, 2, 12}))),
+		}, {
+			Description: "Histogram: round 5 - instance reset (cause of a bucket value going down without sum going down)",
+			Metrics:     testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t5, t5, bounds0, []uint64{7, 4, 20, 11}))),
+			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t4, t5, bounds0, []uint64{7, 4, 20, 11}))),
 		},
 	}
 	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
@@ -395,6 +399,10 @@ func TestExponentialHistogram(t *testing.T) {
 			Description: "Exponential Histogram: round 4 - instance adjusted based on round 3",
 			Metrics:     testhelper.Metrics(testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t4, t4, 3, 1, 0, []uint64{}, -2, []uint64{7, 4, 2, 12}))),
 			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t2, t4, 3, 1, 0, []uint64{}, -2, []uint64{7, 4, 2, 12}))),
+		}, {
+			Description: "Exponential Histogram: round 4 - instance reset again",
+			Metrics:     testhelper.Metrics(testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t5, t5, 3, 1, 0, []uint64{}, -2, []uint64{6, 3, 1, 11}))),
+			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t4, t5, 3, 1, 0, []uint64{}, -2, []uint64{6, 3, 1, 11}))),
 		},
 	}
 	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
@@ -101,9 +101,9 @@ func (*Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, curr
 			// initialize everything.
 			refTsi.Histogram = datapointstorage.HistogramInfo{
 				PreviousCount: currentDist.Count(), PreviousSum: currentDist.Sum(),
-				StartTime:      currentDist.Timestamp(),
-				BucketCounts:   currentDist.BucketCounts().AsRaw(),
-				ExplicitBounds: currentDist.ExplicitBounds().AsRaw(),
+				StartTime:            currentDist.Timestamp(),
+				PreviousBucketCounts: currentDist.BucketCounts().AsRaw(),
+				ExplicitBounds:       currentDist.ExplicitBounds().AsRaw(),
 			}
 
 			// For the first point, set the start time as the point timestamp.
@@ -125,7 +125,7 @@ func (*Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, curr
 
 		// Update only previous values.
 		refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = currentDist.Count(), currentDist.Sum()
-		refTsi.Histogram.BucketCounts = currentDist.BucketCounts().AsRaw()
+		refTsi.Histogram.PreviousBucketCounts = currentDist.BucketCounts().AsRaw()
 		currentDist.SetStartTimestamp(refTsi.Histogram.StartTime)
 	}
 }
@@ -146,10 +146,10 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 			// initialize everything.
 			refTsi.ExponentialHistogram = datapointstorage.ExponentialHistogramInfo{
 				PreviousCount: currentDist.Count(), PreviousSum: currentDist.Sum(), PreviousZeroCount: currentDist.ZeroCount(),
-				Scale:           currentDist.Scale(),
-				StartTime:       currentDist.Timestamp(),
-				PositiveBuckets: currentDist.Positive(),
-				NegativeBuckets: currentDist.Negative(),
+				Scale:            currentDist.Scale(),
+				StartTime:        currentDist.Timestamp(),
+				PreviousPositive: currentDist.Positive(),
+				PreviousNegative: currentDist.Negative(),
 			}
 
 			// For the first point, set the start time as the point timestamp.
@@ -171,8 +171,8 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 		}
 
 		// Update only previous values.
-		refTsi.ExponentialHistogram.PositiveBuckets = currentDist.Positive()
-		refTsi.ExponentialHistogram.NegativeBuckets = currentDist.Negative()
+		refTsi.ExponentialHistogram.PreviousPositive = currentDist.Positive()
+		refTsi.ExponentialHistogram.PreviousNegative = currentDist.Negative()
 		refTsi.ExponentialHistogram.PreviousCount, refTsi.ExponentialHistogram.PreviousSum, refTsi.ExponentialHistogram.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
 		currentDist.SetStartTimestamp(refTsi.ExponentialHistogram.StartTime)
 	}

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
@@ -99,11 +99,12 @@ func (*Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, curr
 		refTsi, found := tsm.Get(current, currentDist.Attributes())
 		if !found {
 			// initialize everything.
-			refTsi.Histogram = *datapointstorage.NewHistogramInfo()
-			refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = currentDist.Count(), currentDist.Sum()
-			refTsi.Histogram.StartTime = currentDist.Timestamp()
-			refTsi.Histogram.BucketCounts = currentDist.BucketCounts().AsRaw()
-			refTsi.Histogram.ExplicitBounds = currentDist.ExplicitBounds().AsRaw()
+			refTsi.Histogram = datapointstorage.HistogramInfo{
+				PreviousCount: currentDist.Count(), PreviousSum: currentDist.Sum(),
+				StartTime:      currentDist.Timestamp(),
+				BucketCounts:   currentDist.BucketCounts().AsRaw(),
+				ExplicitBounds: currentDist.ExplicitBounds().AsRaw(),
+			}
 
 			// For the first point, set the start time as the point timestamp.
 			currentDist.SetStartTimestamp(currentDist.Timestamp())
@@ -143,13 +144,13 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 		refTsi, found := tsm.Get(current, currentDist.Attributes())
 		if !found {
 			// initialize everything.
-			ehRef := *datapointstorage.NewExponentialHistogramInfo()
-			ehRef.Scale = currentDist.Scale()
-			ehRef.PreviousCount, ehRef.PreviousSum, ehRef.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
-			ehRef.StartTime = currentDist.Timestamp()
-			ehRef.PositiveBuckets = currentDist.Positive()
-			ehRef.NegativeBuckets = currentDist.Negative()
-			refTsi.ExponentialHistogram = ehRef
+			refTsi.ExponentialHistogram = datapointstorage.ExponentialHistogramInfo{
+				PreviousCount: currentDist.Count(), PreviousSum: currentDist.Sum(), PreviousZeroCount: currentDist.ZeroCount(),
+				Scale:           currentDist.Scale(),
+				StartTime:       currentDist.Timestamp(),
+				PositiveBuckets: currentDist.Positive(),
+				NegativeBuckets: currentDist.Negative(),
+			}
 
 			// For the first point, set the start time as the point timestamp.
 			currentDist.SetStartTimestamp(currentDist.Timestamp())
@@ -185,8 +186,7 @@ func (*Adjuster) adjustMetricSum(tsm *datapointstorage.TimeseriesMap, current pm
 		refTsi, found := tsm.Get(current, currentSum.Attributes())
 		if !found {
 			// initialize everything.
-			refTsi.Number.PreviousValue = currentSum.DoubleValue()
-			refTsi.Number.StartTime = currentSum.Timestamp()
+			refTsi.Number = datapointstorage.NumberInfo{PreviousValue: currentSum.DoubleValue(), StartTime: currentSum.Timestamp()}
 
 			// For the first point, set the start time as the point timestamp.
 			currentSum.SetStartTimestamp(currentSum.Timestamp())
@@ -220,10 +220,10 @@ func (*Adjuster) adjustMetricSummary(tsm *datapointstorage.TimeseriesMap, curren
 		refTsi, found := tsm.Get(current, currentSummary.Attributes())
 		if !found {
 			// initialize everything.
-			sTsi := datapointstorage.NewSummaryDataPoint()
-			sTsi.PreviousCount, sTsi.PreviousSum = currentSummary.Count(), currentSummary.Sum()
-			sTsi.StartTime = currentSummary.Timestamp()
-			refTsi.Summary = *sTsi
+			refTsi.Summary = datapointstorage.SummaryInfo{
+				PreviousCount: currentSummary.Count(), PreviousSum: currentSummary.Sum(),
+				StartTime: currentSummary.Timestamp(),
+			}
 
 			// For the first point, set the start time as the point timestamp.
 			currentSummary.SetStartTimestamp(currentSummary.Timestamp())

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
@@ -264,12 +264,12 @@ func TestHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
 		{
 			Description: "Histogram: round 1 - initial instance, start time is unknown",
 			Metrics:     testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, tUnknown, t1))),
-			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, tUnknown, t1))),
+			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, t1, t1))),
 		},
 		{
 			Description: "Histogram: round 2 - instance unchanged",
 			Metrics:     testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, tUnknown, t2))),
-			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, tUnknown, t2))),
+			Adjusted:    testhelper.Metrics(testhelper.HistogramMetric(histogram1, testhelper.HistogramPointNoValue(k1v1k2v2, t1, t2))),
 		},
 	}
 
@@ -325,12 +325,12 @@ func TestExponentialHistogramFlagNoRecordedValueFirstObservation(t *testing.T) {
 		{
 			Description: "Histogram: round 1 - initial instance, start time is unknown",
 			Metrics:     testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, tUnknown, t1))),
-			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, tUnknown, t1))),
+			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, t1, t1))),
 		},
 		{
 			Description: "Histogram: round 2 - instance unchanged",
 			Metrics:     testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, tUnknown, t2))),
-			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, tUnknown, t2))),
+			Adjusted:    testhelper.Metrics(testhelper.ExponentialHistogramMetric(histogram1, testhelper.ExponentialHistogramPointNoValue(k1v1k2v2, t1, t2))),
 		},
 	}
 
@@ -342,12 +342,12 @@ func TestSummaryFlagNoRecordedValueFirstObservation(t *testing.T) {
 		{
 			Description: "Summary: round 1 - initial instance, start time is unknown",
 			Metrics:     testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, tUnknown, t1))),
-			Adjusted:    testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, tUnknown, t1))),
+			Adjusted:    testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, t1, t1))),
 		},
 		{
 			Description: "Summary: round 2 - instance unchanged",
 			Metrics:     testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, tUnknown, t2))),
-			Adjusted:    testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, tUnknown, t2))),
+			Adjusted:    testhelper.Metrics(testhelper.SummaryMetric(summary1, testhelper.SummaryPointNoValue(k1v1k2v2, t1, t2))),
 		},
 	}
 
@@ -376,12 +376,12 @@ func TestSumFlagNoRecordedValueFirstObservation(t *testing.T) {
 		{
 			Description: "Sum: round 1 - initial instance, start time is unknown",
 			Metrics:     testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, tUnknown, t1))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, tUnknown, t1))),
+			Adjusted:    testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, t1, t1))),
 		},
 		{
 			Description: "Sum: round 2 - instance unchanged",
 			Metrics:     testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, tUnknown, t2))),
-			Adjusted:    testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, tUnknown, t2))),
+			Adjusted:    testhelper.Metrics(testhelper.SumMetric("sum1", testhelper.DoublePointNoValue(k1v1k2v2, t1, t2))),
 		},
 	}
 


### PR DESCRIPTION




<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This change does the following:

- Instead of caching the whole datapoint, it only caches the relevant things needed by the adjuster
- Uses the same cache for a reference value and the previous value
- Makes the existing strategies use the new cache
- Update tests to make sure they work

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38381.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated unit tests

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
