### PR TITLE
[chore] ignore opentelemetry-mapping-go in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -100,6 +100,10 @@
       ]
     },
     {
+      "matchPackagePatterns": ["^github.com/DataDog/opentelemetry-mapping-go/"],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
#### Description
We've been updating opentelemetry-mapping-go manually, renovate shouldn't do it. Also the repo is going to be archived.

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41293, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42145