### PR TITLE
[receiver/prometheusremotewritereceiver] accept unspecified types as gauge

### DIFF
--- a/.chloggen/accept-unspecified-types-as-gauges-in-prometheusremotewrite-receiver.yaml
+++ b/.chloggen/accept-unspecified-types-as-gauges-in-prometheusremotewrite-receiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewritereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds support to accept METRIC_TYPE_UNSPECIFIED as gauge type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -154,3 +154,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor => ../../processor/deltatocumulativeprocessor
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus => ../../pkg/translator/prometheus
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.135.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.135.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.132.0
 	github.com/prometheus/prometheus v0.304.3-0.20250703114031-419d436a447a
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.41.1-0.20250911090542-8b3a08ca2a38

--- a/receiver/prometheusremotewritereceiver/go.sum
+++ b/receiver/prometheusremotewritereceiver/go.sum
@@ -256,6 +256,10 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.132.0 h1:MBGhsjWU/jtDgUqblFEBoeSw/TtQHp9xSCSO/iZ0OkE=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.132.0/go.mod h1:unPwed5hcfsE8wwev7+Jiflxr8ZtAxQ5H9RuwOoRV6A=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.132.0 h1:xwpoUi57vQtWgymJ2mje76r27Paqq3weLNlwcu/aQAU=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.132.0/go.mod h1:cRkSkWzpoy7Q+eSQ9Yrv5sF1EFcLZACEYHHwm2wF+k8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=

--- a/receiver/prometheusremotewritereceiver/go.sum
+++ b/receiver/prometheusremotewritereceiver/go.sum
@@ -256,10 +256,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.132.0 h1:MBGhsjWU/jtDgUqblFEBoeSw/TtQHp9xSCSO/iZ0OkE=
-github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.132.0/go.mod h1:unPwed5hcfsE8wwev7+Jiflxr8ZtAxQ5H9RuwOoRV6A=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.132.0 h1:xwpoUi57vQtWgymJ2mje76r27Paqq3weLNlwcu/aQAU=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.132.0/go.mod h1:cRkSkWzpoy7Q+eSQ9Yrv5sF1EFcLZACEYHHwm2wF+k8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 )
 
 func newRemoteWriteReceiver(settings receiver.Settings, cfg *Config, nextConsumer consumer.Metrics) (receiver.Metrics, error) {
@@ -347,14 +348,20 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		metric, exists := metricCache[metricKey]
 		if !exists {
 			switch ts.Metadata.Type {
-			case writev2.Metadata_METRIC_TYPE_GAUGE:
+			case writev2.Metadata_METRIC_TYPE_GAUGE, writev2.Metadata_METRIC_TYPE_UNSPECIFIED:
 				metric = setMetric(scope, metricName, unit, description)
 				metric.SetEmptyGauge()
+				if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_UNSPECIFIED {
+					metric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "unknown")
+				} else {
+					metric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
+				}
 			case writev2.Metadata_METRIC_TYPE_COUNTER:
 				metric = setMetric(scope, metricName, unit, description)
 				sum := metric.SetEmptySum()
 				sum.SetIsMonotonic(true)
 				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				metric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "counter")
 			case writev2.Metadata_METRIC_TYPE_SUMMARY:
 				// Drop summary series as we will not handle them.
 				continue
@@ -370,7 +377,7 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		}
 
 		switch ts.Metadata.Type {
-		case writev2.Metadata_METRIC_TYPE_GAUGE:
+		case writev2.Metadata_METRIC_TYPE_GAUGE, writev2.Metadata_METRIC_TYPE_UNSPECIFIED:
 			addNumberDatapoints(metric.Gauge().DataPoints(), ls, ts, &stats)
 		case writev2.Metadata_METRIC_TYPE_COUNTER:
 			addNumberDatapoints(metric.Sum().DataPoints(), ls, ts, &stats)

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -30,7 +30,9 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/internal/metadata"
 )
 
@@ -282,6 +284,7 @@ func TestTranslateV2(t *testing.T) {
 				metric.SetName("test_metric")
 				metric.SetUnit("")
 				metric.SetDescription("")
+				metric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "unknown")
 
 				dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -315,6 +318,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics1.SetName("test_metric1")
 				metrics1.SetUnit("")
 				metrics1.SetDescription("")
+				metrics1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -342,6 +346,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics2.SetName("test_metric1")
 				metrics2.SetUnit("")
 				metrics2.SetDescription("")
+				metrics2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
@@ -443,6 +448,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics1.SetName("test_metric")
 				metrics1.SetUnit("")
 				metrics1.SetDescription("")
