### PR TITLE
Add tenant_id field to ActiveDirectoryDS receiver config

### DIFF
--- a/receiver/activedirectorydsreceiver/config.go
+++ b/receiver/activedirectorydsreceiver/config.go
@@ -12,4 +12,6 @@ import (
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig  `mapstructure:",squash"`
+		// TenantID es el identificador del tenant para conectar con Active Directory DS
+	TenantID string `mapstructure:"tenantid"`
 }


### PR DESCRIPTION
This PR adds support for the "tenantid" field in the ActiveDirectoryDS receiver configuration.

Changes:
- Added `TenantID` to the Config struct.
- Added mapstructure tag to ensure the field is parsed from configuration.

