### PR TITLE
[chore] update filestats to use the latest weaver

### DIFF
--- a/receiver/filestatsreceiver/Makefile
+++ b/receiver/filestatsreceiver/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.Common
 
-WEAVER_CONTAINER=otel/weaver@sha256:0466739a9c9bba8273ef5767ed2b417b82ef652d4e5fd3498185c714fa809460
+WEAVER_CONTAINER=otel/weaver:v0.17.1
 
 # Next - we want to run docker as our local file user, so generated code is not
 # owned by root, and we don't give unecessary access.

--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -30,17 +30,19 @@ metrics:
     description: Elapsed time since the last modification of the file or folder, in seconds since Epoch.
     enabled: true
     sum:
-      monotonic: false
       aggregation_temporality: cumulative
+      monotonic: false
       value_type: int
+      
     unit: "s"
   file.ctime:
     description: Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.
     enabled: false
     sum:
-      monotonic: false
       aggregation_temporality: cumulative
+      monotonic: false
       value_type: int
+      
     unit: "s"
     attributes:
       - file.permissions
@@ -48,19 +50,22 @@ metrics:
     description: Elapsed time since last access of the file or folder, in seconds since Epoch.
     enabled: false
     sum:
-      monotonic: false
       aggregation_temporality: cumulative
+      monotonic: false
       value_type: int
+      
     unit: "s"
   file.size:
     description: The size of the file or folder, in bytes.
     enabled: true
     gauge:
       value_type: int
+      
     unit: "b"
   file.count:
     description: The number of files matched
     enabled: false
     gauge:
       value_type: int
+      
     unit: "{file}"

--- a/receiver/filestatsreceiver/model/metrics.yaml
+++ b/receiver/filestatsreceiver/model/metrics.yaml
@@ -6,10 +6,10 @@ groups:
     brief: "Elapsed time since the last modification of the file or folder, in seconds since Epoch."
     instrument: updowncounter
     unit: "s"
-    value_type: int
     annotations:
       scraper:
         enabled: true
+        value_type: int
   - id: file.ctime
     type: metric
     metric_name: file.ctime
@@ -17,13 +17,13 @@ groups:
     brief: Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.
     instrument: updowncounter
     unit: "s"
-    value_type: int
     attributes:
       - ref: file.permissions
         requirement_level: required
     annotations:
       scraper:
         enabled: false
+        value_type: int
   - id: file.atime
     type: metric
     metric_name: file.atime
@@ -31,10 +31,10 @@ groups:
     brief: Elapsed time since last access of the file or folder, in seconds since Epoch.
     instrument: updowncounter
     unit: "s"
-    value_type: int
     annotations:
       scraper:
         enabled: false
+        value_type: int
   - id: file.size
     type: metric
     metric_name: file.size
@@ -42,10 +42,10 @@ groups:
     brief: The size of the file or folder, in bytes.
     instrument: gauge
     unit: "b"
-    value_type: int
     annotations:
       scraper:
         enabled: true
+        value_type: int
   - id: file.count
     type: metric
     metric_name: file.count
@@ -53,7 +53,7 @@ groups:
     brief: The number of files matched
     instrument: gauge
     unit: "{file}"
-    value_type: int
     annotations:
       scraper:
         enabled: false
+        value_type: int

--- a/receiver/filestatsreceiver/templates/registry/metadata/metadata.yaml.j2
+++ b/receiver/filestatsreceiver/templates/registry/metadata/metadata.yaml.j2
@@ -25,12 +25,19 @@ metrics:
 {% for m in ctx.groups | selectattr("type", "equalto", "metric") %}  {{ m.id | safe }}:
     description: {{ m.brief | safe }}
     enabled: {{ m.annotations.scraper.enabled | safe }}
-    {% if m.instrument == "updowncounter" %}sum:
-      monotonic: false
+    {% if m.instrument == "counter" %}sum:
       aggregation_temporality: cumulative
-      value_type: int
+      monotonic: true
+      value_type: {{ m.annotations.scraper.value_type | safe }}
+      {% if m.annotations.scraper.input_type == "string"%}input_type: string{% endif %}
+    {% elif m.instrument == "updowncounter" %}sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: {{ m.annotations.scraper.value_type | safe }}
+      {% if m.annotations.scraper.input_type == "string"%}input_type: string{% endif %}
     {% else %}gauge:
-      value_type: int
+      value_type: {{ m.annotations.scraper.value_type | safe }}
+      {% if m.annotations.scraper.input_type == "string"%}input_type: string{% endif %}
     {% endif %}unit: {{ m.unit }}
 {% if m.attributes %}    attributes:{% for attr in m.attributes %}
       - {{ attr.name | safe }}{% endfor %}


### PR DESCRIPTION
Weaver changed how it handles `value_type` - it's now an annotation. See https://github.com/open-telemetry/weaver/pull/816 and https://github.com/open-telemetry/weaver/issues/817#issuecomment-3039466462