### PR TITLE
[chore] docs: extension/observer/k8sobserver: Add k8s_observer to service.extensions in example config

### DIFF
--- a/extension/observer/k8sobserver/README.md
+++ b/extension/observer/k8sobserver/README.md
@@ -201,6 +201,7 @@ data:
         endpoint: <OTLP_ENDPOINT>
 
     service:
+      extensions: [k8s_observer]
       pipelines:
         metrics:
           receivers: [receiver_creator]


### PR DESCRIPTION
**Description**  
The example configuration in the `k8s_observer` [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/k8sobserver/README.md) omits `k8s_observer` from `service.extensions`, causing the Collector to fail on startup. This PR adds it, so the example is complete and works as intended.

**Link to tracking issue**  
None.

**Testing**  
Manually tested with the updated example in a Kubernetes cluster: Collector starts and the observer is functional.

**Documentation**  
Only the README example is updated; no further docs changes are needed.