### PR TITLE
[elasticsearchexporter] Fix a config validation test

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,3 @@ config-variables: null
 paths:
   .github/workflows/**/*.{yml,yaml}:
     ignore:
-
-      # shellcheck gets confused between VERSION env var and version bash variable.
-      - ".*VERSION may not be assigned. Did you mean version.*"

--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -71,8 +71,7 @@ jobs:
             exit 1
           fi
 
-          version="${VERSION//-alpha/}"
-          hash=$(curl -L "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v$version/opentelemetry-jmx-metrics.jar" \
+          hash=$(curl -L "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v${VERSION//-alpha/}/opentelemetry-jmx-metrics.jar" \
                          | sha256sum \
                          | cut -d ' ' -f 1)
 
@@ -180,14 +179,14 @@ jobs:
 
       - name: Update version
         env:
-          version: ${{ needs.check-jmx-scraper-version.outputs.latest-version }}
+          VERSION: ${{ needs.check-jmx-scraper-version.outputs.latest-version }}
         run: |
-          if [[ ! "$version" =~ -alpha$ ]]; then
+          if [[ ! "$VERSION" =~ -alpha$ ]]; then
             echo currently expecting jmx scraper version to end with "-alpha"
             exit 1
           fi
 
-          hash=$(curl -L "https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/$version/opentelemetry-jmx-scraper-$version.jar" \
+          hash=$(curl -L "https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/${VERSION//-alpha/}/opentelemetry-jmx-scraper-$VERSION.jar" \
                          | sha256sum \
                          | cut -d ' ' -f 1)
 

--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |  
           cd opentelemetry-collector-contrib
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
-          gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release"
+          gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release" --draft
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
       - name: File an issue if the workflow failed

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -372,7 +372,10 @@ func TestConfig(t *testing.T) {
 				cfg.QueueBatchConfig.Sizer = exporterhelper.RequestSizerTypeRequests
 				cfg.QueueBatchConfig.Batch = configoptional.Some(
 					exporterhelper.BatchConfig{
-						Sizer: exporterhelper.RequestSizerTypeRequests,
+						FlushTimeout: time.Second,
+						Sizer: exporterhelper.RequestSizerTypeBytes,
+						MinSize: 10000,
+						MaxSize: 100000,
 					},
 				)
 			}),

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -120,13 +120,21 @@ elasticsearch/metadata_keys:
   metadata_keys:
     - x-test-1
     - x-test-2
-elasticsearch/queuebatch_enabled:
+elasticsearch/queuebatch_enabled_invalid:
   endpoint: https://elastic.example.com:9200
   sending_queue:
     enabled: true
     num_consumers: 100
+    batch: {}
+elasticsearch/queuebatch_enabled_complete:
+  endpoint: https://elastic.example.com:9200
+  sending_queue:
+    enabled: true
+    num_consumers: 100
+    sizer: items
+    queue_size: 1000
     batch:
-      flush_timeout: 1s
+      flush_timeout: 2s
       sizer: bytes
-      min_size: 10000
-      max_size: 100000
+      min_size: 100000
+      max_size: 10000000

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -125,4 +125,8 @@ elasticsearch/queuebatch_enabled:
   sending_queue:
     enabled: true
     num_consumers: 100
-    batch: {}
+    batch:
+      flush_timeout: 1s
+      sizer: bytes
+      min_size: 10000
+      max_size: 100000

--- a/renovate.json
+++ b/renovate.json
@@ -100,6 +100,10 @@
       ]
     },
     {
+      "matchPackagePatterns": ["^github.com/DataDog/opentelemetry-mapping-go/"],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
#### Description

The former test was not really testing anything until configoptional validation. This adds a new test and verifies that the former setting "{}" will cause problems. Owners may want to pay attention.

The config.yaml input was:

```
elasticsearch/queuebatch_enabled:
  endpoint: https://elastic.example.com:9200
  sending_queue:
    enabled: true
    num_consumers: 100
    batch: {}
```
