### PR TITLE
[chore] Fix usage of the bufferPool

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_v2.go
+++ b/exporter/prometheusremotewriteexporter/exporter_v2.go
@@ -51,40 +51,43 @@ func (prwe *prwExporter) exportV2(ctx context.Context, requests []*writev2.Reque
 	for i := 0; i < concurrencyLimit; i++ {
 		go func() {
 			defer wg.Done()
-			buf := bufferPool.Get().(*buffer)
-			defer bufferPool.Put(buf)
-			for {
-				select {
-				case <-ctx.Done(): // Check firstly to ensure that the context wasn't cancelled.
-					return
-
-				case request, ok := <-input:
-					if !ok {
-						return
-					}
-
-					reqBuf, errMarshal := buf.MarshalAndEncode(request)
-					if errMarshal != nil {
-						mu.Lock()
-						errs = multierr.Append(errs, errMarshal)
-						mu.Unlock()
-						bufferPool.Put(buf)
-						return
-					}
-
-					if errExecute := prwe.execute(ctx, reqBuf); errExecute != nil {
-						mu.Lock()
-						errs = multierr.Append(errs, errExecute)
-						mu.Unlock()
-					}
-					bufferPool.Put(buf)
-				}
+			err := prwe.handleRequestsV2(ctx, input)
+			if err != nil {
+				mu.Lock()
+				errs = multierr.Append(errs, err)
+				mu.Unlock()
 			}
 		}()
 	}
 	wg.Wait()
 
 	return errs
+}
+
+func (prwe *prwExporter) handleRequestsV2(ctx context.Context, input chan *writev2.Request) error {
+	var errs error
+	buf := bufferPool.Get().(*buffer)
+	defer bufferPool.Put(buf)
+	for {
+		select {
+		case <-ctx.Done(): // Check firstly to ensure that the context wasn't cancelled.
+			return errs
+
+		case request, ok := <-input:
+			if !ok {
+				return errs
+			}
+
+			reqBuf, errMarshal := buf.MarshalAndEncode(request)
+			if errMarshal != nil {
+				return multierr.Append(errs, errMarshal)
+			}
+
+			if errExecute := prwe.execute(ctx, reqBuf); errExecute != nil {
+				errs = multierr.Append(errs, errExecute)
+			}
+		}
+	}
 }
 
 func (prwe *prwExporter) handleExportV2(ctx context.Context, symbolsTable writev2.SymbolsTable, tsMap map[string]*writev2.TimeSeries) error {


### PR DESCRIPTION
The bug was that in the exporter_v2 we called `bufferPool.Put(buf)` extra times, so a buffer was added to the pool multiple times and since the pool is shared we hit this bug in v1.

No changelog because this is not released.