### PR TITLE
[chore][kubeletstats] Add stability level per metric

### DIFF
--- a/receiver/kubeletstatsreceiver/documentation.md
+++ b/receiver/kubeletstatsreceiver/documentation.md
@@ -16,185 +16,185 @@ metrics:
 
 Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 ### container.cpu.usage
 
 Total CPU usage (sum of all cores per second) averaged over the sample window
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {cpu} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {cpu} | Gauge | Double | development |
 
 ### container.filesystem.available
 
 Container filesystem available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.filesystem.capacity
 
 Container filesystem capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.filesystem.usage
 
 Container filesystem usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.memory.available
 
 Container memory available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.memory.major_page_faults
 
 Container memory major_page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### container.memory.page_faults
 
 Container memory page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### container.memory.rss
 
 Container memory rss
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.memory.usage
 
 Container memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### container.memory.working_set
 
 Container memory working_set
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.cpu.time
 
 Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 ### k8s.node.cpu.usage
 
 Total CPU usage (sum of all cores per second) averaged over the sample window
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {cpu} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {cpu} | Gauge | Double | development |
 
 ### k8s.node.filesystem.available
 
 Node filesystem available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.filesystem.capacity
 
 Node filesystem capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.filesystem.usage
 
 Node filesystem usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.memory.available
 
 Node memory available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.memory.major_page_faults
 
 Node memory major_page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.node.memory.page_faults
 
 Node memory page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.node.memory.rss
 
 Node memory rss
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.memory.usage
 
 Node memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.memory.working_set
 
 Node memory working_set
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.node.network.errors
 
 Node network errors
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -207,9 +207,9 @@ Node network errors
 
 Node network IO
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -222,97 +222,97 @@ Node network IO
 
 Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 ### k8s.pod.cpu.usage
 
 Total CPU usage (sum of all cores per second) averaged over the sample window
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {cpu} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {cpu} | Gauge | Double | development |
 
 ### k8s.pod.filesystem.available
 
 Pod filesystem available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.filesystem.capacity
 
 Pod filesystem capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.filesystem.usage
 
 Pod filesystem usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.memory.available
 
 Pod memory available
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.memory.major_page_faults
 
 Pod memory major_page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.pod.memory.page_faults
 
 Pod memory page_faults
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.pod.memory.rss
 
 Pod memory rss
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.memory.usage
 
 Pod memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.memory.working_set
 
 Pod memory working_set
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.pod.network.errors
 
 Pod network errors
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -325,9 +325,9 @@ Pod network errors
 
 Pod network IO
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -340,41 +340,41 @@ Pod network IO
 
 The number of available bytes in the volume.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.volume.capacity
 
 The total capacity in bytes of the volume.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### k8s.volume.inodes
 
 The total inodes in the filesystem.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.volume.inodes.free
 
 The free inodes in the filesystem.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### k8s.volume.inodes.used
 
 The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ## Optional Metrics
 
@@ -390,129 +390,129 @@ metrics:
 
 The time since the container started
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 ### k8s.container.cpu.node.utilization
 
 Container cpu utilization as a ratio of the node's capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.container.cpu_limit_utilization
 
 Container cpu utilization as a ratio of the container's limits
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.container.cpu_request_utilization
 
 Container cpu utilization as a ratio of the container's requests
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.container.memory.node.utilization
 
 Container memory utilization as a ratio of the node's capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.container.memory_limit_utilization
 
 Container memory utilization as a ratio of the container's limits
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.container.memory_request_utilization
 
 Container memory utilization as a ratio of the container's requests
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.node.uptime
 
 The time since the node started
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 ### k8s.pod.cpu.node.utilization
 
 Pod cpu utilization as a ratio of the node's capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.cpu_limit_utilization
 
 Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.cpu_request_utilization
 
 Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.memory.node.utilization
 
 Pod memory utilization as a ratio of the node's capacity
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.memory_limit_utilization
 
 Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.memory_request_utilization
 
 Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### k8s.pod.uptime
 
 The time since the pod started
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 ### k8s.pod.volume.usage
 
 The number of used bytes in the pod volume.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ## Resource Attributes
 

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -85,6 +85,8 @@ metrics:
     enabled: true
     description: "Total CPU usage (sum of all cores per second) averaged over the sample window"
     unit: "{cpu}"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: []
@@ -92,6 +94,8 @@ metrics:
     enabled: true
     description: "Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: double
       monotonic: true
@@ -101,6 +105,8 @@ metrics:
     enabled: true
     description: "Node memory available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -108,6 +114,8 @@ metrics:
     enabled: true
     description: "Node memory usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -115,6 +123,8 @@ metrics:
     enabled: true
     description: "Node memory rss"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -122,6 +132,8 @@ metrics:
     enabled: true
     description: "Node memory working_set"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -129,6 +141,8 @@ metrics:
     enabled: true
     description: "Node memory page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -136,6 +150,8 @@ metrics:
     enabled: true
     description: "Node memory major_page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -143,6 +159,8 @@ metrics:
     enabled: true
     description: "Node filesystem available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -150,6 +168,8 @@ metrics:
     enabled: true
     description: "Node filesystem capacity"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -157,6 +177,8 @@ metrics:
     enabled: true
     description: "Node filesystem usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -164,6 +186,8 @@ metrics:
     enabled: true
     description: "Node network IO"
     unit: By
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -173,6 +197,8 @@ metrics:
     enabled: true
     description: "Node network errors"
     unit: "1"
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -182,6 +208,8 @@ metrics:
     enabled: false
     description: "The time since the node started"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -191,6 +219,8 @@ metrics:
     enabled: true
     description: "Total CPU usage (sum of all cores per second) averaged over the sample window"
     unit: "{cpu}"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -198,6 +228,8 @@ metrics:
     enabled: true
     description: "Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: double
       monotonic: true
