### PR TITLE
[chore] OTel-Arrow e2e tests should WaitForResult

### DIFF
--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -147,6 +147,10 @@ func basicTestConfig(t *testing.T, tp testParams, cfgF CfgFunc) (*testConsumer, 
 	exporterCfg.Arrow.MaxStreamLifetime = 5 * time.Second
 	exporterCfg.Arrow.DisableDowngrade = true
 
+	// The default exporter setting enables the memory queue; we
+	// disable to avoid flaky tests.
+	exporterCfg.QueueSettings.WaitForResult = true
+
 	if cfgF != nil {
 		cfgF(exporterCfg, receiverCfg)
 	}


### PR DESCRIPTION

#### Description

These tests have been flaky since #40211, I suspect.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41810.

#### Testing

Deflaked (I believe).

#### Documentation

n/a