### PR TITLE
[exporter/tinybird] limit request size to 10mb

### DIFF
--- a/.chloggen/exporter-tinybird-limit-requests-to-10mb.yaml
+++ b/.chloggen/exporter-tinybird-limit-requests-to-10mb.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tinybirdexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Limit request body to 10MB to avoid exceeding the EventsAPI size limit.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41782]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/tinybirdexporter/internal/encoder.go
+++ b/exporter/tinybirdexporter/internal/encoder.go
@@ -3,6 +3,53 @@
 
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter/internal"
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Encoder is an interface for encoding data
 type Encoder interface {
 	Encode(v any) error
+}
+
+// ChunkedEncoder is an encoder that splits the encoded data into chunks
+// when the total size exceeds a configured maximum.
+type ChunkedEncoder struct {
+	maxSize       int
+	currentBuffer *bytes.Buffer
+	buffers       []*bytes.Buffer
+}
+
+// NewChunkedEncoderWithMaxSize creates a new ChunkedEncoder with the specified maximum size.
+func NewChunkedEncoder(maxChunkSize int) *ChunkedEncoder {
+	return &ChunkedEncoder{
+		maxSize:       maxChunkSize,
+		currentBuffer: nil,
+		buffers:       make([]*bytes.Buffer, 0, 1),
+	}
+}
+
+// Encode encodes the value to the current buffer.
+// If encoding the value would exceed the maximum size,
+// a new buffer is created and the value is encoded to the new buffer.
+func (e *ChunkedEncoder) Encode(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if e.currentBuffer == nil || e.currentBuffer.Len()+len(data)+1 >= e.maxSize {
+		e.currentBuffer = bytes.NewBuffer(nil)
+		e.buffers = append(e.buffers, e.currentBuffer)
+	}
+
+	e.currentBuffer.Write(data)
+	e.currentBuffer.WriteByte('\n')
+
+	return nil
+}
+
+func (e *ChunkedEncoder) Buffers() []*bytes.Buffer {
+	return e.buffers
 }

--- a/exporter/tinybirdexporter/internal/encoder_test.go
+++ b/exporter/tinybirdexporter/internal/encoder_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChunkedEncoder_Encode(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxChunkSize int
+		items        []any
+		expected     []string // expected buffer contents
+	}{
+		{
+			name:         "single chunk",
+			maxChunkSize: 1024,
+			items:        []any{map[string]string{"a": "b"}, map[string]string{"c": "d"}},
+			expected:     []string{`{"a":"b"}` + "\n" + `{"c":"d"}` + "\n"},
+		},
+		{
+			name:         "multiple chunks",
+			maxChunkSize: 15, // small enough to force chunking
+			items:        []any{map[string]string{"a": "b"}, map[string]string{"c": "d"}},
+			expected:     []string{`{"a":"b"}` + "\n", `{"c":"d"}` + "\n"},
+		},
+		{
+			name:         "complex types",
+			maxChunkSize: 1024,
+			items:        []any{map[string]any{"str": "v", "num": 1, "arr": []int{1, 2}}},
+			expected:     []string{`{"arr":[1,2],"num":1,"str":"v"}` + "\n"},
+		},
+		{
+			name:         "empty map",
+			maxChunkSize: 1024,
+			items:        []any{map[string]any{}},
+			expected:     []string{"{}\n"},
+		},
+		{
+			name:         "invalid json",
+			maxChunkSize: 1024,
+			items:        []any{make(chan int)},
+			expected:     []string{}, // buffer remains empty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoder := NewChunkedEncoder(tt.maxChunkSize)
+			for _, item := range tt.items {
+				_ = encoder.Encode(item)
+			}
+			buffers := encoder.Buffers()
+			got := []string{}
+			for _, b := range buffers {
+				got = append(got, b.String())
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/exporter/tinybirdexporter/options.go
+++ b/exporter/tinybirdexporter/options.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tinybirdexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter"
+
+import "fmt"
+
+// option represents a configuration option that can be passed to the tinybird exporter.
+type option func(*tinybirdExporter) error
+
+// withMaxRequestBodySize sets the maximum size of the request body in bytes.
+func withMaxRequestBodySize(size int) option {
+	return func(e *tinybirdExporter) error {
+		if size <= 0 {
+			return fmt.Errorf("max request body size must be positive, got %d", size)
+		}
+		e.maxRequestBodySize = size
+		return nil
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When a request to the EventsAPI exceeds 10 MB, split it into N smaller requests, each no larger than 10 MB.

If any of these requests fail, data processing stops and an at-most-once delivery approach is followed:
- If at least one request succeeds: return a permanent error to prevent data duplication.
- If no request succeeds: return the error from the first request, following the original error retry policy.

This change ensures that large requests (≥ 10 MB) do not result in complete data loss. Some data may still be lost because processing halts after the first failure, but this can be improved later by returning the missing data via `consumererror.Trace` and derivatives, allowing the collector to retry (out of the scope for this PR).

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41782

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested were added to ensure that the at-most-once delivery approach is followed

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
