### PR TITLE
[signalfxexporter] Add missing host identifying attribute metrics sent in OTLP format

### DIFF
--- a/.chloggen/sfxExporterOTLPDimensions.yaml
+++ b/.chloggen/sfxExporterOTLPDimensions.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add HostID resource attribute to Histogram data in OTLP format
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42905]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/internal/utils/histogram_utils.go
+++ b/exporter/signalfxexporter/internal/utils/histogram_utils.go
@@ -78,6 +78,7 @@ func matchedHistogramMetrics(ilm pmetric.ScopeMetrics) (matchedMetricsIdx []int)
 
 // GetHistograms returns new Metrics slice containing only Histogram metrics found in the input
 // and the count of histogram metrics
+// This function also adds the host ID attribute to the resource if it can be derived from the resource attributes
 func GetHistograms(md pmetric.Metrics) (pmetric.Metrics, int) {
 	matchedMetricsIdxes := matchedHistogramResourceMetrics(md)
 	matchedRmCount := len(matchedMetricsIdxes)
@@ -95,6 +96,9 @@ func GetHistograms(md pmetric.Metrics) (pmetric.Metrics, int) {
 	for rmIdx, ilmMap := range matchedMetricsIdxes {
 		srcRm := srcRms.At(rmIdx)
 
+		if hostID, ok := splunk.ResourceToHostID(srcRm.Resource()); ok && hostID.Key != splunk.HostIDKeyHost {
+			srcRm.Resource().Attributes().PutStr(string(hostID.Key), hostID.ID)
+		}
 		// Copy resource metric properties to dest
 		destRm := dstRms.AppendEmpty()
 		srcRm.Resource().CopyTo(destRm.Resource())


### PR DESCRIPTION
Add missing host identifying attribute to the metrics sent in OTLP format:
- `AWSUniqueId` for AWS
- `gcp_id` for GCP
- `azure_resource_id` for Azure