### PR TITLE
[exporter/kafka_exporter]: Add topic-based partitioning support for grouping same topics on the same partition

### DIFF
--- a/.chloggen/kafkaexporter-topic-partitioning.yaml
+++ b/.chloggen/kafkaexporter-topic-partitioning.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: If TopicFromAttribute enabled, at least partition by topic for correct topic routing.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37470]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When TopicFromAttribute is configured, messages with the same topic attribute value are grouped on the same partition for correct topic routing.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
#### Description
When TopicFromAttribute is configured, messages with the same topic attribute value are grouped on the same partition for correct topic routing.

#### Link to tracking issue
Fixes #37470

#### Testing
- Added topic_partitioning test cases to both logs and metrics partitioning tests
- Tests verify that the same topic attributes get the same partition keys, different topics get different keys

#### Documentation
- Created a changelog entry documenting the enhancement for end users
