### PR TITLE
[receiver/dockerstatsreceiver] Add Windows support

### DIFF
--- a/.chloggen/dockerstatsreceiver-add-windows-support.yaml
+++ b/.chloggen/dockerstatsreceiver-add-windows-support.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: dockerstatsreceiver
+note: "Add Windows support"
+issues: [42297]
+subtext: |
+  The dockerstatsreceiver now supports Windows hosts.
+change_logs: [user]

--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -20,13 +20,13 @@ all desired running containers on a configured interval.  These stats are for co
 resource usage of cpu, memory, network, and the
 [blkio controller](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt).
 
-> :information_source: Requires Docker API version 1.22+ and only Linux is supported.
+> :information_source: Requires Docker API version 1.22+
 
 ## Configuration
 
 The following settings are optional:
 
-- `endpoint` (default = `unix:///var/run/docker.sock`): Address to reach the desired Docker daemon.
+- `endpoint` (default = `unix:///var/run/docker.sock` (Linux) , default = `npipe:////./pipe/docker_engine` (Windows) ): Address to reach the desired Docker daemon.
 - `collection_interval` (default = `10s`): The interval at which to gather container stats.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `container_labels_to_metric_labels` (no default): A map of Docker container label names whose label values to use

--- a/receiver/dockerstatsreceiver/documentation.md
+++ b/receiver/dockerstatsreceiver/documentation.md
@@ -74,7 +74,7 @@ Amount of memory used to cache filesystem data, including tmpfs and shared memor
 
 ### container.memory.percent
 
-Percentage of memory used.
+Percentage of memory used. Not supported on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -82,7 +82,7 @@ Percentage of memory used.
 
 ### container.memory.total_cache
 
-Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -90,7 +90,7 @@ Total amount of memory used by the processes of this cgroup (and descendants) th
 
 ### container.memory.usage.limit
 
-Memory limit of the container.
+Memory limit of the container. Not supported on Windows.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -658,7 +658,7 @@ Number of bytes of file/anon cache that are queued for syncing to disk in this c
 
 ### container.network.io.usage.rx_errors
 
-Received errors.
+Received errors. Not supported on Windows.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -686,7 +686,7 @@ Packets received.
 
 ### container.network.io.usage.tx_errors
 
