### PR TITLE
[chore] Remove usages of deprecated symbols

### DIFF
--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -218,7 +218,7 @@ func exporterhelperOptions(
 	cfg *Config,
 	start component.StartFunc,
 	shutdown component.ShutdownFunc,
-	qbs exporterhelper.QueueBatchSettings,
+	qbs xexporterhelper.QueueBatchSettings,
 ) []exporterhelper.Option {
 	opts := []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
@@ -229,7 +229,7 @@ func exporterhelperOptions(
 	switch {
 	case qbc.Batch.HasValue():
 		// Latest queue batch settings are used, prioritize them even if sending queue is disabled
-		opts = append(opts, exporterhelper.WithQueueBatch(qbc, qbs))
+		opts = append(opts, xexporterhelper.WithQueueBatch(qbc, qbs))
 
 		// Effectively disable timeout_sender because timeout is enforced in bulk indexer.
 		//

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -169,7 +169,7 @@ func exporterhelperOptions(
 		// and will rely on the sarama Producer Timeout logic.
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(cfg.BackOffConfig),
-		exporterhelper.WithQueueBatch(cfg.QueueBatchConfig, qbs),
+		xexporterhelper.WithQueueBatch(cfg.QueueBatchConfig, qbs),
 		exporterhelper.WithStart(startFunc),
 		exporterhelper.WithShutdown(shutdownFunc),
 	}

--- a/exporter/otelarrowexporter/factory.go
+++ b/exporter/otelarrowexporter/factory.go
@@ -88,13 +88,13 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func helperOptions(e exp, qbs exporterhelper.QueueBatchSettings) []exporterhelper.Option {
+func helperOptions(e exp) []exporterhelper.Option {
 	cfg := e.getConfig().(*Config)
 	return []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		exporterhelper.WithTimeout(cfg.TimeoutSettings),
 		exporterhelper.WithRetry(cfg.RetryConfig),
-		exporterhelper.WithQueueBatch(cfg.QueueSettings, qbs),
+		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithStart(e.start),
 		exporterhelper.WithShutdown(e.shutdown),
 	}
@@ -125,7 +125,7 @@ func createTracesExporter(
 	}
 	return exporterhelper.NewTraces(ctx, e.getSettings(), e.getConfig(),
 		e.pushTraces,
-		helperOptions(e, exporterhelper.NewTracesQueueBatchSettings())...,
+		helperOptions(e)...,
 	)
 }
 
@@ -144,7 +144,7 @@ func createMetricsExporter(
 	}
 	return exporterhelper.NewMetrics(ctx, e.getSettings(), e.getConfig(),
 		e.pushMetrics,
-		helperOptions(e, exporterhelper.NewMetricsQueueBatchSettings())...,
+		helperOptions(e)...,
 	)
 }
 
@@ -163,6 +163,6 @@ func createLogsExporter(
 	}
 	return exporterhelper.NewLogs(ctx, e.getSettings(), e.getConfig(),
 		e.pushLogs,
-		helperOptions(e, exporterhelper.NewLogsQueueBatchSettings())...,
+		helperOptions(e)...,
 	)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Removes usages of deprecated symbols, unblocks #42782.

The otelarrow changes are equivalent since we pass the queuebatchsettings: https://github.com/open-telemetry/opentelemetry-collector/blob/ba0b327d5fe91b230f97e48f56f3c191bd89df2d/exporter/exporterhelper/internal/base_exporter.go#L199

which is the default one https://github.com/open-telemetry/opentelemetry-collector/blob/ba0b327d5fe91b230f97e48f56f3c191bd89df2d/exporter/exporterhelper/traces.go#L145

I can't do this in other exporters because they modify the settings struct.
