### PR TITLE
Fix UB in logdedupprocessor caused by holding reference to mutable data

### DIFF
--- a/.chloggen/fix-dedup-proc.yaml
+++ b/.chloggen/fix-dedup-proc.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logdedupprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix UB caused by holding reference to mutable data.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42147]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -105,8 +105,10 @@ type resourceAggregator struct {
 
 // newResourceAggregator creates a new ResourceCounter.
 func newResourceAggregator(resource pcommon.Resource, dedupFields []string) *resourceAggregator {
+	cloneResource := pcommon.NewResource()
+	resource.CopyTo(cloneResource)
 	return &resourceAggregator{
-		resource:      resource,
+		resource:      cloneResource,
 		scopeCounters: make(map[uint64]*scopeAggregator),
 		dedupFields:   dedupFields,
 	}
@@ -132,8 +134,10 @@ type scopeAggregator struct {
 
 // newScopeAggregator creates a new ScopeCounter.
 func newScopeAggregator(scope pcommon.InstrumentationScope, dedupFields []string) *scopeAggregator {
+	cloneScope := pcommon.NewInstrumentationScope()
+	scope.CopyTo(cloneScope)
 	return &scopeAggregator{
-		scope:       scope,
+		scope:       cloneScope,
 		logCounters: make(map[uint64]*logCounter),
 		dedupFields: dedupFields,
 	}
@@ -160,8 +164,11 @@ type logCounter struct {
 
 // newLogCounter creates a new AttributeCounter.
 func newLogCounter(logRecord plog.LogRecord) *logCounter {
+	// Since we always remove the logRecord if we got to this point, we can move it instead of copying.
+	movedLogRecord := plog.NewLogRecord()
+	logRecord.MoveTo(movedLogRecord)
 	return &logCounter{
-		logRecord:              logRecord,
+		logRecord:              movedLogRecord,
 		count:                  0,
 		firstObservedTimestamp: timeNow().UTC(),
 		lastObservedTimestamp:  timeNow().UTC(),

--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -135,10 +135,8 @@ func Test_logAggregatorExport(t *testing.T) {
 
 	scope := pcommon.NewInstrumentationScope()
 
-	logRecord := generateTestLogRecord(t, "body string")
-
 	// Add logRecord
-	aggregator.Add(resource, scope, logRecord)
+	aggregator.Add(resource, scope, generateTestLogRecord(t, "body string"))
 
 	exportedLogs := aggregator.Export(t.Context())
 	require.Equal(t, 1, exportedLogs.LogRecordCount())
@@ -156,15 +154,17 @@ func Test_logAggregatorExport(t *testing.T) {
 	require.Equal(t, 1, sl.LogRecords().Len())
 	actualLogRecord := sl.LogRecords().At(0)
 
+	expectedLogRecord := generateTestLogRecord(t, "body string")
+
 	// Check logRecord
-	require.Equal(t, logRecord.Body().AsString(), actualLogRecord.Body().AsString())
-	require.Equal(t, logRecord.SeverityNumber(), actualLogRecord.SeverityNumber())
-	require.Equal(t, logRecord.SeverityText(), actualLogRecord.SeverityText())
+	require.Equal(t, expectedLogRecord.Body().AsString(), actualLogRecord.Body().AsString())
+	require.Equal(t, expectedLogRecord.SeverityNumber(), actualLogRecord.SeverityNumber())
+	require.Equal(t, expectedLogRecord.SeverityText(), actualLogRecord.SeverityText())
 	require.Equal(t, expectedTimestamp.UnixMilli(), actualLogRecord.ObservedTimestamp().AsTime().UnixMilli())
 	require.Equal(t, expectedTimestamp.UnixMilli(), actualLogRecord.Timestamp().AsTime().UnixMilli())
 
 	actualRawAttrs := actualLogRecord.Attributes().AsRaw()
-	for key, val := range logRecord.Attributes().AsRaw() {
+	for key, val := range expectedLogRecord.Attributes().AsRaw() {
 		actualVal, ok := actualRawAttrs[key]
 		require.True(t, ok)
 		require.Equal(t, val, actualVal)


### PR DESCRIPTION
The problem is that the processor keeps reference to Resource and Scope objects which may be changed in the next processor since the pipeline components can change data like transform processor. Another problem is that the pipeline expects removed data like the LogRecord to no longer be used (since pdata is a reference/view to the data we need to move removed data if we need to hold references).