-Sent errors.
+Sent errors. Not supported on Windows.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -28,13 +28,12 @@ func createDefaultConfig() component.Config {
 	scs := scraperhelper.NewDefaultControllerConfig()
 	scs.CollectionInterval = 10 * time.Second
 	scs.Timeout = 5 * time.Second
+	config := *docker.NewDefaultConfig()
+	config.DockerAPIVersion = defaultDockerAPIVersion
+	config.Timeout = scs.Timeout
 	return &Config{
-		ControllerConfig: scs,
-		Config: docker.Config{
-			Endpoint:         "unix:///var/run/docker.sock",
-			DockerAPIVersion: defaultDockerAPIVersion,
-			Timeout:          scs.Timeout,
-		},
+		ControllerConfig:     scs,
+		Config:               config,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
 }

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -1974,7 +1974,7 @@ type metricContainerMemoryPercent struct {
 // init fills container.memory.percent metric with initial data.
 func (m *metricContainerMemoryPercent) init() {
 	m.data.SetName("container.memory.percent")
-	m.data.SetDescription("Percentage of memory used.")
+	m.data.SetDescription("Percentage of memory used. Not supported on Windows.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 }
@@ -2431,7 +2431,7 @@ type metricContainerMemoryTotalCache struct {
 // init fills container.memory.total_cache metric with initial data.
 func (m *metricContainerMemoryTotalCache) init() {
 	m.data.SetName("container.memory.total_cache")
-	m.data.SetDescription("Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).")
+	m.data.SetDescription("Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
@@ -3145,7 +3145,7 @@ type metricContainerMemoryUsageLimit struct {
 // init fills container.memory.usage.limit metric with initial data.
 func (m *metricContainerMemoryUsageLimit) init() {
 	m.data.SetName("container.memory.usage.limit")
-	m.data.SetDescription("Memory limit of the container.")
+	m.data.SetDescription("Memory limit of the container. Not supported on Windows.")
 	m.data.SetUnit("By")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)
@@ -3455,7 +3455,7 @@ type metricContainerNetworkIoUsageRxErrors struct {
 // init fills container.network.io.usage.rx_errors metric with initial data.
 func (m *metricContainerNetworkIoUsageRxErrors) init() {
 	m.data.SetName("container.network.io.usage.rx_errors")
-	m.data.SetDescription("Received errors.")
+	m.data.SetDescription("Received errors. Not supported on Windows.")
 	m.data.SetUnit("{errors}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -3667,7 +3667,7 @@ type metricContainerNetworkIoUsageTxErrors struct {
 // init fills container.network.io.usage.tx_errors metric with initial data.
 func (m *metricContainerNetworkIoUsageTxErrors) init() {
 	m.data.SetName("container.network.io.usage.tx_errors")
-	m.data.SetDescription("Sent errors.")
+	m.data.SetDescription("Sent errors. Not supported on Windows.")
 	m.data.SetUnit("{errors}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -845,7 +845,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["container.memory.percent"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Percentage of memory used.", ms.At(i).Description())
+					assert.Equal(t, "Percentage of memory used. Not supported on Windows.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
@@ -969,7 +969,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["container.memory.total_cache"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).", ms.At(i).Description())
+					assert.Equal(t, "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.", ms.At(i).Description())
 					assert.Equal(t, "By", ms.At(i).Unit())
 					assert.False(t, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -1165,7 +1165,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["container.memory.usage.limit"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Memory limit of the container.", ms.At(i).Description())
+					assert.Equal(t, "Memory limit of the container. Not supported on Windows.", ms.At(i).Description())
 					assert.Equal(t, "By", ms.At(i).Unit())
 					assert.False(t, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -1255,7 +1255,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["container.network.io.usage.rx_errors"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Received errors.", ms.At(i).Description())
+					assert.Equal(t, "Received errors. Not supported on Windows.", ms.At(i).Description())
 					assert.Equal(t, "{errors}", ms.At(i).Unit())
 					assert.True(t, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -1323,7 +1323,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["container.network.io.usage.tx_errors"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Sent errors.", ms.At(i).Description())
+					assert.Equal(t, "Sent errors. Not supported on Windows.", ms.At(i).Description())
 					assert.Equal(t, "{errors}", ms.At(i).Unit())
 					assert.True(t, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -171,7 +171,7 @@ metrics:
   # Memory
   container.memory.usage.limit:
     enabled: true
-    description: "Memory limit of the container."
+    description: "Memory limit of the container. Not supported on Windows."
     unit: By
     sum:
       value_type: int
@@ -195,7 +195,7 @@ metrics:
       monotonic: false
   container.memory.percent:
     enabled: true
-    description: "Percentage of memory used."
+    description: "Percentage of memory used. Not supported on Windows."
     unit: "1"
     gauge:
       value_type: double
@@ -341,7 +341,7 @@ metrics:
       monotonic: false
   container.memory.total_cache:
     enabled: true
-    description: "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1)."
+    description: "Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows."
     unit: By
     sum:
       value_type: int
@@ -641,7 +641,7 @@ metrics:
       - interface
   container.network.io.usage.rx_errors:
     enabled: false
-    description: "Received errors."
+    description: "Received errors. Not supported on Windows."
     unit: "{errors}"
     sum:
       value_type: int
@@ -651,7 +651,7 @@ metrics:
       - interface
   container.network.io.usage.tx_errors:
     enabled: false
-    description: "Sent errors."
+    description: "Sent errors. Not supported on Windows."
     unit: "{errors}"
     sum:
       value_type: int

--- a/receiver/dockerstatsreceiver/metric_helper.go
+++ b/receiver/dockerstatsreceiver/metric_helper.go
@@ -13,62 +13,6 @@ import (
 
 const nanosInASecond = 1e9
 
-// Following functions has been copied from: calculateCPUPercentUnix(), calculateMemUsageUnixNoCache(), calculateMemPercentUnixNoCache()
-// https://github.com/docker/cli/blob/a2e9ed3b874fccc177b9349f3b0277612403934f/cli/command/container/stats_helpers.go
-
-// Copyright 2012-2017 Docker, Inc.
-// This product includes software developed at Docker, Inc. (https://www.docker.com).
-// The following is courtesy of our legal counsel:
-// Use and transfer of Docker may be subject to certain restrictions by the
-// United States and other governments.
-// It is your responsibility to ensure that your use and/or transfer does not
-// violate applicable laws.
-// For more information, please see https://www.bis.doc.gov
-// See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
-
-func calculateCPUPercent(previous, v *ctypes.CPUStats) float64 {
-	var (
-		cpuPercent = 0.0
-		// calculate the change for the cpu usage of the container in between readings
-		cpuDelta = float64(v.CPUUsage.TotalUsage) - float64(previous.CPUUsage.TotalUsage)
-		// calculate the change for the entire system between readings
-		systemDelta = float64(v.SystemUsage) - float64(previous.SystemUsage)
-		onlineCPUs  = float64(v.OnlineCPUs)
-	)
-
-	if onlineCPUs == 0.0 {
-		onlineCPUs = float64(len(v.CPUUsage.PercpuUsage))
-	}
-	if systemDelta > 0.0 && cpuDelta > 0.0 {
-		cpuPercent = (cpuDelta / systemDelta) * onlineCPUs * 100.0
-	}
-	return cpuPercent
-}
-
-// calculateMemUsageNoCache calculate memory usage of the container.
-// Cache is intentionally excluded to avoid misinterpretation of the output.
-//
-// On cgroup v1 host, the result is `mem.Usage - mem.Stats["total_inactive_file"]` .
-// On cgroup v2 host, the result is `mem.Usage - mem.Stats["inactive_file"] `.
-//
-// This definition is consistent with cadvisor and containerd/CRI.
-// * https://github.com/google/cadvisor/commit/307d1b1cb320fef66fab02db749f07a459245451
-// * https://github.com/containerd/cri/commit/6b8846cdf8b8c98c1d965313d66bc8489166059a
-//
-// On Docker 19.03 and older, the result was `mem.Usage - mem.Stats["cache"]`.
-// See https://github.com/moby/moby/issues/40727 for the background.
-func calculateMemUsageNoCache(memoryStats *ctypes.MemoryStats) uint64 {
-	// cgroup v1
-	if v, isCgroup1 := memoryStats.Stats["total_inactive_file"]; isCgroup1 && v < memoryStats.Usage {
-		return memoryStats.Usage - v
-	}
-	// cgroup v2
-	if v := memoryStats.Stats["inactive_file"]; v < memoryStats.Usage {
-		return memoryStats.Usage - v
-	}
-	return memoryStats.Usage
-}
-
 func calculateMemoryPercent(limit, usedNoCache uint64) float64 {
 	// MemoryStats.Limit will never be 0 unless the container is not running and we haven't
 	// got any data from cgroup

--- a/receiver/dockerstatsreceiver/metric_helper_others.go
+++ b/receiver/dockerstatsreceiver/metric_helper_others.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package dockerstatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
+
+import (
+	ctypes "github.com/docker/docker/api/types/container"
+)
+
+// Following functions has been copied from: calculateCPUPercentUnix(), calculateMemUsageUnixNoCache(), calculateMemPercentUnixNoCache()
+// https://github.com/docker/cli/blob/a2e9ed3b874fccc177b9349f3b0277612403934f/cli/command/container/stats_helpers.go
+
+// Copyright 2012-2017 Docker, Inc.
+// This product includes software developed at Docker, Inc. (https://www.docker.com).
+// The following is courtesy of our legal counsel:
+// Use and transfer of Docker may be subject to certain restrictions by the
+// United States and other governments.
+// It is your responsibility to ensure that your use and/or transfer does not
+// violate applicable laws.
+// For more information, please see https://www.bis.doc.gov
+// See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+func calculateCPUPercent(containerStats *ctypes.StatsResponse) float64 {
+	v := containerStats.CPUStats
+	previous := containerStats.PreCPUStats
+	var (
+		cpuPercent = 0.0
+		// calculate the change for the cpu usage of the container in between readings
+		cpuDelta = float64(v.CPUUsage.TotalUsage) - float64(previous.CPUUsage.TotalUsage)
+		// calculate the change for the entire system between readings
+		systemDelta = float64(v.SystemUsage) - float64(previous.SystemUsage)
+		onlineCPUs  = float64(v.OnlineCPUs)
+	)
+
+	if onlineCPUs == 0.0 {
+		onlineCPUs = float64(len(v.CPUUsage.PercpuUsage))
+	}
+	if systemDelta > 0.0 && cpuDelta > 0.0 {
+		cpuPercent = (cpuDelta / systemDelta) * onlineCPUs * 100.0
+	}
+	return cpuPercent
+}
+
+// calculateMemUsageNoCache calculate memory usage of the container.
+// Cache is intentionally excluded to avoid misinterpretation of the output.
+//
+// On cgroup v1 host, the result is `mem.Usage - mem.Stats["total_inactive_file"]` .
+// On cgroup v2 host, the result is `mem.Usage - mem.Stats["inactive_file"] `.
+//
+// This definition is consistent with cadvisor and containerd/CRI.
+// * https://github.com/google/cadvisor/commit/307d1b1cb320fef66fab02db749f07a459245451
+// * https://github.com/containerd/cri/commit/6b8846cdf8b8c98c1d965313d66bc8489166059a
+//
+// On Docker 19.03 and older, the result was `mem.Usage - mem.Stats["cache"]`.
+// See https://github.com/moby/moby/issues/40727 for the background.
+func calculateMemUsageNoCache(memoryStats *ctypes.MemoryStats) uint64 {
+	// cgroup v1
+	if v, isCgroup1 := memoryStats.Stats["total_inactive_file"]; isCgroup1 && v < memoryStats.Usage {
+		return memoryStats.Usage - v
+	}
+	// cgroup v2
+	if v := memoryStats.Stats["inactive_file"]; v < memoryStats.Usage {
+		return memoryStats.Usage - v
+	}
+	return memoryStats.Usage
+}

--- a/receiver/dockerstatsreceiver/metric_helper_windows.go
+++ b/receiver/dockerstatsreceiver/metric_helper_windows.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package dockerstatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
+
+import (
+	ctypes "github.com/docker/docker/api/types/container"
+)
+
+// Following functions has been copied from: calculateCPUPercentWindows()
+// https://github.com/docker/cli/blob/f40caed86c0f90d4295702e248c4824cd75839f1/cli/command/container/stats_helpers.go
+
+// Copyright 2012-2017 Docker, Inc.
+// This product includes software developed at Docker, Inc. (https://www.docker.com).
+// The following is courtesy of our legal counsel:
+// Use and transfer of Docker may be subject to certain restrictions by the
+// United States and other governments.
+// It is your responsibility to ensure that your use and/or transfer does not
+// violate applicable laws.
+// For more information, please see https://www.bis.doc.gov
+// See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+func calculateCPUPercent(v *ctypes.StatsResponse) float64 {
+	// Max number of 100ns intervals between the previous time read and now
+	possIntervals := uint64(v.Read.Sub(v.PreRead).Nanoseconds()) // Start with number of ns intervals
+	possIntervals /= 100                                         // Convert to number of 100ns intervals
+	possIntervals *= uint64(v.NumProcs)                          // Multiple by the number of processors
+
+	// Intervals used
+	intervalsUsed := v.CPUStats.CPUUsage.TotalUsage - v.PreCPUStats.CPUUsage.TotalUsage
+
+	// Percentage avoiding divide-by-zero
+	if possIntervals > 0 {
+		return float64(intervalsUsed) / float64(possIntervals) * 100.0
+	}
+	return 0.00
+}
+
+// calculateMemUsageNoCache calculate memory usage of the container.
+func calculateMemUsageNoCache(memoryStats *ctypes.MemoryStats) uint64 {
+	return memoryStats.PrivateWorkingSet
+}

--- a/receiver/dockerstatsreceiver/testdata/integration/expected.yaml
+++ b/receiver/dockerstatsreceiver/testdata/integration/expected.yaml
@@ -99,7 +99,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.009669439735715272
@@ -107,7 +107,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: container.memory.percent
             unit: "1"
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
@@ -210,7 +210,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 87.41302490234375
@@ -247,7 +247,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -302,7 +302,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -358,7 +358,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
@@ -270,7 +270,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.016875995187363255
@@ -307,7 +307,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -362,7 +362,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -418,7 +418,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
@@ -443,7 +443,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.006938014912420301
@@ -527,7 +527,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
             name: container.memory.total_cache
             sum:
               aggregationTemporality: 2
@@ -657,7 +657,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -721,7 +721,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -777,7 +777,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
@@ -262,7 +262,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.016875995187363255
@@ -299,7 +299,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -354,7 +354,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -410,7 +410,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -448,7 +448,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.006938014912420301
@@ -532,7 +532,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
             name: container.memory.total_cache
             sum:
               aggregationTemporality: 2
@@ -662,7 +662,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -726,7 +726,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -782,7 +782,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
@@ -449,7 +449,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.006938014912420301
@@ -533,7 +533,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
             name: container.memory.total_cache
             sum:
               aggregationTemporality: 2
@@ -663,7 +663,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -727,7 +727,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -783,7 +783,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
@@ -393,7 +393,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.02053846320949035
@@ -477,7 +477,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
             name: container.memory.total_cache
             sum:
               aggregationTemporality: 2
@@ -607,7 +607,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -671,7 +671,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -727,7 +727,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2
@@ -1178,7 +1178,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Percentage of memory used.
+          - description: Percentage of memory used. Not supported on Windows.
             gauge:
               dataPoints:
                 - asDouble: 0.037324707178785346
@@ -1262,7 +1262,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1).
+          - description: Total amount of memory used by the processes of this cgroup (and descendants) that can be associated with a block on a block device. Also accounts for memory used by tmpfs (Only available with cgroups v1). Not supported on Windows.
             name: container.memory.total_cache
             sum:
               aggregationTemporality: 2
@@ -1392,7 +1392,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: Memory limit of the container.
+          - description: Memory limit of the container. Not supported on Windows.
             name: container.memory.usage.limit
             sum:
               aggregationTemporality: 2
@@ -1456,7 +1456,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Received errors.
+          - description: Received errors. Not supported on Windows.
             name: container.network.io.usage.rx_errors
             sum:
               aggregationTemporality: 2
@@ -1512,7 +1512,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{packets}'
-          - description: Sent errors.
+          - description: Sent errors. Not supported on Windows.
             name: container.network.io.usage.tx_errors
             sum:
               aggregationTemporality: 2


### PR DESCRIPTION
#### Description
dockerstatsreceiver logic to read CPU and memory seems to be copied from Docker CLI but for some reason only *nix related parts was copied.

As result of that it is possible to run this receiver in Windows but only network related metrics actually provides any data.

So now I copied also Windows specific functions and added needed logic that default endpoint is correctly detected.

#### Testing
Unfortunately it is not possible easily add tests for this because:
* ~Integration test is currently completely disabled #42204~
* testcontainers-go does not support Windows containers https://github.com/testcontainers/testcontainers-go/issues/948

What I did instead of was using this configuration to see that all metrics are working in both Linux and Windows:
```yaml
receivers:
  docker_stats:
    api_version: "1.25"
    metrics:
      # Disable metrics which Windows does not support
      container.network.io.usage.rx_errors:
        enabled: false
      container.network.io.usage.tx_errors:
        enabled: false
      container.memory.percent:
        enabled: false
      container.memory.usage.limit:
        enabled: false
      container.memory.total_cache:
        enabled: false

exporters:
  debug:
    verbosity: detailed

service:
  telemetry:
    logs:
      level: debug

  pipelines:
    metrics:
      receivers: [docker_stats]
      exporters: [debug]
```
Documentation about which metrics are expected to be working can be found from https://github.com/moby/moby/blob/38be9f12574b4d38c76be2864a6b09574644aff5/api/types/container/stats.go

#### Documentation
Updated info about default endpoint and removed comment that only Linux is supported.
