### PR TITLE
[opencensus] deprecate the exporter and receiver as Go modules

### DIFF
--- a/.chloggen/deprecate_go.yaml
+++ b/.chloggen/deprecate_go.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opencensusreceiver, opencensusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate opencensusreceiver and opencensusexporter.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/opencensusexporter/doc.go
+++ b/exporter/opencensusexporter/doc.go
@@ -4,4 +4,5 @@
 //go:generate mdatagen metadata.yaml
 
 // Package opencensusexporter exports data to an OpenCensus agent.
+// Deprecated: this exporter is no longer maintained and has reached end-of-life. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791
 package opencensusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter"

--- a/exporter/opencensusexporter/go.mod
+++ b/exporter/opencensusexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: this exporter is no longer maintained and has reached end-of-life. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
 
 go 1.24

--- a/receiver/opencensusreceiver/doc.go
+++ b/receiver/opencensusreceiver/doc.go
@@ -4,4 +4,5 @@
 //go:generate mdatagen metadata.yaml
 
 // Package opencensusreceiver receives OpenCensus traces and metrics.
+// Deprecated: this receiver is no longer maintained and has reached end-of-life. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791
 package opencensusreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"

--- a/receiver/opencensusreceiver/go.mod
+++ b/receiver/opencensusreceiver/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: this receiver is no longer maintained and has reached end-of-life. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36791
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
 
 go 1.24


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecate the go code itself as packages and modules.

See #36791

Once merged, after a release, the code will be removed.
