### PR TITLE
[tailsamplingprocessor] Record cached decisions when record policy

### DIFF
--- a/.chloggen/logiraptor_set-policy-on-cached-decision.yaml
+++ b/.chloggen/logiraptor_set-policy-on-cached-decision.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set a `tailsampling.cached_decision` attribute on traces that were sampled by the decision cache.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42535]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -565,10 +565,11 @@ To better understand _which_ sampling policy made the decision to include a trac
 
 When this feature gate is set, this will add additional attributes on each sampled span:
 
-| Attribute                       | Description                                                               | Present?                   |
-|---------------------------------|---------------------------------------------------------------------------|----------------------------|
-| `tailsampling.policy`           | Records the configured name of the policy that sampled a trace            | Always                     |
-| `tailsampling.composite_policy` | Records the configured name of a composite subpolicy that sampled a trace | When composite policy used |
+| Attribute                       | Description                                                               | Present?                                               |
+|---------------------------------|---------------------------------------------------------------------------|--------------------------------------------------------|
+| `tailsampling.policy`           | Records the configured name of the policy that sampled a trace            | Always, unless trace was sampled by the decision cache |
+| `tailsampling.composite_policy` | Records the configured name of a composite subpolicy that sampled a trace | When composite policy used                             |
+| `tailsampling.cached_decision`  | Records whether a trace was sampled by the decision cache                 | When decision cache used                               |
 
 ### Disable invert decisions
 

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -104,3 +104,14 @@ func SetAttrOnScopeSpans(data *TraceData, attrName, attrKey string) {
 		}
 	}
 }
+
+func SetBoolAttrOnScopeSpans(data ptrace.Traces, attrName string, attrValue bool) {
+	rs := data.ResourceSpans()
+	for i := 0; i < rs.Len(); i++ {
+		rss := rs.At(i)
+		for j := 0; j < rss.ScopeSpans().Len(); j++ {
+			ss := rss.ScopeSpans().At(j)
+			ss.Scope().Attributes().PutBool(attrName, attrValue)
+		}
+	}
+}

--- a/processor/tailsamplingprocessor/internal/telemetry/featureflag.go
+++ b/processor/tailsamplingprocessor/internal/telemetry/featureflag.go
@@ -18,7 +18,7 @@ func IsMetricStatCountSpansSampledEnabled() bool {
 var recordPolicyFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"processor.tailsamplingprocessor.recordpolicy",
 	featuregate.StageAlpha,
-	featuregate.WithRegisterDescription("When enabled, attaches the name of the policy (and if applicable, composite policy) responsible for sampling a trace in the 'tailsampling.policy'/ 'tailsampling.composite_policy' attributes."),
+	featuregate.WithRegisterDescription("When enabled, attaches the name of the policy (and if applicable, composite policy) responsible for sampling a trace in the 'tailsampling.policy', 'tailsampling.composite_policy', and `tailsampling.cached_decision` attributes."),
 )
 
 func IsRecordPolicyEnabled() bool {

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -568,6 +568,9 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans ptrace.Resourc
 			tsp.logger.Debug("Trace ID is in the sampled cache", zap.Stringer("id", id))
 			traceTd := ptrace.NewTraces()
 			appendToTraces(traceTd, resourceSpans, spans)
+			if tsp.recordPolicy {
+				sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
+			}
 			tsp.forwardSpans(tsp.ctx, traceTd)
 			tsp.telemetry.ProcessorTailSamplingEarlyReleasesFromCacheDecision.
 				Add(tsp.ctx, int64(len(spans)), attrSampledTrue)


### PR DESCRIPTION
#### Description

Currently, when the record policy feature gate is enabled, and a trace uses a cached sampling decision, we don't record the policy name anywhere. This is not currently possible since the decision cache doesn't store the sampling policy. I plan to submit a few more refactors which will make that possible, but for now it's useful to have _some_ indication of why the trace was sampled, to avoid confusing end users who don't see the attribute for `tailsampling.policy`.

