### PR TITLE
[enhancement] kafkareceiver - permanent error handling option (on_permanent_error)

### DIFF
--- a/.chloggen/feature_add-on-permanent-error-option.yaml
+++ b/.chloggen/feature_add-on-permanent-error-option.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `on_permanent_error` option to `message_marking` configuration.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41333]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -103,7 +103,9 @@ The following settings can be optionally configured:
   - `interval`: (default = 1s) How frequently to commit updated offsets. Ineffective unless auto-commit is enabled
 - `message_marking`:
   - `after`: (default = false) If true, the messages are marked after the pipeline execution
-  - `on_error`: (default = false) If false, only the successfully processed messages are marked
+  - `on_error`: (default = false) If false, only the successfully processed messages are marked. This applies to non-permanent errors.
+    **Note: this can block the entire partition in case a message processing returns a non-permanent error**
+  - `on_permanent_error`: (default = value of `on_error`) If false, messages that generate permanent errors are not marked. If true, messages that generate permanent errors are marked.
     **Note: this can block the entire partition in case a message processing returns a permanent error**
 - `header_extraction`:
   - `extract_headers` (default = false): Allows user to attach header fields to resource attributes in otel pipeline

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -194,6 +194,87 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "message_marking"),
+			expected: &Config{
+				ClientConfig:   configkafka.NewDefaultClientConfig(),
+				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
+				Logs: TopicEncodingConfig{
+					Topic:    "otlp_logs",
+					Encoding: "otlp_proto",
+				},
+				Metrics: TopicEncodingConfig{
+					Topic:    "otlp_metrics",
+					Encoding: "otlp_proto",
+				},
+				Traces: TopicEncodingConfig{
+					Topic:    "otlp_spans",
+					Encoding: "otlp_proto",
+				},
+				MessageMarking: MessageMarking{
+					After:            true,
+					OnError:          true,
+					OnPermanentError: true,
+				},
+				ErrorBackOff: configretry.BackOffConfig{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "message_marking_not_specified"),
+			expected: &Config{
+				ClientConfig:   configkafka.NewDefaultClientConfig(),
+				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
+				Logs: TopicEncodingConfig{
+					Topic:    "otlp_logs",
+					Encoding: "otlp_proto",
+				},
+				Metrics: TopicEncodingConfig{
+					Topic:    "otlp_metrics",
+					Encoding: "otlp_proto",
+				},
+				Traces: TopicEncodingConfig{
+					Topic:    "otlp_spans",
+					Encoding: "otlp_proto",
+				},
+				MessageMarking: MessageMarking{
+					After:            false,
+					OnError:          false,
+					OnPermanentError: false,
+				},
+				ErrorBackOff: configretry.BackOffConfig{
+					Enabled: false,
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "message_marking_on_permanent_error_inherited"),
+			expected: &Config{
+				ClientConfig:   configkafka.NewDefaultClientConfig(),
+				ConsumerConfig: configkafka.NewDefaultConsumerConfig(),
+				Logs: TopicEncodingConfig{
+					Topic:    "otlp_logs",
+					Encoding: "otlp_proto",
+				},
+				Metrics: TopicEncodingConfig{
+					Topic:    "otlp_metrics",
+					Encoding: "otlp_proto",
+				},
+				Traces: TopicEncodingConfig{
+					Topic:    "otlp_spans",
+					Encoding: "otlp_proto",
+				},
+				MessageMarking: MessageMarking{
+					After:            true,
+					OnError:          true,
+					OnPermanentError: true,
+				},
+				ErrorBackOff: configretry.BackOffConfig{
+					Enabled: false,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -214,7 +214,7 @@ func TestLoadConfig(t *testing.T) {
 				MessageMarking: MessageMarking{
 					After:            true,
 					OnError:          true,
-					OnPermanentError: true,
+					OnPermanentError: false,
 				},
 				ErrorBackOff: configretry.BackOffConfig{
 					Enabled: false,

--- a/receiver/kafkareceiver/consumer_sarama.go
+++ b/receiver/kafkareceiver/consumer_sarama.go
@@ -313,8 +313,13 @@ func (c *consumerGroupHandler) handleMessage(
 				zap.Duration("max_elapsed_time", c.backOff.MaxElapsedTime),
 			)
 		}
-		if c.messageMarking.After && !c.messageMarking.OnError {
-			// Only return an error if messages are marked after successful processing.
+
+		isPermanent := consumererror.IsPermanent(err)
+		shouldMark := (!isPermanent && c.messageMarking.OnError) || (isPermanent && c.messageMarking.OnPermanentError)
+
+		if c.messageMarking.After && !shouldMark {
+			// Only return an error if messages are marked after successful processing
+			// and the error type is not configured to be marked.
 			return err
 		}
 		// We're either marking messages as consumed ahead of time (disregarding outcome),

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -53,8 +53,9 @@ func createDefaultConfig() component.Config {
 			Encoding: defaultTracesEncoding,
 		},
 		MessageMarking: MessageMarking{
-			After:   false,
-			OnError: false,
+			After:            false,
+			OnError:          false,
+			OnPermanentError: false,
 		},
 		HeaderExtraction: HeaderExtraction{
 			ExtractHeaders: false,

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -300,7 +301,8 @@ func processMessage[T plog.Logs | pmetric.Metrics | ptrace.Traces](
 		handler.getUnmarshalFailureCounter(telBldr).Add(ctx, 1, metric.WithAttributeSet(attrs))
 		logger.Error("failed to unmarshal message", zap.Error(err))
 		handler.endObsReport(obsCtx, n, err)
-		return err
+		// Return permanent error for unmarshalling failures
+		return consumererror.NewPermanent(err)
 	}
 
 	// Add resource attributes from headers if configured

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -457,8 +457,9 @@ func TestReceiver_InternalTelemetry(t *testing.T) {
 
 func TestReceiver_MessageMarking(t *testing.T) {
 	for name, testcase := range map[string]struct {
-		markAfter  bool
-		markErrors bool
+		markAfter           bool
+		markErrors          bool
+		markPermanentErrors bool
 
 		errorShouldRestart bool
 	}{
@@ -469,9 +470,21 @@ func TestReceiver_MessageMarking(t *testing.T) {
 			markAfter:          true,
 			errorShouldRestart: true,
 		},
-		"mark_after_all": {
-			markAfter:  true,
-			markErrors: true,
+		"mark_after_errors": {
+			markAfter:           true,
+			markErrors:          true,
+			markPermanentErrors: true,
+		},
+		"mark_after_non_permanent_only": {
+			markAfter:           true,
+			markErrors:          true,
+			markPermanentErrors: false,
+			errorShouldRestart:  true,
+		},
+		"mark_after_permanent_only": {
+			markAfter:           true,
+			markErrors:          false,
+			markPermanentErrors: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -499,6 +512,7 @@ func TestReceiver_MessageMarking(t *testing.T) {
 				// Only mark messages after consuming, including for errors.
 				receiverConfig.MessageMarking.After = testcase.markAfter
 				receiverConfig.MessageMarking.OnError = testcase.markErrors
+				receiverConfig.MessageMarking.OnPermanentError = testcase.markPermanentErrors
 				set, tel, observedLogs := mustNewSettings(t)
 				f := NewFactory()
 				r, err := f.CreateTraces(t.Context(), set, receiverConfig, consumer)

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -479,7 +479,7 @@ func TestReceiver_MessageMarking(t *testing.T) {
 			markAfter:           true,
 			markErrors:          true,
 			markPermanentErrors: false,
-			errorShouldRestart:  true,
+			errorShouldRestart:  true, // error is permanent, so it isn't marked and will cause a restart
 		},
 		"mark_after_permanent_only": {
 			markAfter:           true,

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -74,7 +74,7 @@ kafka/message_marking:
   message_marking:
     after: true
     on_error: true
-    on_permanent_error: true
+    on_permanent_error: false
 kafka/message_marking_not_specified:
   metrics:
     topic: otlp_metrics

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -61,3 +61,40 @@ kafka/rebalance_strategy:
     encoding: otlp_proto
   group_rebalance_strategy: sticky
   group_instance_id: test-instance
+kafka/message_marking:
+  metrics:
+    topic: otlp_metrics
+    encoding: otlp_proto
+  traces:
+    topic: otlp_spans
+    encoding: otlp_proto
+  logs:
+    topic: otlp_logs
+    encoding: otlp_proto
+  message_marking:
+    after: true
+    on_error: true
+    on_permanent_error: true
+kafka/message_marking_not_specified:
+  metrics:
+    topic: otlp_metrics
+    encoding: otlp_proto
+  traces:
+    topic: otlp_spans
+    encoding: otlp_proto
+  logs:
+    topic: otlp_logs
+    encoding: otlp_proto
+kafka/message_marking_on_permanent_error_inherited:
+  metrics:
+    topic: otlp_metrics
+    encoding: otlp_proto
+  traces:
+    topic: otlp_spans
+    encoding: otlp_proto
+  logs:
+    topic: otlp_logs
+    encoding: otlp_proto
+  message_marking:
+    after: true
+    on_error: true


### PR DESCRIPTION
#### Description

- Changed unmarshalling error to be treated as a permanent error
- Added an option in `kafkareceiver` to control message marking behavior based on permanent error occurrence
- Backward compatibility: if `on_permanent_error` is not specified, it inherits the value of `on_error`

#### Link to tracking issue
- Resolves : https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41333

#### Testing

- Added unit tests
- Verified `on_permanent_error` behavior with both Sarama and Franz in e2e tests (producing messages to Kafka that trigger unmarshalling errors)

#### Documentation

- Updated kafkareceiver README
