### PR TITLE
metricstarttimeprocessor: add reset detection to starttimemetric strategy

### DIFF
--- a/.chloggen/starttimemetric-reset.yaml
+++ b/.chloggen/starttimemetric-reset.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add reset detection to the starttimemetric strategy in the metricstarttimeprocessor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41870]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricstarttimeprocessor/factory.go
+++ b/processor/metricstarttimeprocessor/factory.go
@@ -53,7 +53,7 @@ func createMetricsProcessor(
 				return nil, err
 			}
 		}
-		adjuster := starttimemetric.NewAdjuster(set.TelemetrySettings, startTimeMetricRegex)
+		adjuster := starttimemetric.NewAdjuster(set.TelemetrySettings, startTimeMetricRegex, rCfg.GCInterval)
 		adjustMetrics = adjuster.AdjustMetrics
 	}
 

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
@@ -13,6 +13,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/datapointstorage"
 )
 
 const (
@@ -36,13 +39,15 @@ func init() {
 }
 
 type Adjuster struct {
+	referenceValueCache  *datapointstorage.Cache
 	startTimeMetricRegex *regexp.Regexp
 	set                  component.TelemetrySettings
 }
 
 // NewAdjuster returns a new Adjuster which adjust metrics' start times based on the initial received points.
-func NewAdjuster(set component.TelemetrySettings, startTimeMetricRegex *regexp.Regexp) *Adjuster {
+func NewAdjuster(set component.TelemetrySettings, startTimeMetricRegex *regexp.Regexp, gcInterval time.Duration) *Adjuster {
 	return &Adjuster{
+		referenceValueCache:  datapointstorage.NewCache(gcInterval),
 		set:                  set,
 		startTimeMetricRegex: startTimeMetricRegex,
 	}
@@ -59,6 +64,12 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 	startTimeTs := timestampFromFloat64(startTime)
 	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
 		rm := metrics.ResourceMetrics().At(i)
+		attrHash := pdatautil.MapHash(rm.Resource().Attributes())
+		tsm, _ := a.referenceValueCache.Get(attrHash)
+
+		// The lock on the relevant timeseriesMap is held throughout the adjustment process to ensure that
+		// nothing else can modify the data used for adjustment.
+		tsm.Lock()
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			ilm := rm.ScopeMetrics().At(j)
 			for k := 0; k < ilm.Metrics().Len(); k++ {
@@ -71,28 +82,59 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 					dataPoints := metric.Sum().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
-						dp.SetStartTimestamp(startTimeTs)
+						refTsi, found := tsm.Get(metric, dp.Attributes())
+						if !found {
+							refTsi.Number = datapointstorage.NumberInfo{StartTime: startTimeTs}
+						} else if refTsi.IsResetSum(dp) {
+							refTsi.Number.StartTime = pcommon.NewTimestampFromTime(dp.Timestamp().AsTime().Add(-1 * time.Millisecond))
+						}
+						refTsi.Number.PreviousValue = dp.DoubleValue()
+						dp.SetStartTimestamp(refTsi.Number.StartTime)
 					}
 
 				case pmetric.MetricTypeSummary:
 					dataPoints := metric.Summary().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
-						dp.SetStartTimestamp(startTimeTs)
+						refTsi, found := tsm.Get(metric, dp.Attributes())
+						if !found {
+							refTsi.Summary = datapointstorage.SummaryInfo{StartTime: startTimeTs}
+						} else if refTsi.IsResetSummary(dp) {
+							refTsi.Summary.StartTime = pcommon.NewTimestampFromTime(dp.Timestamp().AsTime().Add(-1 * time.Millisecond))
+						}
+						refTsi.Summary.PreviousCount, refTsi.Summary.PreviousSum = dp.Count(), dp.Sum()
+						dp.SetStartTimestamp(refTsi.Summary.StartTime)
 					}
 
 				case pmetric.MetricTypeHistogram:
 					dataPoints := metric.Histogram().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
-						dp.SetStartTimestamp(startTimeTs)
+						refTsi, found := tsm.Get(metric, dp.Attributes())
+						if !found {
+							refTsi.Histogram = datapointstorage.HistogramInfo{StartTime: startTimeTs, ExplicitBounds: dp.ExplicitBounds().AsRaw()}
+						} else if refTsi.IsResetHistogram(dp) {
+							refTsi.Histogram.StartTime = pcommon.NewTimestampFromTime(dp.Timestamp().AsTime().Add(-1 * time.Millisecond))
+						}
+						refTsi.Histogram.PreviousCount, refTsi.Histogram.PreviousSum = dp.Count(), dp.Sum()
+						refTsi.Histogram.PreviousBucketCounts = dp.BucketCounts().AsRaw()
+						dp.SetStartTimestamp(refTsi.Histogram.StartTime)
 					}
 
 				case pmetric.MetricTypeExponentialHistogram:
 					dataPoints := metric.ExponentialHistogram().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
-						dp.SetStartTimestamp(startTimeTs)
+						refTsi, found := tsm.Get(metric, dp.Attributes())
+						if !found {
+							refTsi.ExponentialHistogram = datapointstorage.ExponentialHistogramInfo{StartTime: startTimeTs, Scale: dp.Scale()}
+						} else if refTsi.IsResetExponentialHistogram(dp) {
+							refTsi.ExponentialHistogram.StartTime = pcommon.NewTimestampFromTime(dp.Timestamp().AsTime().Add(-1 * time.Millisecond))
+						}
+						refTsi.ExponentialHistogram.PreviousPositive = dp.Positive()
+						refTsi.ExponentialHistogram.PreviousNegative = dp.Negative()
+						refTsi.ExponentialHistogram.PreviousCount, refTsi.ExponentialHistogram.PreviousSum, refTsi.ExponentialHistogram.PreviousZeroCount = dp.Count(), dp.Sum(), dp.ZeroCount()
+						dp.SetStartTimestamp(refTsi.ExponentialHistogram.StartTime)
 					}
 
 				default:
