### PR TITLE
[chore] remove ambiguous language

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -28,8 +28,6 @@ available on your system.
 
 # Configuration
 
-Note: this receiver is in alpha and functionality and configuration fields are subject to change.
-
 Example configuration:
 
 ```yaml

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -23,8 +23,6 @@ https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L1159.
 
 ## Configuration
 
-> :information_source: This receiver is in beta and configuration fields are subject to change.
-
 The following settings are required:
 
 - `endpoint` (default: `localhost:11211`): The hostname/IP address and port or, unix socket file path of the memcached instance

--- a/receiver/postgresqlreceiver/README.md
+++ b/receiver/postgresqlreceiver/README.md
@@ -18,8 +18,6 @@
 
 This receiver queries the PostgreSQL [statistics collector](https://www.postgresql.org/docs/13/monitoring-stats.html).
 
-> :construction: This receiver is in **BETA**. Configuration fields and metric data model are subject to change.
-
 ## Prerequisites
 
 See PostgreSQL documentation for [supported versions](https://www.postgresql.org/support/versioning).

--- a/receiver/rabbitmqreceiver/README.md
+++ b/receiver/rabbitmqreceiver/README.md
@@ -16,7 +16,6 @@
 
 This receiver fetches stats from a RabbitMQ node using the [RabbitMQ Management Plugin](https://www.rabbitmq.com/management.html).
 
-> :construction: This receiver is in **BETA**. Configuration fields and metric data model are subject to change.
 ## Prerequisites
 
 This receiver supports RabbitMQ versions `3.8` and `3.9`.

--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -47,8 +47,6 @@ with a metric name of `redis.cpu.time` and a units value of `s` (seconds).
 
 ## Configuration
 
-> :information_source: This receiver is in beta and configuration fields are subject to change.
-
 The following settings are required:
 
 - `endpoint` (no default): The hostname and port of the Redis instance,

--- a/receiver/saphanareceiver/README.md
+++ b/receiver/saphanareceiver/README.md
@@ -59,8 +59,6 @@ GRANT OTEL_MONITORING TO otel_monitoring_user;
 
 ## Configuration
 
-> :information_source: This receiver is in beta and configuration fields are subject to change.
-
 The following settings are required:
 
 - `endpoint` (default: `localhost:33015`): The hostname/IP address and port of the SAP HANA instance

--- a/receiver/splunkhecreceiver/README.md
+++ b/receiver/splunkhecreceiver/README.md
@@ -20,8 +20,6 @@ The collector accepts data formatted as JSON [HEC events](https://docs.splunk.co
 under any path or as EOL separated log [raw data](https://docs.splunk.com/Documentation/Splunk/8.2.2/Data/FormateventsforHTTPEventCollector#Raw_event_parsing) 
 if sent to the `raw_path` path.
 
-> :construction: This receiver is in beta and configuration fields are subject to change.
-
 ## Configuration
 
 The following settings are required:


### PR DESCRIPTION
Remove a few instances of the same sentence promising breaking changes on a component.

* This language is applied liberally across components. Any components in beta stability should not be promising breaking changes.
* This language is vague and promises pain, reducing adoption.
* The stability levels already set the rules by which we will change components. Adding this sentence is redundant.