### PR TITLE
[internal/kafka] disable client metrics

### DIFF
--- a/.chloggen/franzgo-disable-client-metrics.yaml
+++ b/.chloggen/franzgo-disable-client-metrics.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: internal/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable Kafka client metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42662]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  We disable publishing Kafka client metrics to brokers, since they were not
+  added intentionally and may lead to log spam when the broker does not really
+  support metrics. We may make this configurable in the future.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -184,6 +184,10 @@ func commonOpts(ctx context.Context, clientCfg configkafka.ClientConfig,
 	opts = append(opts,
 		kgo.WithLogger(kzap.New(logger.Named("franz"))),
 		kgo.SeedBrokers(clientCfg.Brokers...),
+		// Disable client metrics, since some brokers may falsely indicate
+		// that they support them when they don't, causing errors to be
+		// logged. We may want to make this configurable in the future.
+		kgo.DisableClientMetrics(),
 	)
 	// Configure TLS if needed
 	if clientCfg.TLS != nil {


### PR DESCRIPTION
#### Description

Disable franz-go's Kafka client metrics support. We did not intentionally add these, we may consider reintroducing them in the future with configuration.

Labeling this as a breaking change, though it's dubious: this isn't documented, and came as part of the switch to franz-go which is still under a feature gate.

#### Link to tracking issue

Fixes #42662

#### Testing

None

#### Documentation

None