@@ -100,8 +142,8 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 				}
 			}
 		}
+		tsm.Unlock()
 	}
-	// TODO: handle resets by factoring reset handling out of other strategies
 	return metrics, nil
 }
 

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
@@ -17,6 +17,28 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor/internal/testhelper"
 )
 
+var (
+	t1 = testhelper.TimestampFromMs(1)
+	t2 = testhelper.TimestampFromMs(2)
+	t3 = testhelper.TimestampFromMs(3)
+	t4 = testhelper.TimestampFromMs(4)
+	t5 = testhelper.TimestampFromMs(5)
+
+	bounds0  = []float64{1, 2, 4}
+	percent0 = []float64{10, 50, 90}
+
+	sum1                  = "sum1"
+	gauge1                = "gauge1"
+	histogram1            = "histogram1"
+	summary1              = "summary1"
+	exponentialHistogram1 = "exponentialHistogram1"
+
+	k1v1k2v2 = []*testhelper.KV{
+		{Key: "k1", Value: "v1"},
+		{Key: "k2", Value: "v2"},
+	}
+)
+
 func TestStartTimeMetricMatch(t *testing.T) {
 	const startTime = pcommon.Timestamp(123 * 1e9)
 	const currentTime = pcommon.Timestamp(126 * 1e9)
@@ -121,7 +143,7 @@ func TestStartTimeMetricMatch(t *testing.T) {
 			// directly.
 			approximateCollectorStartTime = collectorStartTime.AsTime()
 
-			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex)
+			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex, time.Minute)
 
 			// We need to make sure the job and instance labels are set before the adjuster is used.
 			pmetrics := tt.inputs
@@ -215,7 +237,7 @@ func TestStartTimeMetricFallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex)
+			stma := NewAdjuster(componenttest.NewNopTelemetrySettings(), tt.startTimeMetricRegex, time.Minute)
 
 			// To test that the adjuster is using the fallback correctly, override the fallback time to use
 			// directly.
