### PR TITLE
hostmetricsreceiver: add example metrics configuration to readme

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -23,8 +23,8 @@ used when the collector is deployed as an agent.
 
 ## Getting Started
 
-The collection interval, root path, and the categories of metrics to be scraped can be
-configured:
+The collection interval, root path, the categories of metrics, and individual
+metrics to be scraped can be configured:
 
 ```yaml
 hostmetrics:
@@ -33,6 +33,12 @@ hostmetrics:
   root_path: <string>
   scrapers:
     <scraper1>:
+      metrics:
+        <metric1>:
+          enabled: true
+        <metric2>:
+          enabled: false
+        ...
     <scraper2>:
     ...
 ```


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Just to be explicit for dummies like me, I think it would be better to note where to place the "metrics" configurations. They are mentioned in each scraper, but not explicitly in context. I had to try both the root (outside of scrapers) and then within each scraper to get it to work.

Probably not a big issue to most, but I hope this will avoid at least some confusion.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
As above.

<!--Please delete paragraphs that you did not use before submitting.-->
