### PR TITLE
Revert "[internal/otelarrow] Remove manual time.Sleep call"

### DIFF
--- a/internal/otelarrow/admission2/boundedqueue_test.go
+++ b/internal/otelarrow/admission2/boundedqueue_test.go
@@ -67,10 +67,12 @@ func (bq *bqTest) startWaiter(ctx context.Context, size uint64, relp *ReleaseFun
 }
 
 func (bq *bqTest) waitForPending(admitted, waiting uint64) {
-	require.EventuallyWithT(bq.t, func(c *assert.CollectT) {
+	// TODO: Remove time.Sleep below, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42514
+	time.Sleep(20 * time.Millisecond)
+	require.Eventually(bq.t, func() bool {
 		bq.lock.Lock()
 		defer bq.lock.Unlock()
-		assert.True(c, bq.currentAdmitted == admitted && bq.currentWaiting == waiting)
+		return bq.currentAdmitted == admitted && bq.currentWaiting == waiting
 	}, 10*time.Second, 20*time.Millisecond)
 }
 


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#42548

It looks like the test started failing again around the time this PR was merged so I am proposing we revert this

cc @JaredTan95 

Reopens #42514
Fixes #42758