### PR TITLE
[chore][zookeeperscraper] Add stability level per metric

### DIFF
--- a/scraper/zookeeperscraper/documentation.md
+++ b/scraper/zookeeperscraper/documentation.md
@@ -16,49 +16,49 @@ metrics:
 
 Number of active clients connected to a ZooKeeper server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.data_tree.ephemeral_node.count
 
 Number of ephemeral nodes that a ZooKeeper server has in its data tree.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {nodes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {nodes} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.data_tree.size
 
 Size of data in bytes that a ZooKeeper server has in its data tree.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.file_descriptor.limit
 
 Maximum number of file descriptors that a ZooKeeper server can open.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {file_descriptors} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {file_descriptors} | Gauge | Int | development |
 
 ### zookeeper.file_descriptor.open
 
 Number of file descriptors that a ZooKeeper server has open.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {file_descriptors} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {file_descriptors} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.follower.count
 
 The number of followers. Only exposed by the leader.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {followers} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {followers} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -70,41 +70,41 @@ The number of followers. Only exposed by the leader.
 
 Number of times fsync duration has exceeded warning threshold.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {events} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {events} | Sum | Int | Cumulative | true | development |
 
 ### zookeeper.latency.avg
 
 Average time in milliseconds for requests to be processed.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### zookeeper.latency.max
 
 Maximum time in milliseconds for requests to be processed.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### zookeeper.latency.min
 
 Minimum time in milliseconds for requests to be processed.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### zookeeper.packet.count
 
 The number of ZooKeeper packets received or sent by a server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {packets} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {packets} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -116,41 +116,41 @@ The number of ZooKeeper packets received or sent by a server.
 
 Number of currently executing requests.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.ruok
 
 Response from zookeeper ruok command
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### zookeeper.sync.pending
 
 The number of pending syncs from the followers. Only exposed by the leader.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {syncs} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {syncs} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.watch.count
 
 Number of watches placed on Z-Nodes on a ZooKeeper server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {watches} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {watches} | Sum | Int | Cumulative | false | development |
 
 ### zookeeper.znode.count
 
 Number of z-nodes that a ZooKeeper server has in its data tree.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {znodes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {znodes} | Sum | Int | Cumulative | false | development |
 
 ## Resource Attributes
 

--- a/scraper/zookeeperscraper/metadata.yaml
+++ b/scraper/zookeeperscraper/metadata.yaml
@@ -38,6 +38,8 @@ metrics:
   zookeeper.follower.count:
     enabled: true
     description: The number of followers. Only exposed by the leader.
+    stability:
+      level: development
     unit: "{followers}"
     attributes: [state]
     sum:
@@ -47,6 +49,8 @@ metrics:
   zookeeper.sync.pending:
     enabled: true
     description: The number of pending syncs from the followers. Only exposed by the leader.
+    stability:
+      level: development
     unit: "{syncs}"
     sum:
       monotonic: false
@@ -55,24 +59,32 @@ metrics:
   zookeeper.latency.avg:
     enabled: true
     description: Average time in milliseconds for requests to be processed.
+    stability:
+      level: development
     unit: ms
     gauge:
       value_type: int
   zookeeper.latency.max:
     enabled: true
     description: Maximum time in milliseconds for requests to be processed.
+    stability:
+      level: development
     unit: ms
     gauge:
       value_type: int
   zookeeper.latency.min:
     enabled: true
     description: Minimum time in milliseconds for requests to be processed.
+    stability:
+      level: development
     unit: ms
     gauge:
       value_type: int
   zookeeper.connection.active:
     enabled: true
     description: Number of active clients connected to a ZooKeeper server.
+    stability:
+      level: development
     unit: "{connections}"
     sum:
       monotonic: false
@@ -81,6 +93,8 @@ metrics:
   zookeeper.request.active:
     enabled: true
     description: Number of currently executing requests.
+    stability:
+      level: development
     unit: "{requests}"
     sum:
       monotonic: false
@@ -89,6 +103,8 @@ metrics:
   zookeeper.znode.count:
     enabled: true
     description: Number of z-nodes that a ZooKeeper server has in its data tree.
+    stability:
+      level: development
     unit: "{znodes}"
     sum:
       monotonic: false
@@ -97,6 +113,8 @@ metrics:
   zookeeper.watch.count:
     enabled: true
     description: Number of watches placed on Z-Nodes on a ZooKeeper server.
+    stability:
+      level: development
     unit: "{watches}"
     sum:
       monotonic: false
@@ -105,6 +123,8 @@ metrics:
   zookeeper.data_tree.ephemeral_node.count:
     enabled: true
     description: Number of ephemeral nodes that a ZooKeeper server has in its data tree.
+    stability:
+      level: development
     unit: "{nodes}"
     sum:
       monotonic: false
@@ -113,6 +133,8 @@ metrics:
   zookeeper.data_tree.size:
     enabled: true
     description: Size of data in bytes that a ZooKeeper server has in its data tree.
+    stability:
+      level: development
     unit: By
     sum:
       monotonic: false
@@ -121,6 +143,8 @@ metrics:
   zookeeper.file_descriptor.open:
     enabled: true
     description: Number of file descriptors that a ZooKeeper server has open.
+    stability:
+      level: development
     unit: "{file_descriptors}"
     sum:
       monotonic: false
@@ -129,12 +153,16 @@ metrics:
   zookeeper.file_descriptor.limit:
     enabled: true
     description: Maximum number of file descriptors that a ZooKeeper server can open.
+    stability:
+      level: development
     unit: "{file_descriptors}"
     gauge:
       value_type: int
   zookeeper.packet.count:
     enabled: true
     description: The number of ZooKeeper packets received or sent by a server.
+    stability:
+      level: development
     unit: "{packets}"
     attributes: [direction]
     sum:
@@ -144,6 +172,8 @@ metrics:
   zookeeper.fsync.exceeded_threshold.count:
     enabled: true
     description: Number of times fsync duration has exceeded warning threshold.
+    stability:
+      level: development
     unit: "{events}"
     sum:
       value_type: int
@@ -152,6 +182,8 @@ metrics:
   zookeeper.ruok:
     enabled: true
     description: Response from zookeeper ruok command
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
