### PR TITLE
[chore][exporter/elasticsearch,exporter/kafka] Switch to using experimental versions of symbols

### DIFF
--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -113,7 +113,7 @@ func createLogsExporter(
 		return nil, err
 	}
 
-	qbs := exporterhelper.NewLogsQueueBatchSettings()
+	qbs := xexporterhelper.NewLogsQueueBatchSettings()
 	if len(cf.MetadataKeys) > 0 {
 		qbs.Partitioner = metadataKeysPartitioner{keys: cf.MetadataKeys}
 	}
@@ -141,7 +141,7 @@ func createMetricsExporter(
 		return nil, err
 	}
 
-	qbs := exporterhelper.NewMetricsQueueBatchSettings()
+	qbs := xexporterhelper.NewMetricsQueueBatchSettings()
 	if len(cf.MetadataKeys) > 0 {
 		qbs.Partitioner = metadataKeysPartitioner{keys: cf.MetadataKeys}
 	}
@@ -168,7 +168,7 @@ func createTracesExporter(ctx context.Context,
 		return nil, err
 	}
 
-	qbs := exporterhelper.NewTracesQueueBatchSettings()
+	qbs := xexporterhelper.NewTracesQueueBatchSettings()
 	if len(cf.MetadataKeys) > 0 {
 		qbs.Partitioner = metadataKeysPartitioner{keys: cf.MetadataKeys}
 	}

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -88,7 +88,7 @@ func createTracesExporter(
 		exp.exportData,
 		exporterhelperOptions(
 			oCfg,
-			exporterhelper.NewTracesQueueBatchSettings(),
+			xexporterhelper.NewTracesQueueBatchSettings(),
 			exp.Start, exp.Close,
 		)...,
 	)
@@ -108,7 +108,7 @@ func createMetricsExporter(
 		exp.exportData,
 		exporterhelperOptions(
 			oCfg,
-			exporterhelper.NewMetricsQueueBatchSettings(),
+			xexporterhelper.NewMetricsQueueBatchSettings(),
 			exp.Start, exp.Close,
 		)...,
 	)
@@ -128,7 +128,7 @@ func createLogsExporter(
 		exp.exportData,
 		exporterhelperOptions(
 			oCfg,
-			exporterhelper.NewLogsQueueBatchSettings(),
+			xexporterhelper.NewLogsQueueBatchSettings(),
 			exp.Start, exp.Close,
 		)...,
 	)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Uses the `xexporterhelper` version of these symbols since we are removing the `exporterhelper` version.

#### Link to tracking issue

Unblocks open-telemetry/opentelemetry-collector/pull/13872
