### PR TITLE
[receiver/libhoney] Response body sends proper partial errors for batches

### DIFF
--- a/.chloggen/libhoney-full-response.yaml
+++ b/.chloggen/libhoney-full-response.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: libhoneyreceiver
+note: return full array of statuses per event
+issues: [42272]
+subtext:
+  Libhoney has a per-event-within-each-batch response code array for each batch received.
+  This has now been implemented for both initial parsing errors as well as downstream consumer errors.
+change_logs: [user]

--- a/receiver/libhoneyreceiver/README.md
+++ b/receiver/libhoneyreceiver/README.md
@@ -28,7 +28,7 @@ The following settings are required:
 
 - `http`
   - `endpoint` must set an endpoint. Defaults to `127.0.0.1:8080`
-  - `compression_algorithms` (optional): List of supported compression algorithms. Defaults to `["", "gzip", "zstd", "zlib", "snappy", "deflate"]`. Set to `[]` to disable automatic decompression.
+  - `compression_algorithms` (optional): List of supported compression algorithms. Defaults to `["", "gzip", "zstd", "zlib", "deflate"]`. Set to `[]` to disable automatic decompression.
 - `resources`: if the `service.name` field is different, map it here.
 - `scopes`: to get the `library.name` and `library.version` set in the scope section, set them here.
 - `attributes`: if the other trace-related data have different keys, map them here, defaults are otlp-like field names.

