### PR TITLE
[receiver/splunkenterprise] 41527 kvstoremetrics bug

### DIFF
--- a/.chloggen/41527-kvstoremetrics-bug.yaml
+++ b/.chloggen/41527-kvstoremetrics-bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkenterprisereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'fixes behavior of kvstore metrics scraper'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41527]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -1582,9 +1582,9 @@ func (s *splunkScraper) scrapeIntrospectionQueuesBytes(_ context.Context, now pc
 
 // Scrape introspection kv store status
 func (s *splunkScraper) scrapeKVStoreStatus(_ context.Context, now pcommon.Timestamp, info infoDict, errs chan error) {
-	if !s.conf.Metrics.SplunkKvstoreStatus.Enabled ||
-		!s.conf.Metrics.SplunkKvstoreReplicationStatus.Enabled ||
-		!s.conf.Metrics.SplunkKvstoreBackupStatus.Enabled ||
+	if !s.conf.Metrics.SplunkKvstoreStatus.Enabled &&
+		!s.conf.Metrics.SplunkKvstoreReplicationStatus.Enabled &&
+		!s.conf.Metrics.SplunkKvstoreBackupStatus.Enabled &&
 		!s.splunkClient.isConfigured(typeCm) {
 		return
 	}

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -1584,7 +1584,7 @@ func (s *splunkScraper) scrapeIntrospectionQueuesBytes(_ context.Context, now pc
 func (s *splunkScraper) scrapeKVStoreStatus(_ context.Context, now pcommon.Timestamp, info infoDict, errs chan error) {
 	if !s.conf.Metrics.SplunkKvstoreStatus.Enabled &&
 		!s.conf.Metrics.SplunkKvstoreReplicationStatus.Enabled &&
-		!s.conf.Metrics.SplunkKvstoreBackupStatus.Enabled &&
+		!s.conf.Metrics.SplunkKvstoreBackupStatus.Enabled ||
 		!s.splunkClient.isConfigured(typeCm) {
 		return
 	}

--- a/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
+++ b/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
@@ -140,7 +140,7 @@ resourceMetrics:
           - description: Gauge tracking the number of indexing process cpu seconds per instance
             gauge:
               dataPoints:
-                - asDouble: "69.20"
+                - asDouble: 69.2
                   attributes:
                     - key: splunk.host
                       value:
@@ -215,7 +215,7 @@ resourceMetrics:
           - description: Gauge tracking the average runtime of scheduled searches
             gauge:
               dataPoints:
-                - asDouble: 200.40
+                - asDouble: 200.4
                   attributes:
                     - key: splunk.host
                       value:


### PR DESCRIPTION
#### Description
Fixes an issue in the `scraper.go` logic for kvstore metrics that makes it so the scrape would not occur if any of the kvstore related metrics were disabled.

#### Link to tracking issue
Fixes [41527](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41527)

#### Testing
automated tests pass and ran `make otelcontribcol` and tested the enterprise receiver with the following metric config:
```yaml
metrics:
  splunk.health:
    enabled: false # for brevity
  splunk.kvstore.status:
    enabled: false
  splunk.kvstore.replication.status:
    enabled: true
```

#### Documentation
Nothing was changed that needed to be documented.
<!--Please delete paragraphs that you did not use before submitting.-->
