### PR TITLE
 exporters/prometheusremotewrite: set concurrency and add docs for the WAL

### DIFF
--- a/.chloggen/kgeckhart_prw-exporter-set-concurrency.yaml
+++ b/.chloggen/kgeckhart_prw-exporter-set-concurrency.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make sure concurrency is set to the appropriate value"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41785]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -58,12 +58,18 @@ The following settings can be optionally configured:
   - `num_consumers`: minimum number of workers to use to fan out the outgoing requests. (default: `5` or default: `1` if `EnableMultipleWorkersFeatureGate` is enabled).
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
+- `wal`: Write-Ahead-Log settings for the exporter.
+  - `directory` (default = ``): The directory to store the WAL in.
+  - `buffer_size` (default = `300`): Count of elements to be read from the WAL before truncating.
+  - `truncate_frequency` (default = `1m`): Frequency for how often the WAL should be truncated. 
+  - `lag_record_frequency` (default = `15s`): Frequency for how often the exporter will record the lag of the WAL. 
 - `target_info`: customize `target_info` metric
   - `enabled` (default = true): If `enabled` is `true`, a `target_info` metric will be generated for each resource metric (see https://github.com/open-telemetry/opentelemetry-specification/pull/2381).
-- `max_batch_size_bytes` (default = `3000000` -> `~2.861 mb`): Maximum size of a batch of
-  samples to be sent to the remote write endpoint. If the batch size is larger
-  than this value, it will be split into multiple batches.
-- `max_batch_request_parallelism` (default = `5`): Maximum parallelism allowed for a single request bigger than `max_batch_size_bytes`.
+- `max_batch_size_bytes` (default = `3000000` -> `~2.861 mb`): Maximum size of a batch of samples to be sent to the remote 
+  write endpoint. If the batch size is larger than this value, it will be split into multiple batches. This option is ignored
+  when using the wal and where the wal buffer_size / truncate_frequency will be used.
+- `max_batch_request_parallelism` (default = `5`): Maximum parallelism allowed when sending multiple requests to the remote write endpoint. 
+  If the remote write endpoint does not support out of order samples, this should be set to `1`. 
 - `protobuf_message` (default = `prometheus.WriteRequest`): 
   - Protobuf message to use when writing to the remote write endpoint. This option is ignored unless the `exporter.prometheusremotewritexporter.enableSendingRW2` feature gate is enabled.
   - `prometheus.WriteRequest` is the message used in [Remote Write 1.0](https://prometheus.io/docs/specs/remote_write_spec/).

--- a/exporter/prometheusremotewriteexporter/config.go
+++ b/exporter/prometheusremotewriteexporter/config.go
@@ -44,8 +44,10 @@ type Config struct {
 	// ResourceToTelemetrySettings is the option for converting resource attributes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
 	// If enabled, all the resource attributes will be converted to metric labels by default.
-	ResourceToTelemetrySettings resourcetotelemetry.Settings       `mapstructure:"resource_to_telemetry_conversion"`
-	WAL                         configoptional.Optional[WALConfig] `mapstructure:"wal"`
+	ResourceToTelemetrySettings resourcetotelemetry.Settings `mapstructure:"resource_to_telemetry_conversion"`
+
+	// WAL enables persisting metrics to a write-ahead-log before sending to the remote storage.
+	WAL configoptional.Optional[WALConfig] `mapstructure:"wal"`
 
 	// TargetInfo allows customizing the target_info metric
 	TargetInfo TargetInfo `mapstructure:"target_info,omitempty"`

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -175,7 +175,7 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 		closeChan:           make(chan struct{}),
 		userAgentHeader:     userAgentHeader,
 		maxBatchSizeBytes:   cfg.MaxBatchSizeBytes,
-		concurrency:         cfg.RemoteWriteQueue.NumConsumers,
+		concurrency:         concurrency,
 		clientSettings:      &cfg.ClientConfig,
 		settings:            set.TelemetrySettings,
 		retrySettings:       cfg.BackOffConfig,


### PR DESCRIPTION
#### Description
This PR reverts a change that was made in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35888/files#diff-2631d8a8855fdc08cf077c0ab99544147ca73eec572bc871d8fe717e826eda38R161 causing the concurrency value to not be set as expected for remote write v1.

It also adds documentation for the WAL settings and how various settings interact with the WAL. There's a special call out for what needs configured if out of order support is not enabled in the remote write endpoint as the default config does not work in this scenario with the WAL. AFAICT the default configuration always had the potential to produce out of order writes since the concurrency would default to 5.

#### Link to tracking issue
Related to #41785

#### Testing
I used 
```yaml
receivers:
  hostmetrics:
    collection_interval: 15s
    scrapers:
      cpu:
      memory:

exporters:
  prometheusremotewrite:
    endpoint: http://localhost:9090/api/v1/write
    max_batch_request_parallelism: 1
    wal:
      directory: "./wal"

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      exporters: [prometheusremotewrite]
```
to verify things work end-to-end. It still results in out of order samples so that's not the only fix necessary here but concurrently writing samples can certainly result in ordering issues.

#### Documentation
Described in the description