### PR TITLE
[receiver/k8seventsreceiver] docs: increase RBAC permissions

### DIFF
--- a/receiver/k8seventsreceiver/README.md
+++ b/receiver/k8seventsreceiver/README.md
@@ -167,6 +167,14 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - "events.k8s.io"
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
 EOF
 ```
 


### PR DESCRIPTION
#### Documentation
I added permissions in the apiGroup `events.k8s.io`. Without them, the receiver in auth mode `serviceAccount` did not work.