### PR TITLE
[chore][sqlserverreceiver] Add stability level per metric

### DIFF
--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -16,33 +16,33 @@ metrics:
 
 Number of batch requests received by SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {requests}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {requests}/s | Gauge | Double | development |
 
 ### sqlserver.batch.sql_compilation.rate
 
 Number of SQL compilations needed.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {compilations}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {compilations}/s | Gauge | Double | development |
 
 ### sqlserver.batch.sql_recompilation.rate
 
 Number of SQL recompilations needed.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {compilations}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {compilations}/s | Gauge | Double | development |
 
 ### sqlserver.lock.wait.rate
 
 Number of lock requests resulting in a wait.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {requests}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {requests}/s | Gauge | Double | development |
 
 ### sqlserver.lock.wait_time.avg
 
@@ -50,17 +50,17 @@ Average wait time for all lock requests that had to wait.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Double | development |
 
 ### sqlserver.page.buffer_cache.hit_ratio
 
 Pages found in the buffer pool without having to read from disk.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| % | Gauge | Double | development |
 
 ### sqlserver.page.checkpoint.flush.rate
 
@@ -68,9 +68,9 @@ Number of pages flushed by operations requiring dirty pages to be flushed.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {pages}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {pages}/s | Gauge | Double | development |
 
 ### sqlserver.page.lazy_write.rate
 
@@ -78,17 +78,17 @@ Number of lazy writes moving dirty pages to disk.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {writes}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {writes}/s | Gauge | Double | development |
 
 ### sqlserver.page.life_expectancy
 
 Time a page will stay in the buffer pool.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -102,9 +102,9 @@ Number of physical database page operations issued.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {operations}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {operations}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -118,9 +118,9 @@ Number of pages split as a result of overflowing index pages.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {pages}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {pages}/s | Gauge | Double | development |
 
 ### sqlserver.transaction.rate
 
@@ -128,9 +128,9 @@ Number of transactions started for the database (not including XTP-only transact
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {transactions}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions}/s | Gauge | Double | development |
 
 ### sqlserver.transaction.write.rate
 
@@ -138,9 +138,9 @@ Number of transactions that wrote to the database and committed.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {transactions}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions}/s | Gauge | Double | development |
 
 ### sqlserver.transaction_log.flush.data.rate
 
@@ -148,9 +148,9 @@ Total number of log bytes flushed.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 ### sqlserver.transaction_log.flush.rate
 
@@ -158,9 +158,9 @@ Number of log flushes.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {flushes}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {flushes}/s | Gauge | Double | development |
 
 ### sqlserver.transaction_log.flush.wait.rate
 
@@ -168,9 +168,9 @@ Number of commits waiting for a transaction log flush.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {commits}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {commits}/s | Gauge | Double | development |
 
 ### sqlserver.transaction_log.growth.count
 
@@ -178,9 +178,9 @@ Total number of transaction log expansions for a database.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {growths} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {growths} | Sum | Int | Cumulative | true | development |
 
 ### sqlserver.transaction_log.shrink.count
 
@@ -188,9 +188,9 @@ Total number of transaction log shrinks for a database.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {shrinks} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {shrinks} | Sum | Int | Cumulative | true | development |
 
 ### sqlserver.transaction_log.usage
 
@@ -198,17 +198,17 @@ Percent of transaction log space used.
 
 This metric is only available when running on Windows.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| % | Gauge | Int | development |
 
 ### sqlserver.user.connection.count
 
 Number of users connected to the SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {connections} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {connections} | Gauge | Int | development |
 
 ## Optional Metrics
 
@@ -224,25 +224,25 @@ metrics:
 
 Computer uptime.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {seconds} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {seconds} | Gauge | Int | development |
 
 ### sqlserver.cpu.count
 
 Number of CPUs.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {CPUs} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {CPUs} | Gauge | Int | development |
 
 ### sqlserver.database.backup_or_restore.rate
 
 Total number of backups/restores.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{backups_or_restores}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{backups_or_restores}/s” | Gauge | Double | development |
 
 ### sqlserver.database.count
 
