### PR TITLE
[chore] Fix test flakiness in `prometheusexporter`

### DIFF
--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -140,9 +140,9 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, exp.Shutdown(t.Context()))
-	})
+	}()
 
 	assert.NotNil(t, exp)
 
@@ -193,9 +193,9 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 	exp, err := factory.CreateMetrics(t.Context(), set, cfg)
 	assert.NoError(t, err)
 
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, exp.Shutdown(t.Context()))
-	})
+	}()
 
 	assert.NotNil(t, exp)
 
@@ -267,9 +267,9 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	exp, err := factory.CreateMetrics(t.Context(), set, cfg)
 	assert.NoError(t, err)
 
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, exp.Shutdown(t.Context()))
-	})
+	}()
 
 	assert.NotNil(t, exp)
 
@@ -336,9 +336,9 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 	exp, err := factory.CreateMetrics(t.Context(), set, cfg)
 	assert.NoError(t, err)
 
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, exp.Shutdown(t.Context()))
-	})
+	}()
 
 	assert.NotNil(t, exp)
 	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
@@ -408,9 +408,9 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	exp, err := factory.CreateMetrics(t.Context(), set, cfg)
 	assert.NoError(t, err)
 
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, exp.Shutdown(t.Context()))
-	})
+	}()
 
 	assert.NotNil(t, exp)
 	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
@@ -668,9 +668,9 @@ this_one_there_where_{arch="x86",instance="test-instance",job="test-service",os=
 			exp, err := factory.CreateMetrics(t.Context(), set, cfg)
 			require.NoError(t, err)
 
-			t.Cleanup(func() {
+			defer func() {
 				require.NoError(t, exp.Shutdown(t.Context()))
-			})
+			}()
 
 			assert.NotNil(t, exp)
 			require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
@@ -681,7 +681,6 @@ this_one_there_where_{arch="x86",instance="test-instance",job="test-service",os=
 			// Scrape metrics, with the Accept header set to the value specified in the test case
 			req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/metrics", http.NoBody)
 			require.NoError(t, err)
-			req.Close = true
 			for k, v := range tt.extraHeaders {
 				req.Header.Set(k, v)
 			}


### PR DESCRIPTION
With the use `t.Context()` there is a race in which the HTTP server doesn't shutdown on first pass it hits context canceled error since `t.Cleanup` always cancels the context prior to the clean-up code. Moving the shutdown to a `defer` ensures that the shutdown happens before `t.Context()` is cancelled.

Fix #42259
