### PR TITLE
[receiver/awss3receiver] Fix issue with url-encoded S3 keys received from SQS

### DIFF
--- a/.chloggen/awss3receiver_42027_sqs_no_such_key.yaml
+++ b/.chloggen/awss3receiver_42027_sqs_no_such_key.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awss3receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed an issue where the AWS S3 receiver failed to retrieve data from S3 buckets when notified by SQS if the S3 key was URL-encoded."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42027]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awss3receiver/s3sqsreader_test.go
+++ b/receiver/awss3receiver/s3sqsreader_test.go
@@ -138,6 +138,18 @@ func TestS3SQSReader_ReadAll(t *testing.T) {
 					},
 				},
 			},
+			{
+				EventSource: "aws:s3",
+				EventName:   "ObjectCreated:Put",
+				S3: s3Data{
+					Bucket: s3BucketData{
+						Name: "test-bucket",
+					},
+					Object: s3ObjectData{
+						Key: "url-encoding%3dtest-key",
+					},
+				},
+			},
 		},
 	}
 
@@ -184,6 +196,14 @@ func TestS3SQSReader_ReadAll(t *testing.T) {
 		nil,
 	)
 
+	mockS3.On("GetObject", mock.Anything, &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("url-encoding=test-key"),
+	}).Return(
+		[]byte("url-encoded-content"),
+		nil,
+	)
+
 	mockSQS.On("DeleteMessage", mock.Anything, mock.MatchedBy(func(input *sqs.DeleteMessageInput) bool {
 		return *input.QueueUrl == cfg.SQS.QueueURL &&
 			*input.ReceiptHandle == "test-receipt-handle"
@@ -196,14 +216,14 @@ func TestS3SQSReader_ReadAll(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 
-	var callbackCalled bool
-	var receivedKey string
-	var receivedContent []byte
+	var callbackCallCount int
+	var receivedKeys []string
+	var receivedContents [][]byte
 
 	err = reader.readAll(ctx, "test-telemetry", func(_ context.Context, key string, content []byte) error {
-		callbackCalled = true
-		receivedKey = key
-		receivedContent = content
+		callbackCallCount++
+		receivedKeys = append(receivedKeys, key)
+		receivedContents = append(receivedContents, content)
 		return nil
 	})
 
@@ -212,9 +232,11 @@ func TestS3SQSReader_ReadAll(t *testing.T) {
 	assert.Equal(t, context.DeadlineExceeded, err)
 
 	// Verify callback was called with correct data
-	assert.True(t, callbackCalled)
-	assert.Equal(t, "test-key", receivedKey)
-	assert.Equal(t, []byte("test-content"), receivedContent)
+	assert.Equal(t, 2, callbackCallCount)
+	assert.Equal(t, "test-key", receivedKeys[0])
+	assert.Equal(t, []byte("test-content"), receivedContents[0])
+	assert.Equal(t, "url-encoding=test-key", receivedKeys[1])
+	assert.Equal(t, []byte("url-encoded-content"), receivedContents[1])
 
 	// Verify all expectations
 	mockS3.AssertExpectations(t)


### PR DESCRIPTION
#### Description
Fixes an issue where notifications from SQS for new S3 objects were not being processed correctly as the key included in the message was URI encoded. The new code decodes the key before using it to retrieve the data.


#### Link to tracking issue
Fixes #42027 

#### Testing
New unit test added for URI encoded keys.


