### PR TITLE
[tailsamplingprocessor] Remove misleading metric

### DIFF
--- a/.chloggen/logiraptor_remove-policy-latency.yaml
+++ b/.chloggen/logiraptor_remove-policy-latency.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove misleading policy latency metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42620]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/logiraptor_remove-policy-latency.yaml
+++ b/.chloggen/logiraptor_remove-policy-latency.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: tailsamplingprocessor

--- a/processor/tailsamplingprocessor/documentation.md
+++ b/processor/tailsamplingprocessor/documentation.md
@@ -75,14 +75,6 @@ Counts the arrival of new traces
 | ---- | ----------- | ---------- | --------- |
 | {traces} | Sum | Int | true |
 
-### otelcol_processor_tail_sampling_sampling_decision_latency
-
-Latency (in microseconds) of a given sampling policy
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| µs | Histogram | Int |
-
 ### otelcol_processor_tail_sampling_sampling_decision_timer_latency
 
 Latency (in milliseconds) of each run of the sampling decision timer

--- a/processor/tailsamplingprocessor/generated_package_test.go
+++ b/processor/tailsamplingprocessor/generated_package_test.go
@@ -3,9 +3,8 @@
 package tailsamplingprocessor
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -31,7 +31,6 @@ type TelemetryBuilder struct {
 	ProcessorTailSamplingEarlyReleasesFromCacheDecision metric.Int64Counter
 	ProcessorTailSamplingGlobalCountTracesSampled       metric.Int64Counter
 	ProcessorTailSamplingNewTraceIDReceived             metric.Int64Counter
-	ProcessorTailSamplingSamplingDecisionLatency        metric.Int64Histogram
 	ProcessorTailSamplingSamplingDecisionTimerLatency   metric.Int64Histogram
 	ProcessorTailSamplingSamplingLateSpanAge            metric.Int64Histogram
 	ProcessorTailSamplingSamplingPolicyEvaluationError  metric.Int64Counter
@@ -97,13 +96,6 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_processor_tail_sampling_new_trace_id_received",
 		metric.WithDescription("Counts the arrival of new traces"),
 		metric.WithUnit("{traces}"),
-	)
-	errs = errors.Join(errs, err)
-	builder.ProcessorTailSamplingSamplingDecisionLatency, err = builder.meter.Int64Histogram(
-		"otelcol_processor_tail_sampling_sampling_decision_latency",
-		metric.WithDescription("Latency (in microseconds) of a given sampling policy"),
-		metric.WithUnit("µs"),
-		metric.WithExplicitBucketBoundaries([]float64{1, 2, 5, 10, 25, 50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorTailSamplingSamplingDecisionTimerLatency, err = builder.meter.Int64Histogram(

--- a/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -101,21 +101,6 @@ func AssertEqualProcessorTailSamplingNewTraceIDReceived(t *testing.T, tt *compon
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
-func AssertEqualProcessorTailSamplingSamplingDecisionLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
-	want := metricdata.Metrics{
-		Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
-		Description: "Latency (in microseconds) of a given sampling policy",
-		Unit:        "µs",
-		Data: metricdata.Histogram[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			DataPoints:  dps,
-		},
-	}
-	got, err := tt.GetMetric("otelcol_processor_tail_sampling_sampling_decision_latency")
-	require.NoError(t, err)
-	metricdatatest.AssertEqual(t, want, got, opts...)
-}
-
 func AssertEqualProcessorTailSamplingSamplingDecisionTimerLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_processor_tail_sampling_sampling_decision_timer_latency",

--- a/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -10,9 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
-	"go.opentelemetry.io/collector/component/componenttest"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func TestSetupTelemetry(t *testing.T) {
@@ -25,7 +24,6 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorTailSamplingEarlyReleasesFromCacheDecision.Add(context.Background(), 1)
 	tb.ProcessorTailSamplingGlobalCountTracesSampled.Add(context.Background(), 1)
 	tb.ProcessorTailSamplingNewTraceIDReceived.Add(context.Background(), 1)
-	tb.ProcessorTailSamplingSamplingDecisionLatency.Record(context.Background(), 1)
 	tb.ProcessorTailSamplingSamplingDecisionTimerLatency.Record(context.Background(), 1)
 	tb.ProcessorTailSamplingSamplingLateSpanAge.Record(context.Background(), 1)
 	tb.ProcessorTailSamplingSamplingPolicyEvaluationError.Add(context.Background(), 1)
@@ -46,9 +44,6 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorTailSamplingNewTraceIDReceived(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
-		metricdatatest.IgnoreTimestamp())
-	AssertEqualProcessorTailSamplingSamplingDecisionLatency(t, testTel,
-		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorTailSamplingSamplingDecisionTimerLatency(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -29,14 +29,6 @@ attributes:
 
 telemetry:
   metrics:
-    processor_tail_sampling_sampling_decision_latency:
-      description: Latency (in microseconds) of a given sampling policy
-      unit: µs
-      enabled: true
-      histogram:
-        value_type: int
-        bucket_boundaries: [1, 2, 5, 10, 25, 50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 2000, 3000, 4000, 5000, 10000, 20000, 30000, 50000]
-
     processor_tail_sampling_sampling_decision_timer_latency:
       description: Latency (in milliseconds) of each run of the sampling decision timer
       unit: ms

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -462,14 +462,10 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sa
 	}
 
 	ctx := context.Background()
-	startTime := time.Now()
 
 	// Check all policies before making a final decision.
 	for i, p := range tsp.policies {
 		decision, err := p.evaluator.Evaluate(ctx, id, trace)
-		latency := time.Since(startTime)
-		tsp.telemetry.ProcessorTailSamplingSamplingDecisionLatency.Record(ctx, int64(latency/time.Microsecond), p.attribute)
-
 		if err != nil {
 			if samplingDecisions[sampling.Error] == nil {
 				samplingDecisions[sampling.Error] = p

--- a/processor/tailsamplingprocessor/processor_telemetry_test.go
+++ b/processor/tailsamplingprocessor/processor_telemetry_test.go
@@ -70,7 +70,7 @@ func TestMetricsAfterOneEvaluation(t *testing.T) {
 	// verify
 	var md metricdata.ResourceMetrics
 	require.NoError(t, s.reader.Collect(t.Context(), &md))
-	require.Equal(t, 8, s.len(md))
+	require.Equal(t, 7, s.len(md))
 
 	for _, tt := range []struct {
 		opts []metricdatatest.Option
@@ -114,24 +114,6 @@ func TestMetricsAfterOneEvaluation(t *testing.T) {
 								attribute.String("decision", "sampled"),
 							),
 							Value: 1,
-						},
-					},
-				},
-			},
-		},
-		{
-			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
-			m: metricdata.Metrics{
-				Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
-				Description: "Latency (in microseconds) of a given sampling policy",
-				Unit:        "µs",
-				Data: metricdata.Histogram[int64]{
-					Temporality: metricdata.CumulativeTemporality,
-					DataPoints: []metricdata.HistogramDataPoint[int64]{
-						{
-							Attributes: attribute.NewSet(
-								attribute.String("policy", "always"),
-							),
 						},
 					},
 				},
@@ -269,7 +251,7 @@ func TestMetricsWithComponentID(t *testing.T) {
 	// verify
 	var md metricdata.ResourceMetrics
 	require.NoError(t, s.reader.Collect(t.Context(), &md))
-	require.Equal(t, 8, s.len(md))
+	require.Equal(t, 7, s.len(md))
 
 	for _, tt := range []struct {
 		opts []metricdatatest.Option
@@ -292,24 +274,6 @@ func TestMetricsWithComponentID(t *testing.T) {
 								attribute.String("decision", "sampled"),
 							),
 							Value: 1,
-						},
-					},
-				},
-			},
-		},
-		{
-			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
-			m: metricdata.Metrics{
-				Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
-				Description: "Latency (in microseconds) of a given sampling policy",
-				Unit:        "µs",
-				Data: metricdata.Histogram[int64]{
-					Temporality: metricdata.CumulativeTemporality,
-					DataPoints: []metricdata.HistogramDataPoint[int64]{
-						{
-							Attributes: attribute.NewSet(
-								attribute.String("policy", "unique_id.always"),
-							),
 						},
 					},
 				},
@@ -596,7 +560,7 @@ func TestMetricsCountSampled(t *testing.T) {
 			// verify
 			var md metricdata.ResourceMetrics
 			require.NoError(t, s.reader.Collect(t.Context(), &md))
-			require.Equal(t, 9, s.len(md))
+			require.Equal(t, 8, s.len(md))
 
 			for _, m := range tt.m {
 				t.Run(m.Name, func(t *testing.T) {


### PR DESCRIPTION
#### Description

This PR removes the metric otelcol_processor_tail_sampling_sampling_decision_latency.

This metric does not measure the latency of a particular policy. Instead, it measures the latency since policy evaluation began which is mostly not a useful signal.

To make matters worse, profiling shows that recording this metric accounts for >20% of cpu time spent evaluating policies. Since the tailsamplingprocessor is bottlenecked on the single threaded decision loop, this 20% is much better spent on making decisions rather than measuring a misleading metric.

<img width="2130" height="720" alt="Screenshot 2025-09-09 at 11 15 06 PM" src="https://github.com/user-attachments/assets/45a471b6-2a94-40fd-9a16-588edd5ae056" />

#### Link to tracking issue

Originally reported in
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38502, which I closed accidentally with a related PR.

