### PR TITLE
[chore] improve integration test files find

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -137,10 +137,10 @@ endif
 runbuilttest: $(GOTESTSUM)
 ifneq (,$(wildcard ./builtunitetest.test))
 	$(GOTESTSUM) --raw-command -- $(GOCMD) tool test2json -p "./..." -t ./builtunitetest.test -test.v -test.failfast -test.timeout $(GOTEST_TIMEOUT)
-endif	
+endif
 
 INTEGRATION_TEST_FILES := $(shell find . -name *integration_test.go)
-INTEGRATION_TESTS := $(shell cat $(INTEGRATION_TEST_FILES) | sed -n "s/func \(Test[A-Za-z0-9_]*\).*/\1/p" | xargs | sed "s/ /|/g")
+INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES), $(shell cat $(INTEGRATION_TEST_FILES) | sed -n "s/func \(Test[A-Za-z0-9_]*\).*/\1/p" | xargs | sed "s/ /|/g"))
 .PHONY: mod-integration-test
 mod-integration-test: $(GOTESTSUM)
 	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When running commands like `make fmt` from a subdirectory, `INTEGRATION_TEST_FILES` may resolve to an empty list. In this case, the `INTEGRATION_TESTS` assignment ends up executing `cat` with no input files, which causes it to hang.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Improves #42366

@atoulme @pjanotti, please take a look as you have been involved in #42369 
