### PR TITLE
[chore][tcpcheckreceiver] Add stability level per metric

### DIFF
--- a/receiver/tcpcheckreceiver/documentation.md
+++ b/receiver/tcpcheckreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 Measures the duration of TCP connection.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -30,9 +30,9 @@ Measures the duration of TCP connection.
 
 Records errors occurring during TCP check.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {error} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {error} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -45,9 +45,9 @@ Records errors occurring during TCP check.
 
 1 if the TCP client successfully connected, otherwise 0.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 

--- a/receiver/tcpcheckreceiver/metadata.yaml
+++ b/receiver/tcpcheckreceiver/metadata.yaml
@@ -23,6 +23,8 @@ metrics:
   tcpcheck.duration:
     description: Measures the duration of TCP connection.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -30,6 +32,8 @@ metrics:
   tcpcheck.status:
     description: 1 if the TCP client successfully connected, otherwise 0.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: "1"
@@ -37,6 +41,8 @@ metrics:
   tcpcheck.error:
     description: Records errors occurring during TCP check.
     enabled: true
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
