### PR TITLE
[pkg/ottl] Fix performance regression when setting maps

### DIFF
--- a/.chloggen/make-set-samemap-noop.yaml
+++ b/.chloggen/make-set-samemap-noop.yaml
@@ -4,10 +4,10 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: Fix performance regression caused by copying pcommon.Map in a few OTTL functions
+component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: Fix performance regression by making `ctxutil.SetMap` noop when maps are equals.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42350]

--- a/.chloggen/make-set-samemap-noop.yaml
+++ b/.chloggen/make-set-samemap-noop.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: Fix performance regression caused by copying pcommon.Map in a few OTTL functions
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42350]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/contexts/internal/ctxutil/map.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map.go
@@ -83,7 +83,9 @@ func FetchValueFromExpression[K any, T int64 | string](ctx context.Context, tCtx
 
 func SetMap(target pcommon.Map, val any) error {
 	if cm, ok := val.(pcommon.Map); ok {
-		cm.CopyTo(target)
+		if cm != target {
+			cm.CopyTo(target)
+		}
 		return nil
 	}
 	if rm, ok := val.(map[string]any); ok {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix performance regression by making `ctxutil.SetMap` noop when maps are equals.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42350

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
