### PR TITLE
[chore][exporter/azureblob] Remove pointers from fields

### DIFF
--- a/exporter/azureblobexporter/config.go
+++ b/exporter/azureblobexporter/config.go
@@ -72,20 +72,20 @@ type Config struct {
 	URL string `mapstructure:"url"`
 
 	// A container organizes a set of blobs, similar to a directory in a file system.
-	Container *TelemetryConfig `mapstructure:"container"`
-	Auth      *Authentication  `mapstructure:"auth"`
+	Container TelemetryConfig `mapstructure:"container"`
+	Auth      Authentication  `mapstructure:"auth"`
 
 	// BlobNameFormat is the format of the blob name. It controls the uploaded blob name, e.g. "2006/01/02/metrics_15_04_05.json"
-	BlobNameFormat *BlobNameFormat `mapstructure:"blob_name_format"`
+	BlobNameFormat BlobNameFormat `mapstructure:"blob_name_format"`
 
 	// FormatType is the format of encoded telemetry data. Supported values are json and proto.
 	FormatType string `mapstructure:"format"`
 
 	// AppendBlob configures append blob behavior
-	AppendBlob *AppendBlob `mapstructure:"append_blob"`
+	AppendBlob AppendBlob `mapstructure:"append_blob"`
 
 	// Encoding extension to apply for logs/metrics/traces. If present, overrides the marshaler configuration option and format.
-	Encodings *Encodings `mapstructure:"encodings"`
+	Encodings Encodings `mapstructure:"encodings"`
 
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 }

