### PR TITLE
[exporter/elasticsearchexporter] Profiling: fix fetching location for…

### DIFF
--- a/.chloggen/elasticsearchexporter-serializeprofiles-fix-location-index.yaml
+++ b/.chloggen/elasticsearchexporter-serializeprofiles-fix-location-index.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix fetching location for stack
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42891]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter-serializeprofiles-fix-location-index.yaml
+++ b/.chloggen/elasticsearchexporter-serializeprofiles-fix-location-index.yaml
@@ -7,7 +7,7 @@ change_type: 'bug_fix'
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: fix fetching location for stack
+note: "profiling: fix fetching location for stack"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [42891]

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform.go
@@ -290,7 +290,7 @@ func stackFrames(dic pprofile.ProfilesDictionary, sample pprofile.Sample) ([]Sta
 			continue
 		}
 
-		frameTypeStr, err := getStringFromAttribute(dic, location, "profile.frame.type")
+		frameTypeStr, err := getStringFromAttribute(dic, location, string(semconv.ProfileFrameTypeKey))
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -373,7 +373,6 @@ var errMissingAttribute = errors.New("missing attribute")
 // of the profile if the attribute key matches the expected attrKey.
 func getStringFromAttribute(dic pprofile.ProfilesDictionary, record attributable, attrKey string) (string, error) {
 	lenAttrTable := dic.AttributeTable().Len()
-
 	for _, idx32 := range record.AttributeIndices().All() {
 		idx := int(idx32)
 
@@ -472,9 +471,8 @@ func stackTraceID(frames []StackFrame) (string, error) {
 
 func getLocations(dic pprofile.ProfilesDictionary, stack pprofile.Stack) []pprofile.Location {
 	locations := make([]pprofile.Location, 0, stack.LocationIndices().Len())
-
-	for i := range stack.LocationIndices().All() {
-		locations = append(locations, dic.LocationTable().At(i))
+	for _, i := range stack.LocationIndices().All() {
+		locations = append(locations, dic.LocationTable().At(int(i)))
 	}
 
 	return locations

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform_test.go
@@ -960,6 +960,35 @@ func TestStackTrace(t *testing.T) {
 		})
 	}
 }
+func TestGetLocations(t *testing.T) {
+	dic := pprofile.NewProfilesDictionary()
+
+	// By convention location_table[0] is always present with a default value.
+	dic.LocationTable().AppendEmpty()
+	// Add three locations to the dictionary
+	loc1 := dic.LocationTable().AppendEmpty()
+	loc1.SetAddress(0x1000)
+	loc2 := dic.LocationTable().AppendEmpty()
+	loc2.SetAddress(0x2000)
+	loc3 := dic.LocationTable().AppendEmpty()
+	loc3.SetAddress(0x3000)
+
+	// Create a stack with indices to the locations
+	stack := dic.StackTable().AppendEmpty()
+	stack.LocationIndices().Append(1, 2, 3)
+
+	// Call getLocations and check the result
+	locations := getLocations(dic, stack)
+	require.Len(t, locations, 3)
+	assert.Equal(t, uint64(0x1000), locations[0].Address())
+	assert.Equal(t, uint64(0x2000), locations[1].Address())
+	assert.Equal(t, uint64(0x3000), locations[2].Address())
+
+	// Test with empty stack
+	emptyStack := dic.StackTable().AppendEmpty()
+	locations = getLocations(dic, emptyStack)
+	assert.Len(t, locations, 0)
+}
 
 // frameTypesToString converts a slice of FrameType to a RLE encoded string as stored in ES.
 //

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/serializeprofiles/transform_test.go
@@ -960,6 +960,7 @@ func TestStackTrace(t *testing.T) {
 		})
 	}
 }
+
 func TestGetLocations(t *testing.T) {
 	dic := pprofile.NewProfilesDictionary()
 
@@ -987,7 +988,7 @@ func TestGetLocations(t *testing.T) {
 	// Test with empty stack
 	emptyStack := dic.StackTable().AppendEmpty()
 	locations = getLocations(dic, emptyStack)
-	assert.Len(t, locations, 0)
+	assert.Empty(t, locations)
 }
 
 // frameTypesToString converts a slice of FrameType to a RLE encoded string as stored in ES.


### PR DESCRIPTION
… stack

#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Fix incorrect handling of location indices in message stack.

For a stack like [508 91 92 93 94 95 96 97] the function used to look up [0 1 2 3 4 5 6 7] in the location_table. Fix this issue by looking up the actual value of the location_indices instead of its position.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
