### PR TITLE
Fix sqlserver memory leaking

### DIFF
--- a/.chloggen/sqlserver-memory-leak.yaml
+++ b/.chloggen/sqlserver-memory-leak.yaml
@@ -1,0 +1,7 @@
+change_type: bug
+component: sqlserverreceiver
+note: Fix memory leak
+issues: [42302]
+subtext: |
+  The issue was caused by the misuse of the obfuscate library.
+change_logs: [user]

--- a/.chloggen/sqlserver-memory-leak.yaml
+++ b/.chloggen/sqlserver-memory-leak.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 component: sqlserverreceiver
-note: Fix memory leak
+note: Fix memory leak from top queries and query samples features
 issues: [42302]
 subtext: |
   The issue was caused by the misuse of the obfuscate library.

--- a/.chloggen/sqlserver-memory-leak.yaml
+++ b/.chloggen/sqlserver-memory-leak.yaml
@@ -1,4 +1,4 @@
-change_type: bug
+change_type: bug_fix
 component: sqlserverreceiver
 note: Fix memory leak
 issues: [42302]

--- a/receiver/sqlserverreceiver/obfuscate.go
+++ b/receiver/sqlserverreceiver/obfuscate.go
@@ -19,17 +19,20 @@ var (
 		"ScalarString",
 		"ParameterCompiledValue",
 	}
-	obfuscateSQLConfig = obfuscate.SQLConfig{DBMS: "mssql"}
 )
 
 type obfuscator obfuscate.Obfuscator
 
 func newObfuscator() *obfuscator {
-	return (*obfuscator)(obfuscate.NewObfuscator(obfuscate.Config{}))
+	return (*obfuscator)(obfuscate.NewObfuscator(obfuscate.Config{
+		SQL: obfuscate.SQLConfig{
+			DBMS: "mssql",
+		},
+	}))
 }
 
 func (o *obfuscator) obfuscateSQLString(sql string) (string, error) {
-	obfuscatedQuery, err := (*obfuscate.Obfuscator)(o).ObfuscateSQLStringWithOptions(sql, &obfuscateSQLConfig, "")
+	obfuscatedQuery, err := (*obfuscate.Obfuscator)(o).ObfuscateSQLString(sql)
 	if err != nil {
 		return "", err
 	}

--- a/receiver/sqlserverreceiver/obfuscate.go
+++ b/receiver/sqlserverreceiver/obfuscate.go
@@ -12,14 +12,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 )
 
-var (
-	xmlPlanObfuscationAttrs = []string{
-		"StatementText",
-		"ConstValue",
-		"ScalarString",
-		"ParameterCompiledValue",
-	}
-)
+var xmlPlanObfuscationAttrs = []string{
+	"StatementText",
+	"ConstValue",
+	"ScalarString",
+	"ParameterCompiledValue",
+}
 
 type obfuscator obfuscate.Obfuscator
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Calling `ObfuscateSQLStringWithOptions` method with an empty `optsStr` is not the ideal way to use this [obfuscate](https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/obfuscate) library.

See, https://github.com/DataDog/datadog-agent/blob/928f3f3972c57296ca37e65e344489e2dd407dee/pkg/obfuscate/sql.go#L315-L323

> // Ideally we should never fallback to this because it's expensive
> log.Warn("falling back to JSON marshalling of SQLConfig options, this should be avoided if possible")

And, this also triggers a memory leak issue in `log.Warn` from https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/util/log

#### Changes

This PR uses the correct and efficient way to call the `obfuscate` package, and it also resolves the memory leak issue from #42302


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42302
