### PR TITLE
[chore] Promote Douglas Camata as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For more information about the approver role, see the [community repository](htt
 
 - [Andrew Wilkins](https://github.com/axw), Elastic
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
+- [Douglas Camata](https://github.com/douglascamata), Coralogix
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace
 - [Israel Blancas](https://github.com/iblancasa), Coralogix
 - [James Moessis](https://github.com/jamesmoessis), Atlassian


### PR DESCRIPTION
Douglas is a thoughtful, active contributor for a little while and I would like to offer that we promote him as triager to benefit from his dedication and his insights.