--- a/receiver/libhoneyreceiver/factory.go
+++ b/receiver/libhoneyreceiver/factory.go
@@ -42,7 +42,7 @@ func createDefaultConfig() component.Config {
 		HTTP: configoptional.Default(HTTPConfig{
 			ServerConfig: confighttp.ServerConfig{
 				Endpoint:              endpointStr,
-				CompressionAlgorithms: []string{},
+				CompressionAlgorithms: []string{"", "zstd", "gzip", "deflate"},
 			},
 			TracesURLPaths: defaultTracesURLPaths,
 		}),

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
@@ -74,15 +74,15 @@ func (l *LibhoneyEvent) UnmarshalJSON(j []byte) error {
 	if err != nil {
 		return err
 	}
-	if (tmp.MsgPackTimestamp == nil || tmp.MsgPackTimestamp.IsZero()) && tmp.Time == "none" {
-		// neither timestamp was set. give it right now.
-		tmp.Time = tstr
-		tnow := time.Now()
-		tmp.MsgPackTimestamp = &tnow
-	}
 	if tmp.MsgPackTimestamp == nil || tmp.MsgPackTimestamp.IsZero() {
-		propertime := eventtime.GetEventTime(tmp.Time)
-		tmp.MsgPackTimestamp = &propertime
+		if tmp.Time == "none" {
+			tmp.Time = tstr
+			tnow := time.Now()
+			tmp.MsgPackTimestamp = &tnow
+		} else {
+			propertime := eventtime.GetEventTime(tmp.Time)
+			tmp.MsgPackTimestamp = &propertime
+		}
 	}
 
 	*l = LibhoneyEvent(tmp)
@@ -123,16 +123,15 @@ func (l *LibhoneyEvent) UnmarshalMsgpack(data []byte) error {
 		tmp.Time = timeStr
 	}
 
-	// Apply the same timestamp logic as JSON
-	if (tmp.MsgPackTimestamp == nil || tmp.MsgPackTimestamp.IsZero()) && tmp.Time == "none" {
-		// neither timestamp was set. give it right now.
-		tmp.Time = tstr
-		tnow := time.Now()
-		tmp.MsgPackTimestamp = &tnow
-	}
 	if tmp.MsgPackTimestamp == nil || tmp.MsgPackTimestamp.IsZero() {
-		propertime := eventtime.GetEventTime(tmp.Time)
-		tmp.MsgPackTimestamp = &propertime
+		if tmp.Time == "none" {
+			tmp.Time = tstr
+			tnow := time.Now()
+			tmp.MsgPackTimestamp = &tnow
+		} else {
+			propertime := eventtime.GetEventTime(tmp.Time)
+			tmp.MsgPackTimestamp = &propertime
+		}
 	}
 
 	*l = LibhoneyEvent(tmp)

--- a/receiver/libhoneyreceiver/internal/parser/parser.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser.go
@@ -6,6 +6,7 @@ package parser // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"encoding/hex"
 	"errors"
+	"net/http"
 	"net/url"
 	"slices"
 	"time"
@@ -18,7 +19,14 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/libhoneyevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/response"
 )
+
+// IndexMapping tracks which original libhoney event indices became logs vs traces
+type IndexMapping struct {
+	LogIndices   []int // Original event indices that became logs
+	TraceIndices []int // Original event indices that became traces/spans/span events
+}
 
 // GetDatasetFromRequest extracts the dataset name from the request path
 func GetDatasetFromRequest(path string) (string, error) {
@@ -32,8 +40,8 @@ func GetDatasetFromRequest(path string) (string, error) {
 	return dataset, nil
 }
 
-// ToPdata converts a list of LibhoneyEvents to a Pdata Logs object
-func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyevent.FieldMapConfig, logger zap.Logger) (plog.Logs, ptrace.Traces) {
+// ToPdata converts a list of LibhoneyEvents to a Pdata Logs object and tracks which original indices became what
+func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyevent.FieldMapConfig, logger zap.Logger) (plog.Logs, ptrace.Traces, IndexMapping, []response.ResponseInBatch) {
 	foundServices := libhoneyevent.ServiceHistory{}
 	foundServices.NameCount = make(map[string]int)
 	foundScopes := libhoneyevent.ScopeHistory{}
@@ -41,6 +49,15 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 
 	spanLinks := map[trc.SpanID][]libhoneyevent.LibhoneyEvent{}
 	spanEvents := map[trc.SpanID][]libhoneyevent.LibhoneyEvent{}
+
+	// Initialize index mapping to track which original events become logs vs traces
+	indexMapping := IndexMapping{
+		LogIndices:   make([]int, 0),
+		TraceIndices: make([]int, 0),
+	}
+
+	// Initialize parsing results to track success/failure per original event
+	parsingResults := make([]response.ResponseInBatch, len(lhes))
 
 	foundScopes.Scope = make(map[string]libhoneyevent.SimpleScope) // a list of already seen scopes
 
@@ -51,7 +68,7 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 		cfg.Attributes.Error, cfg.Attributes.SpanKind,
 	}
 
-	for _, lhe := range lhes {
+	for i, lhe := range lhes {
 		parentID, err := lhe.GetParentID(cfg.Attributes.ParentID)
 		if err != nil {
 			logger.Debug("parent id not found")
@@ -68,6 +85,16 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 			err := lhe.ToPTraceSpan(&newSpan, &alreadyUsedFields, cfg, logger)
 			if err != nil {
 				logger.Warn("span could not be converted from libhoney to ptrace", zap.String("span.object", lhe.DebugString()))
+				parsingResults[i] = response.ResponseInBatch{
+					Status:   http.StatusBadRequest,
+					ErrorStr: "span parsing failed: " + err.Error(),
+				}
+			} else {
+				// Track successful span for consumer processing
+				indexMapping.TraceIndices = append(indexMapping.TraceIndices, i)
+				parsingResults[i] = response.ResponseInBatch{
+					Status: http.StatusAccepted,
+				}
 			}
 		case "log":
 			logService, _ := lhe.GetService(cfg, &foundServices, dataset)
@@ -76,10 +103,24 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 			err := lhe.ToPLogRecord(&newLog, &alreadyUsedFields, logger)
 			if err != nil {
 				logger.Warn("log could not be converted from libhoney to plog", zap.String("span.object", lhe.DebugString()))
+				parsingResults[i] = response.ResponseInBatch{
+					Status:   http.StatusBadRequest,
+					ErrorStr: "log parsing failed: " + err.Error(),
+				}
+			} else {
+				// Track successful log for consumer processing
+				indexMapping.LogIndices = append(indexMapping.LogIndices, i)
+				parsingResults[i] = response.ResponseInBatch{
+					Status: http.StatusAccepted,
+				}
 			}
 		case "span_event":
+			// Span events are processed later, so we need index mapping for them
+			indexMapping.TraceIndices = append(indexMapping.TraceIndices, i)
 			spanEvents[parentID] = append(spanEvents[parentID], lhe)
 		case "span_link":
+			// Span links are processed later, so we need index mapping for them
+			indexMapping.TraceIndices = append(indexMapping.TraceIndices, i)
 			spanLinks[parentID] = append(spanLinks[parentID], lhe)
 		}
 	}
@@ -127,7 +168,7 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 		}
 	}
 
