### PR TITLE
[chore] use pull_request_target to have correct permissions on the PR

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -1,7 +1,9 @@
 name: 'First time contributor'
 on:
-  pull_request:
-    types: [opened, labeled]
+  pull_request_target:
+    types:
+      - opened
+      - labeled
 
 permissions: read-all
 


### PR DESCRIPTION
This action still fails for contributors, because they are not trusted. Moving to `pull_request_target` should help.

Example of failure:
https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17182949667/job/48747879727?pr=42158