### PR TITLE
ci: jmx-scraper maven artifacts contain alpha keyword

### DIFF
--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -191,7 +191,6 @@ jobs:
             exit 1
           fi
 
-          version=${VERSION//-alpha/}
           hash=$(curl -L https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/$version/opentelemetry-jmx-scraper-$version.jar \
                          | sha256sum \
                          | cut -d ' ' -f 1)


### PR DESCRIPTION
Maven sample url: https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/1.48.0-alpha/

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41864

