### PR TITLE
Revert "[chore][.github] Add Ubuntu to scoped-test runs"

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -55,10 +55,7 @@ jobs:
   scoped-tests:
     needs: changedfiles
     if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
-    strategy:
-      matrix:
-        runner: [windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.runner }}
+    runs-on: windows-latest
     steps:
       - name: Echo changed files
         shell: bash
@@ -80,7 +77,6 @@ jobs:
 
       - name: Build gotestsum on Windows
         if: runner.os == 'Windows'
-        shell: pwsh # Explicitly set the shell to avoid actionlint treating this an attempt to escape single quote
         run: make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
 
       - name: Build gotestsum


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#42532

we still need to identify the problem causing this, but this PR changed the behavior of the scoped-test run, which stopped reporting back in. Reverting the change is a possible fix. Running this revert PR to check if reverting helps and identifies for sure that it is the issue.