### PR TITLE
[receiver/vcenter]: Fix potential NPE on VM metrics collection

### DIFF
--- a/.chloggen/fix_panic-in-vcenter-vm-collection.yaml
+++ b/.chloggen/fix_panic-in-vcenter-vm-collection.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a potential issue with vm collection without a types.VirtualMachineConfigInfo attached to the VM.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42098]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/vcenterreceiver/resources.go
+++ b/receiver/vcenterreceiver/resources.go
@@ -115,7 +115,7 @@ func (v *vcenterMetricScraper) createVMResourceBuilder(
 	}
 	rb.SetVcenterHostName(hs.Name)
 
-	if vm.Config.Template {
+	if vm.Config != nil && vm.Config.Template {
 		rb.SetVcenterVMTemplateName(vm.Name)
 		rb.SetVcenterVMTemplateID(vm.Config.InstanceUuid)
 
@@ -123,7 +123,9 @@ func (v *vcenterMetricScraper) createVMResourceBuilder(
 	}
 
 	rb.SetVcenterVMName(vm.Name)
-	rb.SetVcenterVMID(vm.Config.InstanceUuid)
+	if vm.Config != nil {
+		rb.SetVcenterVMID(vm.Config.InstanceUuid)
+	}
 
 	if rp == nil {
 		return nil, fmt.Errorf("no Resource Pool found for VM: %s", vm.Name)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR just practices being defensive around accessing of the `types.VirtualMachineConfigInfo`. As I've never seen this field been nil I am still not quite certain which prerequisites cause this for a specific VM but figured the nil checks are safe enough to guard us from any nil-pointer access. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42098

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

Changelog entry
