### PR TITLE
[receiver/awscloudwatch] Remove unused pointer from type

### DIFF
--- a/.chloggen/mx-psi_receiver_awscloudreceiver-pointer.yaml
+++ b/.chloggen/mx-psi_receiver_awscloudreceiver-pointer.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove pointer from type of config"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41975]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	Region       string        `mapstructure:"region"`
 	Profile      string        `mapstructure:"profile"`
 	IMDSEndpoint string        `mapstructure:"imds_endpoint"`
-	Logs         *LogsConfig   `mapstructure:"logs"`
+	Logs         LogsConfig    `mapstructure:"logs"`
 	StorageID    *component.ID `mapstructure:"storage"`
 }
 
@@ -58,7 +58,6 @@ type StreamConfig struct {
 
 var (
 	errNoRegion                       = errors.New("no region was specified")
-	errNoLogsConfigured               = errors.New("no logs configured")
 	errInvalidEventLimit              = errors.New("event limit is improperly configured, value must be greater than 0")
 	errInvalidPollInterval            = errors.New("poll interval is incorrect, it must be a duration greater than one second")
 	errInvalidAutodiscoverLimit       = errors.New("the limit of autodiscovery of log groups is improperly configured, value must be greater than 0")
@@ -102,10 +101,6 @@ func (c *Config) Unmarshal(componentParser *confmap.Conf) error {
 }
 
 func (c *Config) validateLogsConfig() error {
-	if c.Logs == nil {
-		return errNoLogsConfigured
-	}
-
 	if c.Logs.StartFrom != "" {
 		_, err := time.Parse(time.RFC3339, c.Logs.StartFrom)
 		if err != nil {

--- a/receiver/awscloudwatchreceiver/config_test.go
+++ b/receiver/awscloudwatchreceiver/config_test.go
@@ -28,7 +28,7 @@ func TestValidate(t *testing.T) {
 			name: "Valid Config",
 			config: Config{
 				Region: "us-west-2",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        defaultPollInterval,
 					Groups: GroupConfig{
@@ -45,18 +45,10 @@ func TestValidate(t *testing.T) {
 			expectedErr: errNoRegion,
 		},
 		{
-			name: "Nil Logs",
-			config: Config{
-				Region: "us-west-2",
-				Logs:   nil,
-			},
-			expectedErr: errNoLogsConfigured,
-		},
-		{
 			name: "Invalid Event Limit",
 			config: Config{
 				Region: "us-west-2",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: -1,
 					PollInterval:        defaultPollInterval,
 				},
@@ -67,7 +59,7 @@ func TestValidate(t *testing.T) {
 			name: "Invalid Poll Interval",
 			config: Config{
 				Region: "us-west-2",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        100 * time.Millisecond,
 					Groups: GroupConfig{
@@ -81,7 +73,7 @@ func TestValidate(t *testing.T) {
 			name: "Invalid Log Group Limit",
 			config: Config{
 				Region: "us-east-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        defaultPollInterval,
 					Groups: GroupConfig{
@@ -97,7 +89,7 @@ func TestValidate(t *testing.T) {
 			name: "Invalid Log Group Prefix And Pattern",
 			config: Config{
 				Region: "us-east-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        defaultPollInterval,
 					Groups: GroupConfig{
@@ -116,7 +108,7 @@ func TestValidate(t *testing.T) {
 			config: Config{
 				Region:       "us-east-1",
 				IMDSEndpoint: "xyz",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        defaultPollInterval,
 					Groups: GroupConfig{
@@ -130,7 +122,7 @@ func TestValidate(t *testing.T) {
 			name: "Both Logs Autodiscover and Named Set",
 			config: Config{
 				Region: "us-east-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					MaxEventsPerRequest: defaultEventLimit,
 					PollInterval:        defaultPollInterval,
 					Groups: GroupConfig{
@@ -173,7 +165,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "default",
 			expectedConfig: &Config{
 				Region: "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -188,7 +180,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "prefix-log-group-autodiscover",
 			expectedConfig: &Config{
 				Region: "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -204,7 +196,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "name-pattern-log-group-autodiscover",
 			expectedConfig: &Config{
 				Region: "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -220,7 +212,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "autodiscover-filter-streams",
 			expectedConfig: &Config{
 				Region: "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -238,7 +230,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "autodiscover-filter-streams",
 			expectedConfig: &Config{
 				Region: "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -257,7 +249,7 @@ func TestLoadConfig(t *testing.T) {
 			expectedConfig: &Config{
 				Profile: "my-profile",
 				Region:  "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        5 * time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{
@@ -273,7 +265,7 @@ func TestLoadConfig(t *testing.T) {
 			expectedConfig: &Config{
 				Profile: "my-profile",
 				Region:  "us-west-1",
-				Logs: &LogsConfig{
+				Logs: LogsConfig{
 					PollInterval:        5 * time.Minute,
 					MaxEventsPerRequest: defaultEventLimit,
 					Groups: GroupConfig{

--- a/receiver/awscloudwatchreceiver/factory.go
+++ b/receiver/awscloudwatchreceiver/factory.go
@@ -35,7 +35,7 @@ func createLogsReceiver(
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Logs: &LogsConfig{
+		Logs: LogsConfig{
 			PollInterval:        defaultPollInterval,
 			MaxEventsPerRequest: defaultEventLimit,
 			Groups: GroupConfig{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removes pointer from `LogsConfig` type. This field can never be null (we validate that, and besides the default config has a non-null value) so I think we can just use the bare type.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41975
