### PR TITLE
[chore][elasticsearchreceiver] Add stability level per metric

### DIFF
--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 Estimated memory used for the operation.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -30,9 +30,9 @@ Estimated memory used for the operation.
 
 Memory limit for the circuit breaker.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -44,9 +44,9 @@ Memory limit for the circuit breaker.
 
 Total number of times the circuit breaker has been triggered and prevented an out of memory error.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -58,9 +58,9 @@ Total number of times the circuit breaker has been triggered and prevented an ou
 
 The number of data nodes in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {nodes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {nodes} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.cluster.health
 
@@ -68,9 +68,9 @@ The health status of the cluster.
 
 Health status is based on the state of its primary and replica shards. Green indicates all shards are assigned. Yellow indicates that one or more replica shards are unassigned. Red indicates that one or more primary shards are unassigned, making some data unavailable.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {status} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {status} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -82,33 +82,33 @@ Health status is based on the state of its primary and replica shards. Green ind
 
 The number of unfinished fetches.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {fetches} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {fetches} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.cluster.nodes
 
 The total number of nodes in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {nodes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {nodes} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.cluster.pending_tasks
 
 The number of cluster-level changes that have not yet been executed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {tasks} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {tasks} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.cluster.published_states.differences
 
 Number of differences between published cluster states.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -120,17 +120,17 @@ Number of differences between published cluster states.
 
 Number of published cluster states.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.cluster.shards
 
 The number of shards in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {shards} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {shards} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -142,9 +142,9 @@ The number of shards in the cluster.
 
 Number of cluster states in queue.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -156,9 +156,9 @@ Number of cluster states in queue.
 
 The number of cluster state update attempts that changed the cluster state since the node started.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -170,9 +170,9 @@ The number of cluster state update attempts that changed the cluster state since
 
 The cumulative amount of time updating the cluster state since the node started.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -185,9 +185,9 @@ The cumulative amount of time updating the cluster state since the node started.
 
 The number of documents for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -200,9 +200,9 @@ The number of documents for an index.
 
 The number of operations completed for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -215,9 +215,9 @@ The number of operations completed for an index.
 
 The number of currently active segment merges
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {merges} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {merges} | Gauge | Int | development |
 
 #### Attributes
 
@@ -229,9 +229,9 @@ The number of currently active segment merges
 
 Time spent on operations for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -244,9 +244,9 @@ Time spent on operations for an index.
 
 Number of segments of an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {segments} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {segments} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -258,9 +258,9 @@ Number of segments of an index.
 
 The size of the shards assigned to this index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -272,33 +272,33 @@ The size of the shards assigned to this index.
 
 Configured memory limit, in bytes, for the indexing requests.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### elasticsearch.indexing_pressure.memory.total.primary_rejections
 
 Cumulative number of indexing requests rejected in the primary stage.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.indexing_pressure.memory.total.replica_rejections
 
 Number of indexing requests rejected in the replica stage.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.memory.indexing_pressure
 
 Memory consumed, in bytes, by indexing requests in the specified stage.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -310,9 +310,9 @@ Memory consumed, in bytes, by indexing requests in the specified stage.
 
 Total count of query cache misses across all shards assigned to selected nodes.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {count} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {count} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -324,9 +324,9 @@ Total count of query cache misses across all shards assigned to selected nodes.
 
 The number of evictions from the cache on a node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {evictions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {evictions} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -338,9 +338,9 @@ The number of evictions from the cache on a node.
 
 The size in bytes of the cache on a node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -352,17 +352,17 @@ The size in bytes of the cache on a node.
 
 The number of open tcp connections for internal cluster communication.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.cluster.io
 
 The number of bytes sent and received on the network for internal cluster communication.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -376,9 +376,9 @@ The total number of kilobytes read across all file stores for this node.
 
 This metric is available only on Linux systems.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| KiBy | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| KiBy | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.disk.io.write
 
@@ -386,17 +386,17 @@ The total number of kilobytes written across all file stores for this node.
 
 This metric is available only on Linux systems.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| KiBy | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| KiBy | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.documents
 
 The number of documents on the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -408,57 +408,57 @@ The number of documents on the node.
 
 The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.fs.disk.free
 
 The amount of unallocated disk space across all file stores for this node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.fs.disk.total
 
 The amount of disk space across all file stores for this node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.http.connections
 
 The number of HTTP connections to the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.ingest.documents
 
 Total number of documents ingested during the lifetime of this node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.node.ingest.documents.current
 
 Total number of documents currently being ingested.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.ingest.operations.failed
 
 Total number of failed ingest operations during the lifetime of this node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.node.open_files
 
@@ -472,9 +472,9 @@ The number of open file descriptors held by the node.
 
 The number of operations completed by a node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -486,9 +486,9 @@ The number of operations completed by a node.
 
 Time spent on operations by a node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -500,9 +500,9 @@ Time spent on operations by a node.
 
 Total number of documents currently being ingested by a pipeline.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -514,9 +514,9 @@ Total number of documents currently being ingested by a pipeline.
 
 Number of documents preprocessed by the ingest pipeline.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -528,9 +528,9 @@ Number of documents preprocessed by the ingest pipeline.
 
 Total number of failed operations for the ingest pipeline.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -542,57 +542,57 @@ Total number of failed operations for the ingest pipeline.
 
 Total number of times the script cache has evicted old data.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.node.script.compilation_limit_triggered
 
 Total number of times the script compilation circuit breaker has limited inline script compilations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.node.script.compilations
 
 Total number of inline script compilations performed by the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {compilations} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {compilations} | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.shards.data_set.size
 
 Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.shards.reserved.size
 
 A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.shards.size
 
 The size of the shards assigned to this node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.thread_pool.tasks.finished
 
 The number of tasks finished by the thread pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {tasks} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {tasks} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -605,9 +605,9 @@ The number of tasks finished by the thread pool.
 
 The number of queued tasks in the thread pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {tasks} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {tasks} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -619,9 +619,9 @@ The number of queued tasks in the thread pool.
 
 The number of threads in the thread pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {threads} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {threads} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -634,65 +634,65 @@ The number of threads in the thread pool.
 
 Number of transaction log operations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.node.translog.size
 
 Size of the transaction log.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.translog.uncommitted.size
 
 Size of uncommitted transaction log operations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.os.cpu.load_avg.15m
 
 Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### elasticsearch.os.cpu.load_avg.1m
 
 One-minute load average on the system (field is not present if one-minute load average is not available).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### elasticsearch.os.cpu.load_avg.5m
 
 Five-minute load average on the system (field is not present if five-minute load average is not available).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### elasticsearch.os.cpu.usage
 
 Recent CPU usage for the whole system, or -1 if not supported.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| % | Gauge | Int | development |
 
 ### elasticsearch.os.memory
 
 Amount of physical memory.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -704,17 +704,17 @@ Amount of physical memory.
 
 The number of loaded classes
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### jvm.gc.collections.count
 
 The total number of garbage collections that have occurred
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -726,9 +726,9 @@ The total number of garbage collections that have occurred
 
 The approximate accumulated collection elapsed time
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -740,49 +740,49 @@ The approximate accumulated collection elapsed time
 
 The amount of memory that is guaranteed to be available for the heap
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### jvm.memory.heap.max
 
 The maximum amount of memory can be used for the heap
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### jvm.memory.heap.used
 
 The current heap memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### jvm.memory.nonheap.committed
 
 The amount of memory that is guaranteed to be available for non-heap purposes
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### jvm.memory.nonheap.used
 
 The current non-heap memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 ### jvm.memory.pool.max
 
 The maximum amount of memory can be used for the memory pool
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -794,9 +794,9 @@ The maximum amount of memory can be used for the memory pool
 
 The current memory pool memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -808,9 +808,9 @@ The current memory pool memory usage
 
 The current number of threads
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ## Optional Metrics
 
@@ -826,9 +826,9 @@ metrics:
 
 The number of evictions from the cache for indices in cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {evictions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {evictions} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -840,9 +840,9 @@ The number of evictions from the cache for indices in cluster.
 
 The number of evictions from the cache for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {evictions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {evictions} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -855,9 +855,9 @@ The number of evictions from the cache for an index.
 
 The size in bytes of the cache for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -870,9 +870,9 @@ The size in bytes of the cache for an index.
 
 The number of elements of the query cache for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -884,9 +884,9 @@ The number of elements of the query cache for an index.
 
 The total number of documents in merge operations for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -898,9 +898,9 @@ The total number of documents in merge operations for an index.
 
 The total size of merged segments for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -912,9 +912,9 @@ The total size of merged segments for an index.
 
 Size of memory for segment object of an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -927,9 +927,9 @@ Size of memory for segment object of an index.
 
 Size of segments of an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -941,9 +941,9 @@ Size of segments of an index.
 
 Number of transaction log operations for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -955,9 +955,9 @@ Number of transaction log operations for an index.
 
 Size of the transaction log for an index.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -969,17 +969,17 @@ Size of the transaction log for an index.
 
 Total amount of memory used for the query cache across all shards assigned to the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### elasticsearch.node.operations.current
 
 Number of query operations currently running.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {operations} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {operations} | Gauge | Int | development |
 
 #### Attributes
 
@@ -991,9 +991,9 @@ Number of query operations currently running.
 
 The number of hits and misses resulting from GET operations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -1005,9 +1005,9 @@ The number of hits and misses resulting from GET operations.
 
 The time spent on hits and misses resulting from GET operations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -1019,9 +1019,9 @@ The time spent on hits and misses resulting from GET operations.
 
 Size of memory for segment object of a node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -1033,33 +1033,33 @@ Size of memory for segment object of a node.
 
 CPU time used by the process on which the Java virtual machine is running.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 ### elasticsearch.process.cpu.usage
 
 CPU usage in percent.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### elasticsearch.process.memory.virtual
 
 Size of virtual memory that is guaranteed to be available to the running process.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### jvm.memory.heap.utilization
 
 Fraction of heap memory usage
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ## Resource Attributes
 

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -195,6 +195,8 @@ metrics:
   # these metrics are from /_nodes/stats, and are node level metrics
   elasticsearch.breaker.memory.estimated:
     description: Estimated memory used for the operation.
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -202,6 +204,8 @@ metrics:
     enabled: true
   elasticsearch.breaker.memory.limit:
     description: Memory limit for the circuit breaker.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -211,6 +215,8 @@ metrics:
     enabled: true
   elasticsearch.breaker.tripped:
     description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -220,6 +226,8 @@ metrics:
     enabled: true
   elasticsearch.node.cache.memory.usage:
     description: The size in bytes of the cache on a node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -229,6 +237,8 @@ metrics:
     enabled: true
   elasticsearch.node.cache.evictions:
     description: The number of evictions from the cache on a node.
+    stability:
+      level: development
     unit: "{evictions}"
     sum:
       monotonic: true
@@ -238,6 +248,8 @@ metrics:
     enabled: true
   elasticsearch.node.cache.count:
     description: Total count of query cache misses across all shards assigned to selected nodes.
+    stability:
+      level: development
     unit: "{count}"
     sum:
       monotonic: false
@@ -247,6 +259,8 @@ metrics:
     enabled: true
   elasticsearch.node.cache.size:
     description: Total amount of memory used for the query cache across all shards assigned to the node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -256,6 +270,8 @@ metrics:
     enabled: false
   elasticsearch.node.fs.disk.available:
     description: The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -265,6 +281,8 @@ metrics:
     enabled: true
   elasticsearch.node.fs.disk.free:
     description: The amount of unallocated disk space across all file stores for this node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -274,6 +292,8 @@ metrics:
     enabled: true
   elasticsearch.node.fs.disk.total:
     description: The amount of disk space across all file stores for this node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -288,6 +308,8 @@ metrics:
   # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
   elasticsearch.node.disk.io.read:
     description: The total number of kilobytes read across all file stores for this node.
+    stability:
+      level: development
     unit: KiBy
     sum:
       monotonic: false
@@ -303,6 +325,8 @@ metrics:
   # Linux always considers sectors to be 512 bytes https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/linux/types.h#L125
   elasticsearch.node.disk.io.write:
     description: The total number of kilobytes written across all file stores for this node.
+    stability:
+      level: development
     unit: KiBy
     sum:
       monotonic: false
@@ -313,6 +337,8 @@ metrics:
     extended_documentation: This metric is available only on Linux systems.
   elasticsearch.node.cluster.io:
     description: The number of bytes sent and received on the network for internal cluster communication.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: true
@@ -322,6 +348,8 @@ metrics:
     enabled: true
   elasticsearch.node.cluster.connections:
     description: The number of open tcp connections for internal cluster communication.
+    stability:
+      level: development
     unit: "{connections}"
     sum:
       monotonic: false
@@ -331,6 +359,8 @@ metrics:
     enabled: true
   elasticsearch.node.http.connections:
     description: The number of HTTP connections to the node.
+    stability:
+      level: development
     unit: "{connections}"
     sum:
       monotonic: false
@@ -340,6 +370,8 @@ metrics:
     enabled: true
   elasticsearch.node.operations.current:
     description: Number of query operations currently running.
+    stability:
+      level: development
     unit: "{operations}"
     gauge:
       value_type: int
@@ -347,6 +379,8 @@ metrics:
     enabled: false
   elasticsearch.node.operations.completed:
     description: The number of operations completed by a node.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -356,6 +390,8 @@ metrics:
     enabled: true
   elasticsearch.node.operations.time:
     description: Time spent on operations by a node.
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -365,6 +401,8 @@ metrics:
     enabled: true
   elasticsearch.node.operations.get.completed:
     description: The number of hits and misses resulting from GET operations.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -374,6 +412,8 @@ metrics:
     enabled: false
   elasticsearch.node.operations.get.time:
     description: The time spent on hits and misses resulting from GET operations.
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -383,6 +423,8 @@ metrics:
     enabled: false
   elasticsearch.node.shards.size:
     description: The size of the shards assigned to this node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -392,6 +434,8 @@ metrics:
     enabled: true
   elasticsearch.node.shards.data_set.size:
     description: Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -401,6 +445,8 @@ metrics:
     enabled: true
   elasticsearch.node.shards.reserved.size:
     description: A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -410,6 +456,8 @@ metrics:
     enabled: true
   elasticsearch.node.translog.operations:
     description: Number of transaction log operations.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -419,6 +467,8 @@ metrics:
     enabled: true
   elasticsearch.node.translog.size:
     description: Size of the transaction log.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -428,6 +478,8 @@ metrics:
     enabled: true
   elasticsearch.node.translog.uncommitted.size:
     description: Size of uncommitted transaction log operations.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -437,6 +489,8 @@ metrics:
     enabled: true
   elasticsearch.node.thread_pool.threads:
     description: The number of threads in the thread pool.
+    stability:
+      level: development
     unit: "{threads}"
     sum:
       monotonic: false
@@ -446,6 +500,8 @@ metrics:
     enabled: true
   elasticsearch.node.thread_pool.tasks.queued:
     description: The number of queued tasks in the thread pool.
+    stability:
+      level: development
     unit: "{tasks}"
     sum:
       monotonic: false
@@ -455,6 +511,8 @@ metrics:
     enabled: true
   elasticsearch.node.thread_pool.tasks.finished:
     description: The number of tasks finished by the thread pool.
+    stability:
+      level: development
     unit: "{tasks}"
     sum:
       monotonic: true
@@ -464,6 +522,8 @@ metrics:
     enabled: true
   elasticsearch.node.documents:
     description: The number of documents on the node.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: false
@@ -484,6 +544,8 @@ metrics:
   # See https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/jvm.md
   jvm.classes.loaded:
     description: The number of loaded classes
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -491,6 +553,8 @@ metrics:
     enabled: true
   jvm.gc.collections.count:
     description: The total number of garbage collections that have occurred
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -500,6 +564,8 @@ metrics:
     enabled: true
   jvm.gc.collections.elapsed:
     description: "The approximate accumulated collection elapsed time"
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -509,6 +575,8 @@ metrics:
     enabled: true
   jvm.memory.heap.max:
     description: The maximum amount of memory can be used for the heap
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -516,6 +584,8 @@ metrics:
     enabled: true
   jvm.memory.heap.used:
     description: The current heap memory usage
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -523,6 +593,8 @@ metrics:
     enabled: true
   jvm.memory.heap.utilization:
     description: Fraction of heap memory usage
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -530,6 +602,8 @@ metrics:
     enabled: false
   jvm.memory.heap.committed:
     description: The amount of memory that is guaranteed to be available for the heap
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -537,6 +611,8 @@ metrics:
     enabled: true
   jvm.memory.nonheap.used:
     description: The current non-heap memory usage
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -544,6 +620,8 @@ metrics:
     enabled: true
   jvm.memory.nonheap.committed:
     description: The amount of memory that is guaranteed to be available for non-heap purposes
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -551,6 +629,8 @@ metrics:
     enabled: true
   jvm.memory.pool.max:
     description: The maximum amount of memory can be used for the memory pool
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -558,6 +638,8 @@ metrics:
     enabled: true
   jvm.memory.pool.used:
     description: The current memory pool memory usage
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -565,6 +647,8 @@ metrics:
     enabled: true
   jvm.threads.count:
     description: The current number of threads
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -573,6 +657,8 @@ metrics:
   # these metrics are from /_cluster/pending_tasks, and are cluster level metrics
   elasticsearch.cluster.pending_tasks:
     description: The number of cluster-level changes that have not yet been executed.
+    stability:
+      level: development
     unit: "{tasks}"
     sum:
       monotonic: false
@@ -582,6 +668,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.in_flight_fetch:
     description: The number of unfinished fetches.
+    stability:
+      level: development
     unit: "{fetches}"
     sum:
       monotonic: false
@@ -592,6 +680,8 @@ metrics:
   # these metrics are from /_cluster/health, and are cluster level metrics
   elasticsearch.cluster.shards:
     description: The number of shards in the cluster.
+    stability:
+      level: development
     unit: "{shards}"
     sum:
       monotonic: false
@@ -601,6 +691,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.data_nodes:
     description: The number of data nodes in the cluster.
+    stability:
+      level: development
     unit: "{nodes}"
     sum:
       monotonic: false
@@ -610,6 +702,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.nodes:
     description: The total number of nodes in the cluster.
+    stability:
+      level: development
     unit: "{nodes}"
     sum:
       monotonic: false
@@ -619,6 +713,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.health:
     description: The health status of the cluster.
+    stability:
+      level: development
     extended_documentation:
       Health status is based on the state of its primary and replica shards.
       Green indicates all shards are assigned.
@@ -633,6 +729,8 @@ metrics:
     enabled: true
   elasticsearch.os.cpu.usage:
     description: Recent CPU usage for the whole system, or -1 if not supported.
+    stability:
+      level: development
     unit: '%'
     gauge:
       value_type: int
@@ -640,6 +738,8 @@ metrics:
     enabled: true
   elasticsearch.os.cpu.load_avg.1m:
     description: One-minute load average on the system (field is not present if one-minute load average is not available).
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -647,6 +747,8 @@ metrics:
     enabled: true
   elasticsearch.os.cpu.load_avg.5m:
     description: Five-minute load average on the system (field is not present if five-minute load average is not available).
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -654,6 +756,8 @@ metrics:
     enabled: true
   elasticsearch.os.cpu.load_avg.15m:
     description: Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -661,6 +765,8 @@ metrics:
     enabled: true
   elasticsearch.os.memory:
     description: Amount of physical memory.
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -668,6 +774,8 @@ metrics:
     enabled: true
   elasticsearch.memory.indexing_pressure:
     description: Memory consumed, in bytes, by indexing requests in the specified stage.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -677,6 +785,8 @@ metrics:
     enabled: true
   elasticsearch.indexing_pressure.memory.total.primary_rejections:
     description: Cumulative number of indexing requests rejected in the primary stage.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -686,6 +796,8 @@ metrics:
     enabled: true
   elasticsearch.indexing_pressure.memory.total.replica_rejections:
     description: Number of indexing requests rejected in the replica stage.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -695,6 +807,8 @@ metrics:
     enabled: true
   elasticsearch.indexing_pressure.memory.limit:
     description: Configured memory limit, in bytes, for the indexing requests.
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -702,6 +816,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.state_queue:
     description: Number of cluster states in queue.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: false
@@ -711,6 +827,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.published_states.full:
     description: Number of published cluster states.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: false
@@ -720,6 +838,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.published_states.differences:
     description: Number of differences between published cluster states.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: false
@@ -729,6 +849,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.state_update.count:
     description: The number of cluster state update attempts that changed the cluster state since the node started.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -738,6 +860,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.state_update.time:
     description: The cumulative amount of time updating the cluster state since the node started.
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -747,6 +871,8 @@ metrics:
     enabled: true
   elasticsearch.cluster.indices.cache.evictions:
     description: The number of evictions from the cache for indices in cluster.
+    stability:
+      level: development
     unit: "{evictions}"
     sum:
       monotonic: true
@@ -756,6 +882,8 @@ metrics:
     enabled: false
   elasticsearch.node.ingest.documents:
     description: Total number of documents ingested during the lifetime of this node.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: true
@@ -765,6 +893,8 @@ metrics:
     enabled: true
   elasticsearch.node.ingest.documents.current:
     description: Total number of documents currently being ingested.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: false
@@ -774,6 +904,8 @@ metrics:
     enabled: true
   elasticsearch.node.ingest.operations.failed:
     description: Total number of failed ingest operations during the lifetime of this node.
+    stability:
+      level: development
     unit: "{operation}"
     sum:
       monotonic: true
@@ -783,6 +915,8 @@ metrics:
     enabled: true
   elasticsearch.node.pipeline.ingest.documents.preprocessed:
     description: Number of documents preprocessed by the ingest pipeline.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: false
@@ -792,6 +926,8 @@ metrics:
     enabled: true
   elasticsearch.node.pipeline.ingest.operations.failed:
     description: Total number of failed operations for the ingest pipeline.
+    stability:
+      level: development
     unit: "{operation}"
     sum:
       monotonic: true
@@ -801,6 +937,8 @@ metrics:
     enabled: true
   elasticsearch.node.pipeline.ingest.documents.current:
     description: Total number of documents currently being ingested by a pipeline.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: false
@@ -810,6 +948,8 @@ metrics:
     enabled: true
   elasticsearch.node.script.compilations:
     description: Total number of inline script compilations performed by the node.
+    stability:
+      level: development
     unit: "{compilations}"
     sum:
       monotonic: false
@@ -819,6 +959,8 @@ metrics:
     enabled: true
   elasticsearch.node.script.cache_evictions:
     description: Total number of times the script cache has evicted old data.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -828,6 +970,8 @@ metrics:
     enabled: true
   elasticsearch.node.script.compilation_limit_triggered:
     description: Total number of times the script compilation circuit breaker has limited inline script compilations.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: true
@@ -837,6 +981,8 @@ metrics:
     enabled: true
   elasticsearch.node.segments.memory:
     description: Size of memory for segment object of a node.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -847,6 +993,8 @@ metrics:
   # these metrics are from /*/_stats and are index level metrics
   elasticsearch.index.operations.completed:
     description: The number of operations completed for an index.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -856,6 +1004,8 @@ metrics:
     enabled: true
   elasticsearch.index.operations.time:
     description: Time spent on operations for an index.
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -865,6 +1015,8 @@ metrics:
     enabled: true
   elasticsearch.index.shards.size:
     description: The size of the shards assigned to this index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -874,6 +1026,8 @@ metrics:
     enabled: true
   elasticsearch.index.operations.merge.size:
     description: The total size of merged segments for an index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: true
@@ -883,6 +1037,8 @@ metrics:
     enabled: false
   elasticsearch.index.operations.merge.docs_count:
     description: The total number of documents in merge operations for an index.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: true
@@ -892,6 +1048,8 @@ metrics:
     enabled: false
   elasticsearch.index.operations.merge.current:
     description: The number of currently active segment merges
+    stability:
+      level: development
     unit: "{merges}"
     gauge:
       value_type: int
@@ -899,6 +1057,8 @@ metrics:
     enabled: true
   elasticsearch.index.segments.count:
     description: Number of segments of an index.
+    stability:
+      level: development
     unit: "{segments}"
     sum:
       monotonic: false
@@ -908,6 +1068,8 @@ metrics:
     enabled: true
   elasticsearch.index.segments.size:
     description: Size of segments of an index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -917,6 +1079,8 @@ metrics:
     enabled: false
   elasticsearch.index.segments.memory:
     description: Size of memory for segment object of an index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -926,6 +1090,8 @@ metrics:
     enabled: false
   elasticsearch.index.translog.operations:
     description: Number of transaction log operations for an index.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -935,6 +1101,8 @@ metrics:
     enabled: false
   elasticsearch.index.translog.size:
     description: Size of the transaction log for an index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -944,6 +1112,8 @@ metrics:
     enabled: false
   elasticsearch.index.cache.memory.usage:
     description: The size in bytes of the cache for an index.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -953,6 +1123,8 @@ metrics:
     enabled: false
   elasticsearch.index.cache.size:
     description: The number of elements of the query cache for an index.
+    stability:
+      level: development
     unit: "1"
     sum:
       monotonic: false
@@ -962,6 +1134,8 @@ metrics:
     enabled: false
   elasticsearch.index.cache.evictions:
     description: The number of evictions from the cache for an index.
+    stability:
+      level: development
     unit: "{evictions}"
     sum:
       monotonic: true
@@ -971,6 +1145,8 @@ metrics:
     enabled: false
   elasticsearch.index.documents:
     description: The number of documents for an index.
+    stability:
+      level: development
     unit: "{documents}"
     sum:
       monotonic: false
@@ -980,6 +1156,8 @@ metrics:
     enabled: true
   elasticsearch.process.cpu.usage:
     description: CPU usage in percent.
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -987,6 +1165,8 @@ metrics:
     enabled: false
   elasticsearch.process.cpu.time:
     description: CPU time used by the process on which the Java virtual machine is running.
+    stability:
+      level: development
     unit: ms
     sum:
       monotonic: true
@@ -996,6 +1176,8 @@ metrics:
     enabled: false
   elasticsearch.process.memory.virtual:
     description: Size of virtual memory that is guaranteed to be available to the running process.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
