### PR TITLE
[chore][cmd/opampsupervisor] Remove use of deprecated settings.Capabilities

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -688,15 +688,15 @@ func (s *Supervisor) startOpAMPClient() error {
 		return err
 	}
 
-	supportedCapabilities := s.config.Capabilities.SupportedCapabilities()
-	if err := s.opampClient.SetCapabilities(&supportedCapabilities); err != nil {
-		return err
-	}
-
 	if ac, ok := s.availableComponents.Load().(*protobufs.AvailableComponents); ok && ac != nil {
 		if err := s.opampClient.SetAvailableComponents(ac); err != nil {
 			return err
 		}
+	}
+
+	supportedCapabilities := s.config.Capabilities.SupportedCapabilities()
+	if err := s.opampClient.SetCapabilities(&supportedCapabilities); err != nil {
+		return err
 	}
 
 	s.telemetrySettings.Logger.Debug("Starting OpAMP client...")

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -679,16 +679,17 @@ func (s *Supervisor) startOpAMPClient() error {
 			},
 		},
 	}
-	supportedCapabilities := s.config.Capabilities.SupportedCapabilities()
-	if err := s.opampClient.SetCapabilities(&supportedCapabilities); err != nil {
-		return err
-	}
 	ad := s.agentDescription.Load().(*protobufs.AgentDescription)
 	if err := s.opampClient.SetAgentDescription(ad); err != nil {
 		return err
 	}
 
 	if err := s.opampClient.SetHealth(&protobufs.ComponentHealth{Healthy: false}); err != nil {
+		return err
+	}
+
+	supportedCapabilities := s.config.Capabilities.SupportedCapabilities()
+	if err := s.opampClient.SetCapabilities(&supportedCapabilities); err != nil {
 		return err
 	}
 

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -678,7 +678,10 @@ func (s *Supervisor) startOpAMPClient() error {
 				return s.createEffectiveConfigMsg(), nil
 			},
 		},
-		Capabilities: s.config.Capabilities.SupportedCapabilities(),
+	}
+	supportedCapabilities := s.config.Capabilities.SupportedCapabilities()
+	if err := s.opampClient.SetCapabilities(&supportedCapabilities); err != nil {
+		return err
 	}
 	ad := s.agentDescription.Load().(*protobufs.AgentDescription)
 	if err := s.opampClient.SetAgentDescription(ad); err != nil {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
[Logs in tests](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17243845621/job/48931324717?pr=42250) are full of the following stack trace:
```
2025-08-26T16:56:09.225Z	ERROR	opamp-client	supervisor/logger.go:26	settings.Capabilities is deprecated, use client.SetCapabilities() instead
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor.(*opAMPLogger).Errorf
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/logger.go:26
github.com/open-telemetry/opamp-go/client/internal.(*ClientCommon).PrepareStart
	C:/Users/runneradmin/go/pkg/mod/github.com/open-telemetry/opamp-go@v0.21.0/client/internal/clientcommon.go:108
github.com/open-telemetry/opamp-go/client.(*wsClient).Start
	C:/Users/runneradmin/go/pkg/mod/github.com/open-telemetry/opamp-go@v0.21.0/client/wsclient.go:77
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor.(*Supervisor).startOpAMPClient
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/supervisor.go:699
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor.(*Supervisor).startOpAMP
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/supervisor.go:610
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor.(*Supervisor).Start
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/supervisor.go:331
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor.TestSupervisorStartsCollectorWithRemoteConfig.func1
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/e2e_test.go:295
testing.tRunner
	C:/hostedtoolcache/windows/go/1.24.6/x64/src/testing/testing.go:1792
```
This PR is to move from usages of `settings.Capabilities` -> `client.SetCapabilities`.