### PR TITLE
[chore] Only run scoped-test workflow for PRs

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   changedfiles:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.sha != '' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:


### PR DESCRIPTION
Follow-up to #42112

Currently the workflow is broken when running as result of a merge to main. This change skips the workflow if there is no SHA to compare against. Later we can evaluate if we want to run this after merges to main and do a proper fix.