### PR TITLE
[chore] fix panic issued in test when the gauge data is not present

### DIFF
--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -468,7 +468,7 @@ func TestPeriodicMetrics(t *testing.T) {
 	go em.periodicMetrics()
 
 	// ensure our gauge is showing 1 item in the queue
-	assert.EventuallyWithT(t, func(tt *assert.CollectT)  {
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		val := getGaugeValue(t.Context(), tt, "otelcol_processor_groupbytrace_num_events_in_queue", s)
 		assert.Equal(tt, int64(1), val)
 	}, 1*time.Second, 10*time.Millisecond)
@@ -476,7 +476,7 @@ func TestPeriodicMetrics(t *testing.T) {
 	wg.Done() // release all events
 
 	// ensure our gauge is now showing no items in the queue
-	assert.EventuallyWithT(t, func(tt *assert.CollectT)  {
+	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
 		val := getGaugeValue(t.Context(), tt, "otelcol_processor_groupbytrace_num_events_in_queue", s)
 		assert.Equal(tt, int64(0), val)
 	}, 1*time.Second, 10*time.Millisecond)

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -468,15 +468,17 @@ func TestPeriodicMetrics(t *testing.T) {
 	go em.periodicMetrics()
 
 	// ensure our gauge is showing 1 item in the queue
-	assert.Eventually(t, func() bool {
-		return getGaugeValue(t, "otelcol_processor_groupbytrace_num_events_in_queue", s) == 1
+	assert.EventuallyWithT(t, func(tt *assert.CollectT)  {
+		val := getGaugeValue(t.Context(), tt, "otelcol_processor_groupbytrace_num_events_in_queue", s)
+		assert.Equal(tt, int64(1), val)
 	}, 1*time.Second, 10*time.Millisecond)
 
 	wg.Done() // release all events
 
 	// ensure our gauge is now showing no items in the queue
-	assert.Eventually(t, func() bool {
-		return getGaugeValue(t, "otelcol_processor_groupbytrace_num_events_in_queue", s) == 0
+	assert.EventuallyWithT(t, func(tt *assert.CollectT)  {
+		val := getGaugeValue(t.Context(), tt, "otelcol_processor_groupbytrace_num_events_in_queue", s)
+		assert.Equal(tt, int64(0), val)
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// signal and wait for the recursive call to finish
@@ -534,12 +536,17 @@ func TestDoWithTimeout_TimeoutTrigger(t *testing.T) {
 	assert.WithinDuration(t, start, time.Now(), 100*time.Millisecond)
 }
 
-func getGaugeValue(t *testing.T, name string, tt testTelemetry) int64 {
+func getGaugeValue(ctx context.Context, t *assert.CollectT, name string, tt testTelemetry) int64 {
 	var md metricdata.ResourceMetrics
-	require.NoError(t, tt.reader.Collect(t.Context(), &md))
+	require.NoError(t, tt.reader.Collect(ctx, &md))
 	m := tt.getMetric(name, md).Data
-	g := m.(metricdata.Gauge[int64])
-	assert.Len(t, g.DataPoints, 1, "expected exactly one data point")
+	var g metricdata.Gauge[int64]
+	var ok bool
+	if g, ok = m.(metricdata.Gauge[int64]); !ok {
+		assert.Fail(t, "missing gauge data")
+	} else {
+		assert.Len(t, g.DataPoints, 1, "expected exactly one data point")
+	}
 	return g.DataPoints[0].Value
 }
 


### PR DESCRIPTION
See the failing CI run https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17329322611/job/49201552364?pr=42354