@@ -250,9 +250,9 @@ The number of databases
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {databases} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {databases} | Gauge | Int | development |
 
 #### Attributes
 
@@ -264,17 +264,17 @@ This metric is only available when the receiver is configured to directly connec
 
 Number of execution errors.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{errors}” | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{errors}” | Gauge | Int | development |
 
 ### sqlserver.database.full_scan.rate
 
 The number of unrestricted full table or index scans.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {scans}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {scans}/s | Gauge | Double | development |
 
 ### sqlserver.database.io
 
@@ -282,9 +282,9 @@ The number of bytes of I/O on this file.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -301,9 +301,9 @@ Total time that the users waited for I/O issued on this file.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 #### Attributes
 
@@ -320,9 +320,9 @@ The number of operations issued on the file.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -337,9 +337,9 @@ This metric is only available when the receiver is configured to directly connec
 
 Total free space in temporary DB.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| “KB” | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| “KB” | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -351,33 +351,33 @@ Total free space in temporary DB.
 
 TempDB version store size.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “KB” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “KB” | Gauge | Double | development |
 
 ### sqlserver.deadlock.rate
 
 Total number of deadlocks.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{deadlocks}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{deadlocks}/s” | Gauge | Double | development |
 
 ### sqlserver.index.search.rate
 
 Total number of index searches.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{searches}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{searches}/s” | Gauge | Double | development |
 
 ### sqlserver.lock.timeout.rate
 
 Total number of lock timeouts.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{timeouts}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{timeouts}/s” | Gauge | Double | development |
 
 ### sqlserver.lock.wait.count
 
@@ -385,41 +385,41 @@ Cumulative count of lock waits that occurred.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {wait} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {wait} | Sum | Int | Cumulative | true | development |
 
 ### sqlserver.login.rate
 
 Total number of logins.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{logins}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{logins}/s” | Gauge | Double | development |
 
 ### sqlserver.logout.rate
 
 Total number of logouts.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{logouts}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{logouts}/s” | Gauge | Double | development |
 
 ### sqlserver.memory.grants.pending.count
 
 Total number of memory grants pending.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| “{grants}” | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| “{grants}” | Sum | Int | Cumulative | false | development |
 
 ### sqlserver.memory.usage
 
 Total memory in use.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| “KB” | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| “KB” | Sum | Double | Cumulative | false | development |
 
 ### sqlserver.os.wait.duration
 
@@ -427,9 +427,9 @@ Total wait time for this wait type
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 #### Attributes
 
@@ -442,17 +442,17 @@ This metric is only available when the receiver is configured to directly connec
 
 Number of free list stalls.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{stalls}/s” | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{stalls}/s” | Gauge | Int | development |
 
 ### sqlserver.page.lookup.rate
 
 Total number of page lookups.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{lookups}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{lookups}/s” | Gauge | Double | development |
 
 ### sqlserver.processes.blocked
 
@@ -460,17 +460,17 @@ The number of processes that are currently blocked
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {processes} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {processes} | Gauge | Int | development |
 
 ### sqlserver.replica.data.rate
 
 Throughput rate of replica data.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -484,9 +484,9 @@ The rate of operations issued.
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {operations}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {operations}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -500,9 +500,9 @@ The number of read operations that were throttled in the last second
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {reads}/s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {reads}/s | Gauge | Int | development |
 
 ### sqlserver.resource_pool.disk.throttled.write.rate
 
@@ -510,17 +510,17 @@ The number of write operations that were throttled in the last second
 
 This metric is only available when the receiver is configured to directly connect to SQL Server.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {writes}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {writes}/s | Gauge | Double | development |
 
 ### sqlserver.table.count
 
 The number of tables.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| “{tables}” | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| “{tables}” | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -533,17 +533,17 @@ The number of tables.
 
 Time consumed in transaction delays.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | false | development |
 
 ### sqlserver.transaction.mirror_write.rate
 
 Total number of mirror write transactions.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| “{transactions}/s” | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| “{transactions}/s” | Gauge | Double | development |
 
 ## Default Events
 

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -286,12 +286,16 @@ metrics:
   sqlserver.user.connection.count:
     enabled: true
     description: Number of users connected to the SQL Server.
