### PR TITLE
[receiver/opencensus] perform graceful shutdown

### DIFF
--- a/.chloggen/graceful_shutdown.yaml
+++ b/.chloggen/graceful_shutdown.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opencensusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Perform graceful shutdown of HTTP server on shutdown
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42117]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -188,7 +188,7 @@ func (ocr *ocReceiver) Start(ctx context.Context, host component.Host) error {
 }
 
 // Shutdown is a method to turn off receiving.
-func (ocr *ocReceiver) Shutdown(context.Context) error {
+func (ocr *ocReceiver) Shutdown(ctx context.Context) error {
 	if ocr.cancel != nil {
 		ocr.cancel()
 	}
@@ -199,7 +199,7 @@ func (ocr *ocReceiver) Shutdown(context.Context) error {
 	}
 
 	if ocr.serverHTTP != nil {
-		_ = ocr.serverHTTP.Close()
+		_ = ocr.serverHTTP.Shutdown(ctx)
 	}
 
 	if ocr.ln != nil {


### PR DESCRIPTION
This helps the HTTP server shutdown all connections properly and avoid flaky tests.
