### PR TITLE
[chore] Skip test on Windows ARM

### DIFF
--- a/internal/datadog/hostmetadata/internal/gohai/gohai_test.go
+++ b/internal/datadog/hostmetadata/internal/gohai/gohai_test.go
@@ -6,6 +6,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !(windows && arm64)
+
 package gohai
 
 import (


### PR DESCRIPTION
This is in preparation to enable Windows ARM CI.

Since `gohai` has a noop implementation for Windows ARM, see #41695, I opted to simply to not test it on Windows ARM, that should be added when Windows ARM support is enabled since it should be exact the same test for the other platforms.