### PR TITLE
[chore] Fix 3 flaky tests on datadogreceiver

### DIFF
--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -179,9 +179,6 @@ func TestDatadogResponse(t *testing.T) {
 
 			require.NoError(t, dd.Start(ctx, componenttest.NewNopHost()))
 			defer func() {
-				// Not using t.Cleanup because this is a graceful shutdown of an HTTP server
-				// and the context shouldn't be already cancelled during a graceful shutdown
-				// if the server still can have any live connections. See issue #42005.
 				require.NoError(t, dd.Shutdown(ctx), "Must not error shutting down")
 			}()
 
@@ -312,9 +309,6 @@ func TestDatadogInfoEndpoint(t *testing.T) {
 
 			require.NoError(t, dd.Start(ctx, componenttest.NewNopHost()))
 			defer func() {
-				// Not using t.Cleanup because this is a graceful shutdown of an HTTP server
-				// and the context shouldn't be already cancelled during a graceful shutdown
-				// if the server still can have any live connections. See issue #42005.
 				require.NoError(t, dd.Shutdown(ctx), "Must not error shutting down")
 			}()
 


### PR DESCRIPTION
With the use `t.Context()` there is a race in which the HTTP server doesn't shutdown on first pass it hits context canceled error since `t.Cleanup` always cancels the context prior to the clean-up code. Moving the shutdown to a `defer` ensures that the shutdown happens before `t.Context()` is cancelled.

Fix #42005