-	return resultLogs, resultTraces
+	return resultLogs, resultTraces, indexMapping, parsingResults
 }
 
 func addSpanEventsToSpan(sp ptrace.Span, events []libhoneyevent.LibhoneyEvent, alreadyUsedFields []string, logger *zap.Logger) {

--- a/receiver/libhoneyreceiver/internal/parser/parser_test.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser_test.go
@@ -148,7 +148,7 @@ func TestToPdata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logs, traces := ToPdata(tt.dataset, tt.events, tt.cfg, *logger)
+			logs, traces, _, _ := ToPdata(tt.dataset, tt.events, tt.cfg, *logger)
 			assert.Equal(t, tt.wantSpans, traces.SpanCount())
 			assert.Equal(t, tt.wantLogs, logs.LogRecordCount())
 		})

--- a/receiver/libhoneyreceiver/internal/response/response.go
+++ b/receiver/libhoneyreceiver/internal/response/response.go
@@ -24,3 +24,16 @@ func MakeResponse(eventErrs []int) []ResponseInBatch {
 	}
 	return responses
 }
+
+// MakeSuccessResponse creates a response array with all events marked as accepted
+func MakeSuccessResponse(numEvents int) []ResponseInBatch {
+	if numEvents <= 0 {
+		return []ResponseInBatch{{Status: http.StatusAccepted}}
+	}
+
+	responses := make([]ResponseInBatch, numEvents)
+	for i := 0; i < numEvents; i++ {
+		responses[i] = ResponseInBatch{Status: http.StatusAccepted}
+	}
+	return responses
+}

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/collector/component"
@@ -27,7 +26,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/errorutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/encoder"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/eventtime"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/libhoneyevent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/parser"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver/internal/response"
@@ -253,6 +251,7 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 	libhoneyevents := make([]libhoneyevent.LibhoneyEvent, 0)
 	switch req.Header.Get("Content-Type") {
 	case "application/x-msgpack", "application/msgpack":
+		// The custom UnmarshalMsgpack will handle timestamp normalization
 		decoder := msgpack.NewDecoder(bytes.NewReader(body))
 		decoder.UseLooseInterfaceDecoding(true)
 		err = decoder.Decode(&libhoneyevents)
@@ -261,27 +260,9 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 			writeLibhoneyError(resp, enc, "failed to unmarshal msgpack")
 			return
 		}
-		// Post-process msgpack events to ensure timestamps are set
-		for i := range libhoneyevents {
-			if libhoneyevents[i].MsgPackTimestamp == nil {
-				if libhoneyevents[i].Time != "" {
-					// Parse the time string and set MsgPackTimestamp
-					propertime := eventtime.GetEventTime(libhoneyevents[i].Time)
-					libhoneyevents[i].MsgPackTimestamp = &propertime
-				} else {
-					// No time field, use current time
-					tnow := time.Now()
-					libhoneyevents[i].MsgPackTimestamp = &tnow
-					libhoneyevents[i].Time = eventtime.GetEventTimeDefaultString()
-				}
-			}
-		}
 		if len(libhoneyevents) > 0 {
-			if libhoneyevents[0].MsgPackTimestamp != nil {
-				r.settings.Logger.Debug("Decoding with msgpack worked", zap.Time("timestamp.first.msgpacktimestamp", *libhoneyevents[0].MsgPackTimestamp), zap.String("timestamp.first.time", libhoneyevents[0].Time))
-			} else {
-				r.settings.Logger.Debug("Decoding with msgpack worked", zap.String("timestamp.first.time", libhoneyevents[0].Time))
-			}
+			// MsgPackTimestamp is guaranteed to be non-nil after UnmarshalMsgpack
+			r.settings.Logger.Debug("Decoding with msgpack worked", zap.Time("timestamp.first.msgpacktimestamp", *libhoneyevents[0].MsgPackTimestamp), zap.String("timestamp.first.time", libhoneyevents[0].Time))
 			r.settings.Logger.Debug("event zero", zap.String("event.data", libhoneyevents[0].DebugString()))
 		}
 	case encoder.JSONContentType:

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -214,11 +214,6 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 		dataset = strings.Replace(dataset, p, "", 1)
 		r.settings.Logger.Debug("dataset parsed", zap.String("dataset.parsed", dataset))
 	}
