### PR TITLE
[exporter/loadbalancing] drop resources if the service routing key does not exist

### DIFF
--- a/.chloggen/loadbalancing-retry-blockage.yaml
+++ b/.chloggen/loadbalancing-retry-blockage.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loadbalancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Drop resources if the service routing key does not exist"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41550]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/collector/config/configretry v1.41.0
 	go.opentelemetry.io/collector/confmap v1.41.0
 	go.opentelemetry.io/collector/consumer v1.41.0
+	go.opentelemetry.io/collector/consumer/consumererror v0.135.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.135.0
 	go.opentelemetry.io/collector/exporter v0.135.0
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.135.0
@@ -129,7 +130,6 @@ require (
 	go.opentelemetry.io/collector/connector v0.135.0 // indirect
 	go.opentelemetry.io/collector/connector/connectortest v0.135.0 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.135.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.135.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.135.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.135.0 // indirect
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.135.0 // indirect

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -5,7 +5,6 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -98,10 +97,12 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 
 	switch e.routingKey {
 	case svcRouting:
-		var err error
-		batches, err = splitMetricsByResourceServiceName(md)
-		if err != nil {
-			return err
+		var errs []error
+		batches, errs = splitMetricsByResourceServiceName(md)
+		if len(errs) > 0 {
+			for _, ee := range errs {
+				e.logger.Error("failed to export metric", zap.Error(ee))
+			}
 		}
 	case resourceRouting:
 		batches = splitMetricsByResourceID(md)
@@ -152,15 +153,17 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	return errs
 }
 
-func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.Metrics, error) {
+func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.Metrics, []error) {
 	results := map[string]pmetric.Metrics{}
+	var errs []error
 
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
 
 		svc, ok := rm.Resource().Attributes().Get(string(conventions.ServiceNameKey))
 		if !ok {
-			return nil, errors.New("unable to get service name")
+			errs = append(errs, fmt.Errorf("unable to get service name from resource metric with attributes: %v", rm.Resource().Attributes().AsRaw()))
+			continue
 		}
 
 		newMD := pmetric.NewMetrics()
@@ -176,7 +179,7 @@ func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.M
 		}
 	}
 
-	return results, nil
+	return results, errs
 }
 
 func splitMetricsByResourceID(md pmetric.Metrics) map[string]pmetric.Metrics {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -5,12 +5,14 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -104,7 +106,7 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 				e.logger.Error("failed to export metric", zap.Error(ee))
 			}
 			if len(batches) == 0 {
-				return consumererror.NewPermanent(errors.Join(ee))
+				return consumererror.NewPermanent(errors.Join(errs...))
 			}
 		}
 	case resourceRouting:

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -103,6 +103,9 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 			for _, ee := range errs {
 				e.logger.Error("failed to export metric", zap.Error(ee))
 			}
+			if len(batches) == 0 {
+				return consumererror.NewPermanent(errors.Join(ee))
+			}
 		}
 	case resourceRouting:
 		batches = splitMetricsByResourceID(md)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -411,7 +411,7 @@ func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	createSettings := ts
 	config := &Config{
 		Resolver: ResolverSettings{
-			Static: &StaticResolver{Hostnames: []string{"endpoint-1"}},
+			Static: configoptional.Some(StaticResolver{Hostnames: []string{"endpoint-1"}}),
 		},
 		RoutingKey: svcRoutingStr,
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -432,7 +432,7 @@ func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lb)
 
-	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(_ context.Context) ([]string, error) {
@@ -442,10 +442,10 @@ func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	p.loadBalancer = lb
 
 	// Start everything up
-	err = p.Start(context.Background(), componenttest.NewNopHost())
+	err = p.Start(t.Context(), componenttest.NewNopHost())
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, p.Shutdown(context.Background()))
+		require.NoError(t, p.Shutdown(t.Context()))
 	}()
 
 	// Test
@@ -454,7 +454,7 @@ func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	input, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
 	require.NoError(t, err)
 
-	err = p.ConsumeMetrics(context.Background(), input)
+	err = p.ConsumeMetrics(t.Context(), input)
 	require.NoError(t, err)
 
 	expectedOutput, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -237,8 +237,8 @@ func TestSplitMetricsByResourceServiceName(t *testing.T) {
 
 			expectedOutput := loadMetricsMap(t, filepath.Join(dir, "output.yaml"))
 
-			output, err := splitMetricsByResourceServiceName(input)
-			require.NoError(t, err)
+			output, errs := splitMetricsByResourceServiceName(input)
+			require.Nil(t, errs)
 			compareMetricsMaps(t, expectedOutput, output)
 		})
 	}
@@ -250,8 +250,8 @@ func TestSplitMetricsByResourceServiceNameFailsIfMissingServiceNameAttribute(t *
 	input, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "split_metrics", "missing_service_name", "input.yaml"))
 	require.NoError(t, err)
 
-	_, err = splitMetricsByResourceServiceName(input)
-	require.Error(t, err)
+	_, errs := splitMetricsByResourceServiceName(input)
+	require.NotNil(t, errs)
 }
 
 func TestSplitMetrics(t *testing.T) {
@@ -403,6 +403,77 @@ func TestConsumeMetrics_SingleEndpoint(t *testing.T) {
 			))
 		})
 	}
+}
+
+func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	createSettings := ts
+	config := &Config{
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{Hostnames: []string{"endpoint-1"}},
+		},
+		RoutingKey: svcRoutingStr,
+	}
+
+	p, err := newMetricsExporter(createSettings, config)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// newMetricsExporter will internally create a loadBalancer instance which is
+	// hardcoded to use OTLP exporters
+	// We manually override that to use our testing sink
+	sink := consumertest.MetricsSink{}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newMockMetricsExporter(sink.ConsumeMetrics), nil
+	}
+
+	lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+	require.NoError(t, err)
+	require.NotNil(t, lb)
+
+	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(_ context.Context) ([]string, error) {
+			return []string{"endpoint-1"}, nil
+		},
+	}
+	p.loadBalancer = lb
+
+	// Start everything up
+	err = p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(context.Background()))
+	}()
+
+	// Test
+	dir := filepath.Join("testdata", "metrics", "consume_metrics", "single_endpoint", "resource_no_service_name")
+
+	input, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
+	require.NoError(t, err)
+
+	err = p.ConsumeMetrics(context.Background(), input)
+	require.NoError(t, err)
+
+	expectedOutput, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))
+	require.NoError(t, err)
+
+	allOutputs := sink.AllMetrics()
+	require.Len(t, allOutputs, 1)
+
+	actualOutput := allOutputs[0]
+	require.NoError(t, pmetrictest.CompareMetrics(
+		expectedOutput, actualOutput,
+		// We have to ignore ordering, because we do MergeMetrics() inside a map
+		// iteration. And golang map iteration order is random. This means the
+		// order of the merges is random
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
 }
 
 func TestConsumeMetrics_TripleEndpoint(t *testing.T) {

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_no_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_no_service_name/input.yaml
@@ -1,0 +1,78 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 22
+                  asDouble: 444
+                  attributes:
+                    - key: aaan
+                      value:
+                        stringValue: bbbc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_no_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_no_service_name/output.yaml
@@ -1,0 +1,34 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Drop metric resources, which do not have service.name defined to avoid blocking behavior when retry resilience option 1 is enabled

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41550 

