### PR TITLE
Fix testify issues

### DIFF
--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -905,6 +905,8 @@ func TestConsumeTraces(t *testing.T) {
 
 				// Trigger flush.
 				mockClock.Advance(time.Nanosecond)
+				// Eventually checks immediately since testify v1.11.0 thus we sleep for one period before checking
+				time.Sleep(10 * time.Millisecond)
 				require.Eventually(t, func() bool {
 					return len(mcon.AllMetrics()) > 0
 				}, 1*time.Second, 10*time.Millisecond)

--- a/extension/k8sleaderelector/extension_test.go
+++ b/extension/k8sleaderelector/extension_test.go
@@ -103,6 +103,8 @@ func TestExtension_WithDelay(t *testing.T) {
 
 	// Simulate a delay of setting up callbacks after the leader has been elected.
 	expectedLeaseDurationSeconds := ptr.To(int32(15))
+	// Eventually checks immediately since testify v1.11.0 thus we sleep for one period before checking
+	time.Sleep(100 * time.Millisecond)
 	require.Eventually(t, func() bool {
 		lease, err := fakeClient.CoordinationV1().Leases("default").Get(ctx, "foo", metav1.GetOptions{})
 		require.NoError(t, err)

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -110,6 +110,8 @@ func (it *IntegrationTest) Run(t *testing.T) {
 		}
 	}()
 
+	// Eventually checks immediately since testify v1.11.0 thus we sleep for one period before checking
+	time.Sleep(it.compareTimeout / 20)
 	require.Eventually(t,
 		func() bool {
 			allMetrics := sink.AllMetrics()

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -468,6 +468,8 @@ func TestPeriodicMetrics(t *testing.T) {
 	go em.periodicMetrics()
 
 	// ensure our gauge is showing 1 item in the queue
+	// Eventually checks immediately since testify v1.11.0 thus we sleep for one period before checking
+	time.Sleep(10 * time.Millisecond)
 	assert.Eventually(t, func() bool {
 		return getGaugeValue(t, "otelcol_processor_groupbytrace_num_events_in_queue", s) == 1
 	}, 1*time.Second, 10*time.Millisecond)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes testify update issues by adding an explicit `time.Sleep`. I don't love this solution but it unblocks us from upgrading the packages and it's effectively what happened before.