### PR TITLE
[connector/signaltometrics] Remove WithIgnoreUnused option

### DIFF
--- a/.chloggen/mx-psi_signaltometrics-ignoreunused.yaml
+++ b/.chloggen/mx-psi_signaltometrics-ignoreunused.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signaltometricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Strictly validate configuration for component.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41970]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/signaltometricsconnector/config/config.go
+++ b/connector/signaltometricsconnector/config/config.go
@@ -124,7 +124,7 @@ func (c *Config) Unmarshal(collectorCfg *confmap.Conf) error {
 	if collectorCfg == nil {
 		return nil
 	}
-	if err := collectorCfg.Unmarshal(c, confmap.WithIgnoreUnused()); err != nil {
+	if err := collectorCfg.Unmarshal(c); err != nil {
 		return err
 	}
 	for i, info := range c.Spans {

--- a/connector/signaltometricsconnector/testdata/logs/metric_identity/config.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/metric_identity/config.yaml
@@ -11,7 +11,7 @@ signaltometrics:
       exponential_histogram:
         count: "1"
         value: attributes["log.duration"]
-        buckets: [1, 10, 50, 100, 200]
+        max_size: 160
     - name: metric.log.duration
       description: Logrecords as sum with log.duration from attributes
       sum:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removes `WithIgnoreUnused` option, in preparation for #41925. I believe this option was not added intentionally (it was added on #36671 without much discussion, possibly taking a different legacy component as inspiration).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Updates #41922