### PR TITLE
chore: add unroll processor to builder-config.yaml and contrib distribution

### DIFF
--- a/.chloggen/chore_add-unroll-to-builder-config.yaml
+++ b/.chloggen/chore_add-unroll-to-builder-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: unrollprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump the stability to Alpha, and include it in otelcontribcol
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42917]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -140,6 +140,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.136.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.136.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.136.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor v0.136.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor v0.136.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor v0.136.0
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Component in initial PR was marked as alpha and in the contrib as that was the intentional goal of the upstream effort. Apologies for the order of operations as the component should have been marked as development initially.

Will plan to make an upstream issue/PR for [releases](https://github.com/open-telemetry/opentelemetry-collector-releases)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42917

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<details>

<summary>make genotelcontribcol </summary>

```
2025-10:01 in opentelemetry-collector-contrib on  chore/add-unroll-to-builder-config [$!?] via 🐹 v1.25.0 using ☁️  default/iris-dev
➜ make genotelcontribcol
./internal/buildscripts/ocb-add-replaces.sh otelcontribcol
Wrote replace statements to cmd/otelcontribcol/builder-config-replaced.yaml
/Users/keithschmitt/workspace/opentelemetry-collector-contrib/.tools/builder --skip-compilation --config cmd/otelcontribcol/builder-config-replaced.yaml
2025-09-25T10:01:31.735-0400	INFO	internal/command.go:98	OpenTelemetry Collector Builder	{"version": "v0.136.0"}
2025-09-25T10:01:31.738-0400	INFO	internal/command.go:103	Using config file	{"path": "cmd/otelcontribcol/builder-config-replaced.yaml"}
2025-09-25T10:01:31.745-0400	INFO	builder/config.go:160	Using go	{"go-executable": "/opt/homebrew/Cellar/go/1.25.0/libexec/bin/go"}
2025-09-25T10:01:31.764-0400	INFO	builder/main.go:99	Sources created	{"path": "./cmd/otelcontribcol"}
2025-09-25T10:01:33.138-0400	INFO	builder/main.go:200	Getting go modules
2025-09-25T10:01:33.648-0400	INFO	builder/main.go:106	Generating source codes only, the distribution will not be compiled.

2025-10:01 in opentelemetry-collector-contrib on  chore/add-unroll-to-builder-config [$!?] via 🐹 v1.25.0 using ☁️  default/iris-dev took 8.5s
➜ echo "$?"
0
```
</details>

<details>
<summary> make generate </summary>

```
2025-09:59 in opentelemetry-collector-contrib on  chore/add-unroll-to-builder-config [$?] via 🐹 v1.25.0 using ☁️  default/iris-dev 
➜ make generate &> /dev/null

2025-10:01 in opentelemetry-collector-contrib on  chore/add-unroll-to-builder-config [$?] via 🐹 v1.25.0 using ☁️  default/iris-dev took 1m 50.1s 
➜ echo "$?"
0
```
</details>

<!--Please delete paragraphs that you did not use before submitting.-->
