### PR TITLE
[chore] Fix uses of testify Eventually

### DIFF
--- a/extension/k8sleaderelector/extension_test.go
+++ b/extension/k8sleaderelector/extension_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
@@ -61,12 +62,11 @@ func TestExtension(t *testing.T) {
 
 	expectedLeaseDurationSeconds := ptr.To(int32(15))
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		lease, err := fakeClient.CoordinationV1().Leases("default").Get(ctx, "foo", metav1.GetOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, lease)
 		require.Equal(t, expectedLeaseDurationSeconds, lease.Spec.LeaseDurationSeconds)
-		return true
 	}, 10*time.Second, 100*time.Millisecond)
 
 	require.True(t, onStartLeadingInvoked.Load())

--- a/receiver/envoyalsreceiver/als_test.go
+++ b/receiver/envoyalsreceiver/als_test.go
@@ -164,7 +164,9 @@ func TestLogs(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				gotLogs := sink.AllLogs()
-
+				if len(gotLogs) <= i {
+					return false
+				}
 				err := plogtest.CompareLogs(tt.expected, gotLogs[i], plogtest.IgnoreObservedTimestamp())
 				if err == nil {
 					return true

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -538,7 +538,7 @@ func TestReceiver_MessageMarking(t *testing.T) {
 
 						dataPoints := m.Data.(metricdata.Sum[int64]).DataPoints
 						assert.Len(t, dataPoints, 1)
-						assert.True(t, dataPoints[0].Value >= value)
+						assert.GreaterOrEqual(t, dataPoints[0].Value, value)
 					}, time.Second, 100*time.Millisecond, "unmarshal error should restart consumer")
 
 					// reprocesses of the same message

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -532,13 +532,13 @@ func TestReceiver_MessageMarking(t *testing.T) {
 					}
 
 					// Verify that the consumer restarts at least once.
-					assert.Eventually(t, func() bool {
+					assert.EventuallyWithT(t, func(t *assert.CollectT) {
 						m, err := tel.GetMetric("otelcol_kafka_receiver_partition_start")
 						require.NoError(t, err)
 
 						dataPoints := m.Data.(metricdata.Sum[int64]).DataPoints
 						assert.Len(t, dataPoints, 1)
-						return dataPoints[0].Value >= value
+						assert.True(t, dataPoints[0].Value >= value)
 					}, time.Second, 100*time.Millisecond, "unmarshal error should restart consumer")
 
 					// reprocesses of the same message


### PR DESCRIPTION
#### Description

The latest version of testify (v1.11.0) makes it so that `assert.Eventually(condition, timeout, period)` performs its first check of `condition` immediately in stead of waiting for the end of the first `period`. This revealed a few incorrect uses of `Eventually` in the codebase which make the test fail if the condition is checked too early.
