### PR TITLE
Adding receiver creator discoverability to prometheus receiver

### DIFF
--- a/.chloggen/vijaynandwani_discoverability-prometheusreceiver.yaml
+++ b/.chloggen/vijaynandwani_discoverability-prometheusreceiver.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver, receivercreator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add discoverability support for receiver creator integration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36595]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Implements the new Discoverable interface allowing prometheus receiver to be used
+  with receiver creator's discovery mechanism for automatic endpoint configuration.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -7,13 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/goccy/go-yaml"
 	commonconfig "github.com/prometheus/common/config"
+	model "github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
 	"github.com/prometheus/prometheus/discovery/kubernetes"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
@@ -43,6 +46,11 @@ type Config struct {
 	// server in agent mode. This allows the user to call the endpoint to get
 	// the config, service discovery, and targets for debugging purposes.
 	APIServer *APIServer `mapstructure:"api_server"`
+
+	// Endpoint field is included for unmarshaling compatibility with receiver_creator.
+	// Discoverable receivers do not use this field as they handle endpoint validation internally.
+	// This field is ignored during processing and should remain empty for discoverable receivers.
+	Endpoint string `mapstructure:"endpoint,omitempty"`
 }
 
 // Validate checks the receiver configuration is valid.
@@ -58,6 +66,136 @@ func (cfg *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateDiscovery validates the rawCfg provided via discovery annotations and
+// ensures it would only scrape the discovered endpoint.
+// This validation occurs AFTER template substitution, so all template expressions
+// like `endpoint` have already been expanded to concrete values.
+func (cfg *Config) ValidateDiscovery(rawCfg map[string]any, discoveredEndpoint string) error {
+	// Create a temporary config to unmarshal the configuration
+	tempCfg := &Config{}
+	if err := tempCfg.unmarshalFromMap(rawCfg); err != nil {
+		return fmt.Errorf("failed to unmarshal prometheus config: %w", err)
+	}
+
+	// Ensure the endpoint field is not set for discoverable receivers
+	if tempCfg.Endpoint != "" {
+		return errors.New("endpoint field should not be set for discoverable receivers - targets are validated directly in prometheus config")
+	}
+
+	// Validate that the prometheus config only targets the discovered endpoint
+	return validatePrometheusTargets(tempCfg.PrometheusConfig, discoveredEndpoint)
+}
+
+// unmarshalFromMap unmarshals a map into the Config struct
+func (cfg *Config) unmarshalFromMap(rawCfg map[string]any) error {
+	// Handle the endpoint field if present
+	if endpoint, exists := rawCfg["endpoint"]; exists {
+		if endpointStr, ok := endpoint.(string); ok {
+			cfg.Endpoint = endpointStr
+		}
+	}
+
+	// Handle the nested "config" field which contains the actual prometheus configuration
+	if configMap, exists := rawCfg["config"]; exists {
+		promCfgMap, ok := configMap.(map[string]any)
+		if !ok {
+			return fmt.Errorf("invalid config field format: expected map[string]any but got %T", configMap)
+		}
+		cfg.PrometheusConfig = &PromConfig{}
+		return reloadPromConfig(cfg.PrometheusConfig, promCfgMap)
+	}
+	return errors.New("missing prometheus config field")
+}
+
+// validatePrometheusTargets validates that all targets in the prometheus configuration
+// only target the discovered endpoint, preventing scraping from unintended sources.
+func validatePrometheusTargets(promCfg *PromConfig, discoveredEndpoint string) error {
+	if promCfg == nil {
+		return errors.New("prometheus configuration is nil")
+	}
+
+	// In discovery mode, disallow externalized configs to prevent bypassing validation
+	if len(promCfg.ScrapeConfigFiles) > 0 {
+		return errors.New("scrape_config_files are not allowed in discovery mode")
+	}
+
+	// Validate all scrape configs
+	for i, scrapeConfig := range promCfg.ScrapeConfigs {
+		if err := validateScrapeConfig(scrapeConfig, discoveredEndpoint, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateScrapeConfig validates a single scrape configuration
+func validateScrapeConfig(scrapeConfig *promconfig.ScrapeConfig, discoveredEndpoint string, index int) error {
+	if scrapeConfig == nil {
+		return fmt.Errorf("scrape config %d is nil", index)
+	}
+
+	// Allow only static discovery; reject all other discovery mechanisms in discovery mode
+	for sdIdx, sd := range scrapeConfig.ServiceDiscoveryConfigs {
+		switch cfg := sd.(type) {
+		case discovery.StaticConfig:
+			// Validate each target group and target address
+			for tgIdx, tg := range cfg {
+				for tIdx, lbls := range tg.Targets {
+					addr := string(lbls[model.AddressLabel])
+					if err := validatePrometheusTarget(addr, discoveredEndpoint); err != nil {
+						return fmt.Errorf("invalid target %d in target_group %d of sd[%d] in scrape_config %d: %w", tIdx, tgIdx, sdIdx, index, err)
+					}
+				}
+			}
+		default:
+			return fmt.Errorf("service discovery type %T is not allowed in discovery mode (scrape_config index %d)", sd, index)
+		}
+	}
+
+	return nil
+}
+
+// validatePrometheusTarget validates that a prometheus target matches the discovered endpoint.
+// At this point, all template expressions have been expanded to concrete values by expandConfig().
+func validatePrometheusTarget(target, discoveredEndpoint string) error {
+	if target == "" {
+		return errors.New("target cannot be empty")
+	}
+
+	// Extract host information from the target
+	targetHost := extractHostFromTarget(target)
+	if targetHost == "" {
+		return errors.New("could not extract host from target")
+	}
+
+	// The target host must exactly match the discovered endpoint
+	if targetHost != discoveredEndpoint {
+		return fmt.Errorf("target host %s does not match discovered endpoint %s", targetHost, discoveredEndpoint)
+	}
+
+	return nil
+}
+
+// extractHostFromTarget extracts the host portion from a prometheus target
+func extractHostFromTarget(target string) string {
+	// Handle various target formats:
+	// - "host:port" (most common)
+	// - "http://host:port/path" (URL format)
+	// - "https://host:port/path" (HTTPS URL format)
+
+	// First, try to parse as URL
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		if u, err := url.Parse(target); err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+
+	// If not a full URL, treat as host:port and return as-is since prometheus targets are typically host:port
+	// This handles both IPv4 (host:port) and IPv6 ([::1]:port) formats
+	return target
 }
 
 // PromConfig is a redeclaration of promconfig.Config because we need custom unmarshaling
@@ -80,6 +218,30 @@ func (cfg *PromConfig) Unmarshal(componentParser *confmap.Conf) error {
 	if len(cfgMap) == 0 {
 		return nil
 	}
+
+	// Handle discovery annotations: if scrape_configs is at root level,
+	// this is likely from a discovery annotation and should be passed directly
+	if _, hasPrometheusConfig := cfgMap["scrape_configs"]; hasPrometheusConfig {
+		return reloadPromConfig(cfg, cfgMap)
+	}
+
+	// Handle nested structure from discovery annotations
+	if _, hasGlobalConfig := cfgMap["global"]; hasGlobalConfig {
+		return reloadPromConfig(cfg, cfgMap)
+	}
+
+	// For other nested structures, try to extract prometheus config
+	// This handles cases where config might be nested under another key
+	for k, v := range cfgMap {
+		if k != "scrape_configs" && k != "global" {
+			if promCfgMap, ok := v.(map[string]any); ok {
+				if _, hasPrometheusFields := promCfgMap["scrape_configs"]; hasPrometheusFields {
+					return reloadPromConfig(cfg, promCfgMap)
+				}
+			}
+		}
+	}
+
 	return reloadPromConfig(cfg, cfgMap)
 }
 

--- a/receiver/prometheusreceiver/discoverable_test.go
+++ b/receiver/prometheusreceiver/discoverable_test.go
@@ -1,0 +1,428 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate_Discoverable(t *testing.T) {
+	tests := []struct {
+		name               string
+		rawCfg             map[string]any
+		discoveredEndpoint string
+		expectError        bool
+		errorContains      string
+	}{
+		{
+			name: "valid single target matching discovered endpoint",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "discovered-app",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name: "valid target - template expansion already occurred",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "templated-app",
+							"static_configs": []any{
+								map[string]any{
+									// Template already expanded to concrete value before validation
+									"targets": []any{"10.1.2.3:9090"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:9090",
+			expectError:        false,
+		},
+		{
+			name: "valid multiple scrape configs all targeting discovered endpoint",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "app-metrics",
+							"static_configs": []any{
+								map[string]any{
+									// Template already expanded before validation
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+						map[string]any{
+							"job_name": "app-health",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name: "invalid target not matching discovered endpoint",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "malicious-job",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"evil.com:9090"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name: "mixed valid and invalid targets",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "good-job",
+							"static_configs": []any{
+								map[string]any{
+									// Template already expanded before validation
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+						map[string]any{
+							"job_name": "bad-job",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"attacker.com:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name: "valid HTTP URL format target",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name":     "http-app",
+							"scheme":       "http",
+							"metrics_path": "/metrics",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name: "valid HTTPS URL format target",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name":     "https-app",
+							"scheme":       "https",
+							"metrics_path": "/health",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"10.1.2.3:8443"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8443",
+			expectError:        false,
+		},
+		{
+			name: "invalid HTTP URL with wrong host",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name":     "wrong-host",
+							"scheme":       "http",
+							"metrics_path": "/metrics",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"wrong.host:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name: "missing prometheus config",
+			rawCfg: map[string]any{
+				"other_field": "value",
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "missing prometheus config field",
+		},
+		{
+			name: "invalid config field format",
+			rawCfg: map[string]any{
+				"config": "invalid_string_instead_of_map",
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "invalid config field format",
+		},
+		{
+			name: "invalid - scrape_config_files are not allowed",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_config_files": []any{"external.yml"},
+					"scrape_configs":      []any{},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "scrape_config_files are not allowed",
+		},
+		{
+			name: "invalid - endpoint field is set for discoverable receiver",
+			rawCfg: map[string]any{
+				"endpoint": "10.1.2.3:8080", // This should not be present for discoverable receivers
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "valid-job",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"10.1.2.3:8080"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "endpoint field should not be set for discoverable receivers",
+		},
+		{
+			name: "invalid - empty target",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "empty-target-job",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{""},
+								},
+							},
+						},
+					},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "target cannot be empty",
+		},
+		{
+			name: "empty scrape configs (valid)",
+			rawCfg: map[string]any{
+				"config": map[string]any{
+					"scrape_configs": []any{},
+				},
+			},
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			err := cfg.ValidateDiscovery(tt.rawCfg, tt.discoveredEndpoint)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidatePrometheusTarget(t *testing.T) {
+	tests := []struct {
+		name               string
+		target             string
+		discoveredEndpoint string
+		expectError        bool
+		errorContains      string
+	}{
+		{
+			name:               "exact match",
+			target:             "10.1.2.3:8080",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name:               "post-expansion target matches endpoint",
+			target:             "10.1.2.3:8080",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name:               "template not expanded - should fail",
+			target:             "`endpoint`",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name:               "HTTP URL format matching",
+			target:             "http://10.1.2.3:8080/metrics",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        false,
+		},
+		{
+			name:               "HTTPS URL format matching",
+			target:             "https://10.1.2.3:8443/health",
+			discoveredEndpoint: "10.1.2.3:8443",
+			expectError:        false,
+		},
+		{
+			name:               "mismatch host",
+			target:             "evil.com:8080",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name:               "mismatch port",
+			target:             "10.1.2.3:9090",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+		{
+			name:               "HTTP URL with wrong host",
+			target:             "http://attacker.com:8080/metrics",
+			discoveredEndpoint: "10.1.2.3:8080",
+			expectError:        true,
+			errorContains:      "does not match discovered endpoint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePrometheusTarget(tt.target, tt.discoveredEndpoint)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExtractHostFromTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{
+			name:     "simple host:port",
+			target:   "10.1.2.3:8080",
+			expected: "10.1.2.3:8080",
+		},
+		{
+			name:     "HTTP URL",
+			target:   "http://example.com:8080/metrics",
+			expected: "example.com:8080",
+		},
+		{
+			name:     "HTTPS URL",
+			target:   "https://example.com:8443/health",
+			expected: "example.com:8443",
+		},
+		{
+			name:     "IPv6 with port",
+			target:   "[::1]:8080",
+			expected: "[::1]:8080",
+		},
+		{
+			name:     "hostname only",
+			target:   "hostname",
+			expected: "hostname",
+		},
+		{
+			name:     "localhost with port",
+			target:   "localhost:9090",
+			expected: "localhost:9090",
+		},
+		{
+			name:     "IP only",
+			target:   "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractHostFromTarget(tt.target)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/receiver/receivercreator/config_expansion.go
+++ b/receiver/receivercreator/config_expansion.go
@@ -134,9 +134,16 @@ func expandAny(input any, env observer.EndpointEnv) (any, error) {
 			expandedSlice = append(expandedSlice, expanded)
 		}
 		return expandedSlice, nil
-	case map[string]any:
+	case map[string]any, userConfigMap:
+		// Convert to map[string]any for consistent handling
+		var vMap map[string]any
+		if m, ok := v.(map[string]any); ok {
+			vMap = m
+		} else if m, ok := v.(userConfigMap); ok {
+			vMap = map[string]any(m)
+		}
 		expandedMap := map[string]any{}
-		for key, val := range v {
+		for key, val := range vMap {
 			expandedVal, err := expandAny(val, env)
 			if err != nil {
 				return nil, fmt.Errorf("failed evaluating config expression for {%q: %v}: %w", key, val, err)

--- a/receiver/receivercreator/discoverable.go
+++ b/receiver/receivercreator/discoverable.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivercreator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator"
+
+// Discoverable is an interface that receivers can implement to support discovery mode.
+// Receivers implementing this interface can provide custom validation logic for their
+// configurations when used with the receiver creator's discovery mechanism.
+//
+// The ValidateDiscovery method ensures that the receiver configuration only scrapes from the
+// discovered endpoint, preventing security issues where a configuration might attempt
+// to scrape from unintended sources.
+type Discoverable interface {
+	// ValidateDiscovery validates that the rawCfg unmarshals to a valid configuration that
+	// ensures the receiver will only collect data from the discoveredEndpoint.
+	//
+	// Parameters:
+	//   - rawCfg: The raw configuration map as provided in discovery annotations
+	//   - discoveredEndpoint: The endpoint discovered by the observer (e.g., "10.1.2.3:8080")
+	//
+	// Returns:
+	//   - error: nil if the configuration is valid and secure, or an error describing
+	//            why the configuration is invalid or potentially insecure
+	ValidateDiscovery(rawCfg map[string]any, discoveredEndpoint string) error
+}

--- a/receiver/receivercreator/discoverable_test.go
+++ b/receiver/receivercreator/discoverable_test.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivercreator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+// mockDiscoverableConfig implements both component.Config and Discoverable
+type mockDiscoverableConfig struct {
+	validateFunc func(rawCfg map[string]any, discoveredEndpoint string) error
+}
+
+func (m *mockDiscoverableConfig) ValidateDiscovery(rawCfg map[string]any, discoveredEndpoint string) error {
+	if m.validateFunc != nil {
+		return m.validateFunc(rawCfg, discoveredEndpoint)
+	}
+	return nil
+}
+
+// mockNonDiscoverableConfig is a regular config that doesn't implement Discoverable
+type mockNonDiscoverableConfig struct{}
+
+func TestMergeTemplatedAndDiscoveredConfigs_WithDiscoverableReceiver(t *testing.T) {
+	tests := []struct {
+		name             string
+		templated        userConfigMap
+		discovered       userConfigMap
+		validateFunc     func(rawCfg map[string]any, discoveredEndpoint string) error
+		expectedEndpoint string
+		expectError      bool
+	}{
+		{
+			name: "successful discoverable validation",
+			templated: userConfigMap{
+				"job_name": "test-job",
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "discovered-app",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"`endpoint`"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discovered: userConfigMap{
+				endpointConfigKey:       "10.1.2.3:8080",
+				tmpSetEndpointConfigKey: struct{}{},
+			},
+			validateFunc: func(_ map[string]any, _ string) error {
+				// Mock successful validation
+				return nil
+			},
+			expectedEndpoint: "10.1.2.3:8080",
+			expectError:      false,
+		},
+		{
+			name: "failed discoverable validation",
+			templated: userConfigMap{
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "malicious-job",
+							"static_configs": []any{
+								map[string]any{
+									"targets": []any{"evil.com:9090"},
+								},
+							},
+						},
+					},
+				},
+			},
+			discovered: userConfigMap{
+				endpointConfigKey:       "10.1.2.3:8080",
+				tmpSetEndpointConfigKey: struct{}{},
+			},
+			validateFunc: func(_ map[string]any, _ string) error {
+				return assert.AnError // Mock validation failure
+			},
+			expectedEndpoint: "10.1.2.3:8080",
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock factory that returns discoverable config
+			factory := receiver.NewFactory(
+				component.MustNewType("mock_discoverable"),
+				func() component.Config { return &mockDiscoverableConfig{validateFunc: tt.validateFunc} },
+			)
+
+			result, endpoint, err := mergeTemplatedAndDiscoveredConfigs(factory, tt.templated, tt.discovered)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "discoverable validation failed")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				// Verify endpoint was not injected for discoverable receivers
+				resultMap := result.ToStringMap()
+				_, hasEndpoint := resultMap[endpointConfigKey]
+				assert.False(t, hasEndpoint, "Discoverable receivers should not have endpoint field injected")
+			}
+
+			assert.Equal(t, tt.expectedEndpoint, endpoint)
+		})
+	}
+}
+
+func TestMergeTemplatedAndDiscoveredConfigs_WithNonDiscoverableReceiver(t *testing.T) {
+	// Create mock factory that returns non-discoverable config
+	factory := receiver.NewFactory(
+		component.MustNewType("mock_non_discoverable"),
+		func() component.Config { return &mockNonDiscoverableConfig{} },
+	)
+
+	templated := userConfigMap{
+		"collection_interval": "30s",
+	}
+	discovered := userConfigMap{
+		endpointConfigKey:       "10.1.2.3:8080",
+		tmpSetEndpointConfigKey: struct{}{},
+	}
+
+	result, endpoint, err := mergeTemplatedAndDiscoveredConfigs(factory, templated, discovered)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "10.1.2.3:8080", endpoint)
+
+	// Verify the old behavior still works for non-discoverable receivers
+	// (endpoint injection logic should still run)
+	resultMap := result.ToStringMap()
+	assert.Equal(t, "30s", resultMap["collection_interval"])
+}


### PR DESCRIPTION
This PR adds discoverability interface in receivercreator so that it supports complex configurations that do not have `endpoint` config. Currently it only supports simple config like nginx/redis that have `endpoint` key in the config. Other receivers like prometheus do not have the `endpoint` key in config. 

This PR also adds the support prometheusreceiver so that it can be discovered by receivercreator.

Related Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36595 