### PR TITLE
[exporter/datadog] Stop doing character validation for API keys

### DIFF
--- a/.chloggen/mx-psi_datadogexporter-remove-validation.yaml
+++ b/.chloggen/mx-psi_datadogexporter-remove-validation.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates StaticAPIKeyCheck, stops doing validation for API key characters
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42677]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This was causing issues to users since validation of secrets is challenging
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api,user]

--- a/.chloggen/mx-psi_datadogexporter-remove-validation.yaml
+++ b/.chloggen/mx-psi_datadogexporter-remove-validation.yaml
@@ -4,10 +4,10 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: pkg/datadog
+component: pkg/datadog, exporter/datadog, extension/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecates StaticAPIKeyCheck, stops doing validation for API key characters
+note: Deprecates StaticAPIKeyCheck, stops doing validation for API key characters in Datadog exporter and extension.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42677]

--- a/extension/datadogextension/config.go
+++ b/extension/datadogextension/config.go
@@ -5,8 +5,6 @@ package datadogextension // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -35,10 +33,6 @@ func (c *Config) Validate() error {
 	}
 	if c.API.Key == "" {
 		return datadogconfig.ErrUnsetAPIKey
-	}
-	invalidAPIKeyChars := datadogconfig.NonHexRegex.FindAllString(string(c.API.Key), -1)
-	if len(invalidAPIKeyChars) > 0 {
-		return fmt.Errorf("%w: invalid characters: %s", datadogconfig.ErrAPIKeyFormat, strings.Join(invalidAPIKeyChars, ", "))
 	}
 	if c.HTTPConfig == nil {
 		return errors.New("http config is required")

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -5,7 +5,6 @@ package datadogextension // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -75,22 +74,6 @@ func TestConfig_Validate(t *testing.T) {
 				},
 			},
 			wantErr: datadogconfig.ErrUnsetAPIKey,
-		},
-		{
-			name: "Invalid API key characters",
-			config: Config{
-				API: datadogconfig.APIConfig{
-					Site: datadogconfig.DefaultSite,
-					Key:  "1234567890abcdef1234567890abcdeg",
-				},
-				HTTPConfig: &httpserver.Config{
-					ServerConfig: confighttp.ServerConfig{
-						Endpoint: "http://localhost:8080",
-					},
-					Path: "/metadata",
-				},
-			},
-			wantErr: fmt.Errorf("%w: invalid characters: %s", datadogconfig.ErrAPIKeyFormat, "g"),
 		},
 		{
 			name: "Missing HTTP config",

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -28,8 +28,6 @@ var (
 	ErrNoMetadata = errors.New("only_metadata can't be enabled when host_metadata::enabled = false or host_metadata::hostname_source != first_resource")
 	// ErrInvalidHostname is returned when the hostname is invalid.
 	ErrEmptyEndpoint = errors.New("endpoint cannot be empty")
-	// ErrAPIKeyFormat is returned if API key contains invalid characters
-	ErrAPIKeyFormat = errors.New("api::key contains invalid characters")
 	// NonHexRegex is a regex of characters that are always invalid in a Datadog API key
 	NonHexRegex = regexp.MustCompile(NonHexChars)
 )
@@ -135,8 +133,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("hostname field is invalid: %w", err)
 	}
 
-	if err := StaticAPIKeyCheck(string(c.API.Key)); err != nil {
-		return err
+	if c.API.Key == "" {
+		return ErrUnsetAPIKey
 	}
 
 	if err := c.Traces.Validate(); err != nil {
@@ -157,14 +155,12 @@ func (c *Config) Validate() error {
 
 // StaticAPIKey Check checks if api::key is either empty or contains invalid (non-hex) characters
 // It does not validate online; this is handled on startup.
+// Deprecated: [v0.136.0] Do not use, will be removed on the next minor version
 func StaticAPIKeyCheck(key string) error {
 	if key == "" {
 		return ErrUnsetAPIKey
 	}
-	invalidAPIKeyChars := NonHexRegex.FindAllString(key, -1)
-	if len(invalidAPIKeyChars) > 0 {
-		return fmt.Errorf("%w: invalid characters: %s", ErrAPIKeyFormat, strings.Join(invalidAPIKeyChars, ", "))
-	}
+
 	return nil
 }
 

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -47,13 +47,6 @@ func TestValidate(t *testing.T) {
 			err: ErrUnsetAPIKey.Error(),
 		},
 		{
-			name: "invalid format api::key",
-			cfg: &Config{
-				API: APIConfig{Key: "'aaaaaaa"},
-			},
-			err: ErrAPIKeyFormat.Error(),
-		},
-		{
 			name: "invalid hostname",
 			cfg: &Config{
 				API:          APIConfig{Key: "aaaaaaa"},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Stops doing validation of characters in API key. Validation of secrets is challenging. Furthermore, any possible changes on the API key format would mean users would have to upgrade their clients; being more flexible and leaving validation for runtime helps avoid unnecessary upgrades.

#### Link to tracking issue
Fixes #42677
