### PR TITLE
[stefexporter] Fix unstable TestConnManagerFlush

### DIFF
--- a/exporter/stefexporter/internal/connmanager_test.go
+++ b/exporter/stefexporter/internal/connmanager_test.go
@@ -291,7 +291,11 @@ func TestConnManagerFlush(t *testing.T) {
 				cm.Release(context.Background(), conn)
 
 				// Advance the clock so that the connection is flush in the background.
-				cm.clock.(*clockwork.FakeClock).Advance(flushPeriod)
+				// We advance the clock twice the reconnect period to guarantee that
+				// all connections are flushed (all connections are expected to be flushed
+				// in one reconnect period, but that's on the edge, we want a guarantee,
+				// that's why double).
+				cm.clock.(*clockwork.FakeClock).Advance(reconnectPeriod * 2)
 
 				// Make sure the flush is done.
 				assert.Eventually(


### PR DESCRIPTION
The test was incorrectly advancing the fake clock by insufficient amount. Fixed by advancing the clock by sufficient time to make sure flush on all connections is called.

Verified via `for i in {1..10}; do go test -run TestConnManagerFlush -race -count 1000; done`.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41781