+    stability:
+      level: development
     unit: "{connections}"
     gauge:
       value_type: int
   sqlserver.lock.wait_time.avg:
     enabled: true
     description: Average wait time for all lock requests that had to wait.
+    stability:
+      level: development
     unit: ms
     gauge:
       value_type: double
@@ -299,6 +303,8 @@ metrics:
   sqlserver.lock.wait.count:
     enabled: false
     description: Cumulative count of lock waits that occurred.
+    stability:
+      level: development
     unit: "{wait}"
     sum:
       monotonic: true
@@ -308,36 +314,48 @@ metrics:
   sqlserver.lock.wait.rate:
     enabled: true
     description: Number of lock requests resulting in a wait.
+    stability:
+      level: development
     unit: "{requests}/s"
     gauge:
       value_type: double
   sqlserver.batch.request.rate:
     enabled: true
     description: Number of batch requests received by SQL Server.
+    stability:
+      level: development
     unit: "{requests}/s"
     gauge:
       value_type: double
   sqlserver.batch.sql_compilation.rate:
     enabled: true
     description: Number of SQL compilations needed.
+    stability:
+      level: development
     unit: "{compilations}/s"
     gauge:
       value_type: double
   sqlserver.batch.sql_recompilation.rate:
     enabled: true
     description: Number of SQL recompilations needed.
+    stability:
+      level: development
     unit: "{compilations}/s"
     gauge:
       value_type: double
   sqlserver.page.buffer_cache.hit_ratio:
     enabled: true
     description: Pages found in the buffer pool without having to read from disk.
+    stability:
+      level: development
     unit: "%"
     gauge:
       value_type: double
   sqlserver.page.life_expectancy:
     enabled: true
     description: Time a page will stay in the buffer pool.
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -345,6 +363,8 @@ metrics:
   sqlserver.page.split.rate:
     enabled: true
     description: Number of pages split as a result of overflowing index pages.
+    stability:
+      level: development
     unit: "{pages}/s"
     gauge:
       value_type: double
@@ -352,6 +372,8 @@ metrics:
   sqlserver.page.lazy_write.rate:
     enabled: true
     description: Number of lazy writes moving dirty pages to disk.
+    stability:
+      level: development
     unit: "{writes}/s"
     gauge:
       value_type: double
@@ -359,6 +381,8 @@ metrics:
   sqlserver.page.checkpoint.flush.rate:
     enabled: true
     description: Number of pages flushed by operations requiring dirty pages to be flushed.
+    stability:
+      level: development
     unit: "{pages}/s"
     gauge:
       value_type: double
@@ -366,6 +390,8 @@ metrics:
   sqlserver.page.operation.rate:
     enabled: true
     description: Number of physical database page operations issued.
+    stability:
+      level: development
     unit: "{operations}/s"
     gauge:
       value_type: double
@@ -374,6 +400,8 @@ metrics:
   sqlserver.transaction_log.growth.count:
     enabled: true
     description: Total number of transaction log expansions for a database.
+    stability:
+      level: development
     unit: "{growths}"
     sum:
       monotonic: true
@@ -383,6 +411,8 @@ metrics:
   sqlserver.transaction_log.shrink.count:
     enabled: true
     description: Total number of transaction log shrinks for a database.
+    stability:
+      level: development
     unit: "{shrinks}"
     sum:
       monotonic: true
@@ -392,6 +422,8 @@ metrics:
   sqlserver.transaction_log.usage:
     enabled: true
     description: Percent of transaction log space used.
+    stability:
+      level: development
     unit: "%"
     gauge:
       value_type: int
@@ -399,6 +431,8 @@ metrics:
   sqlserver.transaction_log.flush.wait.rate:
     enabled: true
     description: Number of commits waiting for a transaction log flush.
+    stability:
+      level: development
     unit: "{commits}/s"
     gauge:
       value_type: double
