### PR TITLE
[chore] do not run scorecard security runs on forks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,9 +7,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '39 1 * * 3'
+    - cron: "39 1 * * 3"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -17,6 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Prevents the Scorecard supply-chain security workflow from running on repository forks. This change optimizes CI resources by ensuring security scans only run on the main repository.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
Fixes this Issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41809