### PR TITLE
[chore] Guard debug logging with enabled check

### DIFF
--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -55,7 +55,9 @@ func NewOTTLConditionFilter(settings component.TelemetrySettings, spanConditions
 }
 
 func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
-	ocf.logger.Debug("Evaluating with OTTL conditions filter", zap.String("traceID", traceID.String()))
+	if ocf.logger.Core().Enabled(zap.DebugLevel) {
+		ocf.logger.Debug("Evaluating with OTTL conditions filter", zap.String("traceID", traceID.String()))
+	}
 
 	if ocf.sampleSpanExpr == nil && ocf.sampleSpanEventExpr == nil {
 		return NotSampled, nil


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In profiling, we see that this debug log makes up around 13% of total CPU in ottlConditionFilter.Eval. The conversion of traceID to string is a large part of this, so by guarding it we can squeeze some performance out basically for free.
