### PR TITLE
[exporter/datadog] Update HTTP configuration

### DIFF
--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -207,9 +207,9 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *dat
 	acfg.PeerTags = cfg.Traces.PeerTags
 	acfg.MaxSenderRetries = 4
 	if traceCustomHTTPFeatureGate.IsEnabled() {
-		params.Logger.Info("Experimental feature: datadog exporter trace export uses a custom HTTP client from the exporter HTTP configs")
-		acfg.HTTPClientFunc = func() *http.Client {
-			return clientutil.NewHTTPClient(cfg.ClientConfig)
+		params.Logger.Info("Experimental feature: datadog exporter trace export uses a custom HTTP transport from the exporter HTTP configs")
+		acfg.HTTPTransportFunc = func() *http.Transport {
+			return clientutil.NewHTTPTransport(cfg.ClientConfig)
 		}
 	}
 	if !datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {

--- a/internal/datadog/clientutil/http.go
+++ b/internal/datadog/clientutil/http.go
@@ -30,6 +30,14 @@ var (
 
 // NewHTTPClient returns a http.Client configured with a subset of the confighttp.ClientConfig options.
 func NewHTTPClient(hcs confighttp.ClientConfig) *http.Client {
+	return &http.Client{
+		Timeout:   hcs.Timeout,
+		Transport: NewHTTPTransport(hcs),
+	}
+}
+
+// NewHTTPTransport returns a http.Transport configured with a subset of the confighttp.ClientConfig options.
+func NewHTTPTransport(hcs confighttp.ClientConfig) *http.Transport {
 	// If the ProxyURL field in the configuration is set, the HTTP client will use the proxy.
 	// Otherwise, the HTTP client will use the system's proxy settings.
 	httpProxy := http.ProxyFromEnvironment
@@ -55,6 +63,7 @@ func NewHTTPClient(hcs confighttp.ClientConfig) *http.Client {
 		// Not supported by intake
 		ForceAttemptHTTP2: false,
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: hcs.TLS.InsecureSkipVerify},
+		DisableKeepAlives: hcs.DisableKeepAlives,
 	}
 	if hcs.ReadBufferSize > 0 {
 		transport.ReadBufferSize = hcs.ReadBufferSize
@@ -74,11 +83,8 @@ func NewHTTPClient(hcs confighttp.ClientConfig) *http.Client {
 	if hcs.IdleConnTimeout > 0 {
 		transport.IdleConnTimeout = hcs.IdleConnTimeout
 	}
-	transport.DisableKeepAlives = hcs.DisableKeepAlives
-	return &http.Client{
-		Timeout:   hcs.Timeout,
-		Transport: &transport,
-	}
+
+	return &transport
 }
 
 // SetExtraHeaders appends a header map to HTTP headers.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Use HTTPTransportFunc instead of the deprecated HTTPClientFunc.

HTTPClientFunc was initially added to add support for custom transports on the opentelemetry exporter, but since datadog Agent 7.63 we can now use HTTPTransportFunc instead.

This change will allow us to fully remove HTTPClientFunc on the agent, and further simplify the configuration options.
