### PR TITLE
[chore][expvarreceiver] Add stability level per metric

### DIFF
--- a/receiver/expvarreceiver/documentation.md
+++ b/receiver/expvarreceiver/documentation.md
@@ -18,9 +18,9 @@ Bytes of memory in profiling bucket hash tables.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.frees
 
@@ -28,9 +28,9 @@ Cumulative count of heap objects freed.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects} | Sum | Int | Cumulative | true | development |
 
 ### process.runtime.memstats.gc_cpu_fraction
 
@@ -38,9 +38,9 @@ The fraction of this program's available CPU time used by the GC since the progr
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### process.runtime.memstats.gc_sys
 
@@ -48,9 +48,9 @@ Bytes of memory in garbage collection metadata.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_alloc
 
@@ -58,9 +58,9 @@ Bytes of allocated heap objects.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_idle
 
@@ -68,9 +68,9 @@ Bytes in idle (unused) spans.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_inuse
 
@@ -78,9 +78,9 @@ Bytes in in-use spans.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_objects
 
@@ -88,9 +88,9 @@ Number of allocated heap objects.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects} | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_released
 
@@ -98,9 +98,9 @@ Bytes of physical memory returned to the OS.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.heap_sys
 
@@ -108,9 +108,9 @@ Bytes of heap memory obtained by the OS.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.last_pause
 
@@ -118,9 +118,9 @@ The most recent stop-the-world pause time.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ns | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ns | Gauge | Int | development |
 
 ### process.runtime.memstats.mallocs
 
@@ -128,9 +128,9 @@ Cumulative count of heap objects allocated.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects} | Sum | Int | Cumulative | true | development |
 
 ### process.runtime.memstats.mcache_inuse
 
@@ -138,9 +138,9 @@ Bytes of allocated mcache structures.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.mcache_sys
 
@@ -148,9 +148,9 @@ Bytes of memory obtained from the OS for mcache structures.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.mspan_inuse
 
@@ -158,9 +158,9 @@ Bytes of allocated mspan structures.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.mspan_sys
 
@@ -168,9 +168,9 @@ Bytes of memory obtained from the OS for mspan structures.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.next_gc
 
@@ -178,9 +178,9 @@ The target heap size of the next GC cycle.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.num_forced_gc
 
@@ -188,9 +188,9 @@ Number of GC cycles that were forced by the application calling the GC function.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### process.runtime.memstats.num_gc
 
@@ -198,9 +198,9 @@ Number of completed GC cycles.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### process.runtime.memstats.other_sys
 
@@ -208,9 +208,9 @@ Bytes of memory in miscellaneous off-heap runtime allocations.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.pause_total
 
@@ -218,9 +218,9 @@ The cumulative nanoseconds in GC stop-the-world pauses since the program started
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### process.runtime.memstats.stack_inuse
 
@@ -228,9 +228,9 @@ Bytes in stack spans.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.stack_sys
 
@@ -238,9 +238,9 @@ Bytes of stack memory obtained from the OS.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.sys
 
@@ -248,9 +248,9 @@ Total bytes of memory obtained from the OS.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ## Optional Metrics
 
@@ -268,9 +268,9 @@ Number of pointer lookups performed by the runtime.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {lookups} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {lookups} | Sum | Int | Cumulative | false | development |
 
 ### process.runtime.memstats.total_alloc
 
@@ -278,6 +278,6 @@ Cumulative bytes allocated for heap objects.
 
 As defined by https://pkg.go.dev/runtime#MemStats
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |

--- a/receiver/expvarreceiver/metadata.yaml
+++ b/receiver/expvarreceiver/metadata.yaml
@@ -12,6 +12,8 @@ metrics:
   process.runtime.memstats.total_alloc:
     enabled: false
     description: Cumulative bytes allocated for heap objects.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -22,6 +24,8 @@ metrics:
   process.runtime.memstats.sys:
     enabled: true
     description: Total bytes of memory obtained from the OS.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -32,6 +36,8 @@ metrics:
   process.runtime.memstats.lookups:
     enabled: false
     description: Number of pointer lookups performed by the runtime.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: "{lookups}"
     sum:
