### PR TITLE
[extension/encoding] Add StreamingLogsUnmarshalerExtension

### DIFF
--- a/extension/encoding/encoding.go
+++ b/extension/encoding/encoding.go
@@ -4,6 +4,8 @@
 package encoding // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 
 import (
+	"io"
+
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -15,6 +17,19 @@ import (
 type LogsMarshalerExtension interface {
 	extension.Extension
 	plog.Marshaler
+}
+
+// StreamingLogsUnmarshalerExtension is an extension that decodes logs from a stream.
+type StreamingLogsUnmarshalerExtension interface {
+	extension.Extension
+	NewLogsDecoder(io.Reader) (LogsDecoder, error)
+}
+
+type LogsDecoder interface {
+	// DecodeLogs decodes logs and appends them to the given plog.Logs.
+	//
+	// DecodeLogs returns io.EOF if there are no more logs to be decoded.
+	DecodeLogs(to plog.Logs) error
 }
 
 // LogsUnmarshalerExtension is an extension that unmarshals logs.

--- a/extension/encoding/googlecloudlogentryencodingextension/benchmark_test.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/benchmark_test.go
@@ -5,28 +5,68 @@ package googlecloudlogentryencodingextension
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"testing"
 
 	gojson "github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-func BenchmarkTest(b *testing.B) {
-	name := "testdata/log_entry.json"
-	data, err := os.ReadFile(name)
-	require.NoError(b, err)
+func newFileContent(filename string, nLogs int) ([]byte, error) {
+	log, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
 
 	var dest bytes.Buffer
-	err = gojson.Compact(&dest, data)
-	require.NoError(b, err)
+	if err := gojson.Compact(&dest, log); err != nil {
+		return nil, err
+	}
 
+	var buf bytes.Buffer
+	for i := 0; i < nLogs; i++ {
+		buf.Write(dest.Bytes())
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
+}
+
+func BenchmarkUnmarshaler(b *testing.B) {
 	ex := &ext{}
+	testCases := []int{1, 1_000, 100_000}
 
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_, err := ex.UnmarshalLogs(dest.Bytes())
+	for _, n := range testCases {
+		content, err := newFileContent("testdata/log_entry.json", n)
 		require.NoError(b, err)
+		b.Run(fmt.Sprintf("unmarshal %d logs", n), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := ex.UnmarshalLogs(content)
+				require.NoError(b, err)
+			}
+		})
+		b.Run(fmt.Sprintf("decode %d logs", n), func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				decoder, err := ex.NewLogsDecoder(bytes.NewReader(content))
+				require.NoError(b, err)
+
+				// loading everything into memory
+				logs := plog.NewLogs()
+				for {
+					err = decoder.DecodeLogs(logs)
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					require.NoError(b, err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### Description

Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38780.

When decoding logs from a file, the current implementation requires loading the whole file into memory. This becomes more problematic as the file size increases.

This PR adds a new interface to the encoding extension that allows us to use a `io.Reader` instead.

I have implemented the interface in `googlecloudlogentryencodingextension` as an example.

#### Testing

Unit tests added.