### PR TITLE
[exporter/kafka] Fix franz-go ignores deprecated TLS config syntax

### DIFF
--- a/.chloggen/exporter_kafka_fix-franz-ignores-auth-tls.yaml
+++ b/.chloggen/exporter_kafka_fix-franz-ignores-auth-tls.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where Kafka exporter ignored `auth.tls` configuration syntax.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42754]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -185,9 +185,13 @@ func commonOpts(ctx context.Context, clientCfg configkafka.ClientConfig,
 		kgo.WithLogger(kzap.New(logger.Named("franz"))),
 		kgo.SeedBrokers(clientCfg.Brokers...),
 	)
+	tlsConfig := clientCfg.TLS
+	if tlsConfig == nil {
+		tlsConfig = clientCfg.Authentication.TLS
+	}
 	// Configure TLS if needed
-	if clientCfg.TLS != nil {
-		tlsCfg, err := clientCfg.TLS.LoadTLSConfig(ctx)
+	if tlsConfig != nil {
+		tlsCfg, err := tlsConfig.LoadTLSConfig(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load TLS config: %w", err)
 		}


### PR DESCRIPTION
#### Description
The syntax:

    auth:
      tls:
        ...

Was deprecated in v0.124.0, in favor of:

    tls:
      ...

The Sarama Kafka client accepts both syntaxes, but the franz-go client ignores the deprecated syntax and silently falls back to a non-TLS connection.

This fix adds support for the deprecated syntax until such time that it actually gets removed.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42754 

#### Testing
All existing tests pass. Verified deprecated syntax works against a real TLS-enabled cluster, and fails without the fix.

#### Documentation
None.