### PR TITLE
[chore] only have one permissions block

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -5,11 +5,10 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   welcome_first_contributor:
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'open-telemetry' && (github.event.pull_request.author_association == 'NONE' || github.event.label.name == 'first-contrib-test')
     steps:


### PR DESCRIPTION
actionlint complains the two permissions block are conflicting. See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17073937293/job/48410137084?pr=42082