@@ -406,6 +440,8 @@ metrics:
   sqlserver.transaction_log.flush.rate:
     enabled: true
     description: Number of log flushes.
+    stability:
+      level: development
     unit: "{flushes}/s"
     gauge:
       value_type: double
@@ -413,6 +449,8 @@ metrics:
   sqlserver.transaction_log.flush.data.rate:
     enabled: true
     description: Total number of log bytes flushed.
+    stability:
+      level: development
     unit: By/s
     gauge:
       value_type: double
@@ -420,6 +458,8 @@ metrics:
   sqlserver.transaction.rate:
     enabled: true
     description: Number of transactions started for the database (not including XTP-only transactions).
+    stability:
+      level: development
     unit: "{transactions}/s"
     gauge:
       value_type: double
@@ -427,6 +467,8 @@ metrics:
   sqlserver.transaction.write.rate:
     enabled: true
     description: Number of transactions that wrote to the database and committed.
+    stability:
+      level: development
     unit: "{transactions}/s"
     gauge:
       value_type: double
@@ -434,6 +476,8 @@ metrics:
   sqlserver.database.latency:
     enabled: false
     description: Total time that the users waited for I/O issued on this file.
+    stability:
+      level: development
     unit: "s"
     sum:
       monotonic: true
@@ -444,6 +488,8 @@ metrics:
   sqlserver.database.operations:
     enabled: false
     description: The number of operations issued on the file.
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       monotonic: true
@@ -455,6 +501,8 @@ metrics:
   sqlserver.database.io:
     enabled: false
     description: The number of bytes of I/O on this file.
+    stability:
+      level: development
     unit: "By"
     sum:
       monotonic: true
@@ -466,6 +514,8 @@ metrics:
   sqlserver.resource_pool.disk.operations:
     enabled: false
     description: The rate of operations issued.
+    stability:
+      level: development
     unit: "{operations}/s"
     gauge:
       value_type: double
@@ -474,6 +524,8 @@ metrics:
   sqlserver.resource_pool.disk.throttled.read.rate:
     enabled: false
     description: The number of read operations that were throttled in the last second
+    stability:
+      level: development
     unit: "{reads}/s"
     gauge:
       value_type: int
@@ -483,6 +535,8 @@ metrics:
   sqlserver.resource_pool.disk.throttled.write.rate:
     enabled: false
     description: The number of write operations that were throttled in the last second
+    stability:
+      level: development
     unit: "{writes}/s"
     gauge:
       value_type: double
@@ -492,6 +546,8 @@ metrics:
   sqlserver.processes.blocked:
     enabled: false
     description: The number of processes that are currently blocked
+    stability:
+      level: development
     unit: "{processes}"
     gauge:
       value_type: int
@@ -501,6 +557,8 @@ metrics:
   sqlserver.database.count:
     enabled: false
     description: The number of databases
+    stability:
+      level: development
     unit: "{databases}"
     gauge:
       value_type: int
@@ -510,6 +568,8 @@ metrics:
   sqlserver.table.count:
     enabled: false
     description: The number of tables.
+    stability:
+      level: development
     unit: “{tables}”
     sum:
       aggregation_temporality: cumulative
@@ -519,6 +579,8 @@ metrics:
   sqlserver.database.backup_or_restore.rate:
     enabled: false
     description: Total number of backups/restores.
+    stability:
+      level: development
     unit: “{backups_or_restores}/s”
     gauge:
       value_type: double
@@ -526,6 +588,8 @@ metrics:
   sqlserver.replica.data.rate:
     enabled: false
     description: Throughput rate of replica data.
+    stability:
+      level: development
     unit: By/s
     gauge:
       value_type: double
@@ -533,6 +597,8 @@ metrics:
   sqlserver.database.execution.errors:
     enabled: false
     description: Number of execution errors.
+    stability:
+      level: development
     unit: “{errors}”
     gauge:
       value_type: int
@@ -540,6 +606,8 @@ metrics:
   sqlserver.page.buffer_cache.free_list.stalls.rate:
     enabled: false
     description: Number of free list stalls.