@@ -255,4 +277,105 @@ func TestStartTimeMetricFallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiMetrics(t *testing.T) {
+	const startTime = pcommon.Timestamp(123 * 1e9)
+	const currentTime = pcommon.Timestamp(126 * 1e9)
+	const matchBuilderStartTime = 124
+	matchedStartTimeStamp := timestampFromFloat64(matchBuilderStartTime)
+	script := []*testhelper.MetricsAdjusterTest{
+		{
+			Description: "MultiMetrics: round 1 - combined round 1 of individual metrics",
+			Metrics: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t1, t1, 44)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t1, t1, 44)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t1, t1, bounds0, []uint64{4, 2, 3, 7})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t1, t1, 3, 1, 0, []uint64{}, -2, []uint64{4, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t1, t1, 10, 40, percent0, []float64{1, 5, 8})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, matchedStartTimeStamp, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t1, t1, 44)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, matchedStartTimeStamp, t1, 44)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, matchedStartTimeStamp, t1, bounds0, []uint64{4, 2, 3, 7})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, matchedStartTimeStamp, t1, 3, 1, 0, []uint64{}, -2, []uint64{4, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, matchedStartTimeStamp, t1, 10, 40, percent0, []float64{1, 5, 8})),
+			),
+		},
+		{
+			Description: "MultiMetrics: round 2 - combined round 2 of individual metrics",
+			Metrics: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t2, t2, 66)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t2, t2, 66)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t2, t2, bounds0, []uint64{6, 3, 4, 8})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t2, t2, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t2, t2, 15, 70, percent0, []float64{7, 44, 9})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, matchedStartTimeStamp, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t2, t2, 66)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, matchedStartTimeStamp, t2, 66)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, matchedStartTimeStamp, t2, bounds0, []uint64{6, 3, 4, 8})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, matchedStartTimeStamp, t2, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, matchedStartTimeStamp, t2, 15, 70, percent0, []float64{7, 44, 9})),
+			),
+		},
+		{
+			Description: "MultiMetrics: round 3 - combined round 3 of individual metrics (reset)",
+			Metrics: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t3, t3, 55)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t3, t3, 55)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t3, t3, bounds0, []uint64{5, 3, 2, 7})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t3, t3, 3, 1, 0, []uint64{}, -2, []uint64{5, 1, 2, 6})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t3, t3, 12, 66, percent0, []float64{3, 22, 5})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, matchedStartTimeStamp, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t3, t3, 55)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t2, t3, 55)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t2, t3, bounds0, []uint64{5, 3, 2, 7})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t2, t3, 3, 1, 0, []uint64{}, -2, []uint64{5, 1, 2, 6})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t2, t3, 12, 66, percent0, []float64{3, 22, 5})),
+			),
+		},
+		{
+			Description: "MultiMetrics: round 4 - combined round 4 of individual metrics (after reset)",
+			Metrics: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t4, t4, 72)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t4, t4, bounds0, []uint64{7, 4, 2, 12})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t4, t4, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t4, t4, 14, 96, percent0, []float64{9, 47, 8})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, matchedStartTimeStamp, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t2, t4, 72)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t2, t4, bounds0, []uint64{7, 4, 2, 12})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t2, t4, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t2, t4, 14, 96, percent0, []float64{9, 47, 8})),
+			),
+		},
+		{
+			Description: "MultiMetrics: round 5 - combined round 5 of individual metrics (after reset again)",
+			Metrics: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t5, t5, 71)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t5, t5, bounds0, []uint64{7, 4, 20, 11})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t5, t5, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 6})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t5, t5, 14, 95, percent0, []float64{9, 47, 8})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.SumMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, matchedStartTimeStamp, currentTime, matchBuilderStartTime)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t4, t5, 71)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t4, t5, bounds0, []uint64{7, 4, 20, 11})),
+				testhelper.ExponentialHistogramMetric(exponentialHistogram1, testhelper.ExponentialHistogramPoint(k1v1k2v2, t4, t5, 3, 1, 0, []uint64{}, -2, []uint64{6, 2, 3, 6})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t4, t5, 14, 95, percent0, []float64{9, 47, 8})),
+			),
+		},
+	}
+	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), regexp.MustCompile("^.*_process_start_time_seconds$"), time.Minute), script)
 }


### PR DESCRIPTION
#### Description
Adds reset detection to the last strategy in the processor. Builds on top of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41825

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41870.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