-
-	// The confighttp middleware automatically handles decompression based on Content-Encoding header
-	// However, there's a bug where some clients send uncompressed data with Content-Encoding headers
-	// This causes the decompressor middleware to panic. We wrap the read in panic recovery.
-
 	var body []byte
 	func() {
 		defer func() {
@@ -273,6 +268,8 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 		}
 
 		if len(libhoneyevents) > 0 {
+			// Debug: Log the state of MsgPackTimestamp
+			r.settings.Logger.Debug("JSON event decoded", zap.Bool("has_msgpacktimestamp", libhoneyevents[0].MsgPackTimestamp != nil))
 			if libhoneyevents[0].MsgPackTimestamp != nil {
 				r.settings.Logger.Debug("Decoding with json worked", zap.Time("timestamp.first.msgpacktimestamp", *libhoneyevents[0].MsgPackTimestamp), zap.String("timestamp.first.time", libhoneyevents[0].Time))
 			} else {

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -231,9 +231,9 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 	if err != nil {
 		r.settings.Logger.Error("Failed to read request body", zap.Error(err))
 		writeLibhoneyError(resp, enc, "failed to read request body")
-		// Drain any remaining body to allow connection reuse
+		// Don't try to drain body if we got an error from compressed reader
+		// The reader may be in a corrupted state and cause another panic
 		if req.Body != nil {
-			_, _ = io.ReadAll(req.Body)
 			_ = req.Body.Close()
 		}
 		return

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -135,6 +135,7 @@ func (r *libhoneyReceiver) registerLogConsumer(tc consumer.Logs) {
 }
 
 func (r *libhoneyReceiver) handleAuth(resp http.ResponseWriter, req *http.Request) {
+	r.settings.Logger.Debug("handling auth request", zap.String("auth_api", r.cfg.AuthAPI))
 	authURL := fmt.Sprintf("%s/1/auth", r.cfg.AuthAPI)
 	authReq, err := http.NewRequest(http.MethodGet, authURL, http.NoBody)
 	if err != nil {

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -271,8 +271,13 @@ func (r *libhoneyReceiver) handleEvent(resp http.ResponseWriter, req *http.Reque
 			writeLibhoneyError(resp, enc, "failed to unmarshal JSON")
 			return
 		}
+
 		if len(libhoneyevents) > 0 {
-			r.settings.Logger.Debug("Decoding with json worked", zap.Time("timestamp.first.msgpacktimestamp", *libhoneyevents[0].MsgPackTimestamp), zap.String("timestamp.first.time", libhoneyevents[0].Time))
+			if libhoneyevents[0].MsgPackTimestamp != nil {
+				r.settings.Logger.Debug("Decoding with json worked", zap.Time("timestamp.first.msgpacktimestamp", *libhoneyevents[0].MsgPackTimestamp), zap.String("timestamp.first.time", libhoneyevents[0].Time))
+			} else {
+				r.settings.Logger.Debug("Decoding with json worked", zap.String("timestamp.first.time", libhoneyevents[0].Time))
+			}
 		}
 	default:
 		r.settings.Logger.Info("unsupported content type", zap.String("content-type", req.Header.Get("Content-Type")))

--- a/receiver/libhoneyreceiver/receiver_test.go
+++ b/receiver/libhoneyreceiver/receiver_test.go
@@ -574,8 +574,6 @@ func TestLibhoneyReceiver_ZstdDecompressionPanic(t *testing.T) {
 		{
 			name: "valid_json_data_nil_pointer_bug",
 			createPayload: func() []byte {
-				// Create valid JSON payload that triggers the nil pointer bug
-				// JSON events don't get MsgPackTimestamp post-processing!
 				events := []libhoneyevent.LibhoneyEvent{
 					{
 						Time:       time.Now().Format(time.RFC3339),
@@ -586,9 +584,9 @@ func TestLibhoneyReceiver_ZstdDecompressionPanic(t *testing.T) {
 				jsonData, _ := json.Marshal(events)
 				return jsonData
 			},
-			expectPanic:     true, // BUG: Line 233 dereferences nil MsgPackTimestamp
-			expectErrorCode: 0,    // Will panic before status code
-			description:     "JSON processing has nil pointer bug in logging code (line 233)",
+			expectPanic:     false,
+			expectErrorCode: 200,
+			description:     "JSON processing handles nil MsgPackTimestamp correctly after fix",
 		},
 		{
 			name: "valid_msgpack_data",
@@ -604,8 +602,8 @@ func TestLibhoneyReceiver_ZstdDecompressionPanic(t *testing.T) {
 				msgpackData, _ := msgpack.Marshal(events)
 				return msgpackData
 			},
-			expectPanic:     false, // Should work - msgpack post-processing fixes timestamps
-			expectErrorCode: 200,   // Should succeed
+			expectPanic:     false,
+			expectErrorCode: 200,
 			description:     "Msgpack should work correctly due to timestamp post-processing",
 		},
 	}


### PR DESCRIPTION
#### Description

- Responds to libhoney clients with array of success and failures statuses for proper error handling
- Sets both JSON and Webpack timestamps to avoid nil

#### Testing

Adds unit tests for timestamps and response body generation