@@ -207,6 +239,8 @@ metrics:
     enabled: true
     description: "Pod memory available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -214,6 +248,8 @@ metrics:
     enabled: true
     description: "Pod memory usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -221,6 +257,8 @@ metrics:
     enabled: false
     description: "Pod cpu utilization as a ratio of the node's capacity"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -228,6 +266,8 @@ metrics:
     enabled: false
     description: "Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -235,6 +275,8 @@ metrics:
     enabled: false
     description: "Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -242,6 +284,8 @@ metrics:
     enabled: false
     description: "Pod memory utilization as a ratio of the node's capacity"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -249,6 +293,8 @@ metrics:
     enabled: false
     description: "Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -256,6 +302,8 @@ metrics:
     enabled: false
     description: "Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -263,6 +311,8 @@ metrics:
     enabled: true
     description: "Pod memory rss"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -270,6 +320,8 @@ metrics:
     enabled: true
     description: "Pod memory working_set"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -277,6 +329,8 @@ metrics:
     enabled: true
     description: "Pod memory page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -284,6 +338,8 @@ metrics:
     enabled: true
     description: "Pod memory major_page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -291,6 +347,8 @@ metrics:
     enabled: true
     description: "Pod filesystem available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -298,6 +356,8 @@ metrics:
     enabled: true
     description: "Pod filesystem capacity"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -305,6 +365,8 @@ metrics:
     enabled: true
     description: "Pod filesystem usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -312,6 +374,8 @@ metrics:
     enabled: true
     description: "Pod network IO"
     unit: By
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -321,6 +385,8 @@ metrics:
     enabled: true
     description: "Pod network errors"
     unit: "1"
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -330,6 +396,8 @@ metrics:
     enabled: false
     description: "The time since the pod started"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -339,6 +407,8 @@ metrics:
     enabled: true
     description: "Total CPU usage (sum of all cores per second) averaged over the sample window"
     unit: "{cpu}"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -346,6 +416,8 @@ metrics:
     enabled: true
     description: "Total cumulative CPU time (sum of all cores) spent by the container/pod/node since its creation"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: double
       monotonic: true
@@ -355,6 +427,8 @@ metrics:
     enabled: true
     description: "Container memory available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -362,6 +436,8 @@ metrics:
     enabled: true
     description: "Container memory usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -369,6 +445,8 @@ metrics:
     enabled: false
     description: "Container cpu utilization as a ratio of the node's capacity"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -376,6 +454,8 @@ metrics:
     enabled: false
     description: "Container cpu utilization as a ratio of the container's limits"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -383,6 +463,8 @@ metrics:
     enabled: false
     description: "Container cpu utilization as a ratio of the container's requests"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -390,6 +472,8 @@ metrics:
     enabled: false
     description: "Container memory utilization as a ratio of the node's capacity"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -397,6 +481,8 @@ metrics:
     enabled: false
     description: "Container memory utilization as a ratio of the container's limits"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -404,6 +490,8 @@ metrics:
     enabled: false
     description: "Container memory utilization as a ratio of the container's requests"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: double
     attributes: [ ]
@@ -411,6 +499,8 @@ metrics:
     enabled: true
     description: "Container memory rss"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -418,6 +508,8 @@ metrics:
     enabled: true
     description: "Container memory working_set"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -425,6 +517,8 @@ metrics:
     enabled: true
     description: "Container memory page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -432,6 +526,8 @@ metrics:
     enabled: true
     description: "Container memory major_page_faults"
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -439,6 +535,8 @@ metrics:
     enabled: true
     description: "Container filesystem available"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -446,6 +544,8 @@ metrics:
     enabled: true
     description: "Container filesystem capacity"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -453,6 +553,8 @@ metrics:
     enabled: true
     description: "Container filesystem usage"
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -460,6 +562,8 @@ metrics:
     enabled: false
     description: "The time since the container started"
     unit: s
+    stability:
+      level: development
     sum:
       value_type: int
       monotonic: true
@@ -469,6 +573,8 @@ metrics:
     enabled: true
     description: "The number of available bytes in the volume."
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -476,6 +582,8 @@ metrics:
     enabled: true
     description: "The total capacity in bytes of the volume."
     unit: By
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -483,6 +591,8 @@ metrics:
     enabled: false
     description: "The number of used bytes in the pod volume."
     unit: By
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative 
@@ -492,6 +602,8 @@ metrics:
     enabled: true
     description: "The total inodes in the filesystem."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -499,6 +611,8 @@ metrics:
     enabled: true
     description: "The free inodes in the filesystem."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []
@@ -506,6 +620,8 @@ metrics:
     enabled: true
     description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
     unit: "1"
+    stability:
+      level: development
     gauge:
       value_type: int
     attributes: []


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