+				metrics1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -459,6 +465,7 @@ func TestTranslateV2(t *testing.T) {
 				cbneMetric.SetName("test_metric")
 				cbneMetric.SetUnit("")
 				cbneMetric.SetDescription("")
+				// cbneMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist := cbneMetric.SetEmptyHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -476,7 +483,8 @@ func TestTranslateV2(t *testing.T) {
 				metrics2 := sm2.Metrics().AppendEmpty()
 				metrics2.SetName("test_metric")
 				metrics2.SetUnit("")
-				metrics1.SetDescription("")
+				metrics2.SetDescription("")
+				metrics2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
@@ -488,6 +496,7 @@ func TestTranslateV2(t *testing.T) {
 				expMetric.SetName("test_metric")
 				expMetric.SetUnit("")
 				expMetric.SetDescription("")
+				// expMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				expHist := expMetric.SetEmptyExponentialHistogram()
 				expHist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -571,6 +580,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics1.SetName("test_metric")
 				metrics1.SetUnit("seconds")
 				metrics1.SetDescription("longer description")
+				metrics1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp1 := metrics1.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
@@ -586,6 +596,7 @@ func TestTranslateV2(t *testing.T) {
 				metrics2.SetName("test_metric")
 				metrics2.SetUnit("milliseconds")
 				metrics2.SetDescription("small desc")
+				metrics2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp3 := metrics2.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
@@ -654,6 +665,7 @@ func TestTranslateV2(t *testing.T) {
 				m.SetName("normal_metric")
 				m.SetUnit("")
 				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "gauge")
 
 				dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(1.0)
@@ -731,6 +743,7 @@ func TestTranslateV2(t *testing.T) {
 				m.SetName("test_metric")
 				m.SetUnit("")
 				m.SetDescription("")
+				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -814,6 +827,7 @@ func TestTranslateV2(t *testing.T) {
 				m.SetName("test_metric")
 				m.SetUnit("")
 				m.SetDescription("")
+				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -876,6 +890,7 @@ func TestTranslateV2(t *testing.T) {
 				m := sm.Metrics().AppendEmpty()
 				m.SetName("test_metric")
 				m.SetUnit("")
+				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -965,6 +980,7 @@ func TestTranslateV2(t *testing.T) {
 				m := sm.Metrics().AppendEmpty()
 				m.SetName("test_metric")
 				m.SetUnit("")
+				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -1378,6 +1394,7 @@ func TestTranslateV2(t *testing.T) {
 				m2.SetName("test_mixed_histogram")
 				m2.SetUnit("")
 				m2.SetDescription("")
+				// m2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist2 := m2.SetEmptyExponentialHistogram()
 				hist2.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -1408,6 +1425,7 @@ func TestTranslateV2(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, pmetrictest.CompareMetrics(tc.expectedMetrics, metrics))
 			assert.Equal(t, tc.expectedStats, stats)
+			assert.Equal(t, buildMetaDataMapByID(tc.expectedMetrics), buildMetaDataMapByID(metrics))
 		})
 	}
 }
@@ -1775,4 +1793,29 @@ func TestLRUCacheResourceMetrics(t *testing.T) {
 	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics2, mockConsumer.metrics[2]))
 	// As just have 1 slot in the cache, but the cache for metric1 was evicted, this metric1_1 should generate a new resource metric, even having the same job/instance than the metric1.
 	assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics1_1, mockConsumer.metrics[3]))
+}
+
+func buildMetaDataMapByID(ms pmetric.Metrics) map[string]map[string]any {
+	result := make(map[string]map[string]any)
+	for i := 0; i < ms.ResourceMetrics().Len(); i++ {
+		rm := ms.ResourceMetrics().At(i)
+		resourceID := identity.OfResource(rm.Resource()).String()
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			scopeName := sm.Scope().Name()
+			scopeVersion := sm.Scope().Version()
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				metricID := fmt.Sprintf("%s:%s:%s:%s:%s",
+					resourceID,
+					scopeName,
+					scopeVersion,
+					m.Name(),
+					m.Unit(),
+				)
+				result[metricID] = m.Metadata().AsRaw()
+			}
+		}
+	}
+	return result
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
METRIC_TYPE_UNSPECIFIED are now accepted by prometheusremotewritereceiver and given value of "unknown" in metric.metadata["prometheus.type"]

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes (partially) #41840 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
In TestTranslateV2 the "unsupported metric type UNSPECIFIED" was removed and "accept unspecified metric type as gauge" was added to test that unspecified types are accepted as gauge


<!--Please delete paragraphs that you did not use before submitting.-->
