### PR TITLE
[processor/transformprocessor] Add merge_histogram_buckets OTTL function to transform processor

### DIFF
--- a/.chloggen/40280.yaml
+++ b/.chloggen/40280.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: transformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for merging histogram buckets.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40280]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The transformprocessor now supports merging histogram buckets using the `merge_histogram_buckets` function.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -270,6 +270,7 @@ In addition to the common OTTL functions, the processor defines its own function
 - [aggregate_on_attributes](#aggregate_on_attributes)
 - [convert_exponential_histogram_to_histogram](#convert_exponential_histogram_to_histogram)
 - [aggregate_on_attribute_value](#aggregate_on_attribute_value)
+- [merge_histogram_buckets](#merge_histogram_buckets)
 
 ### convert_sum_to_gauge
 
@@ -617,6 +618,37 @@ statements:
 
 To aggregate only using a specified set of attributes, you can use `keep_matching_keys`.
 
+### merge_histogram_buckets
+
+`merge_histogram_buckets(bound)`
+
+The `merge_histogram_buckets` function merges a specific bucket of a histogram with the next bucket by removing the specified boundary. This effectively combines the counts of the bucket ending at the specified bound with the counts of the next bucket.
+
+`bound` is a float64 value that specifies which bucket boundary to remove. The function will merge the bucket that ends at this boundary with the next bucket.
+
+The function:
+- Preserves the total count and sum of the histogram.  
+- Only works on histogram metrics (no-op for other metric types).  
+- Uses floating-point tolerance (epsilon = 1e-12) when matching the bound.  
+- Makes no changes if:  
+  - The bound is not found.  
+  - The histogram is empty.  
+  - The histogram structure is invalid (mismatched bounds and counts).
+
+Examples:
+
+```yaml
+# Merge the bucket ending at 0.5 with the next bucket
+- merge_histogram_buckets(0.5) where metric.name == "http_request_duration"
+
+# Given a histogram with:
+# bounds: [0.1, 0.5, 1.0]
+# counts: [5, 8, 3, 1]
+#
+# After merging at 0.5:
+# bounds: [0.1, 1.0]
+# counts: [5, 11, 1]
+```
 
 ## Examples
 

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
+
+import (
+	"context"
+	"errors"
+	"math"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+)
+
+type mergeHistogramBucketsArguments struct {
+	Bound float64
+}
+
+func newMergeHistogramBucketsFactory() ottl.Factory[ottldatapoint.TransformContext] {
+	return ottl.NewFactory("merge_histogram_buckets", &mergeHistogramBucketsArguments{}, createMergeHistogramBucketsFunction)
+}
+
+func createMergeHistogramBucketsFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+	args, ok := oArgs.(*mergeHistogramBucketsArguments)
+	if !ok {
+		return nil, errors.New("mergeHistogramBucketsFactory args must be of type *mergeHistogramBucketsArguments")
+	}
+
+	return mergeHistogramBuckets(args.Bound)
+}
+
+func mergeHistogramBuckets(bound float64) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (any, error) {
+		dataPoint := tCtx.GetDataPoint()
+		if dataPoint == nil {
+			return nil, nil
+		}
+
+		histogramDataPoint, ok := dataPoint.(pmetric.HistogramDataPoint)
+		if !ok {
+			return nil, nil
+		}
+
+		mergeHistogramBucketsFromDataPoint(histogramDataPoint, bound)
+		return nil, nil
+	}, nil
+}
+
+func mergeHistogramBucketsFromDataPoint(dp pmetric.HistogramDataPoint, bound float64) {
+	explicitBounds := dp.ExplicitBounds()
+	bucketCounts := dp.BucketCounts()
+
+	if explicitBounds.Len()+1 != bucketCounts.Len() {
+		return
+	}
+
+	if bucketCounts.Len() == 1 {
+		return
+	}
+
+	bounds := explicitBounds.AsRaw()
+	targetIndex := findBoundIndex(&bounds, bound)
+	if targetIndex == -1 {
+		return
+	}
+
+	counts := bucketCounts.AsRaw()
+
+	nextBucketIndex := targetIndex + 1
+	counts[nextBucketIndex] += counts[targetIndex]
+
+	newBounds := make([]float64, 0, len(bounds)-1)
+	newBounds = append(newBounds, bounds[:targetIndex]...)
+	newBounds = append(newBounds, bounds[targetIndex+1:]...)
+
+	newCounts := make([]uint64, 0, len(counts)-1)
+	newCounts = append(newCounts, counts[:targetIndex]...)
+	newCounts = append(newCounts, counts[targetIndex+1:]...)
+
+	explicitBounds.FromRaw(newBounds)
+	bucketCounts.FromRaw(newCounts)
+}
+
+// findBoundIndex finds the index of a target bound in the bounds slice with epsilon tolerance
+func findBoundIndex(bounds *[]float64, target float64) int {
+	const epsilon = 1e-12
+
+	for i, bound := range *bounds {
+		if math.Abs(bound-target) < epsilon {
+			return i
+		}
+	}
+	return -1
+}

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -1,0 +1,230 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
+)
+
+func TestMergeHistogramBuckets(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputBounds    []float64
+		inputCounts    []uint64
+		inputCount     uint64
+		inputSum       float64
+		bound          float64
+		expectedBounds []float64
+		expectedCounts []uint64
+
+		expectNoChange bool
+		expectError    bool
+	}{
+		{
+			name:           "drop middle bucket by bound (0.5)",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			bound:          0.5,
+			expectedBounds: []float64{0.1, 1.0},
+			expectedCounts: []uint64{5, 11, 1},
+		},
+		{
+			name:           "drop first finite bound (0.1)",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			bound:          0.1,
+			expectedBounds: []float64{0.5, 1.0},
+			expectedCounts: []uint64{13, 3, 1},
+		},
+		{
+			name:           "drop last finite bound (1.0)",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			bound:          1.0,
+			expectedBounds: []float64{0.1, 0.5},
+			expectedCounts: []uint64{5, 8, 4},
+		},
+		{
+			name:           "single finite bound collapse",
+			inputBounds:    []float64{0.5},
+			inputCounts:    []uint64{10, 5},
+			inputCount:     15,
+			inputSum:       20.0,
+			bound:          0.5,
+			expectedBounds: nil,
+			expectedCounts: []uint64{15},
+		},
+		{
+			name:           "drop bound (3)",
+			inputBounds:    []float64{1, 2, 3, 4},
+			inputCounts:    []uint64{1, 2, 3, 4, 0},
+			inputCount:     10,
+			inputSum:       10,
+			bound:          3,
+			expectedBounds: []float64{1, 2, 4},
+			expectedCounts: []uint64{1, 2, 7, 0},
+		},
+		{
+			name:           "bound not found - no change",
+			inputBounds:    []float64{0.1, 0.5, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			bound:          2.0,
+			expectedBounds: []float64{0.1, 0.5, 1.0},
+			expectedCounts: []uint64{5, 8, 3, 1},
+
+			expectNoChange: true,
+		},
+		{
+			name:           "malformed histogram (mismatched lengths) - no change",
+			inputBounds:    []float64{0.1, 0.5},
+			inputCounts:    []uint64{5, 8, 3, 1, 2},
+			inputCount:     19,
+			inputSum:       25.5,
+			bound:          0.5,
+			expectedBounds: []float64{0.1, 0.5},
+			expectedCounts: []uint64{5, 8, 3, 1, 2},
+
+			expectNoChange: true,
+		},
+		{
+			name:           "empty histogram - no change",
+			inputBounds:    []float64{},
+			inputCounts:    []uint64{0},
+			inputCount:     0,
+			inputSum:       0.0,
+			bound:          0.5,
+			expectedBounds: nil,
+			expectedCounts: []uint64{0},
+
+			expectNoChange: true,
+		},
+		{
+			name:           "floating point tolerance test",
+			inputBounds:    []float64{0.1, 0.5000000000001, 1.0},
+			inputCounts:    []uint64{5, 8, 3, 1},
+			inputCount:     17,
+			inputSum:       25.5,
+			bound:          0.5,
+			expectedBounds: []float64{0.1, 1.0},
+			expectedCounts: []uint64{5, 11, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := mergeHistogramBuckets(tt.bound)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, exprFunc)
+
+			metric := pmetric.NewMetric()
+			metric.SetName("test_histogram")
+			hist := metric.SetEmptyHistogram()
+			dp := hist.DataPoints().AppendEmpty()
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+			dp.SetCount(tt.inputCount)
+			dp.SetSum(tt.inputSum)
+			dp.BucketCounts().FromRaw(tt.inputCounts)
+			dp.ExplicitBounds().FromRaw(tt.inputBounds)
+
+			ctx := ottldatapoint.NewTransformContext(
+				dp,
+				metric,
+				pmetric.NewMetricSlice(),
+				pcommon.NewInstrumentationScope(),
+				pcommon.NewResource(),
+				pmetric.NewScopeMetrics(),
+				pmetric.NewResourceMetrics(),
+			)
+
+			result, err := exprFunc(t.Context(), ctx)
+
+			assert.NoError(t, err)
+			assert.Nil(t, result)
+
+			actualBounds := dp.ExplicitBounds().AsRaw()
+			actualCounts := dp.BucketCounts().AsRaw()
+			if tt.expectedBounds == nil {
+				assert.Nil(t, actualBounds)
+			} else {
+				assert.Equal(t, tt.expectedBounds, actualBounds, "Bounds mismatch")
+			}
+
+			if tt.expectedCounts == nil {
+				assert.Nil(t, actualCounts)
+			} else {
+				assert.Equal(t, tt.expectedCounts, actualCounts, "Counts mismatch")
+			}
+
+			// The function does not recompute the count. We do it here just to test
+			// the count is really preserved.
+			var totalCount uint64
+			for _, count := range actualCounts {
+				totalCount += count
+			}
+
+			assert.Equal(t, tt.inputCount, totalCount, "Calculated count should be preserved")
+			assert.Equal(t, tt.inputCount, dp.Count(), "Count should be preserved")
+			assert.Equal(t, tt.inputSum, dp.Sum(), "Sum should be preserved")
+
+			if len(actualBounds) > 0 && !tt.expectNoChange {
+				assert.Len(t, actualCounts, len(actualBounds)+1, "Invalid histogram structure: bounds+1 != counts")
+			}
+		})
+	}
+}
+
+func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("gauge_metric")
+	gauge := metric.SetEmptyGauge()
+	dp := gauge.DataPoints().AppendEmpty()
+	dp.SetDoubleValue(10.0)
+
+	exprFunc, err := mergeHistogramBuckets(0.5)
+	assert.NoError(t, err)
+	assert.NotNil(t, exprFunc)
+
+	ctx := ottldatapoint.NewTransformContext(dp, metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	result, err := exprFunc(t.Context(), ctx)
+
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+
+	assert.Equal(t, 10.0, dp.DoubleValue())
+}
+
+func TestNewMergeHistogramBucketsFactory(t *testing.T) {
+	factory := newMergeHistogramBucketsFactory()
+	assert.NotNil(t, factory)
+}
+
+func TestMergeHistogramBucketsFactoryWithInvalidArgs(t *testing.T) {
+	factory := newMergeHistogramBucketsFactory()
+
+	_, err := factory.CreateFunction(ottl.FunctionContext{}, "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mergeHistogramBucketsFactory args must be of type *mergeHistogramBucketsArguments")
+}

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -22,9 +22,10 @@ var UseConvertBetweenSumAndGaugeMetricContext = featuregate.GlobalRegistry().Mus
 func DataPointFunctions() map[string]ottl.Factory[ottldatapoint.TransformContext] {
 	functions := ottlfuncs.StandardFuncs[ottldatapoint.TransformContext]()
 
-	datapointFunctions := ottl.CreateFactoryMap[ottldatapoint.TransformContext](
+	datapointFunctions := ottl.CreateFactoryMap(
 		newConvertSummarySumValToSumFactory(),
 		newConvertSummaryCountValToSumFactory(),
+		newMergeHistogramBucketsFactory(),
 	)
 
 	for k, v := range datapointFunctions {

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -36,6 +36,7 @@ func Test_DataPointFunctions(t *testing.T) {
 			expected := ottlfuncs.StandardFuncs[ottldatapoint.TransformContext]()
 			expected["convert_summary_sum_val_to_sum"] = newConvertSummarySumValToSumFactory()
 			expected["convert_summary_count_val_to_sum"] = newConvertSummaryCountValToSumFactory()
+			expected["merge_histogram_buckets"] = newMergeHistogramBucketsFactory()
 
 			actual := DataPointFunctions()
 


### PR DESCRIPTION
#### Description
Create a `merge_histogram_buckets` OTTL function that merges two buckets.

In #40280, I proposed creating a `drop_bucket` function. Dropping the bucket directly would lead to the loss of data (as it was raised in #40281).

This PR implements this new function avoiding losing data and providing a more meaningful name.

#### Link to tracking issue
Fixes #40280


#### Testing
- Added unit tests
- Manual test:
1. Start the OpenTelemetry Collector with this config:
```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317

processors:
  transform:
    error_mode: ignore
    metric_statements:
      - context: datapoint
        statements:
          - merge_histogram_buckets(3.0) where metric.name == "gen"

exporters:
  debug:
    verbosity: detailed
  prometheus:
    endpoint: "0.0.0.0:8889"   # curl this to inspect metrics

service:
  pipelines:
    metrics:
      receivers: [otlp]
      processors: [transform]
      exporters: [debug, prometheus]
```

Started this program:
```go
package main

import (
	"context"
	"log"
	"time"

	"go.opentelemetry.io/otel"
	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
	"go.opentelemetry.io/otel/metric"
	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
	"go.opentelemetry.io/otel/sdk/resource"
	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
	"google.golang.org/grpc"
	"google.golang.org/grpc/credentials/insecure"
)

func main() {
	ctx := context.Background()

	conn, err := grpc.NewClient("localhost:4317", grpc.WithTransportCredentials(insecure.NewCredentials()))
	if err != nil {
		log.Fatalf("Failed to create gRPC connection: %v", err)
	}
	defer conn.Close()

	exporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
	if err != nil {
		log.Fatalf("Failed to create OTLP exporter: %v", err)
	}

	res, err := resource.New(ctx, resource.WithAttributes(
		semconv.ServiceNameKey.String("histogram-test"),
		semconv.ServiceVersionKey.String("1.0.0"),
	))
	if err != nil {
		log.Fatalf("Failed to create resource: %v", err)
	}

	meterProvider := sdkmetric.NewMeterProvider(
		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(5*time.Second))),
		sdkmetric.WithResource(res),
	)
	defer func() {
		if err := meterProvider.Shutdown(ctx); err != nil {
			log.Printf("Error shutting down meter provider: %v", err)
		}
	}()

	otel.SetMeterProvider(meterProvider)

	meter := otel.Meter("test-meter")
	histogram, err := meter.Float64Histogram("gen",
		metric.WithDescription("Test histogram for merge_histogram_buckets function"),
		metric.WithExplicitBucketBoundaries(1, 2, 3, 4),
	)
	if err != nil {
		log.Fatalf("Failed to create histogram: %v", err)
	}

	// Record 1 value in (-inf,1] bucket
	histogram.Record(ctx, 0.5)

	// Record 2 values in (1,2] bucket
	histogram.Record(ctx, 1.5)
	histogram.Record(ctx, 1.8)

	// Record 3 values in (2,3] bucket
	histogram.Record(ctx, 2.1)
	histogram.Record(ctx, 2.5)
	histogram.Record(ctx, 2.9)

	// Record 4 values in (3,4] bucket
	histogram.Record(ctx, 3.1)
	histogram.Record(ctx, 3.3)
	histogram.Record(ctx, 3.7)
	histogram.Record(ctx, 3.9)

	select {}
}
```

Checked Prometheus endpoint:
```
gen_bucket{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version="",le="1"} 1
gen_bucket{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version="",le="2"} 3
gen_bucket{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version="",le="4"} 10
gen_bucket{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version="",le="+Inf"} 10
gen_sum{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version=""} 25.299999999999997
gen_count{job="histogram-test",otel_scope_name="test-meter",otel_scope_schema_url="",otel_scope_version=""} 10
```

And debug exporter output:
```
Count: 10
Sum: 25.300000
Min: 0.500000
Max: 3.900000
ExplicitBounds #0: 1.000000
ExplicitBounds #1: 2.000000
ExplicitBounds #2: 4.000000
Buckets #0, Count: 1
Buckets #1, Count: 2
Buckets #2, Count: 7
Buckets #3, Count: 0
````
