### PR TITLE
[chore] skip TestSupervisorBootstrapsCollector

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -887,6 +887,7 @@ func TestSupervisorConfiguresCapabilities(t *testing.T) {
 }
 
 func TestSupervisorBootstrapsCollector(t *testing.T) {
+	t.Skip("broken test: http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42108")
 	tests := []struct {
 		name     string
 		cfg      string


### PR DESCRIPTION
#### Description
skip TestSupervisorBootstrapsCollector, it's failing in all PRs

#### Link to tracking issue
http://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42108