### PR TITLE
[chore] try to use context.Background in a test cleanup function

### DIFF
--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -132,7 +133,7 @@ func startHTTPServer(t *testing.T) (string, *consumertest.LogsSink) {
 	require.NoError(t, err)
 
 	require.NoError(t, lr.Start(t.Context(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, lr.Shutdown(t.Context())) })
+	t.Cleanup(func() { require.NoError(t, lr.Shutdown(context.Background())) })
 
 	return addr, sink
 }


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17011624305/job/48228492542?pr=42053

