### PR TITLE
[chore] remove batch from various examples

### DIFF
--- a/cmd/telemetrygen/README.md
+++ b/cmd/telemetrygen/README.md
@@ -46,9 +46,6 @@ receivers:
       grpc:
         endpoint: 0.0.0.0:4317
 
-processors:
-  batch:
-
 exporters:
   debug:
     verbosity: detailed
@@ -57,15 +54,12 @@ service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [batch]
       exporters: [debug]
     metrics:
       receivers: [otlp]
-      processors: [batch]
       exporters: [debug]
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [debug]
 ```
 

--- a/confmap/provider/googlesecretmanagerprovider/README.md
+++ b/confmap/provider/googlesecretmanagerprovider/README.md
@@ -27,8 +27,6 @@ receivers:
     protocols:
       grpc:
       http:
-processors:
-  batch:
 
 exporters:
   logging:
@@ -41,15 +39,12 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [logging, http]
     metrics:
       receivers: [otlp]
-      processors: [batch]
       exporters: [logging, http]
     logs:
       receivers: [otlp]
-      processors: [batch]
       exporters: [logging, http]
 
 ```

--- a/confmap/provider/s3provider/testdata/otel-config.yaml
+++ b/confmap/provider/s3provider/testdata/otel-config.yaml
@@ -9,7 +9,6 @@ receivers:
       http:
 
 processors:
-  batch:
   memory_limiter:
     # 75% of maximum memory up to 4G
     limit_mib: 1536
@@ -25,11 +24,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter]
       exporters: [debug]
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter]
       exporters: [debug]
 
   extensions: [zpages]

--- a/connector/roundrobinconnector/README.md
+++ b/connector/roundrobinconnector/README.md
@@ -50,7 +50,6 @@ receivers:
   otlp:
 processors:
   resourcedetection:
-  batch:
 exporters:
   prometheusremotewrite/1:
   prometheusremotewrite/2:
@@ -60,7 +59,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [resourcedetection, batch]
+      processors: [resourcedetection]
       exporters: [roundrobin]
     metrics/1:
       receivers: [roundrobin]

--- a/examples/secure-tracing/otel-collector-config.yaml
+++ b/examples/secure-tracing/otel-collector-config.yaml
@@ -7,9 +7,6 @@ receivers:
           cert_file: /etc/otel-collector.crt
           key_file: /etc/otel-collector.key
 
-processors:
-  batch:
-
 exporters:
   debug:
     verbosity: detailed
@@ -18,6 +15,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [debug]
 

--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -92,7 +92,7 @@ These instructions are to get you up and running quickly with the GCP exporter i
 
 2.  **Create a configuration file `config.yaml`.** The example below shows a minimal recommended configuration that receives OTLP and sends data to GCP, in addition to verbose logging to help understand what is going on. It uses application default credentials (which we will set up in the next step).
 
-    Note that this configuration includes the recommended `memory_limiter` and `batch` plugins, which avoid high latency for reporting telemetry, and ensure that the collector itself will stay stable (not run out of memory) by dropping telemetry if needed.
+    Note that this configuration includes the recommended `memory_limiter` plugins, which avoid high latency for reporting telemetry, and ensure that the collector itself will stay stable (not run out of memory) by dropping telemetry if needed.
 
     ```yaml
     receivers:
@@ -109,7 +109,6 @@ These instructions are to get you up and running quickly with the GCP exporter i
         check_interval: 1s
         limit_percentage: 65
         spike_limit_percentage: 20
-      batch:
       resourcedetection:
         detectors: [gcp]
         timeout: 10s
@@ -117,15 +116,15 @@ These instructions are to get you up and running quickly with the GCP exporter i
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter]
           exporters: [googlecloud]
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter]
           exporters: [googlecloud]
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter]
           exporters: [googlecloud]
     ```
 

--- a/exporter/logzioexporter/example/config.yaml
+++ b/exporter/logzioexporter/example/config.yaml
@@ -11,9 +11,6 @@ exporters:
     account_token: "<<LOGZIO_ACCOUNT_TOKEN>>"
     #region: "<<LOGZIO_ACCOUNT_REGION_CODE>>" - (Optional): Your logz.io account region code. Defaults to "us". Required only if your logz.io region is different than US East. https://docs.logz.io/user-guide/accounts/account-region.html#available-regions
 
-processors:
-  batch:
-
 extensions:
   pprof:
     endpoint: :1777
@@ -26,7 +23,6 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, zipkin]
-      processors: [batch]
       exporters: [logzio]
 
   telemetry:

--- a/exporter/tinybirdexporter/README.md
+++ b/exporter/tinybirdexporter/README.md
@@ -131,9 +131,6 @@ receivers:
       grpc:
       http:
 
-processors:
-  batch:
-
 exporters:
   tinybird:
     endpoint: ${OTEL_TINYBIRD_API_HOST}
@@ -156,14 +153,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
       exporters: [tinybird]
     metrics:
       receivers: [otlp]
-      processors: [batch]
       exporters: [tinybird]
     logs:
       receivers: [otlp]
-      processors: [batch]
       exporters: [tinybird]
 ```

--- a/extension/encoding/skywalkingencodingextension/testdata/full-config.yaml
+++ b/extension/encoding/skywalkingencodingextension/testdata/full-config.yaml
@@ -19,9 +19,6 @@ receivers:
 exporters:
   debug:
 
-processors:
-  batch:
-
 extensions:
   health_check:
   pprof:
@@ -35,5 +32,4 @@ service:
   pipelines:
     traces:
       receivers: [kafka]
-      processors: [batch]
       exporters: [debug]

--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -134,12 +134,11 @@ With the below configuration, the **groupbyattrs** will re-associate the spans w
 
 ```yaml
 processors:
-  batch:
   groupbyattrs:
 
 pipelines:
   traces:
-    processors: [batch, groupbyattrs/grouping]
+    processors: [groupbyattrs/grouping]
     ...
 ```
 


### PR DESCRIPTION
This updates existing examples to remove the batch processor to reduce dependency on it.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/13766