### PR TITLE
[chore][k8sattributesprocessor] Add stability level per metric

### DIFF
--- a/processor/k8sattributesprocessor/documentation.md
+++ b/processor/k8sattributesprocessor/documentation.md
@@ -43,112 +43,112 @@ The following telemetry is emitted by this component.
 
 ### otelcol_otelsvc_k8s_ip_lookup_miss
 
-Number of times pod by IP lookup failed.
+Number of times pod by IP lookup failed. [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_namespace_added
 
-Number of namespace add events received
+Number of namespace add events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_namespace_deleted
 
-Number of namespace delete events received
+Number of namespace delete events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_namespace_updated
 
-Number of namespace update events received
+Number of namespace update events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_node_added
 
-Number of node add events received
+Number of node add events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_node_deleted
 
-Number of node delete events received
+Number of node delete events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_node_updated
 
-Number of node update events received
+Number of node update events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_pod_added
 
-Number of pod add events received
+Number of pod add events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_pod_deleted
 
-Number of pod delete events received
+Number of pod delete events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_pod_table_size
 
-Size of table containing pod info
+Size of table containing pod info [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_otelsvc_k8s_pod_updated
 
-Number of pod update events received
+Number of pod update events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_replicaset_added
 
-Number of ReplicaSet add events received
+Number of ReplicaSet add events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_replicaset_deleted
 
-Number of ReplicaSet delete events received
+Number of ReplicaSet delete events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_otelsvc_k8s_replicaset_updated
 
-Number of ReplicaSet update events received
+Number of ReplicaSet update events received [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |

--- a/processor/k8sattributesprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/k8sattributesprocessor/internal/metadata/generated_telemetry.go
@@ -85,157 +85,157 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.OtelsvcK8sDaemonsetAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_daemonset_added",
-		metric.WithDescription("Number of daemonset add events received"),
+		metric.WithDescription("Number of daemonset add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sDaemonsetDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_daemonset_deleted",
-		metric.WithDescription("Number of daemonset delete events received"),
+		metric.WithDescription("Number of daemonset delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sDaemonsetUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_daemonset_updated",
-		metric.WithDescription("Number of daemonset update events received"),
+		metric.WithDescription("Number of daemonset update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sDeploymentAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_deployment_added",
-		metric.WithDescription("Number of deployment add events received"),
+		metric.WithDescription("Number of deployment add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sDeploymentDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_deployment_deleted",
-		metric.WithDescription("Number of deployment delete events received"),
+		metric.WithDescription("Number of deployment delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sDeploymentUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_deployment_updated",
-		metric.WithDescription("Number of deployment update events received"),
+		metric.WithDescription("Number of deployment update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sIPLookupMiss, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_ip_lookup_miss",
-		metric.WithDescription("Number of times pod by IP lookup failed."),
+		metric.WithDescription("Number of times pod by IP lookup failed. [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sJobAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_job_added",
-		metric.WithDescription("Number of job add events received"),
+		metric.WithDescription("Number of job add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sJobDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_job_deleted",
-		metric.WithDescription("Number of job delete events received"),
+		metric.WithDescription("Number of job delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sJobUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_job_updated",
-		metric.WithDescription("Number of job update events received"),
+		metric.WithDescription("Number of job update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNamespaceAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_namespace_added",
-		metric.WithDescription("Number of namespace add events received"),
+		metric.WithDescription("Number of namespace add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNamespaceDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_namespace_deleted",
-		metric.WithDescription("Number of namespace delete events received"),
+		metric.WithDescription("Number of namespace delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNamespaceUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_namespace_updated",
-		metric.WithDescription("Number of namespace update events received"),
+		metric.WithDescription("Number of namespace update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNodeAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_node_added",
-		metric.WithDescription("Number of node add events received"),
+		metric.WithDescription("Number of node add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNodeDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_node_deleted",
-		metric.WithDescription("Number of node delete events received"),
+		metric.WithDescription("Number of node delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sNodeUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_node_updated",
-		metric.WithDescription("Number of node update events received"),
+		metric.WithDescription("Number of node update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sPodAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_pod_added",
-		metric.WithDescription("Number of pod add events received"),
+		metric.WithDescription("Number of pod add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sPodDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_pod_deleted",
-		metric.WithDescription("Number of pod delete events received"),
+		metric.WithDescription("Number of pod delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sPodTableSize, err = builder.meter.Int64Gauge(
 		"otelcol_otelsvc_k8s_pod_table_size",
-		metric.WithDescription("Size of table containing pod info"),
+		metric.WithDescription("Size of table containing pod info [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sPodUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_pod_updated",
-		metric.WithDescription("Number of pod update events received"),
+		metric.WithDescription("Number of pod update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sReplicasetAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_replicaset_added",
-		metric.WithDescription("Number of ReplicaSet add events received"),
+		metric.WithDescription("Number of ReplicaSet add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sReplicasetDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_replicaset_deleted",
-		metric.WithDescription("Number of ReplicaSet delete events received"),
+		metric.WithDescription("Number of ReplicaSet delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sReplicasetUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_replicaset_updated",
-		metric.WithDescription("Number of ReplicaSet update events received"),
+		metric.WithDescription("Number of ReplicaSet update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sStatefulsetAdded, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_statefulset_added",
-		metric.WithDescription("Number of statefulset add events received"),
+		metric.WithDescription("Number of statefulset add events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sStatefulsetDeleted, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_statefulset_deleted",
-		metric.WithDescription("Number of statefulset delete events received"),
+		metric.WithDescription("Number of statefulset delete events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.OtelsvcK8sStatefulsetUpdated, err = builder.meter.Int64Counter(
 		"otelcol_otelsvc_k8s_statefulset_updated",
-		metric.WithDescription("Number of statefulset update events received"),
+		metric.WithDescription("Number of statefulset update events received [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/k8sattributesprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/k8sattributesprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -24,7 +24,7 @@ func NewSettings(tt *componenttest.Telemetry) processor.Settings {
 func AssertEqualOtelsvcK8sDaemonsetAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_daemonset_added",
-		Description: "Number of daemonset add events received",
+		Description: "Number of daemonset add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -40,7 +40,7 @@ func AssertEqualOtelsvcK8sDaemonsetAdded(t *testing.T, tt *componenttest.Telemet
 func AssertEqualOtelsvcK8sDaemonsetDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_daemonset_deleted",
-		Description: "Number of daemonset delete events received",
+		Description: "Number of daemonset delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -56,7 +56,7 @@ func AssertEqualOtelsvcK8sDaemonsetDeleted(t *testing.T, tt *componenttest.Telem
 func AssertEqualOtelsvcK8sDaemonsetUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_daemonset_updated",
-		Description: "Number of daemonset update events received",
+		Description: "Number of daemonset update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -72,7 +72,7 @@ func AssertEqualOtelsvcK8sDaemonsetUpdated(t *testing.T, tt *componenttest.Telem
 func AssertEqualOtelsvcK8sDeploymentAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_deployment_added",
-		Description: "Number of deployment add events received",
+		Description: "Number of deployment add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -88,7 +88,7 @@ func AssertEqualOtelsvcK8sDeploymentAdded(t *testing.T, tt *componenttest.Teleme
 func AssertEqualOtelsvcK8sDeploymentDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_deployment_deleted",
-		Description: "Number of deployment delete events received",
+		Description: "Number of deployment delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -104,7 +104,7 @@ func AssertEqualOtelsvcK8sDeploymentDeleted(t *testing.T, tt *componenttest.Tele
 func AssertEqualOtelsvcK8sDeploymentUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_deployment_updated",
-		Description: "Number of deployment update events received",
+		Description: "Number of deployment update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -120,7 +120,7 @@ func AssertEqualOtelsvcK8sDeploymentUpdated(t *testing.T, tt *componenttest.Tele
 func AssertEqualOtelsvcK8sIPLookupMiss(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_ip_lookup_miss",
-		Description: "Number of times pod by IP lookup failed.",
+		Description: "Number of times pod by IP lookup failed. [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -136,7 +136,7 @@ func AssertEqualOtelsvcK8sIPLookupMiss(t *testing.T, tt *componenttest.Telemetry
 func AssertEqualOtelsvcK8sJobAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_job_added",
-		Description: "Number of job add events received",
+		Description: "Number of job add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -152,7 +152,7 @@ func AssertEqualOtelsvcK8sJobAdded(t *testing.T, tt *componenttest.Telemetry, dp
 func AssertEqualOtelsvcK8sJobDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_job_deleted",
-		Description: "Number of job delete events received",
+		Description: "Number of job delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -168,7 +168,7 @@ func AssertEqualOtelsvcK8sJobDeleted(t *testing.T, tt *componenttest.Telemetry, 
 func AssertEqualOtelsvcK8sJobUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_job_updated",
-		Description: "Number of job update events received",
+		Description: "Number of job update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -184,7 +184,7 @@ func AssertEqualOtelsvcK8sJobUpdated(t *testing.T, tt *componenttest.Telemetry, 
 func AssertEqualOtelsvcK8sNamespaceAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_namespace_added",
-		Description: "Number of namespace add events received",
+		Description: "Number of namespace add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -200,7 +200,7 @@ func AssertEqualOtelsvcK8sNamespaceAdded(t *testing.T, tt *componenttest.Telemet
 func AssertEqualOtelsvcK8sNamespaceDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_namespace_deleted",
-		Description: "Number of namespace delete events received",
+		Description: "Number of namespace delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -216,7 +216,7 @@ func AssertEqualOtelsvcK8sNamespaceDeleted(t *testing.T, tt *componenttest.Telem
 func AssertEqualOtelsvcK8sNamespaceUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_namespace_updated",
-		Description: "Number of namespace update events received",
+		Description: "Number of namespace update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -232,7 +232,7 @@ func AssertEqualOtelsvcK8sNamespaceUpdated(t *testing.T, tt *componenttest.Telem
 func AssertEqualOtelsvcK8sNodeAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_node_added",
-		Description: "Number of node add events received",
+		Description: "Number of node add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -248,7 +248,7 @@ func AssertEqualOtelsvcK8sNodeAdded(t *testing.T, tt *componenttest.Telemetry, d
 func AssertEqualOtelsvcK8sNodeDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_node_deleted",
-		Description: "Number of node delete events received",
+		Description: "Number of node delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -264,7 +264,7 @@ func AssertEqualOtelsvcK8sNodeDeleted(t *testing.T, tt *componenttest.Telemetry,
 func AssertEqualOtelsvcK8sNodeUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_node_updated",
-		Description: "Number of node update events received",
+		Description: "Number of node update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -280,7 +280,7 @@ func AssertEqualOtelsvcK8sNodeUpdated(t *testing.T, tt *componenttest.Telemetry,
 func AssertEqualOtelsvcK8sPodAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_pod_added",
-		Description: "Number of pod add events received",
+		Description: "Number of pod add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -296,7 +296,7 @@ func AssertEqualOtelsvcK8sPodAdded(t *testing.T, tt *componenttest.Telemetry, dp
 func AssertEqualOtelsvcK8sPodDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_pod_deleted",
-		Description: "Number of pod delete events received",
+		Description: "Number of pod delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -312,7 +312,7 @@ func AssertEqualOtelsvcK8sPodDeleted(t *testing.T, tt *componenttest.Telemetry, 
 func AssertEqualOtelsvcK8sPodTableSize(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_pod_table_size",
-		Description: "Size of table containing pod info",
+		Description: "Size of table containing pod info [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -326,7 +326,7 @@ func AssertEqualOtelsvcK8sPodTableSize(t *testing.T, tt *componenttest.Telemetry
 func AssertEqualOtelsvcK8sPodUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_pod_updated",
-		Description: "Number of pod update events received",
+		Description: "Number of pod update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -342,7 +342,7 @@ func AssertEqualOtelsvcK8sPodUpdated(t *testing.T, tt *componenttest.Telemetry, 
 func AssertEqualOtelsvcK8sReplicasetAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_replicaset_added",
-		Description: "Number of ReplicaSet add events received",
+		Description: "Number of ReplicaSet add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -358,7 +358,7 @@ func AssertEqualOtelsvcK8sReplicasetAdded(t *testing.T, tt *componenttest.Teleme
 func AssertEqualOtelsvcK8sReplicasetDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_replicaset_deleted",
-		Description: "Number of ReplicaSet delete events received",
+		Description: "Number of ReplicaSet delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -374,7 +374,7 @@ func AssertEqualOtelsvcK8sReplicasetDeleted(t *testing.T, tt *componenttest.Tele
 func AssertEqualOtelsvcK8sReplicasetUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_replicaset_updated",
-		Description: "Number of ReplicaSet update events received",
+		Description: "Number of ReplicaSet update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -390,7 +390,7 @@ func AssertEqualOtelsvcK8sReplicasetUpdated(t *testing.T, tt *componenttest.Tele
 func AssertEqualOtelsvcK8sStatefulsetAdded(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_statefulset_added",
-		Description: "Number of statefulset add events received",
+		Description: "Number of statefulset add events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -406,7 +406,7 @@ func AssertEqualOtelsvcK8sStatefulsetAdded(t *testing.T, tt *componenttest.Telem
 func AssertEqualOtelsvcK8sStatefulsetDeleted(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_statefulset_deleted",
-		Description: "Number of statefulset delete events received",
+		Description: "Number of statefulset delete events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -422,7 +422,7 @@ func AssertEqualOtelsvcK8sStatefulsetDeleted(t *testing.T, tt *componenttest.Tel
 func AssertEqualOtelsvcK8sStatefulsetUpdated(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_otelsvc_k8s_statefulset_updated",
-		Description: "Number of statefulset update events received",
+		Description: "Number of statefulset update events received [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -144,6 +144,8 @@ telemetry:
     otelsvc_k8s_pod_updated:
       enabled: true
       description: Number of pod update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -151,6 +153,8 @@ telemetry:
     otelsvc_k8s_pod_added:
       enabled: true
       description: Number of pod add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -158,6 +162,8 @@ telemetry:
     otelsvc_k8s_pod_deleted:
       enabled: true
       description: Number of pod delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -165,12 +171,16 @@ telemetry:
     otelsvc_k8s_pod_table_size:
       enabled: true
       description: Size of table containing pod info
+      stability:
+        level: development
       unit: "1"
       gauge:
         value_type: int
     otelsvc_k8s_ip_lookup_miss:
       enabled: true
       description: Number of times pod by IP lookup failed.
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -178,6 +188,8 @@ telemetry:
     otelsvc_k8s_namespace_updated:
       enabled: true
       description: Number of namespace update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -185,6 +197,8 @@ telemetry:
     otelsvc_k8s_namespace_added:
       enabled: true
       description: Number of namespace add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -192,6 +206,8 @@ telemetry:
     otelsvc_k8s_namespace_deleted:
       enabled: true
       description: Number of namespace delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -199,6 +215,8 @@ telemetry:
     otelsvc_k8s_node_updated:
       enabled: true
       description: Number of node update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -206,6 +224,8 @@ telemetry:
     otelsvc_k8s_node_added:
       enabled: true
       description: Number of node add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -213,6 +233,8 @@ telemetry:
     otelsvc_k8s_node_deleted:
       enabled: true
       description: Number of node delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -220,6 +242,8 @@ telemetry:
     otelsvc_k8s_deployment_updated:
       enabled: false
       description: Number of deployment update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -227,6 +251,8 @@ telemetry:
     otelsvc_k8s_deployment_added:
       enabled: false
       description: Number of deployment add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -234,6 +260,8 @@ telemetry:
     otelsvc_k8s_deployment_deleted:
       enabled: false
       description: Number of deployment delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -241,6 +269,8 @@ telemetry:
     otelsvc_k8s_statefulset_updated:
       enabled: false
       description: Number of statefulset update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -248,6 +278,8 @@ telemetry:
     otelsvc_k8s_statefulset_added:
       enabled: false
       description: Number of statefulset add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -255,6 +287,8 @@ telemetry:
     otelsvc_k8s_statefulset_deleted:
       enabled: false
       description: Number of statefulset delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -262,6 +296,8 @@ telemetry:
     otelsvc_k8s_job_updated:
       enabled: false
       description: Number of job update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -269,6 +305,8 @@ telemetry:
     otelsvc_k8s_job_added:
       enabled: false
       description: Number of job add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -276,6 +314,8 @@ telemetry:
     otelsvc_k8s_job_deleted:
       enabled: false
       description: Number of job delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -283,6 +323,8 @@ telemetry:
     otelsvc_k8s_daemonset_updated:
       enabled: false
       description: Number of daemonset update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -290,6 +332,8 @@ telemetry:
     otelsvc_k8s_daemonset_added:
       enabled: false
       description: Number of daemonset add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -297,6 +341,8 @@ telemetry:
     otelsvc_k8s_daemonset_deleted:
       enabled: false
       description: Number of daemonset delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -304,6 +350,8 @@ telemetry:
     otelsvc_k8s_replicaset_updated:
       enabled: true
       description: Number of ReplicaSet update events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -311,6 +359,8 @@ telemetry:
     otelsvc_k8s_replicaset_added:
       enabled: true
       description: Number of ReplicaSet add events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int
@@ -318,6 +368,8 @@ telemetry:
     otelsvc_k8s_replicaset_deleted:
       enabled: true
       description: Number of ReplicaSet delete events received
+      stability:
+        level: development
       unit: "1"
       sum:
         value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
