### PR TITLE
[chore][solacereceiver] Add stability level per metric

### DIFF
--- a/receiver/solacereceiver/documentation.md
+++ b/receiver/solacereceiver/documentation.md
@@ -8,104 +8,104 @@ The following telemetry is emitted by this component.
 
 ### otelcol_solacereceiver_dropped_egress_spans
 
-Number of dropped egress spans
+Number of dropped egress spans [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_dropped_span_messages
 
-Number of dropped span messages
+Number of dropped span messages [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_failed_reconnections
 
-Number of failed broker reconnections
+Number of failed broker reconnections [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_fatal_unmarshalling_errors
 
-Number of fatal message unmarshalling errors
+Number of fatal message unmarshalling errors [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_need_upgrade
 
-Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker
+Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_solacereceiver_received_span_messages
 
-Number of received span messages
+Number of received span messages [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_receiver_flow_control_recent_retries
 
-Most recent/current retry count when flow controlled
+Most recent/current retry count when flow controlled [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_solacereceiver_receiver_flow_control_status
 
-Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled
+Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_solacereceiver_receiver_flow_control_total
 
-Number of times the receiver instance became flow controlled
+Number of times the receiver instance became flow controlled [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_receiver_flow_control_with_single_successful_retry
 
-Number of times the receiver instance became flow controlled and resolved situations after the first retry
+Number of times the receiver instance became flow controlled and resolved situations after the first retry [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_receiver_status
 
-Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated
+Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_solacereceiver_recoverable_unmarshalling_errors
 
-Number of recoverable message unmarshalling errors
+Number of recoverable message unmarshalling errors [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_solacereceiver_reported_spans
 
-Number of reported spans
+Number of reported spans [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |

--- a/receiver/solacereceiver/internal/metadata/generated_telemetry.go
+++ b/receiver/solacereceiver/internal/metadata/generated_telemetry.go
@@ -72,79 +72,79 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.SolacereceiverDroppedEgressSpans, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_dropped_egress_spans",
-		metric.WithDescription("Number of dropped egress spans"),
+		metric.WithDescription("Number of dropped egress spans [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverDroppedSpanMessages, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_dropped_span_messages",
-		metric.WithDescription("Number of dropped span messages"),
+		metric.WithDescription("Number of dropped span messages [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverFailedReconnections, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_failed_reconnections",
-		metric.WithDescription("Number of failed broker reconnections"),
+		metric.WithDescription("Number of failed broker reconnections [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverFatalUnmarshallingErrors, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_fatal_unmarshalling_errors",
-		metric.WithDescription("Number of fatal message unmarshalling errors"),
+		metric.WithDescription("Number of fatal message unmarshalling errors [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverNeedUpgrade, err = builder.meter.Int64Gauge(
 		"otelcol_solacereceiver_need_upgrade",
-		metric.WithDescription("Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker"),
+		metric.WithDescription("Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceivedSpanMessages, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_received_span_messages",
-		metric.WithDescription("Number of received span messages"),
+		metric.WithDescription("Number of received span messages [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceiverFlowControlRecentRetries, err = builder.meter.Int64Gauge(
 		"otelcol_solacereceiver_receiver_flow_control_recent_retries",
-		metric.WithDescription("Most recent/current retry count when flow controlled"),
+		metric.WithDescription("Most recent/current retry count when flow controlled [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceiverFlowControlStatus, err = builder.meter.Int64Gauge(
 		"otelcol_solacereceiver_receiver_flow_control_status",
-		metric.WithDescription("Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled"),
+		metric.WithDescription("Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceiverFlowControlTotal, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_receiver_flow_control_total",
-		metric.WithDescription("Number of times the receiver instance became flow controlled"),
+		metric.WithDescription("Number of times the receiver instance became flow controlled [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceiverFlowControlWithSingleSuccessfulRetry, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_receiver_flow_control_with_single_successful_retry",
-		metric.WithDescription("Number of times the receiver instance became flow controlled and resolved situations after the first retry"),
+		metric.WithDescription("Number of times the receiver instance became flow controlled and resolved situations after the first retry [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReceiverStatus, err = builder.meter.Int64Gauge(
 		"otelcol_solacereceiver_receiver_status",
-		metric.WithDescription("Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated"),
+		metric.WithDescription("Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverRecoverableUnmarshallingErrors, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_recoverable_unmarshalling_errors",
-		metric.WithDescription("Number of recoverable message unmarshalling errors"),
+		metric.WithDescription("Number of recoverable message unmarshalling errors [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.SolacereceiverReportedSpans, err = builder.meter.Int64Counter(
 		"otelcol_solacereceiver_reported_spans",
-		metric.WithDescription("Number of reported spans"),
+		metric.WithDescription("Number of reported spans [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)

--- a/receiver/solacereceiver/internal/metadatatest/generated_telemetrytest.go
+++ b/receiver/solacereceiver/internal/metadatatest/generated_telemetrytest.go
@@ -24,7 +24,7 @@ func NewSettings(tt *componenttest.Telemetry) receiver.Settings {
 func AssertEqualSolacereceiverDroppedEgressSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_dropped_egress_spans",
-		Description: "Number of dropped egress spans",
+		Description: "Number of dropped egress spans [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -40,7 +40,7 @@ func AssertEqualSolacereceiverDroppedEgressSpans(t *testing.T, tt *componenttest
 func AssertEqualSolacereceiverDroppedSpanMessages(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_dropped_span_messages",
-		Description: "Number of dropped span messages",
+		Description: "Number of dropped span messages [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -56,7 +56,7 @@ func AssertEqualSolacereceiverDroppedSpanMessages(t *testing.T, tt *componenttes
 func AssertEqualSolacereceiverFailedReconnections(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_failed_reconnections",
-		Description: "Number of failed broker reconnections",
+		Description: "Number of failed broker reconnections [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -72,7 +72,7 @@ func AssertEqualSolacereceiverFailedReconnections(t *testing.T, tt *componenttes
 func AssertEqualSolacereceiverFatalUnmarshallingErrors(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_fatal_unmarshalling_errors",
-		Description: "Number of fatal message unmarshalling errors",
+		Description: "Number of fatal message unmarshalling errors [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -88,7 +88,7 @@ func AssertEqualSolacereceiverFatalUnmarshallingErrors(t *testing.T, tt *compone
 func AssertEqualSolacereceiverNeedUpgrade(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_need_upgrade",
-		Description: "Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker",
+		Description: "Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -102,7 +102,7 @@ func AssertEqualSolacereceiverNeedUpgrade(t *testing.T, tt *componenttest.Teleme
 func AssertEqualSolacereceiverReceivedSpanMessages(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_received_span_messages",
-		Description: "Number of received span messages",
+		Description: "Number of received span messages [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -118,7 +118,7 @@ func AssertEqualSolacereceiverReceivedSpanMessages(t *testing.T, tt *componentte
 func AssertEqualSolacereceiverReceiverFlowControlRecentRetries(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_receiver_flow_control_recent_retries",
-		Description: "Most recent/current retry count when flow controlled",
+		Description: "Most recent/current retry count when flow controlled [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -132,7 +132,7 @@ func AssertEqualSolacereceiverReceiverFlowControlRecentRetries(t *testing.T, tt 
 func AssertEqualSolacereceiverReceiverFlowControlStatus(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_receiver_flow_control_status",
-		Description: "Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled",
+		Description: "Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -146,7 +146,7 @@ func AssertEqualSolacereceiverReceiverFlowControlStatus(t *testing.T, tt *compon
 func AssertEqualSolacereceiverReceiverFlowControlTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_receiver_flow_control_total",
-		Description: "Number of times the receiver instance became flow controlled",
+		Description: "Number of times the receiver instance became flow controlled [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -162,7 +162,7 @@ func AssertEqualSolacereceiverReceiverFlowControlTotal(t *testing.T, tt *compone
 func AssertEqualSolacereceiverReceiverFlowControlWithSingleSuccessfulRetry(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_receiver_flow_control_with_single_successful_retry",
-		Description: "Number of times the receiver instance became flow controlled and resolved situations after the first retry",
+		Description: "Number of times the receiver instance became flow controlled and resolved situations after the first retry [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -178,7 +178,7 @@ func AssertEqualSolacereceiverReceiverFlowControlWithSingleSuccessfulRetry(t *te
 func AssertEqualSolacereceiverReceiverStatus(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_receiver_status",
-		Description: "Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated",
+		Description: "Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -192,7 +192,7 @@ func AssertEqualSolacereceiverReceiverStatus(t *testing.T, tt *componenttest.Tel
 func AssertEqualSolacereceiverRecoverableUnmarshallingErrors(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_recoverable_unmarshalling_errors",
-		Description: "Number of recoverable message unmarshalling errors",
+		Description: "Number of recoverable message unmarshalling errors [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -208,7 +208,7 @@ func AssertEqualSolacereceiverRecoverableUnmarshallingErrors(t *testing.T, tt *c
 func AssertEqualSolacereceiverReportedSpans(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_solacereceiver_reported_spans",
-		Description: "Number of reported spans",
+		Description: "Number of reported spans [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/receiver/solacereceiver/metadata.yaml
+++ b/receiver/solacereceiver/metadata.yaml
@@ -23,6 +23,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of failed broker reconnections
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -30,6 +32,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of recoverable message unmarshalling errors
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -37,6 +41,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of fatal message unmarshalling errors
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -44,6 +50,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of dropped span messages
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -51,6 +59,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of received span messages
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -58,6 +68,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of reported spans
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -65,30 +77,40 @@ telemetry:
       enabled: true
       unit: "1"
       description: Indicates the status of the receiver as an enum. 0 = starting, 1 = connecting, 2 = connected, 3 = disabled (often paired with needs_upgrade), 4 = terminating, 5 = terminated
+      stability:
+        level: development
       gauge:
         value_type: int
     solacereceiver_need_upgrade:
       enabled: true
       unit: "1"
       description: Indicates with value 1 that receiver requires an upgrade and is not compatible with messages received from a broker
+      stability:
+        level: development
       gauge:
         value_type: int
     solacereceiver_receiver_flow_control_status:
       enabled: true
       unit: "1"
       description: Indicates the flow control status of the receiver. 0 = not flow controlled, 1 = currently flow controlled
+      stability:
+        level: development
       gauge:
         value_type: int
     solacereceiver_receiver_flow_control_recent_retries:
       enabled: true
       unit: "1"
       description: Most recent/current retry count when flow controlled
+      stability:
+        level: development
       gauge:
         value_type: int
     solacereceiver_receiver_flow_control_total:
       enabled: true
       unit: "1"
       description: Number of times the receiver instance became flow controlled
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -96,6 +118,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of times the receiver instance became flow controlled and resolved situations after the first retry
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true
@@ -103,6 +127,8 @@ telemetry:
       enabled: true
       unit: "1"
       description: Number of dropped egress spans
+      stability:
+        level: development
       sum:
         value_type: int
         monotonic: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
