### PR TITLE
[exporter/prometheusremotewrite] Use configoptional for WAL

### DIFF
--- a/.chloggen/mx-psi_prw-wal-configoptional.yaml
+++ b/.chloggen/mx-psi_prw-wal-configoptional.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use configoptional for WAL configuration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41980]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
@@ -43,11 +44,11 @@ type Config struct {
 	// ResourceToTelemetrySettings is the option for converting resource attributes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
 	// If enabled, all the resource attributes will be converted to metric labels by default.
-	ResourceToTelemetrySettings resourcetotelemetry.Settings `mapstructure:"resource_to_telemetry_conversion"`
-	WAL                         *WALConfig                   `mapstructure:"wal"`
+	ResourceToTelemetrySettings resourcetotelemetry.Settings       `mapstructure:"resource_to_telemetry_conversion"`
+	WAL                         configoptional.Optional[WALConfig] `mapstructure:"wal"`
 
 	// TargetInfo allows customizing the target_info metric
-	TargetInfo *TargetInfo `mapstructure:"target_info,omitempty"`
+	TargetInfo TargetInfo `mapstructure:"target_info,omitempty"`
 
 	// AddMetricSuffixes controls whether unit and type suffixes are added to metrics on export
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
@@ -107,11 +108,6 @@ func (cfg *Config) Validate() error {
 		return errors.New("remote write consumer number can't be negative")
 	}
 
-	if cfg.TargetInfo == nil {
-		cfg.TargetInfo = &TargetInfo{
-			Enabled: true,
-		}
-	}
 	if cfg.MaxBatchSizeBytes < 0 {
 		return errors.New("max_batch_byte_size must be greater than 0")
 	}

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -79,7 +79,7 @@ func TestLoadConfig(t *testing.T) {
 				ExternalLabels:              map[string]string{"key1": "value1", "key2": "value2"},
 				ClientConfig:                clientConfig,
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
-				TargetInfo: &TargetInfo{
+				TargetInfo: TargetInfo{
 					Enabled: true,
 				},
 				RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV1,

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -194,7 +194,7 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 
 	prwe.settings.Logger.Info("starting prometheus remote write exporter", zap.Any("ProtoMsg", cfg.RemoteWriteProtoMsg))
 
-	prwe.wal, err = newWAL(cfg.WAL, set, prwe.export)
+	prwe.wal, err = newWAL(cfg.WAL.Get(), set, prwe.export)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
@@ -108,7 +108,7 @@ func Test_PushMetricsConcurrent(t *testing.T) {
 		ClientConfig:      clientConfig,
 		MaxBatchSizeBytes: 3000000,
 		RemoteWriteQueue:  RemoteWriteQueue{NumConsumers: 1},
-		TargetInfo: &TargetInfo{
+		TargetInfo: TargetInfo{
 			Enabled: true,
 		},
 		BackOffConfig:       retrySettings,

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -123,7 +123,7 @@ func createDefaultConfig() component.Config {
 			QueueSize:    10000,
 			NumConsumers: numConsumers,
 		},
-		TargetInfo: &TargetInfo{
+		TargetInfo: TargetInfo{
 			Enabled: true,
 		},
 	}

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.132.0
 	go.opentelemetry.io/collector/config/confighttp v0.132.0
 	go.opentelemetry.io/collector/config/configopaque v1.38.0
+	go.opentelemetry.io/collector/config/configoptional v0.132.0
 	go.opentelemetry.io/collector/config/configretry v1.38.0
 	go.opentelemetry.io/collector/config/configtls v1.38.0
 	go.opentelemetry.io/collector/confmap v1.38.0
@@ -110,7 +111,6 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.132.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.38.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v0.132.0 // indirect
-	go.opentelemetry.io/collector/config/configoptional v0.132.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.38.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.132.0 // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.132.0 // indirect

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
@@ -176,10 +177,9 @@ func TestWAL_persist(t *testing.T) {
 
 func TestExportWithWALEnabled(t *testing.T) {
 	cfg := &Config{
-		WAL: &WALConfig{
+		WAL: configoptional.Some(WALConfig{
 			Directory: t.TempDir(),
-		},
-		TargetInfo:          &TargetInfo{}, // Declared just to avoid nil pointer dereference.
+		}),
 		RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV1,
 	}
 	buildInfo := component.BuildInfo{
@@ -241,10 +241,9 @@ func TestWALWrite_Telemetry(t *testing.T) {
 	set := metadatatest.NewSettings(tel)
 
 	cfg := &Config{
-		WAL: &WALConfig{
+		WAL: configoptional.Some(WALConfig{
 			Directory: t.TempDir(),
-		},
-		TargetInfo:          &TargetInfo{}, // Declared just to avoid nil pointer dereference.
+		}),
 		RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV2,
 	}
 
@@ -312,11 +311,10 @@ func TestWALRead_Telemetry(t *testing.T) {
 	// Create a temporary directory for the WAL
 	tempDir := t.TempDir()
 	cfg := &Config{
-		WAL: &WALConfig{
+		WAL: configoptional.Some(WALConfig{
 			BufferSize: 1,
 			Directory:  tempDir,
-		},
-		TargetInfo:          &TargetInfo{}, // Declared just to avoid nil pointer dereference.
+		}),
 		RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV2,
 	}
 
@@ -389,12 +387,11 @@ func TestWALLag_Telemetry(t *testing.T) {
 	set := metadatatest.NewSettings(tel)
 
 	cfg := &Config{
-		WAL: &WALConfig{
+		WAL: configoptional.Some(WALConfig{
 			Directory:          t.TempDir(),
 			BufferSize:         1,
 			LagRecordFrequency: 10 * time.Millisecond, // Very short interval for testing
-		},
-		TargetInfo:          &TargetInfo{},
+		}),
 		RemoteWriteProtoMsg: config.RemoteWriteProtoMsgV2,
 	}
 
@@ -431,7 +428,7 @@ func TestWALLag_Telemetry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for lag recording to happen (longer than lagRecordFrequency)
-	time.Sleep(5 * cfg.WAL.LagRecordFrequency)
+	time.Sleep(5 * cfg.WAL.Get().LagRecordFrequency)
 
 	_, err = tel.GetMetric("otelcol_exporter_prometheusremotewrite_wal_lag")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

- Use `configoptional` for WAL
- Remove pointer type from TargetInfo

#### Link to tracking issue
Fixes #41980
