### PR TITLE
[chore][exporter/prometheusremotewrite] Use os.MktempDir on Windows to avoid error during cleanup

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -392,7 +392,6 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 
 // Test_PushMetrics checks the number of TimeSeries received by server and the number of metrics dropped is the same as
 // expected
-// This is a comment so that scoped tests are run.
 func Test_PushMetrics(t *testing.T) {
 	invalidTypeBatch := testdata.GenerateMetricsMetricTypeInvalid()
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -390,6 +390,7 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 
 // Test_PushMetrics checks the number of TimeSeries received by server and the number of metrics dropped is the same as
 // expected
+// This is a comment so that scoped tests are run.
 func Test_PushMetrics(t *testing.T) {
 	invalidTypeBatch := testdata.GenerateMetricsMetricTypeInvalid()
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -758,8 +759,10 @@ func Test_PushMetrics(t *testing.T) {
 					}
 
 					if useWAL {
+						dir, err := os.MkdirTemp("", tt.name)
+						require.NoError(t, err)
 						cfg.WAL = configoptional.Some(WALConfig{
-							Directory: t.TempDir(),
+							Directory: dir,
 						})
 					}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Uses `osMktempDir` on Windows instead of `t.TempDir` to avoid errors during cleanup. See #42639 for further details