--- a/exporter/azureblobexporter/config_test.go
+++ b/exporter/azureblobexporter/config_test.go
@@ -32,18 +32,18 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "sp"),
 			expected: &Config{
 				URL: "https://fakeaccount.blob.core.windows.net/",
-				Auth: &Authentication{
+				Auth: Authentication{
 					Type:         "service_principal",
 					TenantID:     "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 					ClientID:     "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 					ClientSecret: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 				},
-				Container: &TelemetryConfig{
+				Container: TelemetryConfig{
 					Metrics: "test",
 					Logs:    "test",
 					Traces:  "test",
 				},
-				BlobNameFormat: &BlobNameFormat{
+				BlobNameFormat: BlobNameFormat{
 					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 					LogsFormat:     "2006/01/02/logs_15_04_05.json",
 					TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -51,9 +51,9 @@ func TestLoadConfig(t *testing.T) {
 					Params:         map[string]string{},
 				},
 				FormatType:    "json",
-				Encodings:     &Encodings{},
+				Encodings:     Encodings{},
 				BackOffConfig: configretry.NewDefaultBackOffConfig(),
-				AppendBlob: &AppendBlob{
+				AppendBlob: AppendBlob{
 					Enabled:   false,
 					Separator: "\n",
 				},
@@ -63,15 +63,15 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "smi"),
 			expected: &Config{
 				URL: "https://fakeaccount.blob.core.windows.net/",
-				Auth: &Authentication{
+				Auth: Authentication{
 					Type: "system_managed_identity",
 				},
-				Container: &TelemetryConfig{
+				Container: TelemetryConfig{
 					Metrics: "test",
 					Logs:    "test",
 					Traces:  "test",
 				},
-				BlobNameFormat: &BlobNameFormat{
+				BlobNameFormat: BlobNameFormat{
 					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 					LogsFormat:     "2006/01/02/logs_15_04_05.json",
 					TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -79,9 +79,9 @@ func TestLoadConfig(t *testing.T) {
 					Params:         map[string]string{},
 				},
 				FormatType:    "proto",
-				Encodings:     &Encodings{},
+				Encodings:     Encodings{},
 				BackOffConfig: configretry.NewDefaultBackOffConfig(),
-				AppendBlob: &AppendBlob{
+				AppendBlob: AppendBlob{
 					Enabled:   false,
 					Separator: "\n",
 				},
@@ -91,16 +91,16 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "umi"),
 			expected: &Config{
 				URL: "https://fakeaccount.blob.core.windows.net/",
-				Auth: &Authentication{
+				Auth: Authentication{
 					Type:     "user_managed_identity",
 					ClientID: "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 				},
-				Container: &TelemetryConfig{
+				Container: TelemetryConfig{
 					Metrics: "test",
 					Logs:    "test",
 					Traces:  "test",
 				},
-				BlobNameFormat: &BlobNameFormat{
+				BlobNameFormat: BlobNameFormat{
 					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 					LogsFormat:     "2006/01/02/logs_15_04_05.json",
 					TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -108,9 +108,9 @@ func TestLoadConfig(t *testing.T) {
 					Params:         map[string]string{},
 				},
 				FormatType:    "json",
-				Encodings:     &Encodings{},
+				Encodings:     Encodings{},
 				BackOffConfig: configretry.NewDefaultBackOffConfig(),
-				AppendBlob: &AppendBlob{
+				AppendBlob: AppendBlob{
 					Enabled:   false,
 					Separator: "\n",
 				},
@@ -120,18 +120,18 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "wif"),
 			expected: &Config{
 				URL: "https://fakeaccount.blob.core.windows.net/",
-				Auth: &Authentication{
+				Auth: Authentication{
 					Type:               "workload_identity",
 					ClientID:           "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 					TenantID:           "e4b5a5f0-3d6a-4b1c-9e2f-7c8a1b8f2c3d",
 					FederatedTokenFile: "/path/to/federated/token/file",
 				},
-				Container: &TelemetryConfig{
+				Container: TelemetryConfig{
 					Metrics: "test",
 					Logs:    "test",
 					Traces:  "test",
 				},
-				BlobNameFormat: &BlobNameFormat{
+				BlobNameFormat: BlobNameFormat{
 					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 					LogsFormat:     "2006/01/02/logs_15_04_05.json",
 					TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -139,9 +139,9 @@ func TestLoadConfig(t *testing.T) {
 					Params:         map[string]string{},
 				},
 				FormatType:    "json",
-				Encodings:     &Encodings{},
+				Encodings:     Encodings{},
 				BackOffConfig: configretry.NewDefaultBackOffConfig(),
-				AppendBlob: &AppendBlob{
+				AppendBlob: AppendBlob{
 					Enabled:   false,
 					Separator: "\n",
 				},
@@ -150,16 +150,16 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "conn-string"),
 			expected: &Config{
-				Auth: &Authentication{
+				Auth: Authentication{
 					Type:             "connection_string",
 					ConnectionString: "DefaultEndpointsProtocol=https;AccountName=fakeaccount;AccountKey=ZmFrZWtleQ==;EndpointSuffix=core.windows.net",
 				},
-				Container: &TelemetryConfig{
+				Container: TelemetryConfig{
 					Metrics: "test",
 					Logs:    "test",
 					Traces:  "test",
 				},
-				BlobNameFormat: &BlobNameFormat{
+				BlobNameFormat: BlobNameFormat{
 					MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 					LogsFormat:     "2006/01/02/logs_15_04_05.json",
 					TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -167,9 +167,9 @@ func TestLoadConfig(t *testing.T) {
 					Params:         map[string]string{},
 				},
 				FormatType:    "json",
-				Encodings:     &Encodings{},
+				Encodings:     Encodings{},
 				BackOffConfig: configretry.NewDefaultBackOffConfig(),
-				AppendBlob: &AppendBlob{
+				AppendBlob: AppendBlob{
 					Enabled:   false,
 					Separator: "\n",
 				},

--- a/exporter/azureblobexporter/exporter.go
+++ b/exporter/azureblobexporter/exporter.go
@@ -244,7 +244,7 @@ func (e *azureBlobExporter) consumeData(ctx context.Context, data []byte, signal
 		return fmt.Errorf("unsupported signal type: %v", signal)
 	}
 
-	if e.config.AppendBlob != nil && e.config.AppendBlob.Enabled {
+	if e.config.AppendBlob.Enabled {
 		// Add separator if configured
 		if e.config.AppendBlob.Separator != "" {
 			data = append(data, []byte(e.config.AppendBlob.Separator)...)

--- a/exporter/azureblobexporter/exporter_test.go
+++ b/exporter/azureblobexporter/exporter_test.go
@@ -30,16 +30,16 @@ import (
 func TestNewExporter(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	c := &Config{
-		Auth: &Authentication{
+		Auth: Authentication{
 			Type:             ConnectionString,
 			ConnectionString: "DefaultEndpointsProtocol=https;AccountName=fakeaccount;AccountKey=ZmFrZWtleQ==;EndpointSuffix=core.windows.net",
 		},
-		Container: &TelemetryConfig{
+		Container: TelemetryConfig{
 			Metrics: "metrics",
 			Logs:    "logs",
 			Traces:  "traces",
 		},
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:     "2006/01/02/logs_15_04_05.json",
 			TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -47,7 +47,7 @@ func TestNewExporter(t *testing.T) {
 			Params:         map[string]string{},
 		},
 		FormatType: "json",
-		Encodings:  &Encodings{},
+		Encodings:  Encodings{},
 	}
 
 	me := newAzureBlobExporter(c, logger, pipeline.SignalMetrics)
@@ -138,7 +138,7 @@ func TestGenerateBlobName(t *testing.T) {
 	t.Parallel()
 
 	c := &Config{
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:     "2006/01/02/logs_15_04_05.json",
 			TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -167,7 +167,7 @@ func TestGenerateBlobNameSerialNumBefore(t *testing.T) {
 	t.Parallel()
 
 	c := &Config{
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:            "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:               "2006/01/02/logs_15_04_05.json",
 			TracesFormat:             "2006/01/02/traces_15_04_05", // no extension
@@ -231,27 +231,27 @@ func (_m *mockAzBlobClient) AppendBlock(ctx context.Context, containerName, blob
 func TestExporterAppendBlob(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	c := &Config{
-		Auth: &Authentication{
+		Auth: Authentication{
 			Type:             ConnectionString,
 			ConnectionString: "DefaultEndpointsProtocol=https;AccountName=fakeaccount;AccountKey=ZmFrZWtleQ==;EndpointSuffix=core.windows.net",
 		},
-		Container: &TelemetryConfig{
+		Container: TelemetryConfig{
 			Metrics: "metrics",
 			Logs:    "logs",
 			Traces:  "traces",
 		},
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:     "2006/01/02/logs_15_04_05.json",
 			TracesFormat:   "2006/01/02/traces_15_04_05.json",
 			SerialNumRange: 10000,
 		},
 		FormatType: formatTypeJSON,
-		AppendBlob: &AppendBlob{
+		AppendBlob: AppendBlob{
 			Enabled:   true,
 			Separator: "\n",
 		},
-		Encodings: &Encodings{},
+		Encodings: Encodings{},
 	}
 
 	ae := newAzureBlobExporter(c, logger, pipeline.SignalLogs)
@@ -282,27 +282,27 @@ func TestExporterAppendBlob(t *testing.T) {
 func TestExporterAppendBlobError(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	c := &Config{
-		Auth: &Authentication{
+		Auth: Authentication{
 			Type:             ConnectionString,
 			ConnectionString: "DefaultEndpointsProtocol=https;AccountName=fakeaccount;AccountKey=ZmFrZWtleQ==;EndpointSuffix=core.windows.net",
 		},
-		Container: &TelemetryConfig{
+		Container: TelemetryConfig{
 			Metrics: "metrics",
 			Logs:    "logs",
 			Traces:  "traces",
 		},
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:     "2006/01/02/logs_15_04_05.json",
 			TracesFormat:   "2006/01/02/traces_15_04_05.json",
 			SerialNumRange: 10000,
 		},
 		FormatType: formatTypeJSON,
-		AppendBlob: &AppendBlob{
+		AppendBlob: AppendBlob{
 			Enabled:   true,
 			Separator: "\n",
 		},
-		Encodings: &Encodings{},
+		Encodings: Encodings{},
 	}
 
 	ae := newAzureBlobExporter(c, logger, pipeline.SignalLogs)

--- a/exporter/azureblobexporter/factory.go
+++ b/exporter/azureblobexporter/factory.go
@@ -34,15 +34,15 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Auth: &Authentication{
+		Auth: Authentication{
 			Type: ConnectionString,
 		},
-		Container: &TelemetryConfig{
+		Container: TelemetryConfig{
 			Metrics: "metrics",
 			Logs:    "logs",
 			Traces:  "traces",
 		},
-		BlobNameFormat: &BlobNameFormat{
+		BlobNameFormat: BlobNameFormat{
 			MetricsFormat:  "2006/01/02/metrics_15_04_05.json",
 			LogsFormat:     "2006/01/02/logs_15_04_05.json",
 			TracesFormat:   "2006/01/02/traces_15_04_05.json",
@@ -50,11 +50,11 @@ func createDefaultConfig() component.Config {
 			Params:         map[string]string{},
 		},
 		FormatType: formatTypeJSON,
-		AppendBlob: &AppendBlob{
+		AppendBlob: AppendBlob{
 			Enabled:   false,
 			Separator: "\n",
 		},
-		Encodings:     &Encodings{},
+		Encodings:     Encodings{},
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 	}
 }

--- a/exporter/azureblobexporter/marshaller_test.go
+++ b/exporter/azureblobexporter/marshaller_test.go
@@ -26,7 +26,7 @@ func TestNewMarshaller(t *testing.T) {
 			name: "valid json format",
 			config: &Config{
 				FormatType: formatTypeJSON,
-				Encodings:  &Encodings{},
+				Encodings:  Encodings{},
 			},
 			shouldError: false,
 		},
@@ -34,7 +34,7 @@ func TestNewMarshaller(t *testing.T) {
 			name: "valid proto format",
 			config: &Config{
 				FormatType: formatTypeProto,
-				Encodings:  &Encodings{},
+				Encodings:  Encodings{},
 			},
 			shouldError: false,
 		},
@@ -42,7 +42,7 @@ func TestNewMarshaller(t *testing.T) {
 			name: "invalid format",
 			config: &Config{
 				FormatType: "invalid",
-				Encodings:  &Encodings{},
+				Encodings:  Encodings{},
 			},
 			shouldError: true,
 		},
@@ -83,7 +83,7 @@ func TestMarshalTraces(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: &Encodings{}}, componenttest.NewNopHost())
+			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: Encodings{}}, componenttest.NewNopHost())
 			require.NoError(t, err)
 
 			data, err := m.marshalTraces(tt.traces)
@@ -114,7 +114,7 @@ func TestMarshalMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: &Encodings{}}, componenttest.NewNopHost())
+			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: Encodings{}}, componenttest.NewNopHost())
 			require.NoError(t, err)
 
 			data, err := m.marshalMetrics(tt.metrics)
@@ -145,7 +145,7 @@ func TestMarshalLogs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: &Encodings{}}, componenttest.NewNopHost())
+			m, err := newMarshaller(&Config{FormatType: tt.formatType, Encodings: Encodings{}}, componenttest.NewNopHost())
 			require.NoError(t, err)
 
 			data, err := m.marshalLogs(tt.logs)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Removes pointers from fields in configuration.

As can be seen in https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c5810f48a6a3890c2b8b2dc62d1c522bef8a0f29/exporter/azureblobexporter/factory.go#L35-L60
the fields cannot be disabled so we can just remove the pointers.

#### Link to tracking issue
Fixes #41917
