### PR TITLE
[chore][.github] Run scoped tests multiple times without retries

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -95,4 +95,4 @@ jobs:
         env:
           CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
         run: |
-          make for-affected-components CMD="make"
+          make for-affected-components CMD="make lint test-three-times"

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -105,6 +105,14 @@ common: lint test
 test: $(GOTESTSUM)
 	$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- $(GOTEST_OPT)
 
+# This target is used in scoped tests.
+# We do not pass GOTESTSUM_OPT so that we do not re-run failures
+# and run each changed test three times.
+#
+# This helps us catch flakes more easily before they land on main.
+test-three-times: $(GOTESTSUM)
+	$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) -count=3
+
 .PHONY: test-with-cover
 test-with-cover: $(GOTESTSUM)
 	mkdir -p $(PWD)/coverage/unit
@@ -292,6 +300,9 @@ for-affected-components:
 		fi \
 	fi
 
+# Do not pass GOTESTSUM_OPT so that we do not re-run failures
+# and run each changed test three times.
+# This helps us catch flakes more easily before they land on main.
 CHANGED_GOLANG_TESTS?=$(shell git diff main --name-only | grep -E '.*_test\.go$$')
 .PHONY: run-changed-tests
 run-changed-tests:
@@ -306,7 +317,7 @@ run-changed-tests:
 		else \
 			set -e; for dir in $$(echo $${AFFECTED_TEST_DIRS}); do \
 			(cd "$${dir}" && \
-				$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- $(GOTEST_OPT) ); \
+				$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) -count=3 ); \
 			done \
 		fi \
 	fi


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Runs each test in scoped tests three times. The goal is to reduce the number of flakes we see by detecting them earlier in the PR that introduces them.