### PR TITLE
[chore] Move Andrew Wilkins to approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ For more information about the maintainer role, see the [community repository](h
 
 ### Approvers
 
+- [Andrew Wilkins](https://github.com/axw), Elastic
 - [Arthur Silva Sens](https://github.com/ArthurSens), Grafana Labs
 - [Braydon Kains](https://github.com/braydonk), Google
 - [Christos Markou](https://github.com/ChrsMark), Elastic
@@ -98,7 +99,6 @@ For more information about the approver role, see the [community repository](htt
 
 ### Triagers
 
-- [Andrew Wilkins](https://github.com/axw), Elastic
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace
 - [Israel Blancas](https://github.com/iblancasa), Coralogix


### PR DESCRIPTION
#### Description
This PR proposes to promote @axw from triager to approver. Andrew is an excellent triager and I think the project will benefit from his expertise. He already reviews PRs routinely for several components.

Comments as triager:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20state%3Aopen%20commenter%3Aaxw

PRs initiated:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+review%3Aapproved+author%3Aaxw

PRs reviewed:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3Aaxw

