### PR TITLE
[processor/tailsampling] Expose Sampling Policy interfaces

### DIFF
--- a/processor/tailsamplingprocessor/and_helper.go
+++ b/processor/tailsamplingprocessor/and_helper.go
@@ -10,8 +10,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (samplingpolicy.PolicyEvaluator, error) {
-	subPolicyEvaluators := make([]samplingpolicy.PolicyEvaluator, len(config.SubPolicyCfg))
+func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (samplingpolicy.Evaluator, error) {
+	subPolicyEvaluators := make([]samplingpolicy.Evaluator, len(config.SubPolicyCfg))
 	for i := range config.SubPolicyCfg {
 		policyCfg := &config.SubPolicyCfg[i]
 		policy, err := getAndSubPolicyEvaluator(settings, policyCfg)
@@ -24,6 +24,6 @@ func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (samp
 }
 
 // Return instance of and sub-policy
-func getAndSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getAndSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.Evaluator, error) {
 	return getSharedPolicyEvaluator(settings, &cfg.sharedPolicyCfg)
 }

--- a/processor/tailsamplingprocessor/and_helper.go
+++ b/processor/tailsamplingprocessor/and_helper.go
@@ -7,10 +7,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (sampling.PolicyEvaluator, error) {
-	subPolicyEvaluators := make([]sampling.PolicyEvaluator, len(config.SubPolicyCfg))
+func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (samplingpolicy.PolicyEvaluator, error) {
+	subPolicyEvaluators := make([]samplingpolicy.PolicyEvaluator, len(config.SubPolicyCfg))
 	for i := range config.SubPolicyCfg {
 		policyCfg := &config.SubPolicyCfg[i]
 		policy, err := getAndSubPolicyEvaluator(settings, policyCfg)
@@ -23,6 +24,6 @@ func getNewAndPolicy(settings component.TelemetrySettings, config *AndCfg) (samp
 }
 
 // Return instance of and sub-policy
-func getAndSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (sampling.PolicyEvaluator, error) {
+func getAndSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
 	return getSharedPolicyEvaluator(settings, &cfg.sharedPolicyCfg)
 }

--- a/processor/tailsamplingprocessor/and_helper_test.go
+++ b/processor/tailsamplingprocessor/and_helper_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestAndHelper(t *testing.T) {
@@ -29,7 +30,7 @@ func TestAndHelper(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		expected := sampling.NewAnd(zap.NewNop(), []sampling.PolicyEvaluator{
+		expected := sampling.NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{
 			sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
 		})
 		assert.Equal(t, expected, actual)

--- a/processor/tailsamplingprocessor/and_helper_test.go
+++ b/processor/tailsamplingprocessor/and_helper_test.go
@@ -30,7 +30,7 @@ func TestAndHelper(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		expected := sampling.NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{
+		expected := sampling.NewAnd(zap.NewNop(), []samplingpolicy.Evaluator{
 			sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
 		})
 		assert.Equal(t, expected, actual)

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewCompositePolicy(settings component.TelemetrySettings, config *CompositeCfg) (sampling.PolicyEvaluator, error) {
+func getNewCompositePolicy(settings component.TelemetrySettings, config *CompositeCfg) (samplingpolicy.PolicyEvaluator, error) {
 	subPolicyEvalParams := make([]sampling.SubPolicyEvalParams, len(config.SubPolicyCfg))
 	rateAllocationsMap := getRateAllocationMap(config)
 	for i := range config.SubPolicyCfg {
@@ -47,7 +48,7 @@ func getRateAllocationMap(config *CompositeCfg) map[string]float64 {
 }
 
 // Return instance of composite sub-policy
-func getCompositeSubPolicyEvaluator(settings component.TelemetrySettings, cfg *CompositeSubPolicyCfg) (sampling.PolicyEvaluator, error) {
+func getCompositeSubPolicyEvaluator(settings component.TelemetrySettings, cfg *CompositeSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
 	switch cfg.Type {
 	case And:
 		return getNewAndPolicy(settings, &cfg.AndCfg)

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewCompositePolicy(settings component.TelemetrySettings, config *CompositeCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getNewCompositePolicy(settings component.TelemetrySettings, config *CompositeCfg) (samplingpolicy.Evaluator, error) {
 	subPolicyEvalParams := make([]sampling.SubPolicyEvalParams, len(config.SubPolicyCfg))
 	rateAllocationsMap := getRateAllocationMap(config)
 	for i := range config.SubPolicyCfg {
@@ -48,7 +48,7 @@ func getRateAllocationMap(config *CompositeCfg) map[string]float64 {
 }
 
 // Return instance of composite sub-policy
-func getCompositeSubPolicyEvaluator(settings component.TelemetrySettings, cfg *CompositeSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getCompositeSubPolicyEvaluator(settings component.TelemetrySettings, cfg *CompositeSubPolicyCfg) (samplingpolicy.Evaluator, error) {
 	switch cfg.Type {
 	case And:
 		return getNewAndPolicy(settings, &cfg.AndCfg)

--- a/processor/tailsamplingprocessor/drop_helper.go
+++ b/processor/tailsamplingprocessor/drop_helper.go
@@ -7,10 +7,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (sampling.PolicyEvaluator, error) {
-	subPolicyEvaluators := make([]sampling.PolicyEvaluator, len(config.SubPolicyCfg))
+func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (samplingpolicy.PolicyEvaluator, error) {
+	subPolicyEvaluators := make([]samplingpolicy.PolicyEvaluator, len(config.SubPolicyCfg))
 	for i := range config.SubPolicyCfg {
 		policyCfg := &config.SubPolicyCfg[i]
 		policy, err := getDropSubPolicyEvaluator(settings, policyCfg)
@@ -23,6 +24,6 @@ func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (sa
 }
 
 // Return instance of and sub-policy
-func getDropSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (sampling.PolicyEvaluator, error) {
+func getDropSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
 	return getSharedPolicyEvaluator(settings, &cfg.sharedPolicyCfg)
 }

--- a/processor/tailsamplingprocessor/drop_helper.go
+++ b/processor/tailsamplingprocessor/drop_helper.go
@@ -10,8 +10,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
-func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (samplingpolicy.PolicyEvaluator, error) {
-	subPolicyEvaluators := make([]samplingpolicy.PolicyEvaluator, len(config.SubPolicyCfg))
+func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (samplingpolicy.Evaluator, error) {
+	subPolicyEvaluators := make([]samplingpolicy.Evaluator, len(config.SubPolicyCfg))
 	for i := range config.SubPolicyCfg {
 		policyCfg := &config.SubPolicyCfg[i]
 		policy, err := getDropSubPolicyEvaluator(settings, policyCfg)
@@ -24,6 +24,6 @@ func getNewDropPolicy(settings component.TelemetrySettings, config *DropCfg) (sa
 }
 
 // Return instance of and sub-policy
-func getDropSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getDropSubPolicyEvaluator(settings component.TelemetrySettings, cfg *AndSubPolicyCfg) (samplingpolicy.Evaluator, error) {
 	return getSharedPolicyEvaluator(settings, &cfg.sharedPolicyCfg)
 }

--- a/processor/tailsamplingprocessor/drop_helper_test.go
+++ b/processor/tailsamplingprocessor/drop_helper_test.go
@@ -30,7 +30,7 @@ func TestDropHelper(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		expected := sampling.NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{
+		expected := sampling.NewDrop(zap.NewNop(), []samplingpolicy.Evaluator{
 			sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
 		})
 		assert.Equal(t, expected, actual)

--- a/processor/tailsamplingprocessor/drop_helper_test.go
+++ b/processor/tailsamplingprocessor/drop_helper_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestDropHelper(t *testing.T) {
@@ -29,7 +30,7 @@ func TestDropHelper(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		expected := sampling.NewDrop(zap.NewNop(), []sampling.PolicyEvaluator{
+		expected := sampling.NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{
 			sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
 		})
 		assert.Equal(t, expected, actual)

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample.go
@@ -16,10 +16,10 @@ type alwaysSample struct {
 	logger *zap.Logger
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*alwaysSample)(nil)
+var _ samplingpolicy.Evaluator = (*alwaysSample)(nil)
 
 // NewAlwaysSample creates a policy evaluator the samples all traces.
-func NewAlwaysSample(settings component.TelemetrySettings) samplingpolicy.PolicyEvaluator {
+func NewAlwaysSample(settings component.TelemetrySettings) samplingpolicy.Evaluator {
 	return &alwaysSample{
 		logger: settings.Logger,
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample.go
@@ -6,6 +6,7 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
@@ -15,17 +16,17 @@ type alwaysSample struct {
 	logger *zap.Logger
 }
 
-var _ PolicyEvaluator = (*alwaysSample)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*alwaysSample)(nil)
 
 // NewAlwaysSample creates a policy evaluator the samples all traces.
-func NewAlwaysSample(settings component.TelemetrySettings) PolicyEvaluator {
+func NewAlwaysSample(settings component.TelemetrySettings) samplingpolicy.PolicyEvaluator {
 	return &alwaysSample{
 		logger: settings.Logger,
 	}
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (as *alwaysSample) Evaluate(context.Context, pcommon.TraceID, *TraceData) (Decision, error) {
+func (as *alwaysSample) Evaluate(context.Context, pcommon.TraceID, *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	as.logger.Debug("Evaluating spans in always-sample filter")
-	return Sampled, nil
+	return samplingpolicy.Sampled, nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample.go
@@ -6,10 +6,11 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type alwaysSample struct {

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
@@ -6,10 +6,11 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestEvaluate_AlwaysSample(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -18,5 +19,5 @@ func TestEvaluate_AlwaysSample(t *testing.T) {
 		16,
 	}), newTraceStringAttrs(nil, "example", "value"))
 	assert.NoError(t, err)
-	assert.Equal(t, Sampled, decision)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -13,14 +13,14 @@ import (
 
 type And struct {
 	// the subpolicy evaluators
-	subpolicies []samplingpolicy.PolicyEvaluator
+	subpolicies []samplingpolicy.Evaluator
 	logger      *zap.Logger
 }
 
 func NewAnd(
 	logger *zap.Logger,
-	subpolicies []samplingpolicy.PolicyEvaluator,
-) samplingpolicy.PolicyEvaluator {
+	subpolicies []samplingpolicy.Evaluator,
+) samplingpolicy.Evaluator {
 	return &And{
 		subpolicies: subpolicies,
 		logger:      logger,

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -6,20 +6,21 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 )
 
 type And struct {
 	// the subpolicy evaluators
-	subpolicies []PolicyEvaluator
+	subpolicies []samplingpolicy.PolicyEvaluator
 	logger      *zap.Logger
 }
 
 func NewAnd(
 	logger *zap.Logger,
-	subpolicies []PolicyEvaluator,
-) PolicyEvaluator {
+	subpolicies []samplingpolicy.PolicyEvaluator,
+) samplingpolicy.PolicyEvaluator {
 	return &And{
 		subpolicies: subpolicies,
 		logger:      logger,
@@ -27,17 +28,17 @@ func NewAnd(
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (c *And) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (c *And) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	// The policy iterates over all sub-policies and returns Sampled if all sub-policies returned a Sampled Decision.
 	// If any subpolicy returns NotSampled or InvertNotSampled, it returns NotSampled Decision.
 	for _, sub := range c.subpolicies {
 		decision, err := sub.Evaluate(ctx, traceID, trace)
 		if err != nil {
-			return Unspecified, err
+			return samplingpolicy.Unspecified, err
 		}
-		if decision == NotSampled || decision == InvertNotSampled {
-			return NotSampled, nil
+		if decision == samplingpolicy.NotSampled || decision == samplingpolicy.InvertNotSampled {
+			return samplingpolicy.NotSampled, nil
 		}
 	}
-	return Sampled, nil
+	return samplingpolicy.Sampled, nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -6,9 +6,10 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type And struct {

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -19,7 +19,7 @@ func TestAndEvaluatorNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -43,7 +43,7 @@ func TestAndEvaluatorSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -68,7 +68,7 @@ func TestAndEvaluatorStringInvertSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -93,7 +93,7 @@ func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -6,12 +6,13 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestAndEvaluatorNotSampled(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -18,7 +19,7 @@ func TestAndEvaluatorNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -29,12 +30,12 @@ func TestAndEvaluatorNotSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 }
 
 func TestAndEvaluatorSampled(t *testing.T) {
@@ -42,7 +43,7 @@ func TestAndEvaluatorSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -54,12 +55,12 @@ func TestAndEvaluatorSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, Sampled, decision)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
 }
 
 func TestAndEvaluatorStringInvertSampled(t *testing.T) {
@@ -67,7 +68,7 @@ func TestAndEvaluatorStringInvertSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -79,12 +80,12 @@ func TestAndEvaluatorStringInvertSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, Sampled, decision)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
 }
 
 func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
@@ -92,7 +93,7 @@ func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewAnd(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewAnd(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -104,10 +105,10 @@ func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
@@ -6,11 +6,12 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type booleanAttributeFilter struct {

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
@@ -6,6 +6,7 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -19,11 +20,11 @@ type booleanAttributeFilter struct {
 	invertMatch bool
 }
 
-var _ PolicyEvaluator = (*booleanAttributeFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*booleanAttributeFilter)(nil)
 
 // NewBooleanAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute that match the supplied boolean value.
-func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value, invertMatch bool) PolicyEvaluator {
+func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value, invertMatch bool) samplingpolicy.PolicyEvaluator {
 	return &booleanAttributeFilter{
 		key:         key,
 		value:       value,
@@ -33,7 +34,7 @@ func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string,
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (baf *booleanAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (baf *booleanAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	trace.Lock()
 	defer trace.Unlock()
 	batches := trace.ReceivedBatches

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
@@ -20,11 +20,11 @@ type booleanAttributeFilter struct {
 	invertMatch bool
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*booleanAttributeFilter)(nil)
+var _ samplingpolicy.Evaluator = (*booleanAttributeFilter)(nil)
 
 // NewBooleanAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute that match the supplied boolean value.
-func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value, invertMatch bool) samplingpolicy.PolicyEvaluator {
+func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string, value, invertMatch bool) samplingpolicy.Evaluator {
 	return &booleanAttributeFilter{
 		key:         key,
 		value:       value,

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
@@ -23,23 +24,23 @@ func TestBooleanTagFilter(t *testing.T) {
 
 	cases := []struct {
 		Desc     string
-		Trace    *TraceData
-		Decision Decision
+		Trace    *samplingpolicy.TraceData
+		Decision samplingpolicy.Decision
 	}{
 		{
 			Desc:     "non-matching span attribute",
 			Trace:    newTraceBoolAttrs(empty, "non_matching", true),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "span attribute with unwanted boolean value",
 			Trace:    newTraceBoolAttrs(empty, "example", false),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "span attribute with wanted boolean value",
 			Trace:    newTraceBoolAttrs(empty, "example", true),
-			Decision: Sampled,
+			Decision: samplingpolicy.Sampled,
 		},
 	}
 
@@ -62,35 +63,35 @@ func TestBooleanTagFilterInverted(t *testing.T) {
 
 	cases := []struct {
 		Desc                  string
-		Trace                 *TraceData
-		Decision              Decision
+		Trace                 *samplingpolicy.TraceData
+		Decision              samplingpolicy.Decision
 		DisableInvertDecision bool
 	}{
 		{
 			Desc:     "non-matching span attribute",
 			Trace:    newTraceBoolAttrs(empty, "non_matching", true),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "span attribute with non matching boolean value",
 			Trace:    newTraceBoolAttrs(empty, "example", false),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "span attribute with matching boolean value",
 			Trace:    newTraceBoolAttrs(empty, "example", true),
-			Decision: InvertNotSampled,
+			Decision: samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:                  "span attribute with non matching boolean value with DisableInvertDecision",
 			Trace:                 newTraceBoolAttrs(empty, "example", false),
-			Decision:              Sampled,
+			Decision:              samplingpolicy.Sampled,
 			DisableInvertDecision: true,
 		},
 		{
 			Desc:                  "span attribute with matching boolean value with DisableInvertDecision",
 			Trace:                 newTraceBoolAttrs(empty, "example", true),
-			Decision:              NotSampled,
+			Decision:              samplingpolicy.NotSampled,
 			DisableInvertDecision: true,
 		},
 	}
@@ -113,7 +114,7 @@ func TestBooleanTagFilterInverted(t *testing.T) {
 	}
 }
 
-func newTraceBoolAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValue bool) *TraceData {
+func newTraceBoolAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValue bool) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	//nolint:errcheck
@@ -123,7 +124,7 @@ func newTraceBoolAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrVal
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 	span.Attributes().PutBool(spanAttrKey, spanAttrValue)
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestBooleanTagFilter(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/composite.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite.go
@@ -6,9 +6,10 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type subpolicy struct {

--- a/processor/tailsamplingprocessor/internal/sampling/composite.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite.go
@@ -13,7 +13,7 @@ import (
 
 type subpolicy struct {
 	// the subpolicy evaluator
-	evaluator samplingpolicy.PolicyEvaluator
+	evaluator samplingpolicy.Evaluator
 
 	// spans per second allocated to each subpolicy
 	allocatedSPS int64
@@ -42,11 +42,11 @@ type Composite struct {
 	recordSubPolicy bool
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*Composite)(nil)
+var _ samplingpolicy.Evaluator = (*Composite)(nil)
 
 // SubPolicyEvalParams defines the evaluator and max rate for a sub-policy
 type SubPolicyEvalParams struct {
-	Evaluator         samplingpolicy.PolicyEvaluator
+	Evaluator         samplingpolicy.Evaluator
 	MaxSpansPerSecond int64
 	Name              string
 }
@@ -58,7 +58,7 @@ func NewComposite(
 	subPolicyParams []SubPolicyEvalParams,
 	timeProvider TimeProvider,
 	recordSubPolicy bool,
-) samplingpolicy.PolicyEvaluator {
+) samplingpolicy.Evaluator {
 	var subpolicies []*subpolicy
 
 	for i := 0; i < len(subPolicyParams); i++ {

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type FakeTimeProvider struct {

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,14 +26,14 @@ func (f FakeTimeProvider) getCurSecond() int64 {
 
 var traceID = pcommon.TraceID([16]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x52, 0x96, 0x9A, 0x89, 0x55, 0x57, 0x1A, 0x3F})
 
-func createTrace() *TraceData {
+func createTrace() *samplingpolicy.TraceData {
 	spanCount := &atomic.Int64{}
 	spanCount.Store(1)
-	trace := &TraceData{SpanCount: spanCount, ReceivedBatches: ptrace.NewTraces()}
+	trace := &samplingpolicy.TraceData{SpanCount: spanCount, ReceivedBatches: ptrace.NewTraces()}
 	return trace
 }
 
-func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *TraceData {
+func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ils := rs.ScopeSpans().AppendEmpty()
@@ -49,7 +50,7 @@ func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *TraceData {
 
 	spanCount := &atomic.Int64{}
 	spanCount.Store(1)
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 		SpanCount:       spanCount,
 	}
@@ -70,7 +71,7 @@ func TestCompositeEvaluatorNotSampled(t *testing.T) {
 
 	// None of the numeric filters should match since input trace data does not contain
 	// the "tag", so the decision should be NotSampled.
-	expected := NotSampled
+	expected := samplingpolicy.NotSampled
 	assert.Equal(t, expected, decision)
 }
 
@@ -88,7 +89,7 @@ func TestCompositeEvaluatorSampled(t *testing.T) {
 	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 	// The second policy is AlwaysSample, so the decision should be Sampled.
-	expected := Sampled
+	expected := samplingpolicy.Sampled
 	assert.Equal(t, expected, decision)
 }
 
@@ -106,7 +107,7 @@ func TestCompositeEvaluatorSampled_RecordSubPolicy(t *testing.T) {
 	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 	// The second policy is AlwaysSample, so the decision should be Sampled.
-	expected := Sampled
+	expected := samplingpolicy.Sampled
 	assert.Equal(t, expected, decision)
 	val, ok := trace.ReceivedBatches.ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.composite_policy")
 	assert.True(t, ok, "Did not find expected key")
@@ -129,7 +130,7 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 	// The first policy is NewNumericAttributeFilter and trace tag matches criteria, so the decision should be Sampled.
-	expected := Sampled
+	expected := samplingpolicy.Sampled
 	assert.Equal(t, expected, decision)
 
 	trace = newTraceWithKV(traceID, "tag", int64(11))
@@ -138,7 +139,7 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 	// The first policy is NewNumericAttributeFilter and trace tag matches criteria, so the decision should be Sampled.
-	expected = NotSampled
+	expected = samplingpolicy.NotSampled
 	assert.Equal(t, expected, decision)
 
 	trace = newTraceWithKV(traceID, "tag", int64(1001))
@@ -146,7 +147,7 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 	require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 	// The first policy fails as the tag value is greater than the range set whereas the second policy is AlwaysSample, so the decision should be Sampled.
-	expected = Sampled
+	expected = samplingpolicy.Sampled
 	assert.Equal(t, expected, decision)
 }
 
@@ -165,7 +166,7 @@ func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 		// The second policy is AlwaysSample, so the decision should be Sampled.
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 }
@@ -183,7 +184,7 @@ func TestCompositeEvaluatorInverseSampled_AlwaysSampled(t *testing.T) {
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 		// The second policy is AlwaysSample, so the decision should be Sampled.
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 }
@@ -201,7 +202,7 @@ func TestCompositeEvaluatorInverseSampled_AlwaysSampled_RecordSubPolicy(t *testi
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
 		// The second policy is AlwaysSample, so the decision should be Sampled.
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 		val, ok := trace.ReceivedBatches.ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.composite_policy")
 		assert.True(t, ok, "Did not find expected key")
@@ -223,7 +224,7 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 
@@ -232,7 +233,7 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := NotSampled
+		expected := samplingpolicy.NotSampled
 		assert.Equal(t, expected, decision)
 	}
 
@@ -244,7 +245,7 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 }
@@ -267,7 +268,7 @@ func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		require.Equal(t, expected, decision, "Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
 	}
 
@@ -276,7 +277,7 @@ func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := NotSampled
+		expected := samplingpolicy.NotSampled
 		require.Equal(t, expected, decision, "Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
 	}
 
@@ -288,7 +289,7 @@ func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 
@@ -297,7 +298,7 @@ func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := NotSampled
+		expected := samplingpolicy.NotSampled
 		assert.Equal(t, expected, decision)
 	}
 
@@ -309,7 +310,7 @@ func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 		decision, err := c.Evaluate(t.Context(), traceID, trace)
 		require.NoError(t, err, "Failed to evaluate composite policy: %v", err)
 
-		expected := Sampled
+		expected := samplingpolicy.Sampled
 		assert.Equal(t, expected, decision)
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/drop.go
+++ b/processor/tailsamplingprocessor/internal/sampling/drop.go
@@ -6,9 +6,10 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type Drop struct {

--- a/processor/tailsamplingprocessor/internal/sampling/drop.go
+++ b/processor/tailsamplingprocessor/internal/sampling/drop.go
@@ -13,14 +13,14 @@ import (
 
 type Drop struct {
 	// the subpolicy evaluators
-	subpolicies []samplingpolicy.PolicyEvaluator
+	subpolicies []samplingpolicy.Evaluator
 	logger      *zap.Logger
 }
 
 func NewDrop(
 	logger *zap.Logger,
-	subpolicies []samplingpolicy.PolicyEvaluator,
-) samplingpolicy.PolicyEvaluator {
+	subpolicies []samplingpolicy.Evaluator,
+) samplingpolicy.Evaluator {
 	return &Drop{
 		subpolicies: subpolicies,
 		logger:      logger,

--- a/processor/tailsamplingprocessor/internal/sampling/drop_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/drop_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -18,7 +19,7 @@ func TestDropEvaluatorNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -29,12 +30,12 @@ func TestDropEvaluatorNotSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 }
 
 func TestDropEvaluatorSampled(t *testing.T) {
@@ -42,7 +43,7 @@ func TestDropEvaluatorSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -54,12 +55,12 @@ func TestDropEvaluatorSampled(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, Dropped, decision)
+	assert.Equal(t, samplingpolicy.Dropped, decision)
 }
 
 func TestDropEvaluatorStringInvertMatch(t *testing.T) {
@@ -67,7 +68,7 @@ func TestDropEvaluatorStringInvertMatch(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -79,12 +80,12 @@ func TestDropEvaluatorStringInvertMatch(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, Dropped, decision)
+	assert.Equal(t, samplingpolicy.Dropped, decision)
 }
 
 func TestDropEvaluatorStringInvertNotMatch(t *testing.T) {
@@ -92,7 +93,7 @@ func TestDropEvaluatorStringInvertNotMatch(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -104,10 +105,10 @@ func TestDropEvaluatorStringInvertNotMatch(t *testing.T) {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
-	trace := &TraceData{
+	trace := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 	decision, err := and.Evaluate(t.Context(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/drop_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/drop_test.go
@@ -6,12 +6,13 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestDropEvaluatorNotSampled(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/drop_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/drop_test.go
@@ -19,7 +19,7 @@ func TestDropEvaluatorNotSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -43,7 +43,7 @@ func TestDropEvaluatorSampled(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -68,7 +68,7 @@ func TestDropEvaluatorStringInvertMatch(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -93,7 +93,7 @@ func TestDropEvaluatorStringInvertNotMatch(t *testing.T) {
 	n2, err := NewStatusCodeFilter(componenttest.NewNopTelemetrySettings(), []string{"ERROR"})
 	require.NoError(t, err)
 
-	and := NewDrop(zap.NewNop(), []samplingpolicy.PolicyEvaluator{n1, n2})
+	and := NewDrop(zap.NewNop(), []samplingpolicy.Evaluator{n1, n2})
 
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -19,10 +19,10 @@ type latency struct {
 	upperThresholdMs int64
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*latency)(nil)
+var _ samplingpolicy.Evaluator = (*latency)(nil)
 
 // NewLatency creates a policy evaluator sampling traces with a duration greater than a configured threshold
-func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThresholdMs int64) samplingpolicy.PolicyEvaluator {
+func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThresholdMs int64) samplingpolicy.Evaluator {
 	return &latency{
 		logger:           settings.Logger,
 		thresholdMs:      thresholdMs,

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -6,11 +6,12 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type latency struct {

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -6,6 +6,7 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -18,10 +19,10 @@ type latency struct {
 	upperThresholdMs int64
 }
 
-var _ PolicyEvaluator = (*latency)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*latency)(nil)
 
 // NewLatency creates a policy evaluator sampling traces with a duration greater than a configured threshold
-func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThresholdMs int64) PolicyEvaluator {
+func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThresholdMs int64) samplingpolicy.PolicyEvaluator {
 	return &latency{
 		logger:           settings.Logger,
 		thresholdMs:      thresholdMs,
@@ -30,7 +31,7 @@ func NewLatency(settings component.TelemetrySettings, thresholdMs, upperThreshol
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (l *latency) Evaluate(_ context.Context, _ pcommon.TraceID, traceData *TraceData) (Decision, error) {
+func (l *latency) Evaluate(_ context.Context, _ pcommon.TraceID, traceData *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	l.logger.Debug("Evaluating spans in latency filter")
 
 	traceData.Lock()

--- a/processor/tailsamplingprocessor/internal/sampling/latency_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestEvaluate_Latency(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/latency_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -22,7 +23,7 @@ func TestEvaluate_Latency(t *testing.T) {
 	cases := []struct {
 		Desc     string
 		Spans    []spanWithTimeAndDuration
-		Decision Decision
+		Decision samplingpolicy.Decision
 	}{
 		{
 			"trace duration shorter than threshold",
@@ -32,7 +33,7 @@ func TestEvaluate_Latency(t *testing.T) {
 					Duration:  4500 * time.Millisecond,
 				},
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"trace duration is equal to threshold",
@@ -42,7 +43,7 @@ func TestEvaluate_Latency(t *testing.T) {
 					Duration:  5000 * time.Millisecond,
 				},
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"total trace duration is longer than threshold but every single span is shorter",
@@ -56,7 +57,7 @@ func TestEvaluate_Latency(t *testing.T) {
 					Duration:  3000 * time.Millisecond,
 				},
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 	}
 
@@ -79,7 +80,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 	cases := []struct {
 		Desc     string
 		Spans    []spanWithTimeAndDuration
-		Decision Decision
+		Decision samplingpolicy.Decision
 	}{
 		{
 			"trace duration shorter than lower bound",
@@ -89,7 +90,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  4500 * time.Millisecond,
 				},
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"trace duration is equal to lower bound",
@@ -99,7 +100,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  5000 * time.Millisecond,
 				},
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"trace duration is within lower and upper bounds",
@@ -109,7 +110,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  5001 * time.Millisecond,
 				},
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"trace duration is above upper bound",
@@ -119,7 +120,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  10001 * time.Millisecond,
 				},
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"trace duration equals upper bound",
@@ -129,7 +130,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  10000 * time.Millisecond,
 				},
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"total trace duration is longer than threshold but every single span is shorter",
@@ -143,7 +144,7 @@ func TestEvaluate_Bounded_Latency(t *testing.T) {
 					Duration:  3000 * time.Millisecond,
 				},
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 	}
 
@@ -162,7 +163,7 @@ type spanWithTimeAndDuration struct {
 	Duration  time.Duration
 }
 
-func newTraceWithSpans(spans []spanWithTimeAndDuration) *TraceData {
+func newTraceWithSpans(spans []spanWithTimeAndDuration) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ils := rs.ScopeSpans().AppendEmpty()
@@ -175,7 +176,7 @@ func newTraceWithSpans(spans []spanWithTimeAndDuration) *TraceData {
 		span.SetEndTimestamp(pcommon.NewTimestampFromTime(s.StartTime.Add(s.Duration)))
 	}
 
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -21,12 +22,12 @@ type numericAttributeFilter struct {
 	invertMatch bool
 }
 
-var _ PolicyEvaluator = (*numericAttributeFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*numericAttributeFilter)(nil)
 
 // NewNumericAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range. If minValue is nil, it will use math.MinInt64.
 // If maxValue is nil, it will use math.MaxInt64. At least one of minValue or maxValue must be set.
-func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue *int64, invertMatch bool) PolicyEvaluator {
+func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue *int64, invertMatch bool) samplingpolicy.PolicyEvaluator {
 	if minValue == nil && maxValue == nil {
 		settings.Logger.Error("At least one of minValue or maxValue must be set")
 		return nil
@@ -41,7 +42,7 @@ func NewNumericAttributeFilter(settings component.TelemetrySettings, key string,
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	trace.Lock()
 	defer trace.Unlock()
 	batches := trace.ReceivedBatches

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"math"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type numericAttributeFilter struct {

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -22,12 +22,12 @@ type numericAttributeFilter struct {
 	invertMatch bool
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*numericAttributeFilter)(nil)
+var _ samplingpolicy.Evaluator = (*numericAttributeFilter)(nil)
 
 // NewNumericAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range. If minValue is nil, it will use math.MinInt64.
 // If maxValue is nil, it will use math.MaxInt64. At least one of minValue or maxValue must be set.
-func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue *int64, invertMatch bool) samplingpolicy.PolicyEvaluator {
+func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue *int64, invertMatch bool) samplingpolicy.Evaluator {
 	if minValue == nil && maxValue == nil {
 		settings.Logger.Error("At least one of minValue or maxValue must be set")
 		return nil

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,53 +28,53 @@ func TestNumericTagFilter(t *testing.T) {
 
 	cases := []struct {
 		Desc     string
-		Trace    *TraceData
-		Decision Decision
+		Trace    *samplingpolicy.TraceData
+		Decision samplingpolicy.Decision
 	}{
 		{
 			Desc:     "nonmatching span attribute",
 			Trace:    newTraceIntAttrs(empty, "non_matching", math.MinInt32),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "span attribute at the lower limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
-			Decision: Sampled,
+			Decision: samplingpolicy.Sampled,
 		},
 		{
 			Desc:     "resource attribute at the lower limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32}, "non_matching", math.MinInt32),
-			Decision: Sampled,
+			Decision: samplingpolicy.Sampled,
 		},
 		{
 			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
-			Decision: Sampled,
+			Decision: samplingpolicy.Sampled,
 		},
 		{
 			Desc:     "resource attribute at the upper limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MaxInt),
-			Decision: Sampled,
+			Decision: samplingpolicy.Sampled,
 		},
 		{
 			Desc:     "span attribute below min limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32-1),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "resource attribute below min limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32 - 1}, "non_matching", math.MinInt32),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "span attribute above max limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32+1),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 		{
 			Desc:     "resource attribute above max limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MaxInt32),
-			Decision: NotSampled,
+			Decision: samplingpolicy.NotSampled,
 		},
 	}
 
@@ -98,65 +99,65 @@ func TestNumericTagFilterInverted(t *testing.T) {
 
 	cases := []struct {
 		Desc                  string
-		Trace                 *TraceData
-		Decision              Decision
+		Trace                 *samplingpolicy.TraceData
+		Decision              samplingpolicy.Decision
 		DisableInvertDecision bool
 	}{
 		{
 			Desc:     "nonmatching span attribute",
 			Trace:    newTraceIntAttrs(empty, "non_matching", math.MinInt32),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "span attribute at the lower limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
-			Decision: InvertNotSampled,
+			Decision: samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:     "resource attribute at the lower limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32}, "non_matching", math.MinInt32),
-			Decision: InvertNotSampled,
+			Decision: samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
-			Decision: InvertNotSampled,
+			Decision: samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:     "resource attribute at the upper limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MaxInt32),
-			Decision: InvertNotSampled,
+			Decision: samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:     "span attribute below min limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32-1),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "resource attribute below min limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32 - 1}, "non_matching", math.MinInt32),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "span attribute above max limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32+1),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:     "resource attribute above max limit",
 			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MaxInt32+1),
-			Decision: InvertSampled,
+			Decision: samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:                  "nonmatching span attribute with DisableInvertDecision",
 			Trace:                 newTraceIntAttrs(empty, "non_matching", math.MinInt32),
-			Decision:              Sampled,
+			Decision:              samplingpolicy.Sampled,
 			DisableInvertDecision: true,
 		},
 		{
 			Desc:                  "span attribute at the lower limit with DisableInvertDecision",
 			Trace:                 newTraceIntAttrs(empty, "example", math.MinInt32),
-			Decision:              NotSampled,
+			Decision:              samplingpolicy.NotSampled,
 			DisableInvertDecision: true,
 		},
 	}
@@ -186,49 +187,49 @@ func TestNumericTagFilterOptionalBounds(t *testing.T) {
 		max         *int64
 		value       int64
 		invertMatch bool
-		want        Decision
+		want        samplingpolicy.Decision
 	}{
 		{
 			name:  "only min set - value above min",
 			min:   ptr(int64(100)),
 			max:   nil,
 			value: 200,
-			want:  Sampled,
+			want:  samplingpolicy.Sampled,
 		},
 		{
 			name:  "only min set - value below min",
 			min:   ptr(int64(100)),
 			max:   nil,
 			value: 50,
-			want:  NotSampled,
+			want:  samplingpolicy.NotSampled,
 		},
 		{
 			name:  "only max set - value below max",
 			min:   nil,
 			max:   ptr(int64(100)),
 			value: 50,
-			want:  Sampled,
+			want:  samplingpolicy.Sampled,
 		},
 		{
 			name:  "only max set - value above max",
 			min:   nil,
 			max:   ptr(int64(100)),
 			value: 200,
-			want:  NotSampled,
+			want:  samplingpolicy.NotSampled,
 		},
 		{
 			name:  "both set - value in range",
 			min:   ptr(int64(100)),
 			max:   ptr(int64(200)),
 			value: 150,
-			want:  Sampled,
+			want:  samplingpolicy.Sampled,
 		},
 		{
 			name:  "both set - value out of range",
 			min:   ptr(int64(100)),
 			max:   ptr(int64(200)),
 			value: 50,
-			want:  NotSampled,
+			want:  samplingpolicy.NotSampled,
 		},
 		{
 			name:        "inverted match - only min set - value above min",
@@ -236,7 +237,7 @@ func TestNumericTagFilterOptionalBounds(t *testing.T) {
 			max:         nil,
 			value:       200,
 			invertMatch: true,
-			want:        InvertNotSampled,
+			want:        samplingpolicy.InvertNotSampled,
 		},
 		{
 			name:        "inverted match - only max set - value below max",
@@ -244,7 +245,7 @@ func TestNumericTagFilterOptionalBounds(t *testing.T) {
 			max:         ptr(int64(100)),
 			value:       50,
 			invertMatch: true,
-			want:        InvertNotSampled,
+			want:        samplingpolicy.InvertNotSampled,
 		},
 	}
 
@@ -284,7 +285,7 @@ func ptr(i int64) *int64 {
 	return &i
 }
 
-func newTraceIntAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValue int64) *TraceData {
+func newTraceIntAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValue int64) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	//nolint:errcheck
@@ -294,7 +295,7 @@ func newTraceIntAttrs(nodeAttrs map[string]any, spanAttrKey string, spanAttrValu
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 	span.Attributes().PutInt(spanAttrKey, spanAttrValue)
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestNumericTagFilter(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type ottlConditionFilter struct {
@@ -24,10 +25,10 @@ type ottlConditionFilter struct {
 	logger              *zap.Logger
 }
 
-var _ PolicyEvaluator = (*ottlConditionFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*ottlConditionFilter)(nil)
 
 // NewOTTLConditionFilter looks at the trace data and returns a corresponding SamplingDecision.
-func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions, spanEventConditions []string, errMode ottl.ErrorMode) (PolicyEvaluator, error) {
+func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions, spanEventConditions []string, errMode ottl.ErrorMode) (samplingpolicy.PolicyEvaluator, error) {
 	filter := &ottlConditionFilter{
 		errorMode: errMode,
 		logger:    settings.Logger,
@@ -54,13 +55,13 @@ func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions
 	return filter, nil
 }
 
-func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	if ocf.logger.Core().Enabled(zap.DebugLevel) {
 		ocf.logger.Debug("Evaluating with OTTL conditions filter", zap.String("traceID", traceID.String()))
 	}
 
 	if ocf.sampleSpanExpr == nil && ocf.sampleSpanEventExpr == nil {
-		return NotSampled, nil
+		return samplingpolicy.NotSampled, nil
 	}
 
 	trace.Lock()
@@ -91,10 +92,10 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 				if ocf.sampleSpanExpr != nil {
 					ok, err = ocf.sampleSpanExpr.Eval(ctx, ottlspan.NewTransformContext(span, scope, resource, ss, rs))
 					if err != nil {
-						return Error, err
+						return samplingpolicy.Error, err
 					}
 					if ok {
-						return Sampled, nil
+						return samplingpolicy.Sampled, nil
 					}
 				}
 
@@ -104,15 +105,15 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 					for l := 0; l < spanEvents.Len(); l++ {
 						ok, err = ocf.sampleSpanEventExpr.Eval(ctx, ottlspanevent.NewTransformContext(spanEvents.At(l), span, scope, resource, ss, rs))
 						if err != nil {
-							return Error, err
+							return samplingpolicy.Error, err
 						}
 						if ok {
-							return Sampled, nil
+							return samplingpolicy.Sampled, nil
 						}
 					}
 				}
 			}
 		}
 	}
-	return NotSampled, nil
+	return samplingpolicy.NotSampled, nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -25,10 +25,10 @@ type ottlConditionFilter struct {
 	logger              *zap.Logger
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*ottlConditionFilter)(nil)
+var _ samplingpolicy.Evaluator = (*ottlConditionFilter)(nil)
 
 // NewOTTLConditionFilter looks at the trace data and returns a corresponding SamplingDecision.
-func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions, spanEventConditions []string, errMode ottl.ErrorMode) (samplingpolicy.PolicyEvaluator, error) {
+func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions, spanEventConditions []string, errMode ottl.ErrorMode) (samplingpolicy.Evaluator, error) {
 	filter := &ottlConditionFilter{
 		errorMode: errMode,
 		logger:    settings.Logger,

--- a/processor/tailsamplingprocessor/internal/sampling/ottl_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestEvaluate_OTTL(t *testing.T) {
@@ -23,7 +24,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 		SpanEventConditions []string
 		Spans               []spanWithAttributes
 		WantErr             bool
-		Decision            Decision
+		Decision            samplingpolicy.Decision
 	}{
 		{
 			// policy
@@ -32,7 +33,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{},
 			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_1"}}},
 			true,
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"OTTL conditions match specific span attributes 1",
@@ -40,7 +41,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{},
 			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_1"}}},
 			false,
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"OTTL conditions match specific span attributes 2",
@@ -48,7 +49,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{},
 			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_1"}}},
 			false,
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"OTTL conditions inverse match(!=) span attributes 2",
@@ -56,7 +57,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{},
 			[]spanWithAttributes{{SpanAttributes: map[string]string{"attr_k_1": "attr_v_2"}}},
 			false,
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"OTTL conditions match specific span event attributes",
@@ -64,7 +65,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{"attributes[\"event_attr_k_1\"] == \"event_attr_v_1\""},
 			[]spanWithAttributes{{SpanEventAttributes: map[string]string{"event_attr_k_1": "event_attr_v_1"}}},
 			false,
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"OTTL conditions match specific span event name",
@@ -72,7 +73,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{"name != \"incorrect event name\""},
 			[]spanWithAttributes{{SpanEventAttributes: nil}},
 			false,
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"OTTL conditions not matched",
@@ -80,7 +81,7 @@ func TestEvaluate_OTTL(t *testing.T) {
 			[]string{"attributes[\"event_attr_k_1\"] == \"event_attr_v_1\""},
 			[]spanWithAttributes{},
 			false,
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 	}
 
@@ -103,7 +104,7 @@ type spanWithAttributes struct {
 	SpanEventAttributes map[string]string
 }
 
-func newTraceWithSpansAttributes(spans []spanWithAttributes) *TraceData {
+func newTraceWithSpansAttributes(spans []spanWithAttributes) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ils := rs.ScopeSpans().AppendEmpty()
@@ -122,7 +123,7 @@ func newTraceWithSpansAttributes(spans []spanWithAttributes) *TraceData {
 		}
 	}
 
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
@@ -9,10 +9,11 @@ import (
 	"math"
 	"math/big"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 const (

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
@@ -25,11 +25,11 @@ type probabilisticSampler struct {
 	hashSalt  string
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*probabilisticSampler)(nil)
+var _ samplingpolicy.Evaluator = (*probabilisticSampler)(nil)
 
 // NewProbabilisticSampler creates a policy evaluator that samples a percentage of
 // traces.
-func NewProbabilisticSampler(settings component.TelemetrySettings, hashSalt string, samplingPercentage float64) samplingpolicy.PolicyEvaluator {
+func NewProbabilisticSampler(settings component.TelemetrySettings, hashSalt string, samplingPercentage float64) samplingpolicy.Evaluator {
 	if hashSalt == "" {
 		hashSalt = defaultHashSalt
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
@@ -24,11 +25,11 @@ type probabilisticSampler struct {
 	hashSalt  string
 }
 
-var _ PolicyEvaluator = (*probabilisticSampler)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*probabilisticSampler)(nil)
 
 // NewProbabilisticSampler creates a policy evaluator that samples a percentage of
 // traces.
-func NewProbabilisticSampler(settings component.TelemetrySettings, hashSalt string, samplingPercentage float64) PolicyEvaluator {
+func NewProbabilisticSampler(settings component.TelemetrySettings, hashSalt string, samplingPercentage float64) samplingpolicy.PolicyEvaluator {
 	if hashSalt == "" {
 		hashSalt = defaultHashSalt
 	}
@@ -42,14 +43,14 @@ func NewProbabilisticSampler(settings component.TelemetrySettings, hashSalt stri
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (s *probabilisticSampler) Evaluate(_ context.Context, traceID pcommon.TraceID, _ *TraceData) (Decision, error) {
+func (s *probabilisticSampler) Evaluate(_ context.Context, traceID pcommon.TraceID, _ *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	s.logger.Debug("Evaluating spans in probabilistic filter")
 
 	if hashTraceID(s.hashSalt, traceID[:]) <= s.threshold {
-		return Sampled, nil
+		return samplingpolicy.Sampled, nil
 	}
 
-	return NotSampled, nil
+	return samplingpolicy.NotSampled, nil
 }
 
 // calculateThreshold converts a ratio into a value between 0 and MaxUint64

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
@@ -8,10 +8,11 @@ import (
 	"math/rand/v2"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestProbabilisticSampling(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -76,7 +77,7 @@ func TestProbabilisticSampling(t *testing.T) {
 				decision, err := probabilisticSampler.Evaluate(t.Context(), traceID, trace)
 				assert.NoError(t, err)
 
-				if decision == Sampled {
+				if decision == samplingpolicy.Sampled {
 					sampled++
 				}
 			}

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type rateLimiting struct {

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting.go
@@ -20,10 +20,10 @@ type rateLimiting struct {
 	logger               *zap.Logger
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*rateLimiting)(nil)
+var _ samplingpolicy.Evaluator = (*rateLimiting)(nil)
 
 // NewRateLimiting creates a policy evaluator the samples all traces.
-func NewRateLimiting(settings component.TelemetrySettings, spansPerSecond int64) samplingpolicy.PolicyEvaluator {
+func NewRateLimiting(settings component.TelemetrySettings, spansPerSecond int64) samplingpolicy.Evaluator {
 	return &rateLimiting{
 		spansPerSecond: spansPerSecond,
 		logger:         settings.Logger,

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -23,7 +24,7 @@ func TestRateLimiter(t *testing.T) {
 	trace.SpanCount = traceSpanCount
 	decision, err := rateLimiter.Evaluate(t.Context(), traceID, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 
 	// Trace span count equal to spans per second
 	traceSpanCount = &atomic.Int64{}
@@ -31,7 +32,7 @@ func TestRateLimiter(t *testing.T) {
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, NotSampled, decision)
+	assert.Equal(t, samplingpolicy.NotSampled, decision)
 
 	// Trace span count less than spans per second
 	traceSpanCount = &atomic.Int64{}
@@ -39,12 +40,12 @@ func TestRateLimiter(t *testing.T) {
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, Sampled, decision)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
 
 	// Trace span count less than spans per second
 	traceSpanCount = &atomic.Int64{}
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(t.Context(), traceID, trace)
 	assert.NoError(t, err)
-	assert.Equal(t, Sampled, decision)
+	assert.Equal(t, samplingpolicy.Sampled, decision)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -7,10 +7,11 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestRateLimiter(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
@@ -18,10 +18,10 @@ type spanCount struct {
 	maxSpans int32
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*spanCount)(nil)
+var _ samplingpolicy.Evaluator = (*spanCount)(nil)
 
 // NewSpanCount creates a policy evaluator sampling traces with more than one span per trace
-func NewSpanCount(settings component.TelemetrySettings, minSpans, maxSpans int32) samplingpolicy.PolicyEvaluator {
+func NewSpanCount(settings component.TelemetrySettings, minSpans, maxSpans int32) samplingpolicy.Evaluator {
 	return &spanCount{
 		logger:   settings.Logger,
 		minSpans: minSpans,

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
@@ -6,10 +6,11 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type spanCount struct {

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -21,49 +22,49 @@ func TestEvaluate_OnlyMinSpans(t *testing.T) {
 	cases := []struct {
 		Desc        string
 		NumberSpans []int32
-		Decision    Decision
+		Decision    samplingpolicy.Decision
 	}{
 		{
 			"Spans less than the minSpans, in one single batch",
 			[]int32{
 				1,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Same number of spans as the minSpans, in one single batch",
 			[]int32{
 				3,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans greater than the minSpans, in one single batch",
 			[]int32{
 				4,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans less than the minSpans, across multiple batches",
 			[]int32{
 				1, 1,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Same number of spans as the minSpans, across multiple batches",
 			[]int32{
 				1, 2, 1,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans greater than the minSpans, across multiple batches",
 			[]int32{
 				1, 2, 3,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 	}
 
@@ -85,49 +86,49 @@ func TestEvaluate_OnlyMaxSpans(t *testing.T) {
 	cases := []struct {
 		Desc        string
 		NumberSpans []int32
-		Decision    Decision
+		Decision    samplingpolicy.Decision
 	}{
 		{
 			"Spans greater than the maxSpans, in one single batch",
 			[]int32{
 				21,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Same number of spans as the maxSpans, in one single batch",
 			[]int32{
 				20,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans less than the maxSpans, in one single batch",
 			[]int32{
 				19,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans gather than the maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 3, 4, 5, 6,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Same number of spans as the maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 3, 4, 5, 5,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans less than the maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 3, 4, 5,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 	}
 
@@ -149,77 +150,77 @@ func TestEvaluate_RangeOfSpans(t *testing.T) {
 	cases := []struct {
 		Desc        string
 		NumberSpans []int32
-		Decision    Decision
+		Decision    samplingpolicy.Decision
 	}{
 		{
 			"Spans less than the minSpans, in one single batch",
 			[]int32{
 				1,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Spans greater than the maxSpans, in one single batch",
 			[]int32{
 				21,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Spans range of minSpan and maxSpans, in one single batch",
 			[]int32{
 				4,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Spans less than the minSpans, across multiple batches",
 			[]int32{
 				1, 1,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Spans greater than the maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 3, 4, 5, 6,
 			},
-			NotSampled,
+			samplingpolicy.NotSampled,
 		},
 		{
 			"Spans range of minSpan and maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 1,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Same number of spans as the minSpans, in one single batch",
 			[]int32{
 				3,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Same number of spans as the maxSpans, in one single batch",
 			[]int32{
 				20,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Same number of spans as the minSpans, across multiple batches",
 			[]int32{
 				1, 2,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 		{
 			"Same number of spans as the maxSpans, across multiple batches",
 			[]int32{
 				1, 2, 3, 4, 5, 5,
 			},
-			Sampled,
+			samplingpolicy.Sampled,
 		},
 	}
 
@@ -233,7 +234,7 @@ func TestEvaluate_RangeOfSpans(t *testing.T) {
 	}
 }
 
-func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
+func newTraceWithMultipleSpans(numberSpans []int32) *samplingpolicy.TraceData {
 	totalNumberSpans := int32(0)
 
 	// For each resource, going to create the number of spans defined in the array
@@ -253,7 +254,7 @@ func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
 
 	traceSpanCount := &atomic.Int64{}
 	traceSpanCount.Store(int64(totalNumberSpans))
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 		SpanCount:       traceSpanCount,
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -7,11 +7,12 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestEvaluate_OnlyMinSpans(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/status_code.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code.go
@@ -20,11 +20,11 @@ type statusCodeFilter struct {
 	statusCodes []ptrace.StatusCode
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*statusCodeFilter)(nil)
+var _ samplingpolicy.Evaluator = (*statusCodeFilter)(nil)
 
 // NewStatusCodeFilter creates a policy evaluator that samples all traces with
 // a given status code.
-func NewStatusCodeFilter(settings component.TelemetrySettings, statusCodeString []string) (samplingpolicy.PolicyEvaluator, error) {
+func NewStatusCodeFilter(settings component.TelemetrySettings, statusCodeString []string) (samplingpolicy.Evaluator, error) {
 	if len(statusCodeString) == 0 {
 		return nil, errors.New("expected at least one status code to filter on")
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/status_code.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -19,11 +20,11 @@ type statusCodeFilter struct {
 	statusCodes []ptrace.StatusCode
 }
 
-var _ PolicyEvaluator = (*statusCodeFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*statusCodeFilter)(nil)
 
 // NewStatusCodeFilter creates a policy evaluator that samples all traces with
 // a given status code.
-func NewStatusCodeFilter(settings component.TelemetrySettings, statusCodeString []string) (PolicyEvaluator, error) {
+func NewStatusCodeFilter(settings component.TelemetrySettings, statusCodeString []string) (samplingpolicy.PolicyEvaluator, error) {
 	if len(statusCodeString) == 0 {
 		return nil, errors.New("expected at least one status code to filter on")
 	}
@@ -50,7 +51,7 @@ func NewStatusCodeFilter(settings component.TelemetrySettings, statusCodeString 
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (r *statusCodeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (r *statusCodeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	r.logger.Debug("Evaluating spans in status code filter")
 
 	trace.Lock()

--- a/processor/tailsamplingprocessor/internal/sampling/status_code.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code.go
@@ -8,11 +8,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type statusCodeFilter struct {

--- a/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
@@ -6,11 +6,12 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestNewStatusCodeFilter_errorHandling(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -27,31 +28,31 @@ func TestStatusCodeSampling(t *testing.T) {
 		Desc                  string
 		StatusCodesToFilterOn []string
 		StatusCodesPresent    []ptrace.StatusCode
-		Decision              Decision
+		Decision              samplingpolicy.Decision
 	}{
 		{
 			Desc:                  "filter on ERROR - none match",
 			StatusCodesToFilterOn: []string{"ERROR"},
 			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeOk, ptrace.StatusCodeUnset, ptrace.StatusCodeOk},
-			Decision:              NotSampled,
+			Decision:              samplingpolicy.NotSampled,
 		},
 		{
 			Desc:                  "filter on OK and ERROR - none match",
 			StatusCodesToFilterOn: []string{"OK", "ERROR"},
 			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeUnset, ptrace.StatusCodeUnset},
-			Decision:              NotSampled,
+			Decision:              samplingpolicy.NotSampled,
 		},
 		{
 			Desc:                  "filter on UNSET - matches",
 			StatusCodesToFilterOn: []string{"UNSET"},
 			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeUnset},
-			Decision:              Sampled,
+			Decision:              samplingpolicy.Sampled,
 		},
 		{
 			Desc:                  "filter on OK and UNSET - matches",
 			StatusCodesToFilterOn: []string{"OK", "UNSET"},
 			StatusCodesPresent:    []ptrace.StatusCode{ptrace.StatusCodeError, ptrace.StatusCodeOk},
-			Decision:              Sampled,
+			Decision:              samplingpolicy.Sampled,
 		},
 	}
 
@@ -68,7 +69,7 @@ func TestStatusCodeSampling(t *testing.T) {
 				span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 			}
 
-			trace := &TraceData{
+			trace := &samplingpolicy.TraceData{
 				ReceivedBatches: traces,
 			}
 

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
@@ -31,11 +31,11 @@ type regexStrSetting struct {
 	filterList   []*regexp.Regexp
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*stringAttributeFilter)(nil)
+var _ samplingpolicy.Evaluator = (*stringAttributeFilter)(nil)
 
 // NewStringAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range.
-func NewStringAttributeFilter(settings component.TelemetrySettings, key string, values []string, regexMatchEnabled bool, evictSize int, invertMatch bool) samplingpolicy.PolicyEvaluator {
+func NewStringAttributeFilter(settings component.TelemetrySettings, key string, values []string, regexMatchEnabled bool, evictSize int, invertMatch bool) samplingpolicy.Evaluator {
 	// initialize regex filter rules and LRU cache for matched results
 	if regexMatchEnabled {
 		if evictSize <= 0 {

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/golang/groupcache/lru"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -30,11 +31,11 @@ type regexStrSetting struct {
 	filterList   []*regexp.Regexp
 }
 
-var _ PolicyEvaluator = (*stringAttributeFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*stringAttributeFilter)(nil)
 
 // NewStringAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range.
-func NewStringAttributeFilter(settings component.TelemetrySettings, key string, values []string, regexMatchEnabled bool, evictSize int, invertMatch bool) PolicyEvaluator {
+func NewStringAttributeFilter(settings component.TelemetrySettings, key string, values []string, regexMatchEnabled bool, evictSize int, invertMatch bool) samplingpolicy.PolicyEvaluator {
 	// initialize regex filter rules and LRU cache for matched results
 	if regexMatchEnabled {
 		if evictSize <= 0 {
@@ -91,7 +92,7 @@ func NewStringAttributeFilter(settings component.TelemetrySettings, key string, 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 // The SamplingDecision is made by comparing the attribute values with the matching values,
 // which might be static strings or regular expressions.
-func (saf *stringAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (saf *stringAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	saf.logger.Debug("Evaluating spans in string-tag filter")
 	trace.Lock()
 	defer trace.Unlock()

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
@@ -8,11 +8,12 @@ import (
 	"regexp"
 
 	"github.com/golang/groupcache/lru"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 const defaultCacheSize = 128

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
@@ -6,12 +6,13 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 // TestStringAttributeCfg is replicated with StringAttributeCfg

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
@@ -25,191 +26,191 @@ type TestStringAttributeCfg struct {
 func TestStringTagFilter(t *testing.T) {
 	cases := []struct {
 		Desc                  string
-		Trace                 *TraceData
+		Trace                 *samplingpolicy.TraceData
 		filterCfg             *TestStringAttributeCfg
-		Decision              Decision
+		Decision              samplingpolicy.Decision
 		DisableInvertDecision bool
 	}{
 		{
 			Desc:      "nonmatching node attribute key",
 			Trace:     newTraceStringAttrs(map[string]any{"non_matching": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "nonmatching node attribute value",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "non_matching"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching node attribute",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "nonmatching span attribute key",
 			Trace:     newTraceStringAttrs(nil, "nonmatching", "value"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "nonmatching span attribute value",
 			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching span attribute",
 			Trace:     newTraceStringAttrs(nil, "example", "value"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "matching span attribute with regex",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "nonmatching span attribute with regex",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[a-z]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching span attribute with regex without CacheSize provided in config",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "matching plain text node attribute in regex",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "nonmatching span attribute on empty filter list",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{}, EnabledRegexMatching: true},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "invert nonmatching node attribute key",
 			Trace:     newTraceStringAttrs(map[string]any{"non_matching": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert nonmatching node attribute value",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "non_matching"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert nonmatching node attribute list",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "non_matching"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert matching node attribute",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert matching node attribute list",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute key",
 			Trace:     newTraceStringAttrs(nil, "nonmatching", "value"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute value",
 			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute list",
 			Trace:     newTraceStringAttrs(nil, "example", "nonmatching"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert matching span attribute",
 			Trace:     newTraceStringAttrs(nil, "example", "value"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert matching span attribute list",
 			Trace:     newTraceStringAttrs(nil, "example", "value"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert matching span attribute with regex",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert matching span attribute with regex list",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"^http", "v[0-9]+.HealthCheck$", "metrics$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute with regex",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[a-z]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute with regex list",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"^http", "v[a-z]+.HealthCheck$", "metrics$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:      "invert matching plain text node attribute in regex",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert matching plain text node attribute in regex list",
 			Trace:     newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"first_value", "value", "last_value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:  InvertNotSampled,
+			Decision:  samplingpolicy.InvertNotSampled,
 		},
 		{
 			Desc:      "invert nonmatching span attribute on empty filter list",
 			Trace:     newTraceStringAttrs(nil, "example", "grpc.health.v1.HealthCheck"),
 			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{}, EnabledRegexMatching: true, InvertMatch: true},
-			Decision:  InvertSampled,
+			Decision:  samplingpolicy.InvertSampled,
 		},
 		{
 			Desc:                  "invert matching node attribute key with DisableInvertDecision",
 			Trace:                 newTraceStringAttrs(map[string]any{"example": "value"}, "", ""),
 			filterCfg:             &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:              NotSampled,
+			Decision:              samplingpolicy.NotSampled,
 			DisableInvertDecision: true,
 		},
 		{
 			Desc:                  "invert nonmatching node attribute key with DisableInvertDecision",
 			Trace:                 newTraceStringAttrs(map[string]any{"non_matching": "value"}, "", ""),
 			filterCfg:             &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize, InvertMatch: true},
-			Decision:              Sampled,
+			Decision:              samplingpolicy.Sampled,
 			DisableInvertDecision: true,
 		},
 	}
@@ -252,7 +253,7 @@ func BenchmarkStringTagFilterEvaluateRegex(b *testing.B) {
 	}
 }
 
-func newTraceStringAttrs(nodeAttrs map[string]any, spanAttrKey, spanAttrValue string) *TraceData {
+func newTraceStringAttrs(nodeAttrs map[string]any, spanAttrKey, spanAttrValue string) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	//nolint:errcheck
@@ -262,7 +263,7 @@ func newTraceStringAttrs(nodeAttrs map[string]any, spanAttrKey, spanAttrValue st
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 	span.Attributes().PutStr(spanAttrKey, spanAttrValue)
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
@@ -6,6 +6,7 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -19,11 +20,11 @@ type traceStateFilter struct {
 	matcher func(string) bool
 }
 
-var _ PolicyEvaluator = (*traceStateFilter)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*traceStateFilter)(nil)
 
 // NewTraceStateFilter creates a policy evaluator that samples all traces with
 // the given value by the specific key in the trace_state.
-func NewTraceStateFilter(settings component.TelemetrySettings, key string, values []string) PolicyEvaluator {
+func NewTraceStateFilter(settings component.TelemetrySettings, key string, values []string) samplingpolicy.PolicyEvaluator {
 	// initialize the exact value map
 	valuesMap := make(map[string]struct{})
 	for _, value := range values {
@@ -43,7 +44,7 @@ func NewTraceStateFilter(settings component.TelemetrySettings, key string, value
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (tsf *traceStateFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
+func (tsf *traceStateFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	trace.Lock()
 	defer trace.Unlock()
 	batches := trace.ReceivedBatches

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
@@ -6,12 +6,13 @@ package sampling // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	tracesdk "go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 type traceStateFilter struct {

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
@@ -20,11 +20,11 @@ type traceStateFilter struct {
 	matcher func(string) bool
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*traceStateFilter)(nil)
+var _ samplingpolicy.Evaluator = (*traceStateFilter)(nil)
 
 // NewTraceStateFilter creates a policy evaluator that samples all traces with
 // the given value by the specific key in the trace_state.
-func NewTraceStateFilter(settings component.TelemetrySettings, key string, values []string) samplingpolicy.PolicyEvaluator {
+func NewTraceStateFilter(settings component.TelemetrySettings, key string, values []string) samplingpolicy.Evaluator {
 	// initialize the exact value map
 	valuesMap := make(map[string]struct{})
 	for _, value := range values {

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
@@ -6,11 +6,12 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 // TestTraceStateCfg is replicated with StringAttributeCfg

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -21,57 +22,57 @@ type TestTraceStateCfg struct {
 func TestTraceStateFilter(t *testing.T) {
 	cases := []struct {
 		Desc      string
-		Trace     *TraceData
+		Trace     *samplingpolicy.TraceData
 		filterCfg *TestTraceStateCfg
-		Decision  Decision
+		Decision  samplingpolicy.Decision
 	}{
 		{
 			Desc:      "nonmatching trace_state key",
 			Trace:     newTraceState("non_matching=value"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "nonmatching trace_state value",
 			Trace:     newTraceState("example=non_matching"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching trace_state",
 			Trace:     newTraceState("example=value"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "nonmatching trace_state on empty filter list",
 			Trace:     newTraceState("example=value"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{}},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "nonmatching trace_state on multiple key-values",
 			Trace:     newTraceState("example=non_matching,non_matching=value"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching trace_state on multiple key-values",
 			Trace:     newTraceState("example=value,non_matching=value"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value"}},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 		{
 			Desc:      "nonmatching trace_state on multiple filter list",
 			Trace:     newTraceState("example=non_matching"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value1", "value2"}},
-			Decision:  NotSampled,
+			Decision:  samplingpolicy.NotSampled,
 		},
 		{
 			Desc:      "matching trace_state on multiple filter list",
 			Trace:     newTraceState("example=value1"),
 			filterCfg: &TestTraceStateCfg{Key: "example", Values: []string{"value1", "value2"}},
-			Decision:  Sampled,
+			Decision:  samplingpolicy.Sampled,
 		},
 	}
 
@@ -85,7 +86,7 @@ func TestTraceStateFilter(t *testing.T) {
 	}
 }
 
-func newTraceState(traceState string) *TraceData {
+func newTraceState(traceState string) *samplingpolicy.TraceData {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
 	ils := rs.ScopeSpans().AppendEmpty()
@@ -93,7 +94,7 @@ func newTraceState(traceState string) *TraceData {
 	span.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 	span.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
 	span.TraceState().FromRaw(traceState)
-	return &TraceData{
+	return &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -4,9 +4,10 @@
 package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 // hasResourceOrSpanWithCondition iterates through all the resources and instrumentation library spans until any

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -6,6 +6,7 @@ package sampling
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -13,7 +14,7 @@ import (
 
 func TestSetAttrOnScopeSpans_Empty(_ *testing.T) {
 	traces := ptrace.NewTraces()
-	traceData := &TraceData{
+	traceData := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 
@@ -39,7 +40,7 @@ func TestSetAttrOnScopeSpans_Many(t *testing.T) {
 	ss3 := rs2.ScopeSpans().AppendEmpty()
 	span4 := ss3.Spans().AppendEmpty()
 
-	traceData := &TraceData{
+	traceData := &samplingpolicy.TraceData{
 		ReceivedBatches: traces,
 	}
 
@@ -78,7 +79,7 @@ func BenchmarkSetAttrOnScopeSpans(b *testing.B) {
 			ss3.Spans().AppendEmpty()
 		}
 
-		traceData := &TraceData{
+		traceData := &samplingpolicy.TraceData{
 			ReceivedBatches: traces,
 		}
 

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -6,10 +6,11 @@ package sampling
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestSetAttrOnScopeSpans_Empty(_ *testing.T) {

--- a/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
+++ b/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package sampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+package samplingpolicy // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 
 import (
 	"context"

--- a/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
+++ b/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
@@ -55,9 +55,9 @@ const (
 	InvertNotSampled
 )
 
-// PolicyEvaluator implements a tail-based sampling policy evaluator,
+// Evaluator implements a tail-based sampling policy evaluator,
 // which makes a sampling decision for a given trace when requested.
-type PolicyEvaluator interface {
+type Evaluator interface {
 	// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 	Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error)
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -28,9 +28,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/tracelimiter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 // policy combines a sampling policy evaluator with the destinations to be
@@ -39,7 +39,7 @@ type policy struct {
 	// name used to identify this policy instance.
 	name string
 	// evaluator that decides if a trace is sampled or not by this policy instance.
-	evaluator samplingpolicy.PolicyEvaluator
+	evaluator samplingpolicy.Evaluator
 	// attribute to use in the telemetry to denote the policy.
 	attribute metric.MeasurementOption
 }
@@ -217,7 +217,7 @@ func withRecordPolicy() Option {
 	}
 }
 
-func getPolicyEvaluator(settings component.TelemetrySettings, cfg *PolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getPolicyEvaluator(settings component.TelemetrySettings, cfg *PolicyCfg) (samplingpolicy.Evaluator, error) {
 	switch cfg.Type {
 	case Composite:
 		return getNewCompositePolicy(settings, &cfg.CompositeCfg)
@@ -230,7 +230,7 @@ func getPolicyEvaluator(settings component.TelemetrySettings, cfg *PolicyCfg) (s
 	}
 }
 
-func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedPolicyCfg) (samplingpolicy.PolicyEvaluator, error) {
+func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedPolicyCfg) (samplingpolicy.Evaluator, error) {
 	settings.Logger = settings.Logger.With(zap.Any("policy", cfg.Type))
 
 	switch cfg.Type {

--- a/processor/tailsamplingprocessor/processor_benchmarks_test.go
+++ b/processor/tailsamplingprocessor/processor_benchmarks_test.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/collector/processor/processortest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func BenchmarkSampling(b *testing.B) {
@@ -32,10 +32,10 @@ func BenchmarkSampling(b *testing.B) {
 		require.NoError(b, tsp.Shutdown(b.Context()))
 	}()
 	metrics := &policyMetrics{}
-	sampleBatches := make([]*sampling.TraceData, 0, len(batches))
+	sampleBatches := make([]*samplingpolicy.TraceData, 0, len(batches))
 
 	for i := 0; i < len(batches); i++ {
-		sampleBatches = append(sampleBatches, &sampling.TraceData{
+		sampleBatches = append(sampleBatches, &samplingpolicy.TraceData{
 			ArrivalTime: time.Now(),
 			// SpanCount:       spanCount,
 			ReceivedBatches: ptrace.NewTraces(),

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/cache"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestSamplingPolicyTypicalPath(t *testing.T) {
@@ -46,7 +46,7 @@ func TestSamplingPolicyTypicalPath(t *testing.T) {
 		require.NoError(t, p.Shutdown(t.Context()))
 	}()
 
-	mpe1.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -93,7 +93,7 @@ func TestSamplingPolicyInvertSampled(t *testing.T) {
 		require.NoError(t, p.Shutdown(t.Context()))
 	}()
 
-	mpe1.NextDecision = sampling.InvertSampled
+	mpe1.NextDecision = samplingpolicy.InvertSampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -143,8 +143,8 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 	}()
 
 	// InvertNotSampled takes precedence
-	mpe1.NextDecision = sampling.Sampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.Sampled
+	mpe2.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -196,8 +196,8 @@ func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
 	}()
 
 	// First policy takes precedence
-	mpe1.NextDecision = sampling.Sampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.Sampled
+	mpe2.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -247,7 +247,7 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 	}()
 
 	// InvertNotSampled takes precedence
-	mpe1.NextDecision = sampling.NotSampled
+	mpe1.NextDecision = samplingpolicy.NotSampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -295,7 +295,7 @@ func TestSamplingPolicyDecisionNotSampled_WithRecordPolicy(t *testing.T) {
 	}()
 
 	// InvertNotSampled takes precedence
-	mpe1.NextDecision = sampling.NotSampled
+	mpe1.NextDecision = samplingpolicy.NotSampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -340,8 +340,8 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 	}()
 
 	// InvertNotSampled takes precedence
-	mpe1.NextDecision = sampling.InvertNotSampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.InvertNotSampled
+	mpe2.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -393,8 +393,8 @@ func TestSamplingPolicyDecisionInvertNotSampled_WithRecordPolicy(t *testing.T) {
 	}()
 
 	// InvertNotSampled takes precedence
-	mpe1.NextDecision = sampling.InvertNotSampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.InvertNotSampled
+	mpe2.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
@@ -442,8 +442,8 @@ func TestLateArrivingSpansAssignedOriginalDecision(t *testing.T) {
 	traceID := uInt64ToTraceID(1)
 
 	// The combined decision from the policies is NotSampled
-	mpe1.NextDecision = sampling.InvertSampled
-	mpe2.NextDecision = sampling.NotSampled
+	mpe1.NextDecision = samplingpolicy.InvertSampled
+	mpe2.NextDecision = samplingpolicy.NotSampled
 
 	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
 	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
@@ -516,7 +516,7 @@ func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
 	traceID := uInt64ToTraceID(1)
 
 	// The first span will be sampled, this will later be set to not sampled, but the sampling decision will be cached
-	mpe.NextDecision = sampling.Sampled
+	mpe.NextDecision = samplingpolicy.Sampled
 
 	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
 	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
@@ -550,7 +550,7 @@ func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
 	require.False(t, ok)
 
 	// Set next decision to not sampled, ensuring the next decision is determined by the decision cache, not the policy
-	mpe.NextDecision = sampling.NotSampled
+	mpe.NextDecision = samplingpolicy.NotSampled
 
 	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
 	// The policies should NOT be evaluated again.
@@ -593,7 +593,7 @@ func TestLateSpanUsesNonSampledDecisionCache(t *testing.T) {
 	traceID := uInt64ToTraceID(1)
 
 	// The first span will be NOT sampled, this will later be set to sampled, but the sampling decision will be cached
-	mpe.NextDecision = sampling.NotSampled
+	mpe.NextDecision = samplingpolicy.NotSampled
 
 	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
 	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
@@ -627,7 +627,7 @@ func TestLateSpanUsesNonSampledDecisionCache(t *testing.T) {
 	require.False(t, ok)
 
 	// Set next decision to sampled, ensuring the next decision is determined by the decision cache, not the policy
-	mpe.NextDecision = sampling.Sampled
+	mpe.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
 	// The policies should NOT be evaluated again.
@@ -668,8 +668,8 @@ func TestSampleOnFirstMatch(t *testing.T) {
 	}()
 
 	// Second policy matches, last policy should not be evaluated
-	mpe1.NextDecision = sampling.NotSampled
-	mpe2.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.NotSampled
+	mpe2.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 const (
@@ -52,10 +52,10 @@ var (
 type TestPolicyEvaluator struct {
 	Started       chan struct{}
 	CouldContinue chan struct{}
-	pe            sampling.PolicyEvaluator
+	pe            samplingpolicy.PolicyEvaluator
 }
 
-func (t *TestPolicyEvaluator) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *sampling.TraceData) (sampling.Decision, error) {
+func (t *TestPolicyEvaluator) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	close(t.Started)
 	<-t.CouldContinue
 	return t.pe.Evaluate(ctx, traceID, trace)
@@ -146,7 +146,7 @@ func TestTraceIntegrity(t *testing.T) {
 		require.NoError(t, p.Shutdown(t.Context()))
 	}()
 
-	mpe1.NextDecision = sampling.Sampled
+	mpe1.NextDecision = samplingpolicy.Sampled
 
 	// Generate and deliver first span
 	require.NoError(t, p.ConsumeTraces(t.Context(), traces))
@@ -211,7 +211,7 @@ func TestSequentialTraceArrival(t *testing.T) {
 	for i := range traceIDs {
 		d, ok := tsp.idToTrace.Load(traceIDs[i])
 		require.True(t, ok, "Missing expected traceId")
-		v := d.(*sampling.TraceData)
+		v := d.(*samplingpolicy.TraceData)
 		require.Equal(t, int64(i+1), v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
 	}
 }
@@ -266,7 +266,7 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	for i := range traceIDs {
 		d, ok := tsp.idToTrace.Load(traceIDs[i])
 		require.True(t, ok, "Missing expected traceId")
-		v := d.(*sampling.TraceData)
+		v := d.(*samplingpolicy.TraceData)
 		require.Equal(t, int64(i+1)*2, v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
 	}
 }
@@ -760,7 +760,7 @@ func TestDecisionPolicyMetrics(t *testing.T) {
 	metrics := newPolicyMetrics(len(policy))
 
 	for i, id := range traceIDs {
-		sb := &sampling.TraceData{
+		sb := &samplingpolicy.TraceData{
 			ArrivalTime:     time.Now(),
 			ReceivedBatches: batches[i],
 			SpanCount:       &atomic.Int64{},
@@ -875,14 +875,14 @@ func uInt64ToSpanID(id uint64) pcommon.SpanID {
 }
 
 type mockPolicyEvaluator struct {
-	NextDecision    sampling.Decision
+	NextDecision    samplingpolicy.Decision
 	NextError       error
 	EvaluationCount int
 }
 
-var _ sampling.PolicyEvaluator = (*mockPolicyEvaluator)(nil)
+var _ samplingpolicy.PolicyEvaluator = (*mockPolicyEvaluator)(nil)
 
-func (m *mockPolicyEvaluator) Evaluate(context.Context, pcommon.TraceID, *sampling.TraceData) (sampling.Decision, error) {
+func (m *mockPolicyEvaluator) Evaluate(context.Context, pcommon.TraceID, *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	m.EvaluationCount++
 	return m.NextDecision, m.NextError
 }
@@ -938,7 +938,7 @@ func TestNumericAttributeCases(t *testing.T) {
 		minValue       int64
 		maxValue       int64
 		testValue      int64
-		expectedResult sampling.Decision
+		expectedResult samplingpolicy.Decision
 		description    string
 	}{
 		{
@@ -946,7 +946,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       400,
 			maxValue:       0, // not set (default)
 			testValue:      500,
-			expectedResult: sampling.Sampled,
+			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value >= min_value and max_value not set",
 		},
 		{
@@ -954,7 +954,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       -100,
 			maxValue:       0, // not set (default)
 			testValue:      50,
-			expectedResult: sampling.Sampled,
+			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value >= min_value (negative) and max_value not set",
 		},
 		{
@@ -962,7 +962,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       0, // not set (default)
 			maxValue:       1000,
 			testValue:      500,
-			expectedResult: sampling.Sampled,
+			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value <= max_value and min_value not set",
 		},
 		{
@@ -970,7 +970,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       100,
 			maxValue:       200,
 			testValue:      150,
-			expectedResult: sampling.Sampled,
+			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when min_value <= value <= max_value",
 		},
 		{
@@ -978,7 +978,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       400,
 			maxValue:       0, // not set (default)
 			testValue:      300,
-			expectedResult: sampling.NotSampled,
+			expectedResult: samplingpolicy.NotSampled,
 			description:    "Should not sample when value < min_value",
 		},
 		{
@@ -986,7 +986,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			minValue:       0, // not set (default)
 			maxValue:       100,
 			testValue:      200,
-			expectedResult: sampling.NotSampled,
+			expectedResult: samplingpolicy.NotSampled,
 			description:    "Should not sample when value > max_value",
 		},
 	}
@@ -1010,7 +1010,7 @@ func TestNumericAttributeCases(t *testing.T) {
 			require.NotNil(t, evaluator)
 
 			// Create test trace data
-			trace := &sampling.TraceData{}
+			trace := &samplingpolicy.TraceData{}
 			trace.ReceivedBatches = ptrace.NewTraces()
 
 			rs := trace.ReceivedBatches.ResourceSpans().AppendEmpty()

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -52,7 +52,7 @@ var (
 type TestPolicyEvaluator struct {
 	Started       chan struct{}
 	CouldContinue chan struct{}
-	pe            samplingpolicy.PolicyEvaluator
+	pe            samplingpolicy.Evaluator
 }
 
 func (t *TestPolicyEvaluator) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
@@ -880,7 +880,7 @@ type mockPolicyEvaluator struct {
 	EvaluationCount int
 }
 
-var _ samplingpolicy.PolicyEvaluator = (*mockPolicyEvaluator)(nil)
+var _ samplingpolicy.Evaluator = (*mockPolicyEvaluator)(nil)
 
 func (m *mockPolicyEvaluator) Evaluate(context.Context, pcommon.TraceID, *samplingpolicy.TraceData) (samplingpolicy.Decision, error) {
 	m.EvaluationCount++


### PR DESCRIPTION
#### Description

Refactor the tail sampling processor so that the interfaces that define trace data and policy decisions are available publically. This is the first step in allowing extensions to be added to the tail sampling processor to allow custom logic that is not possible/easy to do with OTTL such as pulling information from other sources.

#### Link to tracking issue
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31582

#### Testing
No behavior changed as this is purely a refactor. All current tests need to continue to pass.
