### PR TITLE
[chore][scoped-tests] Run twice instead of thrice

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -99,7 +99,7 @@ jobs:
         env:
           CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
         run: |
-          make for-affected-components CMD="make lint test-three-times"
+          make for-affected-components CMD="make lint test-twice"
 
   scoped-tests:
     # Keeps the name of the job required for merging in the GH configuration, make it

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -108,11 +108,11 @@ test: $(GOTESTSUM)
 
 # This target is used in scoped tests.
 # We do not pass GOTESTSUM_OPT so that we do not re-run failures
-# and run each changed test three times.
+# and run each changed test two times.
 #
 # This helps us catch flakes more easily before they land on main.
-test-three-times: $(GOTESTSUM)
-	$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) -count=3
+test-twice: $(GOTESTSUM)
+	$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) -count=2
 
 .PHONY: test-with-cover
 test-with-cover: $(GOTESTSUM)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Scoped tests are too slow for certain components (e.g. Prometheus components) after #42498. 

I still think running the tests more than once is a good idea to prevent flakes, but maybe twice is a better balance between catching flakes and not taking ages to merge each PR.

#### Link to tracking issue

Follows #42498
