### PR TITLE
Chore: Disallow support for dev containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 local/
 vendor/
 
+# Dev Container
+/.devcontainer/
+
 # GoLand IDEA
 /.idea/
 *.iml


### PR DESCRIPTION
#### Description

This looks to disallow the project to adopt dev containers as a supported tool chain.  This project (for the most part) is a pure go project and the required effort to get a local developer environment sorted should be minimal. 

As for this reason, there should be no real reason for the maintainers of the project to maintain a secondary developer environment which has the potential to include unwanted security risks. 

This pull request does not stop users from using dev containers, but the maintainers of the project offer no official support for it.