### PR TITLE
[receivers/httpcheck] fix race conditions in http timing

### DIFF
--- a/.chloggen/httpcheck-fix-race.yaml
+++ b/.chloggen/httpcheck-fix-race.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: httpcheckreceiver
+note: Fix race for timing of request steps
+issues: [42042]
+subtext: |
+  The httpcheckreceiver uses atomic operations to track the timing of request steps to avoid race conditions.
+change_logs: [user]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The initial implementation uses an approach that was not safe for async.

This PR changes the calls so they are using atomic store options.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #42042

<!--Describe what testing was performed and which tests were added.-->
#### Testing

This thing is baffling and I have a pretty good sense that this will fix it but I haven't been able to reproduce the race issue locally.

<!--Describe the documentation added.-->
#### Documentation

This fix is an implementation detail so no documentation is added.

<!--Please delete paragraphs that you did not use before submitting.-->
