### PR TITLE
[chore] only run scoped-test in PRs

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -1,8 +1,6 @@
 name: scoped-test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Follow-up of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42112, `scoped-test` fails on mainline right now and only works in PRs