### PR TITLE
[chore] [telemetrygen] Remove scale assertion from TestExponentialHistogramMetricGeneration

### DIFF
--- a/cmd/telemetrygen/pkg/metrics/worker_test.go
+++ b/cmd/telemetrygen/pkg/metrics/worker_test.go
@@ -654,7 +654,6 @@ func TestExponentialHistogramMetricGeneration(t *testing.T) {
 	assert.Equal(t, "test_exp_hist", ms.Name)
 	assert.Positive(t, dp.Count)
 	assert.Positive(t, dp.Sum)
-	assert.GreaterOrEqual(t, dp.Scale, int32(0)) // Scale should be non-negative
 	assert.Equal(t, uint64(0), dp.ZeroCount)
 	assert.Equal(t, 0.0, dp.ZeroThreshold)
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removes wrong assertion that causes a flaky test. The go-expohisto library allows that field to be negative to the assertion is wrong.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42818
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42819
