### PR TITLE
kafka: fix support for protocol_version in franz-go client

### DIFF
--- a/.chloggen/kafka-franz-protocolversion.yaml
+++ b/.chloggen/kafka-franz-protocolversion.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix support for protocol_version in franz-go client
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42795]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
#### Description

The franz-go client was ignoring `protocol_version`. We now set both MinVersions and MaxVersions options based on the specified version, so the client assumes that exact version.

#### Link to tracking issue

Relates to #42795

#### Testing

Tested with kafkaexporter against Azure Event Hubs, which currently only works on Windows if you specify a version < 4 due to https://github.com/twmb/franz-go/issues/1102

#### Documentation

None