### PR TITLE
[chore] Set awsconfig in the host info

### DIFF
--- a/.chloggen/addawsconfig.yaml
+++ b/.chloggen/addawsconfig.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: awscontainerinsightreceiver
+
+note: "Set Aws config in the info to pass the creds"
+
+issues: [41799]
+
+subtext:
+
+change_logs: [user]

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo.go
@@ -78,6 +78,7 @@ func NewInfo(containerOrchestrator string, refreshInterval time.Duration, logger
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aws session: %w", err)
 	}
+	mInfo.awsConfig = cfg
 
 	mInfo.ec2Metadata = mInfo.ec2MetadataCreator(ctx, cfg, refreshInterval, mInfo.instanceIDReadyC, mInfo.instanceIPReadyC, logger)
 

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -123,6 +123,7 @@ func TestInfo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
+	assert.NotNil(t, m.awsConfig)
 	// before ebsVolume and ec2Tags are initialized
 	assert.Empty(t, m.GetEBSVolumeID("dev"))
 	assert.Empty(t, m.GetClusterName())


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Setting  awsconfig, this was [missed when migration to aws-sdk-v2](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39097/files#diff-cfafbd1940f0eba61f3a422ba4ef452baa89fd73724fd3c5811685e7cac7d1d4L82)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
[Fixes
](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41799)
<!--Describe what testing was performed and which tests were added.-->
#### Testing

```

2025/08/07 00:27:46 ADOT Collector version: v0.43.3
2025/08/07 00:27:46 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
2025/08/07 00:27:46 attn: users of the `datadog`, `logzio`, `sapm`, `signalfx` exporter components. please refer to https://github.com/aws-observability/aws-otel-collector/issues/2734 in regards to an upcoming ADOT Collector breaking change
2025-08-07T00:27:46.744Z	info	service@v0.130.0/service.go:197	Setting up own telemetry...	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}}
2025-08-07T00:27:46.744Z	warn	awsemfexporter@v0.130.0/emf_exporter.go:89	the default value for DimensionRollupOption will be changing to NoDimensionRollupin a future release. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23997 for moreinformation	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awsemf", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics"}
2025-08-07T00:27:46.745Z	info	builders/builders.go:26	Development component. May change in the future.	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics"}
2025-08-07T00:27:46.768Z	info	service@v0.130.0/service.go:257	Starting aws-otel-collector...	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "Version": "v0.43.3", "NumCPU": 2}
2025-08-07T00:27:46.768Z	info	extensions/extensions.go:41	Starting extensions...	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}}
2025-08-07T00:27:46.768Z	info	extensions/extensions.go:45	Extension is starting...	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension"}
2025-08-07T00:27:46.768Z	info	healthcheckextension@v0.130.0/healthcheckextension.go:32	Starting health_check extension	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension", "config": {"Endpoint":"localhost:13133","TLS":{},"CORS":{},"Auth":{},"MaxRequestBodySize":0,"IncludeMetadata":false,"ResponseHeaders":null,"CompressionAlgorithms":null,"ReadTimeout":0,"ReadHeaderTimeout":0,"WriteTimeout":0,"IdleTimeout":0,"Middlewares":null,"Path":"/","ResponseBody":null,"CheckCollectorPipeline":{"Enabled":false,"Interval":"5m","ExporterFailureThreshold":5}}}
2025-08-07T00:27:46.769Z	info	extensions/extensions.go:62	Extension started.	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension"}
2025-08-07T00:27:46.833Z	info	host/ec2metadata.go:66	Fetch instance id and type from ec2 metadata	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
E0807 00:27:46.932971       1 info.go:119] Failed to get system UUID: open /etc/machine-id: no such file or directory
I0807 00:27:46.933323       1 factory.go:221] Registration of the containerd container factory failed: unable to create containerd client: containerd: cannot unix dial containerd api service: dial unix /run/containerd/containerd.sock: connect: permission denied
I0807 00:27:46.933478       1 factory.go:221] Registration of the crio container factory failed: Get "http://%2Fvar%2Frun%2Fcrio%2Fcrio.sock/info": dial unix /var/run/crio/crio.sock: connect: no such file or directory
I0807 00:27:46.933819       1 factory.go:221] Registration of the docker container factory failed: failed to validate Docker info: failed to detect Docker info: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.50/info": dial unix /var/run/docker.sock: connect: permission denied
I0807 00:27:46.933833       1 factory.go:223] Registration of the systemd container factory successfully
W0807 00:27:46.934642       1 manager.go:306] Could not configure a source for OOM detection, disabling OOM events: open /dev/kmsg: no such file or directory
2025-08-07T00:27:47.040Z	info	k8sapiserver/k8sapiserver.go:210	Cannot get the leader config map: configmaps "otel-container-insight-clusterleader" not found, try to create the config map...	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
2025-08-07T00:27:47.134Z	info	k8sapiserver/k8sapiserver.go:218	configMap: &ConfigMap{ObjectMeta:{otel-container-insight-clusterleader  aws-otel-eks  1c3b7762-da7d-4f34-9644-a501374a071a 2258334 0 2025-08-07 00:27:47 +0000 UTC <nil> <nil> map[] map[] [] [] []},Data:map[string]string{},BinaryData:map[string][]byte{},Immutable:nil,}, err: <nil>	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
2025-08-07T00:27:47.135Z	info	healthcheck/handler.go:132	Health Check state change	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "health_check", "otelcol.component.kind": "extension", "status": "ready"}
2025-08-07T00:27:47.135Z	info	service@v0.130.0/service.go:280	Everything is ready. Begin running and processing data.	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}}
I0807 00:27:47.135495       1 leaderelection.go:257] attempting to acquire leader lease aws-otel-eks/otel-container-insight-clusterleader...
2025-08-07T00:27:47.145Z	info	k8sapiserver/k8sapiserver.go:305	k8sapiserver Switch New Leader: ip-10-0-190-30.us-west-2.compute.internal	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
2025-08-07T00:27:48.647Z	info	host/ec2tags.go:80	Fetch ec2 tags to detect cluster name and auto scaling group name	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics", "instanceId": "i-0d88f853d1093e25c"}
2025-08-07T00:27:48.647Z	info	host/ebsvolume.go:86	Fetch ebs volumes from ec2 api	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
2025-08-07T00:27:48.741Z	info	host/ec2tags.go:132	Fetch ec2 tags successfully	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics"}
2025-08-07T00:27:48.741Z	info	host/ec2tags.go:135	Fetch ec2 tags to detect cluster name and auto scaling group name	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics", "instanceId": "eks-collectorciamd64128managedn-NwUieolDBS5S-36cc2947-7c5f-3c04-0e5a-09ae853bb421"}
2025-08-07T00:27:48.741Z	info	host/ec2tags.go:136	Fetch ec2 tags to detect cluster name and auto scaling group name	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics", "instanceId": "collector-ci-amd64-1-28"}
2025-08-07T00:28:47.144Z	warn	cadvisor/container_info_processor.go:81	No pod metric collected	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "awscontainerinsightreceiver", "otelcol.component.kind": "receiver", "otelcol.signal": "metrics", "metrics count": 9}
2025-08-07T00:29:46.965Z	info	Metrics	{"resource": {"service.instance.id": "ee01751d-3b40-4ce6-a6e1-420a799df133", "service.name": "aws-otel-collector", "service.version": "v0.43.3"}, "otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics", "resource metrics": 3, "metrics": 27, "data points": 27}
2025-08-07T00:29:46.966Z	info	ResourceMetrics #0
Resource SchemaURL: 
```
Tested in ADOT Distro 

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