+    stability:
+      level: development
     unit: “{stalls}/s”
     gauge:
       value_type: int
@@ -547,6 +615,8 @@ metrics:
   sqlserver.database.tempdb.space:
     enabled: false
     description: Total free space in temporary DB.
+    stability:
+      level: development
     unit: “KB”
     sum:
       monotonic: false
@@ -556,6 +626,8 @@ metrics:
   sqlserver.database.full_scan.rate:
     enabled: false
     description: The number of unrestricted full table or index scans.
+    stability:
+      level: development
     unit: "{scans}/s"
     gauge:
       value_type: double
@@ -563,6 +635,8 @@ metrics:
   sqlserver.index.search.rate:
     enabled: false
     description: Total number of index searches.
+    stability:
+      level: development
     unit: “{searches}/s”
     gauge:
       value_type: double
@@ -570,6 +644,8 @@ metrics:
   sqlserver.lock.timeout.rate:
     enabled: false
     description: Total number of lock timeouts.
+    stability:
+      level: development
     unit: “{timeouts}/s”
     gauge:
       value_type: double
@@ -577,6 +653,8 @@ metrics:
   sqlserver.login.rate:
     enabled: false
     description: Total number of logins.
+    stability:
+      level: development
     unit: “{logins}/s”
     gauge:
       value_type: double
@@ -584,6 +662,8 @@ metrics:
   sqlserver.logout.rate:
     enabled: false
     description: Total number of logouts.
+    stability:
+      level: development
     unit: “{logouts}/s”
     gauge:
       value_type: double
@@ -591,6 +671,8 @@ metrics:
   sqlserver.deadlock.rate:
     enabled: false
     description: Total number of deadlocks.
+    stability:
+      level: development
     unit: “{deadlocks}/s”
     gauge:
       value_type: double
@@ -598,6 +680,8 @@ metrics:
   sqlserver.transaction.mirror_write.rate:
     enabled: false
     description: Total number of mirror write transactions.
+    stability:
+      level: development
     unit: “{transactions}/s”
     gauge:
       value_type: double
@@ -605,6 +689,8 @@ metrics:
   sqlserver.memory.grants.pending.count:
     enabled: false
     description: Total number of memory grants pending.
+    stability:
+      level: development
     unit: “{grants}”
     sum:
       aggregation_temporality: cumulative
@@ -614,6 +700,8 @@ metrics:
   sqlserver.page.lookup.rate:
     enabled: false
     description: Total number of page lookups.
+    stability:
+      level: development
     unit: “{lookups}/s”
     gauge:
       value_type: double
@@ -621,6 +709,8 @@ metrics:
   sqlserver.transaction.delay:
     enabled: false
     description: Time consumed in transaction delays.
+    stability:
+      level: development
     unit: ms
     sum:
       aggregation_temporality: cumulative
@@ -630,6 +720,8 @@ metrics:
   sqlserver.memory.usage:
     enabled: false
     description: Total memory in use.
+    stability:
+      level: development
     unit: “KB”
     sum:
       aggregation_temporality: cumulative
@@ -639,6 +731,8 @@ metrics:
   sqlserver.database.tempdb.version_store.size:
     enabled: false
     description: TempDB version store size.
+    stability:
+      level: development
     unit: “KB”
     gauge:
       value_type: double
@@ -646,6 +740,8 @@ metrics:
   sqlserver.os.wait.duration:
     enabled: false
     description: Total wait time for this wait type
+    stability:
+      level: development
     unit: "s"
     sum:
       aggregation_temporality: cumulative
@@ -656,6 +752,8 @@ metrics:
   sqlserver.cpu.count:
     enabled: false
     description: Number of CPUs.
+    stability:
+      level: development
     unit: "{CPUs}"
     gauge:
       value_type: int
@@ -663,6 +761,8 @@ metrics:
   sqlserver.computer.uptime:
     enabled: false
     description: Computer uptime.
+    stability:
+      level: development
     unit: "{seconds}"
     gauge:
       value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
