### PR TITLE
[chore] Fix flaky ctx canceled error on datadogreceiver tests

### DIFF
--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -128,6 +128,10 @@ func TestDatadogServer(t *testing.T) {
 			)
 			require.NoError(t, err, "Must not error when creating request")
 
+			// Because tests are parallel, and the call to shutdown is happening on a t.Cleanup,
+			// minimize the duration of connections to speed up the shutdown in the test cleanup.
+			req.Close = true
+
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err, "Must not error performing request")
 


### PR DESCRIPTION
PR #42113 improved but didn't completely fix the race with `context canceled` issue in the receiver tests. In particular `req.Close = true` wasn't enough, but I'm keeping it since it should speed up the shutdown. This fix the remaining flakiness, `t.Cleanup` used in conjunction with `t.Parallel`, by wrapping `t.Context()` with `context.WithoutCancel` since the mechanism to terminate the server connections doesn't seem to be deterministic.

Fix #42130, #42337, #42229
