### PR TITLE
[receiver/libhoney] Set scopes more flexibly to avoid losing service.name

### DIFF
--- a/.chloggen/libhoney-scopes-and-errors.yaml
+++ b/.chloggen/libhoney-scopes-and-errors.yaml
@@ -4,6 +4,5 @@ note: Allow service.name with unset scope.name
 issues: [42432]
 subtext:
   This change allows the receiver to handle multiple service.names even if there are spans without the scope set.
-  It also improves error handling by returning the proper array of per-event statuses.
   It also avoids a panic when a downstream consumer is missing.
 change_logs: [user]

--- a/.chloggen/libhoney-scopes-and-errors.yaml
+++ b/.chloggen/libhoney-scopes-and-errors.yaml
@@ -1,7 +1,7 @@
 change_type: bug_fix
 component: libhoneyreceiver
 note: Allow service.name with unset scope.name 
-issues: []
+issues: [42432]
 subtext:
   This change allows the receiver to handle multiple service.names even if there are spans without the scope set.
   It also improves error handling by returning the proper array of per-event statuses.

--- a/.chloggen/libhoney-scopes-and-errors.yaml
+++ b/.chloggen/libhoney-scopes-and-errors.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: libhoneyreceiver
+note: Allow service.name with unset scope.name 
+issues: []
+subtext:
+  This change allows the receiver to handle multiple service.names even if there are spans without the scope set.
+  It also improves error handling by returning the proper array of per-event statuses.
+  It also avoids a panic when a downstream consumer is missing.
+change_logs: [user]

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent_test.go
@@ -273,7 +273,7 @@ func TestLibhoneyEvent_GetScope(t *testing.T) {
 				},
 			},
 			serviceName: "test-service",
-			want:        "libhoney.receiver",
+			want:        "test-service-libhoney.receiver",
 			wantErr:     true,
 		},
 	}

--- a/receiver/libhoneyreceiver/internal/parser/parser.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser.go
@@ -43,7 +43,6 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 	spanEvents := map[trc.SpanID][]libhoneyevent.LibhoneyEvent{}
 
 	foundScopes.Scope = make(map[string]libhoneyevent.SimpleScope) // a list of already seen scopes
-	// Per-service default scopes are now created dynamically in GetScope() when needed
 
 	alreadyUsedFields := []string{cfg.Resources.ServiceName, cfg.Scopes.LibraryName, cfg.Scopes.LibraryVersion}
 	alreadyUsedTraceFields := []string{

--- a/receiver/libhoneyreceiver/internal/parser/parser.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser.go
@@ -43,13 +43,7 @@ func ToPdata(dataset string, lhes []libhoneyevent.LibhoneyEvent, cfg libhoneyeve
 	spanEvents := map[trc.SpanID][]libhoneyevent.LibhoneyEvent{}
 
 	foundScopes.Scope = make(map[string]libhoneyevent.SimpleScope) // a list of already seen scopes
-	foundScopes.Scope["libhoney.receiver"] = libhoneyevent.SimpleScope{
-		ServiceName:    dataset,
-		LibraryName:    "libhoney.receiver",
-		LibraryVersion: "1.0.0",
-		ScopeSpans:     ptrace.NewSpanSlice(),
-		ScopeLogs:      plog.NewLogRecordSlice(),
-	} // seed a default
+	// Per-service default scopes are now created dynamically in GetScope() when needed
 
 	alreadyUsedFields := []string{cfg.Resources.ServiceName, cfg.Scopes.LibraryName, cfg.Scopes.LibraryVersion}
 	alreadyUsedTraceFields := []string{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

A bug happens when a library.name isn't set but service.name is set. This causes the service.name to be dropped since the scope includes both.  

This change adds placeholder scopes for each service.name that comes in, in the event that no library.name exists it has a fall-back. 

This seems to be triggered by Jaeger traces that are converted into otlp since they do not have instrumentation_scope name or version.
