### PR TITLE
[chore] Avoid ctx race on Cleanup/Shutdown

### DIFF
--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -681,6 +681,7 @@ this_one_there_where_{arch="x86",instance="test-instance",job="test-service",os=
 			// Scrape metrics, with the Accept header set to the value specified in the test case
 			req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/metrics", http.NoBody)
 			require.NoError(t, err)
+			req.Close = true
 			for k, v := range tt.extraHeaders {
 				req.Header.Set(k, v)
 			}


### PR DESCRIPTION
With the use `t.Context()` there is a race in which the HTTP server doesn't shutdown on first pass it hits `context canceled` error since `t.Cleanup` always cancels the context prior to the clean-up code.

Related [Slack conversation](https://cloud-native.slack.com/archives/C07CCCMRXBK/p1755542954200629)