### PR TITLE
[chore][exporter/kafka]Fix docs with the correct rety_on_failure defaults

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -88,8 +88,10 @@ The following settings can be optionally configured:
 - `retry_on_failure`
   - `enabled` (default = true)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
+  - `randomization_factor` (default = 0.5): Is the random factor used to calculate the next backoffs.
+  - `multiplier` (default = 1.5): Is the value multiplied by the backoff innterval bounds.
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
-  - `max_elapsed_time` (default = 120s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
+  - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
 - `sending_queue`
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Kafkaexporter uses the [default backoff config](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1573d65f57dc36222b51d7440ede200d32ed8403/exporter/kafkaexporter/factory.go#L52) from the `configretry` module; however, the [defaults for config retry](https://github.com/open-telemetry/opentelemetry-collector/blob/d87c6ce3a89614fd7d30719b22682586b18796c7/config/configretry/backoff.go#L14-L23) don't match what is documented in kafkaexporter.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
Updated