### PR TITLE
ci(load-tests): switch runner to Oracle bare metal

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: equinix-bare-metal
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     if: ${{ github.actor != 'dependabot[bot]' &&  github.repository_owner == 'open-telemetry' }}
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
@@ -52,7 +52,7 @@ jobs:
         run: ./.github/workflows/scripts/setup_e2e_tests.sh
 
   loadtest:
-    runs-on: equinix-bare-metal
+    runs-on: oracle-bare-metal-64cpu-512gb-x86-64
     needs: [setup-environment]
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
# Description

## What
- Updated `.github/workflows/load-tests.yml` to use the `oracle-bare-metal-64cpu-512gb-x86-64` runner instead of the Equinix bare metal/self-hosted pool.

## Why
The [load-tests workflow](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/workflows/load-tests.yml) has been failing(timing out) since workflow run [#496595](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/16583700031) for the past two weeks with the following error.

```
The job has exceeded the maximum execution time while awaiting a runner for 24h0m0s
```

**Reason**:
Equinix Metal is being sunset, and the current Equinix bare metal runners are no longer available. To restore functionality, we’re moving load-tests execution to the Oracle bare metal runner pool.

**References**:
- Community context: [open-telemetry/community#2801](https://github.com/open-telemetry/community/issues/2801)
- Equinix announcement: https://docs.equinix.com/metal/
- Similar PR in otel-go repo: https://github.com/open-telemetry/opentelemetry-go/pull/7183

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes: *No open issue yet* (Please let me know if one is required 🙇)

