### PR TITLE
[receiver/splunkenterprise] fix typo search artifact size metrics

### DIFF
--- a/.chloggen/splunk-searchartifact-fix-typo.yaml
+++ b/.chloggen/splunk-searchartifact-fix-typo.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkenterprisereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a typo from a previous PR implementing the search artifact size metrics, which has caused errors from parsing empty strings.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42615]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/splunkenterprisereceiver/search_result.go
+++ b/receiver/splunkenterprisereceiver/search_result.go
@@ -181,7 +181,7 @@ type dispatchArtifactContent struct {
 	AdhocSize          string `json:"adhoc_size_mb"`
 	ScheduledSize      string `json:"scheduled_size_mb"`
 	CompletedSize      string `json:"completed_size_mb"`
-	IncompleteSize     string `json:"incomplete_size_mb"`
+	IncompleteSize     string `json:"incomple_size_mb"`
 }
 
 // '/services/server/health/splunkd/details'


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fixes a typo in the search artifact size metrics, which is part of the existing search dispatch collection. This typo has been causing errors with parsing empty string values.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42615
