### PR TITLE
[chore] [otelarrowreceiver] Remove one flaky test

### DIFF
--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -947,17 +947,6 @@ func testReceiverHeaders(t *testing.T, includeMeta bool) {
 	wg.Wait()
 }
 
-func TestReceiverCancel(t *testing.T) {
-	tc := newHealthyTestChannel(t)
-	ctc := newCommonTestCase(t, tc)
-
-	ctc.cancel()
-	ctc.start(ctc.newRealConsumer, defaultBQ())
-
-	err := ctc.wait()
-	requireCanceledStatus(t, err)
-}
-
 func requireContainsAll(t *testing.T, md client.Metadata, exp map[string][]string) {
 	for key, vals := range exp {
 		require.Equal(t, vals, md.Get(key))


### PR DESCRIPTION

#### Description

Remove a flaky test. It was failing on Windows, so it's not a good test.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41786
