### PR TITLE
[exporter/kafka] Add support for allow_auto_topic_creation to keep partity between Sarama and Franz-Go

### DIFF
--- a/.chloggen/feat_42468.yaml
+++ b/.chloggen/feat_42468.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "exporter/kafka"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add AllowAutoTopicCreation option to kafka exporter and client"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42468]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/feat_42468.yaml
+++ b/.chloggen/feat_42468.yaml
@@ -7,7 +7,7 @@ change_type: "enhancement"
 component: "exporter/kafka"
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add AllowAutoTopicCreation option to kafka exporter and client"
+note: "Add allow_auto_topic_creation producer option to kafka exporter and client"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42468]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -118,6 +118,7 @@ The following settings can be optionally configured:
       - `snappy`
         No compression levels supported yet
   - `flush_max_messages` (default = 0) The maximum number of messages the producer will send in a single broker request.
+  - `allow_auto_topic_creation` (default = true) whether the broker is allowed to automatically create topics when they are referenced but do not already exist.
 
 ### Supported encodings
 

--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -115,6 +115,7 @@ func setSaramaProducerConfig(
 	out.Producer.Timeout = producerTimeout
 	out.Producer.Compression = saramaCompressionCodecs[producerConfig.Compression]
 	out.Producer.CompressionLevel = convertToSaramaCompressionLevel(producerConfig.CompressionParams.Level)
+	out.Metadata.AllowAutoTopicCreation = producerConfig.AllowAutoTopicCreation
 }
 
 // newSaramaClientConfig returns a Sarama client config, based on the given config.

--- a/internal/kafka/client_test.go
+++ b/internal/kafka/client_test.go
@@ -572,3 +572,19 @@ func TestNewSaramaClientConfigWithAWSMSKIAM(t *testing.T) {
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeOAuth), saramaConfig.Net.SASL.Mechanism)
 	assert.NotNil(t, saramaConfig.Net.SASL.TokenProvider, "TokenProvider should not be nil for AWS_MSK_IAM_OAUTHBEARER")
 }
+
+func TestSetSaramaProducerConfig_AutoTopicCreation(t *testing.T) {
+	cfg := configkafka.NewDefaultProducerConfig()
+
+	// Explicit false
+	cfg.AllowAutoTopicCreation = false
+	sc := sarama.NewConfig()
+	setSaramaProducerConfig(sc, cfg, time.Second)
+	assert.False(t, sc.Metadata.AllowAutoTopicCreation)
+
+	// Explicit true
+	cfg.AllowAutoTopicCreation = true
+	sc = sarama.NewConfig()
+	setSaramaProducerConfig(sc, cfg, time.Second)
+	assert.True(t, sc.Metadata.AllowAutoTopicCreation)
+}

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -81,6 +81,10 @@ func NewFranzSyncProducer(ctx context.Context, clientCfg configkafka.ClientConfi
 	if cfg.FlushMaxMessages > 0 {
 		opts = append(opts, kgo.MaxBufferedRecords(cfg.FlushMaxMessages))
 	}
+	// Configure auto topic creation
+	if cfg.AllowAutoTopicCreation {
+		opts = append(opts, kgo.AllowAutoTopicCreation())
+	}
 
 	return kgo.NewClient(opts...)
 }

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -339,7 +339,7 @@ func TestNewFranzKafkaConsumerRegex(t *testing.T) {
 	topicCount := 10
 	topics := make([]string, topicCount)
 	topicPrefix := "topic-"
-	for i := 0; i < topicCount; i++ {
+	for i := range topicCount {
 		topics[i] = fmt.Sprintf("%s%d", topicPrefix, i)
 	}
 	_, clientConfig := kafkatest.NewCluster(t, kfake.SeedTopics(1, topics...))

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -197,14 +197,19 @@ type ProducerConfig struct {
 	// broker request. Defaults to 0 for unlimited. Similar to
 	// `queue.buffering.max.messages` in the JVM producer.
 	FlushMaxMessages int `mapstructure:"flush_max_messages"`
+
+	// Whether or not to allow automatic topic creation.
+	// (default enabled).
+	AllowAutoTopicCreation bool `mapstructure:"allow_auto_topic_creation"`
 }
 
 func NewDefaultProducerConfig() ProducerConfig {
 	return ProducerConfig{
-		MaxMessageBytes:  1000000,
-		RequiredAcks:     WaitForLocal,
-		Compression:      "none",
-		FlushMaxMessages: 0,
+		MaxMessageBytes:        1000000,
+		RequiredAcks:           WaitForLocal,
+		Compression:            "none",
+		FlushMaxMessages:       0,
+		AllowAutoTopicCreation: true,
 	}
 }
 

--- a/pkg/kafka/configkafka/config_test.go
+++ b/pkg/kafka/configkafka/config_test.go
@@ -182,7 +182,8 @@ func TestProducerConfig(t *testing.T) {
 				CompressionParams: configcompression.CompressionParams{
 					Level: 1,
 				},
-				FlushMaxMessages: 2,
+				FlushMaxMessages:       2,
+				AllowAutoTopicCreation: true,
 			},
 		},
 		"default_compression_level": {
@@ -194,14 +195,24 @@ func TestProducerConfig(t *testing.T) {
 					// zero is treated as the codec-specific default
 					Level: 0,
 				},
-				FlushMaxMessages: 2,
+				FlushMaxMessages:       2,
+				AllowAutoTopicCreation: true,
 			},
 		},
 		"snappy_compression": {
 			expected: ProducerConfig{
-				MaxMessageBytes: 1000000,
-				RequiredAcks:    1,
-				Compression:     "snappy",
+				MaxMessageBytes:        1000000,
+				RequiredAcks:           1,
+				Compression:            "snappy",
+				AllowAutoTopicCreation: true,
+			},
+		},
+		"disable_auto_topic_creation": {
+			expected: ProducerConfig{
+				MaxMessageBytes:        1000000,
+				RequiredAcks:           1,
+				Compression:            "none",
+				AllowAutoTopicCreation: false,
 			},
 		},
 		"invalid_compression_level": {

--- a/pkg/kafka/configkafka/testdata/producer_config.yaml
+++ b/pkg/kafka/configkafka/testdata/producer_config.yaml
@@ -6,6 +6,7 @@ kafka/full:
   compression_params:
     level: 1
   flush_max_messages: 2
+  allow_auto_topic_creation: true
 kafka/default_compression_level:
   max_message_bytes: 1
   required_acks: 0
@@ -22,6 +23,8 @@ kafka/invalid_compression_level:
   flush_max_messages: 2
 kafka/required_acks_all:
   required_acks: all
+kafka/disable_auto_topic_creation:
+  allow_auto_topic_creation: false
 
 # Invalid configurations
 kafka/invalid_compression:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add support for configuring Kafka topic auto-creation in the exporter by introducing the `allow_auto_topic_creation` option for producers.

Franz-go and Sarama differ in their defaults for topic auto-creation. Sarama enables it by default, while Franz-go requires explicit configuration. This PR aligns behavior across both clients and gives users explicit control to avoid unexpected broker errors when topics are not pre-created.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #42468 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

I tested the option using both Sarama and Franz-Go with both values (`true` and `false`) and the behaviour is the expected.
