### PR TITLE
[chore] run actionlint on main

### DIFF
--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -42,7 +42,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX metrics gatherer version $latest_version\"")
-          if [ ! -z "$matches" ]
+          if [ ! -n "$matches" ]
           then
             already_opened=true
           fi
@@ -158,7 +158,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX scraper version $latest_version\"")
-          if [ ! -z "$matches" ]
+          if [ ! -n "$matches" ]
           then
             already_opened=true
           fi

--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -42,7 +42,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX metrics gatherer version $latest_version\"")
-          if [ ! -n "$matches" ]
+          if [ ! -z "$matches" ]
           then
             already_opened=true
           fi
@@ -158,7 +158,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX scraper version $latest_version\"")
-          if [ ! -n "$matches" ]
+          if [ ! -z "$matches" ]
           then
             already_opened=true
           fi

--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -32,7 +32,7 @@ jobs:
                              | sed 's/^v//')
 
           # jmx metric gatherer is currently alpha
-          latest_version=$latest_version-alpha
+          latest_version="$latest_version"-alpha
 
           if grep -Pzo "version: \"$latest_version\",\s*jar:\s*\"JMX metrics gatherer\"" receiver/jmxreceiver/supported_jars.go; then
             already_added=true
@@ -47,9 +47,7 @@ jobs:
             already_opened=true
           fi
 
-          echo "latest-version=$latest_version" >> $GITHUB_OUTPUT
-          echo "already-added=$already_added" >> $GITHUB_OUTPUT
-          echo "already-opened=$already_opened" >> $GITHUB_OUTPUT
+          echo "latest-version=$latest_version"; echo "already-added=$already_added"; echo "already-opened=$already_opened" >> "$GITHUB_OUTPUT"
 
   update-jmx-metrics-component:
     permissions:
@@ -68,13 +66,13 @@ jobs:
         env:
           VERSION: ${{ needs.check-jmx-metrics-version.outputs.latest-version }}
         run: |
-          if [[ ! $VERSION =~ -alpha$ ]]; then
+          if [[ ! "$VERSION" =~ -alpha$ ]]; then
             echo currently expecting jmx metrics version to end with "-alpha"
             exit 1
           fi
 
