### PR TITLE
[exporter/signalfx] root_path validation

### DIFF
--- a/.chloggen/validate_root_path.yaml
+++ b/.chloggen/validate_root_path.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: signalfxexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Do not validate the root_path of the collector if `sync_host_metadata` is not set.
+note: Only validate the root_path of the collector if `sync_host_metadata` is enabled.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42688]

--- a/.chloggen/validate_root_path.yaml
+++ b/.chloggen/validate_root_path.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not validate the root_path of the collector if `sync_host_metadata` is not set.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42688]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -228,10 +228,11 @@ func (cfg *Config) Validate() error {
 		return errors.New(`cannot have a negative "timeout"`)
 	}
 
-	if err := gopsutilenv.ValidateRootPath(cfg.RootPath); err != nil {
-		return fmt.Errorf("invalid root_path: %w", err)
+	if cfg.SyncHostMetadata {
+		if err := gopsutilenv.ValidateRootPath(cfg.RootPath); err != nil {
+			return fmt.Errorf("invalid root_path: %w", err)
+		}
 	}
-
 	return nil
 }
 

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -461,6 +461,15 @@ func TestConfigValidateErrors(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Invalid root_path",
+			cfg: &Config{
+				Realm:       "us0",
+				AccessToken: "access_token",
+				RootPath:    "/foobar",
+				SyncHostMetadata: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -464,9 +464,9 @@ func TestConfigValidateErrors(t *testing.T) {
 		{
 			name: "Invalid root_path",
 			cfg: &Config{
-				Realm:       "us0",
-				AccessToken: "access_token",
-				RootPath:    "/foobar",
+				Realm:            "us0",
+				AccessToken:      "access_token",
+				RootPath:         "/foobar",
 				SyncHostMetadata: true,
 			},
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Do not validate the root_path of the collector if `sync_host_metadata` is not set

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42688
