### PR TITLE
[chore] Add smoke build for Windows arm64

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -25,8 +25,11 @@ permissions: read-all
 
 jobs:
   setup-environment:
-    runs-on: windows-2025
-    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ windows-latest, windows-11-arm ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
@@ -40,6 +43,32 @@ jobs:
       - name: Install Tools
         if: steps.go-setup.outputs.cache-hit != 'true'
         run: make install-tools
+
+  windows-smoke-build:
+    needs: [setup-environment]
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ windows-latest, windows-11-arm ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        id: go-setup
+        with:
+          go-version: oldstable
+          cache-dependency-path: "**/*.sum"
+      - name: Install dependencies
+        if: steps.go-setup.outputs.cache-hit != 'true'
+        run: make -j2 gomoddownload
+      - name: Install Tools
+        if: steps.go-setup.outputs.cache-hit != 'true'
+        run: make install-tools
+      - name: Generate otelcontribcol files
+        run: make genotelcontribcol
+      - name: Build Collector
+        run: make otelcontribcol
+
   windows-unittest-matrix:
     needs: [setup-environment]
     strategy:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -25,7 +25,6 @@ permissions: read-all
 
 jobs:
   setup-environment:
-    runs-on: windows-2025
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     strategy:
       fail-fast: true

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -25,6 +25,8 @@ permissions: read-all
 
 jobs:
   setup-environment:
+    runs-on: windows-2025
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Adds a smoke build for Windows arm64, the goal here is to detect any regressions to the work done in #40247. End to end tests already have similar steps but initially adding same build steps to `build-and-test-windows.yml` while I will evaluate the status of the group tests on Windows arm64. If the tests are not noisey we can add the `windows-11-arm` runner to the group tests and `scoped-tests`.

Fix #40247