### PR TITLE
[chore][telemetrygen] Fix traces count in traces integration test

### DIFF
--- a/cmd/telemetrygen/pkg/traces/integration_test.go
+++ b/cmd/telemetrygen/pkg/traces/integration_test.go
@@ -81,14 +81,14 @@ func startMockReceiver(t *testing.T) (*grpc.Server, string, *mockTracesReceiver)
 // TestTelemetrygenIntegration tests the actual behavior of the telemetrygen tool
 func TestTelemetrygenIntegration(t *testing.T) {
 	buildDir := "../../../telemetrygen"
-	buildCmd := exec.Command("go", "build", "-o", "telemetrygen-test", ".")
+	binaryName := fmt.Sprintf("telemetrygen-test-%d", time.Now().UnixNano())
+	buildCmd := exec.Command("go", "build", "-o", binaryName, ".")
 	buildCmd.Dir = buildDir
 	err := buildCmd.Run()
 	require.NoError(t, err, "Failed to build telemetrygen")
 
-	defer os.Remove("../../../telemetrygen/telemetrygen-test")
-
-	testBinaryPath := "../../../telemetrygen/telemetrygen-test"
+	testBinaryPath := fmt.Sprintf("../../../telemetrygen/%s", binaryName)
+	defer os.Remove(testBinaryPath)
 
 	t.Run("RespectsTracesParameter", func(t *testing.T) {
 		server, endpoint, receiver := startMockReceiver(t)
@@ -111,12 +111,28 @@ func TestTelemetrygenIntegration(t *testing.T) {
 		duration := time.Since(start)
 
 		assert.NoError(t, err, "telemetrygen should complete successfully with --traces parameter")
-		assert.Less(t, duration, 6*time.Second, "Should complete quickly without connection issues")
+		assert.Less(t, duration, 8*time.Second, "Should complete quickly without connection issues")
 
 		// Wait for all traces to be processed
 		time.Sleep(500 * time.Millisecond)
 		traces := receiver.GetTraces()
-		assert.Len(t, traces, 3, "Should have received exactly 3 traces")
+
+		// Count unique trace IDs across all received traces
+		traceIDs := make(map[string]bool)
+		for _, trace := range traces {
+			for i := 0; i < trace.ResourceSpans().Len(); i++ {
+				resourceSpan := trace.ResourceSpans().At(i)
+				for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
+					scopeSpan := resourceSpan.ScopeSpans().At(j)
+					for k := 0; k < scopeSpan.Spans().Len(); k++ {
+						span := scopeSpan.Spans().At(k)
+						traceIDs[span.TraceID().String()] = true
+					}
+				}
+			}
+		}
+
+		assert.Len(t, traceIDs, 3, "Should have received exactly 3 unique traces")
 	})
 
 	t.Run("DurationOverridesTraces", func(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Seems like we can't control how the BatchSpanProcessor batches traces for export. Sometimes it s 3 traces in 3 exports but sometimes there are 4 exports. Changed the logic to count the actual trace ids instead of the number of exports. 

Also made the name of the binary unique to avoid conflicts and increased the duration a bit, that was also failing locally sometimes. 
