### PR TITLE
[chore] set PR_HEAD variable

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Get changes
         shell: bash
         id: changes
+        env:
+          PR_HEAD: ${{ github.head_ref }}
         run: |
           changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
         id: changes
         env:
-          PR_HEAD: ${{ github.head_ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files


### PR DESCRIPTION
This variable was never set ; now that is it double-quoted, it is passing an empty string to the git command, failing the workflow.
