### PR TITLE
Fix UB in metricstarttimeprocessor caused by holding reference to mutable data

### DIFF
--- a/.chloggen/fix-metricstarttimeprocessor.yaml
+++ b/.chloggen/fix-metricstarttimeprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricstarttimeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix UB caused by holding reference to mutable data.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42151]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
+++ b/processor/metricstarttimeprocessor/internal/datapointstorage/timeseries_map_test.go
@@ -275,7 +275,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -290,7 +290,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Sum Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -305,7 +305,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero Count Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousZeroCount: 10, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousZeroCount: 10, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -321,8 +321,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -338,8 +338,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Decreased",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -355,9 +355,9 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "No Reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
-				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts = []uint64{1, 2, 3, 4}
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -374,8 +374,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Positive Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PreviousPositive.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
+				tsi.ExponentialHistogram.PreviousPositive.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -391,8 +391,8 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Negative Bucket Counts Length Mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
-				tsi.ExponentialHistogram.PreviousNegative.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
+				tsi.ExponentialHistogram.PreviousNegative.BucketCounts = []uint64{1, 2, 3, 4}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -408,7 +408,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Scale mismatch",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, Scale: 2, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, Scale: 2, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -424,7 +424,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Reset on zero count",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousCount: 10, PreviousSum: 50, PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {
@@ -439,7 +439,7 @@ func TestTimeseriesInfo_IsResetExponentialHistogram(t *testing.T) {
 			name: "Zero values but no reset",
 			setupTsi: func() *TimeseriesInfo {
 				tsi := &TimeseriesInfo{}
-				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousPositive: pmetric.NewExponentialHistogramDataPointBuckets(), PreviousNegative: pmetric.NewExponentialHistogramDataPointBuckets()}
+				tsi.ExponentialHistogram = ExponentialHistogramInfo{PreviousPositive: ExponentialHistogramBucketInfo{}, PreviousNegative: ExponentialHistogramBucketInfo{}}
 				return tsi
 			},
 			setupEh: func() pmetric.ExponentialHistogramDataPoint {

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
@@ -131,8 +131,8 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 						} else if refTsi.IsResetExponentialHistogram(dp) {
 							refTsi.ExponentialHistogram.StartTime = pcommon.NewTimestampFromTime(dp.Timestamp().AsTime().Add(-1 * time.Millisecond))
 						}
-						refTsi.ExponentialHistogram.PreviousPositive = dp.Positive()
-						refTsi.ExponentialHistogram.PreviousNegative = dp.Negative()
+						refTsi.ExponentialHistogram.PreviousPositive = datapointstorage.NewExponentialHistogramBucketInfo(dp.Positive())
+						refTsi.ExponentialHistogram.PreviousNegative = datapointstorage.NewExponentialHistogramBucketInfo(dp.Negative())
 						refTsi.ExponentialHistogram.PreviousCount, refTsi.ExponentialHistogram.PreviousSum, refTsi.ExponentialHistogram.PreviousZeroCount = dp.Count(), dp.Sum(), dp.ZeroCount()
 						dp.SetStartTimestamp(refTsi.ExponentialHistogram.StartTime)
 					}

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
@@ -148,8 +148,8 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 				PreviousCount: currentDist.Count(), PreviousSum: currentDist.Sum(), PreviousZeroCount: currentDist.ZeroCount(),
 				Scale:            currentDist.Scale(),
 				StartTime:        currentDist.Timestamp(),
-				PreviousPositive: currentDist.Positive(),
-				PreviousNegative: currentDist.Negative(),
+				PreviousPositive: datapointstorage.NewExponentialHistogramBucketInfo(currentDist.Positive()),
+				PreviousNegative: datapointstorage.NewExponentialHistogramBucketInfo(currentDist.Negative()),
 			}
 
 			// For the first point, set the start time as the point timestamp.
@@ -171,8 +171,8 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 		}
 
 		// Update only previous values.
-		refTsi.ExponentialHistogram.PreviousPositive = currentDist.Positive()
-		refTsi.ExponentialHistogram.PreviousNegative = currentDist.Negative()
+		refTsi.ExponentialHistogram.PreviousPositive = datapointstorage.NewExponentialHistogramBucketInfo(currentDist.Positive())
+		refTsi.ExponentialHistogram.PreviousNegative = datapointstorage.NewExponentialHistogramBucketInfo(currentDist.Negative())
 		refTsi.ExponentialHistogram.PreviousCount, refTsi.ExponentialHistogram.PreviousSum, refTsi.ExponentialHistogram.PreviousZeroCount = currentDist.Count(), currentDist.Sum(), currentDist.ZeroCount()
 		currentDist.SetStartTimestamp(refTsi.ExponentialHistogram.StartTime)
 	}


### PR DESCRIPTION
The problem is that the processor keeps reference to `pmetric.ExponentialHistogramDataPointBuckets` objects which may be changed in the next processor since the pipeline components can change data like transform processor.