@@ -42,6 +48,8 @@ metrics:
   process.runtime.memstats.mallocs:
     enabled: true
     description: Cumulative count of heap objects allocated.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: "{objects}"
     sum:
@@ -52,6 +60,8 @@ metrics:
   process.runtime.memstats.frees:
     enabled: true
     description: Cumulative count of heap objects freed.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: "{objects}"
     sum:
@@ -62,6 +72,8 @@ metrics:
   process.runtime.memstats.heap_alloc:
     enabled: true
     description: Bytes of allocated heap objects.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -72,6 +84,8 @@ metrics:
   process.runtime.memstats.heap_sys:
     enabled: true
     description: Bytes of heap memory obtained by the OS.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -82,6 +96,8 @@ metrics:
   process.runtime.memstats.heap_idle:
     enabled: true
     description: Bytes in idle (unused) spans.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -92,6 +108,8 @@ metrics:
   process.runtime.memstats.heap_inuse:
     enabled: true
     description: Bytes in in-use spans.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -102,6 +120,8 @@ metrics:
   process.runtime.memstats.heap_released:
     enabled: true
     description: Bytes of physical memory returned to the OS.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -112,6 +132,8 @@ metrics:
   process.runtime.memstats.heap_objects:
     enabled: true
     description: Number of allocated heap objects.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: "{objects}"
     sum:
@@ -122,6 +144,8 @@ metrics:
   process.runtime.memstats.stack_inuse:
     enabled: true
     description: Bytes in stack spans.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -132,6 +156,8 @@ metrics:
   process.runtime.memstats.stack_sys:
     enabled: true
     description: Bytes of stack memory obtained from the OS.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -142,6 +168,8 @@ metrics:
   process.runtime.memstats.mspan_inuse:
     enabled: true
     description: Bytes of allocated mspan structures.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -152,6 +180,8 @@ metrics:
   process.runtime.memstats.mspan_sys:
     enabled: true
     description: Bytes of memory obtained from the OS for mspan structures.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -162,6 +192,8 @@ metrics:
   process.runtime.memstats.mcache_inuse:
     enabled: true
     description: Bytes of allocated mcache structures.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -172,6 +204,8 @@ metrics:
   process.runtime.memstats.mcache_sys:
     enabled: true
     description: Bytes of memory obtained from the OS for mcache structures.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -182,6 +216,8 @@ metrics:
   process.runtime.memstats.buck_hash_sys:
     enabled: true
     description: Bytes of memory in profiling bucket hash tables.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -192,6 +228,8 @@ metrics:
   process.runtime.memstats.gc_sys:
     enabled: true
     description: Bytes of memory in garbage collection metadata.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -202,6 +240,8 @@ metrics:
   process.runtime.memstats.other_sys:
     enabled: true
     description: Bytes of memory in miscellaneous off-heap runtime allocations.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -212,6 +252,8 @@ metrics:
   process.runtime.memstats.next_gc:
     enabled: true
     description: The target heap size of the next GC cycle.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -222,6 +264,8 @@ metrics:
   process.runtime.memstats.pause_total:
     enabled: true
     description: The cumulative nanoseconds in GC stop-the-world pauses since the program started.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -232,6 +276,8 @@ metrics:
   process.runtime.memstats.last_pause:
     enabled: true
     description: The most recent stop-the-world pause time.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: ns
     gauge:
@@ -240,6 +286,8 @@ metrics:
   process.runtime.memstats.num_gc:
     enabled: true
     description: Number of completed GC cycles.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -250,6 +298,8 @@ metrics:
   process.runtime.memstats.num_forced_gc:
     enabled: true
     description: Number of GC cycles that were forced by the application calling the GC function.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: By
     sum:
@@ -260,6 +310,8 @@ metrics:
   process.runtime.memstats.gc_cpu_fraction:
     enabled: true
     description: The fraction of this program's available CPU time used by the GC since the program started.
+    stability:
+      level: development
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
     unit: "1"
     gauge:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
