### PR TITLE
[chore][CI] update-otel sends PRs in draft first

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |  
           cd opentelemetry-collector-contrib
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
-          gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release"
+          gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release" --draft
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       - name: File an issue if the workflow failed


### PR DESCRIPTION
#### Description
The `update-otel` PRs often need manual fixes so most time they are not in a ready-to-review state. Change to send a draft PR first.

#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42169