### PR TITLE
[chore][exporter/datadog] Add `logs::endpoint` to example

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -461,6 +461,12 @@ exporters:
     ## Logs exporter specific configuration.
     #
     # logs:
+      ## @param endpoint - string - optional
+      ## The host of the Datadog intake server to send logs to.
+      ## If unset, the value is obtained through the `site` parameter in the `api` section.
+      #
+      # endpoint: https://trace.agent.datadoghq.com
+
       ## @param dump_payloads - bool - optional
       ## If set to true, payloads will be dumped when logging level is set to debug. Please note that
       ## This may result in an escaping loop if a filelog receiver is watching the collector log output.

--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -465,7 +465,7 @@ exporters:
       ## The host of the Datadog intake server to send logs to.
       ## If unset, the value is obtained through the `site` parameter in the `api` section.
       #
-      # endpoint: https://trace.agent.datadoghq.com
+      # endpoint: https://http-intake.logs.datadoghq.com
 
       ## @param dump_payloads - bool - optional
       ## If set to true, payloads will be dumped when logging level is set to debug. Please note that


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds missing [`logs::endpoint` option](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/87226d03b53ca75747f19cd83baa96369a3cae49/pkg/datadog/config/logs.go#L10-L12) to example.