### PR TITLE
[chore] lokireceiver: fix use of testing.T.Context

### DIFF
--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -134,7 +134,7 @@ func startHTTPServer(t *testing.T) (string, *consumertest.LogsSink) {
 
 	require.NoError(t, lr.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
-		require.NoError(t, lr.Shutdown(context.Background())) //nolint:usetesting
+		require.NoError(t, lr.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	return addr, sink

--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -132,7 +133,9 @@ func startHTTPServer(t *testing.T) (string, *consumertest.LogsSink) {
 	require.NoError(t, err)
 
 	require.NoError(t, lr.Start(t.Context(), componenttest.NewNopHost()))
-	t.Cleanup(func() { require.NoError(t, lr.Shutdown(t.Context())) })
+	t.Cleanup(func() {
+		require.NoError(t, lr.Shutdown(context.Background())) //nolint:usetesting
+	})
 
 	return addr, sink
 }


### PR DESCRIPTION
#### Description

Don't use `testing.T.Context` in test cleanups, the context is guaranteed to be cancelled and leads to flaky tests, e.g. https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17357035668/job/49288032030?pr=42048

#### Link to tracking issue

None

#### Testing

N/A

#### Documentation

N/A