### PR TITLE
[chore] exclude GO-2025-3829 in go vuln check

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -227,7 +227,7 @@ lint: $(LINT) checklicense misspell
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK)
-	$(GOVULNCHECK) ./...
+	$(GOVULNCHECK) -exclude=GO-2025-3829 ./...
 
 .PHONY: tidy
 tidy:


### PR DESCRIPTION
Related to https://github.com/golang/vulndb/issues/3860, it's a false positive.