### PR TITLE
[receiver/datadogreceiver] Use thread safe LRU

### DIFF
--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	vmsgp "github.com/vmihailenco/msgpack/v5"
@@ -262,7 +262,7 @@ func TestToTraces64to128bits(t *testing.T) {
 	req.Header.Set(header.Lang, "go")
 
 	// Test 1: We reconstructed the 128 bits trace id on both spans
-	cache, _ := simplelru.NewLRU[uint64, pcommon.TraceID](2, func(_ uint64, _ pcommon.TraceID) {})
+	cache, _ := lru.NewWithEvict(2, func(_ uint64, _ pcommon.TraceID) {})
 
 	traces, _ := ToTraces(zap.NewNop(), payload, req, cache)
 	assert.Equal(t, 2, traces.SpanCount(), "Expected 2 spans")

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/agent-payload/v5/gogen"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/tinylib/msgp/msgp"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
@@ -47,7 +47,7 @@ type datadogReceiver struct {
 	server    *http.Server
 	tReceiver *receiverhelper.ObsReport
 
-	traceIDCache *simplelru.LRU[uint64, pcommon.TraceID]
+	traceIDCache *lru.Cache[uint64, pcommon.TraceID]
 }
 
 // Endpoint specifies an API endpoint definition.
@@ -154,9 +154,9 @@ func newDataDogReceiver(ctx context.Context, config *Config, params receiver.Set
 		return nil, err
 	}
 
-	var cache *simplelru.LRU[uint64, pcommon.TraceID]
+	var cache *lru.Cache[uint64, pcommon.TraceID]
 	if FullTraceIDFeatureGate.IsEnabled() {
-		cache, err = simplelru.NewLRU[uint64, pcommon.TraceID](config.TraceIDCacheSize, func(k uint64, _ pcommon.TraceID) {
+		cache, err = lru.NewWithEvict(config.TraceIDCacheSize, func(k uint64, _ pcommon.TraceID) {
 			params.Logger.Debug("evicting datadog trace id from cache", zap.Uint64("id", k))
 		})
 		if err != nil {


### PR DESCRIPTION
#### Description
Uses the thread safe lru package in golang-lru rather than the simplelru within that package.

#### Link to tracking issue
Fixes #42644
Potentially may fix the 40557 issue as well but I was not able to recreate it.

#### Testing
Performed the testing as directed in contributing.md

