### PR TITLE
prometheusremotewriteexporter: Remove unnecessary buffer copy in proto conversion

### DIFF
--- a/.chloggen/fix-proto-copy.yaml
+++ b/.chloggen/fix-proto-copy.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unnecessary buffer copy in proto conversion
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42329]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/prometheus/config"
@@ -80,16 +79,43 @@ func (p *prwTelemetryOtel) recordWrittenExemplars(ctx context.Context, numExempl
 	p.telemetryBuilder.ExporterPrometheusremotewriteWrittenExemplars.Add(ctx, numExemplars, metric.WithAttributes(p.otelAttrs...))
 }
 
+type gogoProto interface {
+	Size() int
+	MarshalToSizedBuffer([]byte) (int, error)
+}
+
 type buffer struct {
-	protobuf *proto.Buffer
+	protobuf []byte
 	snappy   []byte
+}
+
+func (b *buffer) MarshalAndEncode(req gogoProto) ([]byte, error) {
+	sizePb := req.Size()
+	if sizePb > cap(b.protobuf) {
+		b.protobuf = make([]byte, sizePb)
+	}
+	b.protobuf = b.protobuf[:sizePb]
+	n, err := req.MarshalToSizedBuffer(b.protobuf)
+	if err != nil {
+		return nil, err
+	}
+	b.protobuf = b.protobuf[:n]
+
+	// If we don't pass a buffer large enough, Snappy Encode function will not use it and instead will allocate a new buffer.
+	// Manually grow the buffer to make sure Snappy uses it and we can re-use it afterwards.
+	maxCompressedLen := snappy.MaxEncodedLen(len(b.protobuf))
+	if maxCompressedLen > cap(b.snappy) {
+		b.snappy = make([]byte, maxCompressedLen)
+	}
+	b.snappy = b.snappy[:maxCompressedLen]
+	return snappy.Encode(b.snappy, b.protobuf), nil
 }
 
 // A reusable buffer pool for serializing protobufs and compressing them with Snappy.
 var bufferPool = sync.Pool{
 	New: func() any {
 		return &buffer{
-			protobuf: proto.NewBuffer(nil),
+			protobuf: nil,
 			snappy:   nil,
 		}
 	},
@@ -340,6 +366,8 @@ func (prwe *prwExporter) export(ctx context.Context, requests []*prompb.WriteReq
 	for i := 0; i < concurrencyLimit; i++ {
 		go func() {
 			defer wg.Done()
+			buf := bufferPool.Get().(*buffer)
+			defer bufferPool.Put(buf)
 			for {
 				select {
 				case <-ctx.Done(): // Check firstly to ensure that the context wasn't cancelled.
@@ -350,18 +378,15 @@ func (prwe *prwExporter) export(ctx context.Context, requests []*prompb.WriteReq
 						return
 					}
 
-					buf := bufferPool.Get().(*buffer)
-					buf.protobuf.Reset()
-					defer bufferPool.Put(buf)
-
-					if errMarshal := buf.protobuf.Marshal(request); errMarshal != nil {
+					reqBuf, errMarshal := buf.MarshalAndEncode(request)
+					if errMarshal != nil {
 						mu.Lock()
 						errs = multierr.Append(errs, consumererror.NewPermanent(errMarshal))
 						mu.Unlock()
 						return
 					}
 
-					if errExecute := prwe.execute(ctx, buf); errExecute != nil {
+					if errExecute := prwe.execute(ctx, reqBuf); errExecute != nil {
 						mu.Lock()
 						errs = multierr.Append(errs, consumererror.NewPermanent(errExecute))
 						mu.Unlock()
@@ -375,19 +400,7 @@ func (prwe *prwExporter) export(ctx context.Context, requests []*prompb.WriteReq
 	return errs
 }
 
-func (prwe *prwExporter) execute(ctx context.Context, buf *buffer) error {
-	// If we don't pass a buffer large enough, Snappy Encode function will not use it and instead will allocate a new buffer.
-	// Manually grow the buffer to make sure Snappy uses it and we can re-use it afterwards.
-	maxCompressedLen := snappy.MaxEncodedLen(len(buf.protobuf.Bytes()))
-	if maxCompressedLen > len(buf.snappy) {
-		if cap(buf.snappy) < maxCompressedLen {
-			buf.snappy = make([]byte, maxCompressedLen)
-		} else {
-			buf.snappy = buf.snappy[:maxCompressedLen]
-		}
-	}
-	compressedData := snappy.Encode(buf.snappy, buf.protobuf.Bytes())
-
+func (prwe *prwExporter) execute(ctx context.Context, buf []byte) error {
 	retryCount := 0
 	// executeFunc can be used for backoff and non backoff scenarios.
 	executeFunc := func() (int, error) {
@@ -402,7 +415,7 @@ func (prwe *prwExporter) execute(ctx context.Context, buf *buffer) error {
 		}
 
 		// Create the HTTP POST request to send to the endpoint
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, prwe.endpointURL.String(), bytes.NewReader(compressedData))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, prwe.endpointURL.String(), bytes.NewReader(buf))
 		if err != nil {
 			return http.StatusBadRequest, backoff.Permanent(consumererror.NewPermanent(err))
 		}


### PR DESCRIPTION
This happens because the proto message is generated with gogoproto, and it will go on the path https://github.com/gogo/protobuf/blob/f67b8970b736e53dbd7d0a27146c8f1ac52f74e5/proto/table_marshal.go#L2977

Benchmark numbers show improvement as well.

**After:**
```
BenchmarkExecute/numSample=100
BenchmarkExecute/numSample=100-12         	   21752	     52500 ns/op	    6635 B/op	      83 allocs/op
BenchmarkExecute/numSample=1000
BenchmarkExecute/numSample=1000-12        	   10000	    131918 ns/op	   23096 B/op	      86 allocs/op
BenchmarkExecute/numSample=10000
BenchmarkExecute/numSample=10000-12       	    1479	    886487 ns/op	   41477 B/op	      86 allocs/op
```

**Before:**
```
BenchmarkExecute/numSample=100
BenchmarkExecute/numSample=100-12         	   20642	     55670 ns/op	    6635 B/op	      83 allocs/op
BenchmarkExecute/numSample=1000
BenchmarkExecute/numSample=1000-12        	    8640	    145875 ns/op	   23121 B/op	      86 allocs/op
BenchmarkExecute/numSample=10000
BenchmarkExecute/numSample=10000-12       	    1015	   1257688 ns/op	  304366 B/op	      87 allocs/op
```