-          version=${VERSION//-alpha/}
-          hash=$(curl -L https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v$version/opentelemetry-jmx-metrics.jar \
+          version="${VERSION//-alpha/}"
+          hash=$(curl -L "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v$version/opentelemetry-jmx-metrics.jar" \
                          | sha256sum \
                          | cut -d ' ' -f 1)
 
@@ -106,9 +104,9 @@ jobs:
           "
           branch="otelbot/add-jmx-metrics-gatherer-${VERSION}"
 
-          git checkout -b $branch
+          git checkout -b "$branch"
           git commit -a -m "$message"
-          git push --set-upstream origin $branch
+          git push --set-upstream origin "$branch"
           url=$(gh pr create --title "$message" \
                              --body "$body" \
                              --base main)
@@ -116,14 +114,14 @@ jobs:
           pull_request_number=${url//*\//}
 
           # see the template for change log entry file at blob/main/.chloggen/TEMPLATE.yaml
-          cat > .chloggen/add-jmx-metrics-gatherer-$VERSION.yaml << EOF
+          cat > ".chloggen/add-jmx-metrics-gatherer-$VERSION.yaml" << EOF
           change_type: enhancement
           component: jmxreceiver
-          note: Add the JMX metrics gatherer version $VERSION to the supported jars hash list
+          note: Add the JMX metrics gatherer version "$VERSION" to the supported jars hash list
           issues: [ $pull_request_number ]
           EOF
 
-          git add .chloggen/add-jmx-metrics-gatherer-$VERSION.yaml
+          git add ".chloggen/add-jmx-metrics-gatherer-$VERSION.yaml"
 
           git commit -m "Add change log entry"
           git push
@@ -150,7 +148,7 @@ jobs:
                              | sed 's/^v//')
 
           # jmx scraper is currently alpha
-          latest_version=$latest_version-alpha
+          latest_version="$latest_version"-alpha
 
           if grep -Pzo "version: \"$latest_version\",\s*jar:\s*\"JMX scraper\"" receiver/jmxreceiver/supported_jars.go; then
             already_added=true
@@ -165,9 +163,7 @@ jobs:
             already_opened=true
           fi
 
-          echo "latest-version=$latest_version" >> $GITHUB_OUTPUT
-          echo "already-added=$already_added" >> $GITHUB_OUTPUT
-          echo "already-opened=$already_opened" >> $GITHUB_OUTPUT
+          echo "latest-version=$latest_version"; echo "already-added=$already_added"; echo "already-opened=$already_opened" >> "$GITHUB_OUTPUT"
 
   update-jmx-scraper-component:
     permissions:
@@ -186,12 +182,12 @@ jobs:
         env:
           version: ${{ needs.check-jmx-scraper-version.outputs.latest-version }}
         run: |
-          if [[ ! $version =~ -alpha$ ]]; then
+          if [[ ! "$version" =~ -alpha$ ]]; then
             echo currently expecting jmx scraper version to end with "-alpha"
             exit 1
           fi
 
-          hash=$(curl -L https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/$version/opentelemetry-jmx-scraper-$version.jar \
+          hash=$(curl -L "https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/$version/opentelemetry-jmx-scraper-$version.jar" \
                          | sha256sum \
                          | cut -d ' ' -f 1)
 
@@ -224,24 +220,24 @@ jobs:
           "
           branch="otelbot/add-jmx-scraper-${VERSION}"
 
-          git checkout -b $branch
+          git checkout -b "$branch"
           git commit -a -m "$message"
-          git push --set-upstream origin $branch
+          git push --set-upstream origin "$branch"
           url=$(gh pr create --title "$message" \
                              --body "$body" \
                              --base main)
 
-          pull_request_number=${url//*\//}
+          pull_request_number="${url//*\//}"
 
           # see the template for change log entry file at blob/main/.chloggen/TEMPLATE.yaml
-          cat > .chloggen/add-jmx-scraper-$VERSION.yaml << EOF
+          cat > ".chloggen/add-jmx-scraper-$VERSION.yaml" << EOF
           change_type: enhancement
           component: jmxreceiver
-          note: Add the JMX scraper version $VERSION to the supported jars hash list
-          issues: [ $pull_request_number ]
+          note: Add the JMX scraper version "$VERSION" to the supported jars hash list
+          issues: [ "$pull_request_number" ]
           EOF
 
-          git add .chloggen/add-jmx-scraper-$VERSION.yaml
+          git add ".chloggen/add-jmx-scraper-$VERSION.yaml"
 
           git commit -m "Add change log entry"
           git push

--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -42,7 +42,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX metrics gatherer version $latest_version\"")
-          if [ ! -z "$matches" ]
+          if [ -n "$matches" ]
           then
             already_opened=true
           fi
@@ -158,7 +158,7 @@ jobs:
                         --author opentelemetrybot \
                         --state open \
                         --search "in:title \"Add JMX scraper version $latest_version\"")
-          if [ ! -z "$matches" ]
+          if [ -n "$matches" ]
           then
             already_opened=true
           fi

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -567,12 +567,12 @@ jobs:
         run: |
           make genotelcontribcol
           make docker-otelcontribcol
-          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:"$GITHUB_SHA"
           docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
       - name: Validate Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-          docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
+          docker run otel/opentelemetry-collector-contrib-dev:"$GITHUB_SHA" --version
           docker run otel/opentelemetry-collector-contrib-dev:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3
@@ -582,7 +582,7 @@ jobs:
       - name: Push Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-          docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker push otel/opentelemetry-collector-contrib-dev:"$GITHUB_SHA"
           docker push otel/opentelemetry-collector-contrib-dev:latest
   publish-stable:
     runs-on: ubuntu-24.04
@@ -626,7 +626,7 @@ jobs:
 
       - name: Create Github Release
         run: |
-          gh release create $RELEASE_TAG -t $RELEASE_TAG -F ${{ env.RELEASE_NOTES }}
+          gh release create "$RELEASE_TAG" -t "$RELEASE_TAG" -F ${{ env.RELEASE_NOTES }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Ensure no changes to the CHANGELOG.md or CHANGELOG-API.md
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
-          if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./CHANGELOG*.md) ]]
+          if [[ "$(git diff --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" ./CHANGELOG*.md)" ]]
           then
             echo "CHANGELOG.md and CHANGELOG-API.md should not be directly modified."
             echo "Please add a .yaml file to the ./.chloggen/ directory."
@@ -55,7 +55,7 @@ jobs:
       - name: Ensure ./.chloggen/*.yaml addition(s)
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
-          if [[ 1 -gt $(git diff --diff-filter=A --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen | grep -c \\.yaml) ]]
+          if [[ 1 -gt "$(git diff --diff-filter=A --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" ./.chloggen | grep -c \\.yaml)" ]]
           then
             echo "No changelog entry was added to the ./.chloggen/ directory."
             echo "Please add a .yaml file to the ./.chloggen/ directory."

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -27,13 +27,13 @@ jobs:
       - name: Get changed files
         id: changes
         run: |
-          files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)
+          files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" | grep .md$ | xargs)"
 
-          if [ -z "$files" ] && git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep -q "package.json"; then
+          if [ -z "$files" ] && git diff --name-only "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" | grep -q "package.json"; then
             files="**/*.md"
           fi
 
-          echo "files=$files" >> $GITHUB_OUTPUT
+          echo "files=$files" >> "$GITHUB_OUTPUT"
 
   check-links:
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -1,6 +1,9 @@
 name: Lint GitHub Workflow YAML Files
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - '.github/workflows/*.yml'
@@ -17,20 +20,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        id: go-setup
         with:
-          go-version: stable
-          cache: false
-
-      - name: Cache Go
-        id: go-cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            ~/go/bin
-            ~/go/pkg/mod
-          key: go-cache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+          go-version: oldstable
+          cache-dependency-path: "**/*.sum"
+      - name: Install dependencies
+        if: steps.go-setup.outputs.cache-hit != 'true'
+        run: make -j2 gomoddownload
+      - name: Install Tools
+        if: steps.go-setup.outputs.cache-hit != 'true'
+        run: make install-tools
 
       - name: Run Actionlint
         run: |

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/*.yml'
       - '.github/workflows/*.yaml'
+      - '.github/actionlint.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Set results filename
         if: ${{ failure() || success() }}
         id: filename
-        run: echo "name=$(echo '${{ matrix.test }}' | sed -e 's/|/_/g')" >> $GITHUB_OUTPUT
+        run: echo "name=$(echo '${{ matrix.test }}' | sed -e 's/|/_/g')" >> "$GITHUB_OUTPUT"
       - name: Create Test Result Archive
         if: ${{ failure() || success() }}
         continue-on-error: true

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -26,30 +26,30 @@ jobs:
         shell: bash
         id: changes
         run: |
-          changed_files=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD)
+          changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files
-          echo $changed_files
+          echo "$changed_files"
 
           go_sources=$(echo "$changed_files" | tr ' ' '\n' | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
           echo go_sources
-          echo $go_sources
+          echo "$go_sources"
           if [[ -n "$go_sources" ]]; then
             {
               echo 'go_sources<<EOF'
-              echo $go_sources
+              echo "$go_sources"
               echo EOF
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           fi
 
           go_tests=$(echo "$changed_files" | tr ' ' '\n' | grep -E '.*_test\.go$' || true)
           echo go_tests
-          echo $go_tests
+          echo "$go_tests"
           if [[ -n "$go_tests" ]]; then
             {
               echo 'go_tests<<EOF'
-              echo $go_tests
+              echo "$go_tests"
               echo EOF
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           fi
 
   scoped-tests:

--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -31,15 +31,15 @@ jobs:
       - name: Prepare to update dependencies
         run: |
           exec > >(tee log.out) 2>&1
-          LAST_COMMIT=$(git -C ./opentelemetry-collector/ rev-parse HEAD)
+          LAST_COMMIT="$(git -C ./opentelemetry-collector/ rev-parse HEAD)"
           cd opentelemetry-collector-contrib
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
           branch="otelbot/update-otel-$(date +%s)"
-          git checkout -b $branch
+          git checkout -b "$branch"
           make genotelcontribcol
-          echo "LAST_COMMIT=$LAST_COMMIT" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
+          echo "LAST_COMMIT=$LAST_COMMIT" >> "$GITHUB_ENV"
+          echo "BRANCH_NAME=$branch" >> "$GITHUB_ENV"
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       - name: Gets packages from links with retries
@@ -62,8 +62,8 @@ jobs:
       - name: File an issue if the workflow failed
         if: failure()
         run: |
-          template=$(cat <<'END'
-          [Link to job log](%s)
+          job_url="$(gh run view ${{ github.run_id }} -R ${{ github.repository }} --json jobs -q '.jobs[] | select(.name == "update-otel") | .url')"
+          body="$(printf '[Link to job log](%s)
           
           <details>
           <summary>Last 100 lines of log</summary>
@@ -71,11 +71,7 @@ jobs:
           ```
           %s
           ```
-          </details>
-          END
-          )
-          job_url="$(gh run view ${{ github.run_id }} -R ${{ github.repository }} --json jobs -q '.jobs[] | select(.name == "update-otel") | .url')"
-          body="$(printf "$template" "$job_url" "$(tail -n100 log.out | tail -c63K)")"
+          </details>' "$job_url" "$(tail -n100 log.out | tail -c63K)")"
           gh issue create -R ${{ github.repository }} -t 'update-otel workflow failed' -b "$body" -l 'ci-cd'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -657,7 +657,7 @@ crosslink: $(CROSSLINK)
 
 .PHONY: actionlint
 actionlint: $(ACTIONLINT)
-	$(ACTIONLINT) -config-file .github/actionlint.yaml -color .github/workflows/*.yml .github/workflows/*.yaml
+	$(ACTIONLINT) -config-file .github/actionlint.yaml -color $(filter-out $(wildcard .github/workflows/*windows.y*), $(wildcard .github/workflows/*.y*))
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
* Run actionlint when pushing to main.
* Standardize go-setup to match other contrib builds so we can reuse caches.
* Fix all issues found by actionlint and shellcheck to make CI pass.