### PR TITLE
[chore][nginxreceiver] Add stability level per metric

### DIFF
--- a/receiver/nginxreceiver/documentation.md
+++ b/receiver/nginxreceiver/documentation.md
@@ -16,17 +16,17 @@ metrics:
 
 The total number of accepted client connections
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| connections | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| connections | Sum | Int | Cumulative | true | development |
 
 ### nginx.connections_current
 
 The current number of nginx connections by state
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| connections | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| connections | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -38,14 +38,14 @@ The current number of nginx connections by state
 
 The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| connections | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| connections | Sum | Int | Cumulative | true | development |
 
 ### nginx.requests
 
 Total number of requests made to the server since it started
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| requests | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| requests | Sum | Int | Cumulative | true | development |

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -23,6 +23,8 @@ metrics:
   nginx.requests:
     enabled: true
     description: Total number of requests made to the server since it started
+    stability:
+      level: development
     unit: requests
     sum:
       value_type: int
@@ -32,6 +34,8 @@ metrics:
   nginx.connections_accepted:
     enabled: true
     description: The total number of accepted client connections
+    stability:
+      level: development
     unit: connections
     sum:
       value_type: int
@@ -41,6 +45,8 @@ metrics:
   nginx.connections_handled:
     enabled: true
     description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
+    stability:
+      level: development
     unit: connections
     sum:
       value_type: int
@@ -50,6 +56,8 @@ metrics:
   nginx.connections_current:
     enabled: true
     description: The current number of nginx connections by state
+    stability:
+      level: development
     unit: connections
     sum:
       value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
