### PR TITLE
[chore][telemetrygen] Fix flaky test TestExponentialHistogramMetricGeneration

### DIFF
--- a/cmd/telemetrygen/pkg/metrics/worker_test.go
+++ b/cmd/telemetrygen/pkg/metrics/worker_test.go
@@ -734,7 +734,6 @@ func TestExponentialHistogramMetricGeneration(t *testing.T) {
 	assert.Equal(t, "test_exp_hist", ms.Name)
 	assert.Positive(t, dp.Count)
 	assert.Positive(t, dp.Sum)
-	assert.Equal(t, uint64(0), dp.ZeroCount)
 	assert.Equal(t, 0.0, dp.ZeroThreshold)
 
 	// Verify buckets exist


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Removed zerocount assertion since the zero bucket can have items because we are randomly generating values.
Fixes #42854