### PR TITLE
[exporter/faro] update success status code to any 2xx

### DIFF
--- a/.chloggen/rlankfo_faro-exporter-status-codes.yaml
+++ b/.chloggen/rlankfo_faro-exporter-status-codes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: faroexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix success response handling in faroexporter so any HTTP 2xx status code indicates success instead of only 202 Accepted.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42658]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/faroexporter/exporter.go
+++ b/exporter/faroexporter/exporter.go
@@ -109,7 +109,7 @@ func (fe *faroExporter) export(ctx context.Context, fp *faro.Payload) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusAccepted {
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}
 

--- a/exporter/faroexporter/exporter_test.go
+++ b/exporter/faroexporter/exporter_test.go
@@ -118,7 +118,7 @@ func createServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-func TestExporter_ErrorCases(t *testing.T) {
+func TestExporter_ResponseHandling(t *testing.T) {
 	testCases := []struct {
 		name               string
 		statusCode         int
@@ -159,6 +159,14 @@ func TestExporter_ErrorCases(t *testing.T) {
 			expectedThrottled: true,
 			responseBody:      "Service temporarily unavailable",
 			checkResponseBody: true,
+		},
+		{
+			name:       "ok",
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "accepted",
+			statusCode: http.StatusAccepted,
 		},
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
I was exporting faro data and noticed errors for 200 response codes from the faro endpoint.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42658

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
