### PR TITLE
[exporter/elasticsearch] Fix routing of collector self-telemetry into Elasticsearch data streams

### DIFF
--- a/.chloggen/elasticsearchexporter-self-telemetry-routing.yaml
+++ b/.chloggen/elasticsearchexporter-self-telemetry-routing.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix routing of collector self-telemetry data
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42679]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/attribute.go
+++ b/exporter/elasticsearchexporter/attribute.go
@@ -7,12 +7,13 @@ import "go.opentelemetry.io/collector/pdata/pcommon"
 
 // dynamic index attribute key constants
 const (
-	defaultDataStreamDataset      = "generic"
-	defaultDataStreamNamespace    = "default"
-	defaultDataStreamTypeLogs     = "logs"
-	defaultDataStreamTypeMetrics  = "metrics"
-	defaultDataStreamTypeTraces   = "traces"
-	defaultDataStreamTypeProfiles = "profiles"
+	defaultDataStreamDataset                = "generic"
+	collectorSelfTelemetryDataStreamDataset = "collectortelemetry"
+	defaultDataStreamNamespace              = "default"
+	defaultDataStreamTypeLogs               = "logs"
+	defaultDataStreamTypeMetrics            = "metrics"
+	defaultDataStreamTypeTraces             = "traces"
+	defaultDataStreamTypeProfiles           = "profiles"
 )
 
 func getFromAttributes(name, defaultValue string, attributeMaps ...pcommon.Map) (string, bool) {

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -191,13 +191,15 @@ func routeRecord(
 		if selfTelemetryScopeNames[scope.Name()] {
 			// For collector self-telemetry, use a fixed dataset name
 			dataset = collectorSelfTelemetryDataStreamDataset
-		} else if submatch := receiverRegex.FindStringSubmatch(scope.Name()); len(submatch) > 0 {
+		} else {
 			// Receiver-based routing
 			// For example, hostmetricsreceiver (or hostmetricsreceiver.otel in the OTel output mode)
 			// for the scope name
 			// github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper
-			receiverName := submatch[1]
-			dataset = receiverName
+			loc := receiverRegex.FindStringSubmatchIndex(scope.Name())
+			if len(loc) == 4 {
+				dataset = scope.Name()[loc[2]:loc[3]]
+			}
 		}
 	}
 

--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -188,16 +188,16 @@ func routeRecord(
 
 	// Only use receiver-based routing if dataset is not specified.
 	if !datasetExists {
-		// Receiver-based routing
-		// For example, hostmetricsreceiver (or hostmetricsreceiver.otel in the OTel output mode)
-		// for the scope name
-		// github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper
-		if submatch := receiverRegex.FindStringSubmatch(scope.Name()); len(submatch) > 0 {
-			receiverName := submatch[1]
-			dataset = receiverName
-		} else if selfTelemetryScopeNames[scope.Name()] {
+		if selfTelemetryScopeNames[scope.Name()] {
 			// For collector self-telemetry, use a fixed dataset name
 			dataset = collectorSelfTelemetryDataStreamDataset
+		} else if submatch := receiverRegex.FindStringSubmatch(scope.Name()); len(submatch) > 0 {
+			// Receiver-based routing
+			// For example, hostmetricsreceiver (or hostmetricsreceiver.otel in the OTel output mode)
+			// for the scope name
+			// github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper
+			receiverName := submatch[1]
+			dataset = receiverName
 		}
 	}
 

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -65,6 +65,42 @@ func createRouteTests(dsType string) []routeTestCase {
 			want:      renderWantRoute(dsType, defaultDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
 		},
 		{
+			name:      "receiver without a receiver name",
+			mode:      MappingOTel,
+			scopeName: "some.scope.name/receiver/receiver/should/be/ignored",
+			want:      renderWantRoute(dsType, defaultDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
+			name:      "otel collector self-telemetry for receivers",
+			mode:      MappingOTel,
+			scopeName: "go.opentelemetry.io/collector/receiver/receiverhelper",
+			want:      renderWantRoute(dsType, collectorSelfTelemetryDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
+			name:      "otel collector self-telemetry for scrapers",
+			mode:      MappingOTel,
+			scopeName: "go.opentelemetry.io/collector/scraper/scraperhelper",
+			want:      renderWantRoute(dsType, collectorSelfTelemetryDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
+			name:      "otel collector self-telemetry for processors",
+			mode:      MappingOTel,
+			scopeName: "go.opentelemetry.io/collector/processor/processorhelper",
+			want:      renderWantRoute(dsType, collectorSelfTelemetryDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
+			name:      "otel collector self-telemetry for exporters",
+			mode:      MappingOTel,
+			scopeName: "go.opentelemetry.io/collector/exporter/exporterhelper",
+			want:      renderWantRoute(dsType, collectorSelfTelemetryDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
+			name:      "otel collector self-telemetry for service",
+			mode:      MappingOTel,
+			scopeName: "go.opentelemetry.io/collector/service",
+			want:      renderWantRoute(dsType, collectorSelfTelemetryDataStreamDataset, defaultDataStreamNamespace, MappingOTel),
+		},
+		{
 			name:      "otel with elasticsearch.index",
 			mode:      MappingOTel,
 			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/should/be/ignored",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Makes the internal collector telemetry to be routed to the `collectortelemetry` dataset in Elasticsearch.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42679 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
