### PR TITLE
[chore][githubreceiver] Add stability level per metric

### DIFF
--- a/receiver/githubreceiver/documentation.md
+++ b/receiver/githubreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 The number of changes (pull requests) in a repository, categorized by their state (either open or merged).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {change} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {change} | Gauge | Int | development |
 
 #### Attributes
 
@@ -32,9 +32,9 @@ The number of changes (pull requests) in a repository, categorized by their stat
 
 The time duration a change (pull request/merge request/changelist) has been in an open state.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -49,9 +49,9 @@ The time duration a change (pull request/merge request/changelist) has been in a
 
 The amount of time it took a change (pull request) to go from open to approved.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -65,9 +65,9 @@ The amount of time it took a change (pull request) to go from open to approved.
 
 The amount of time it took a change (pull request) to go from open to merged.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -81,9 +81,9 @@ The amount of time it took a change (pull request) to go from open to merged.
 
 The number of refs of type branch in a repository.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ref} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {ref} | Gauge | Int | development |
 
 #### Attributes
 
@@ -97,9 +97,9 @@ The number of refs of type branch in a repository.
 
 The number of lines added/removed in a ref (branch) relative to the default branch (trunk).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {line} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {line} | Gauge | Int | development |
 
 #### Attributes
 
@@ -117,9 +117,9 @@ The number of lines added/removed in a ref (branch) relative to the default bran
 
 The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {revision} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {revision} | Gauge | Int | development |
 
 #### Attributes
 
@@ -137,9 +137,9 @@ The number of revisions (commits) a ref (branch) is ahead/behind the branch from
 
 Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.type` attribute will always be `branch`.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -154,9 +154,9 @@ Time a ref (branch) created from the default branch (trunk) has existed. The `vc
 
 The number of repositories in an organization.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {repository} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {repository} | Gauge | Int | development |
 
 ## Optional Metrics
 
@@ -172,9 +172,9 @@ metrics:
 
 The number of unique contributors to a repository.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {contributor} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {contributor} | Gauge | Int | development |
 
 #### Attributes
 

--- a/receiver/githubreceiver/metadata.yaml
+++ b/receiver/githubreceiver/metadata.yaml
@@ -75,6 +75,8 @@ metrics:
   vcs.repository.count:
     enabled: true
     description: The number of repositories in an organization.
+    stability:
+      level: development
     unit: "{repository}"
     gauge:
       value_type: int
@@ -82,6 +84,8 @@ metrics:
   vcs.ref.count:
     enabled: true
     description: The number of refs of type branch in a repository.
+    stability:
+      level: development
     unit: "{ref}"
     gauge:
       value_type: int
@@ -89,6 +93,8 @@ metrics:
   vcs.ref.time:
     enabled: true
     description: Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.type` attribute will always be `branch`.
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -96,6 +102,8 @@ metrics:
   vcs.ref.revisions_delta:
     enabled: true
     description: The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).
+    stability:
+      level: development
     unit: "{revision}"
     gauge:
       value_type: int
@@ -103,6 +111,8 @@ metrics:
   vcs.ref.lines_delta:
     enabled: true
     description: The number of lines added/removed in a ref (branch) relative to the default branch (trunk).
+    stability:
+      level: development
     unit: "{line}"
     gauge:
       value_type: int
@@ -110,6 +120,8 @@ metrics:
   vcs.contributor.count:
     enabled: false
     description: The number of unique contributors to a repository.
+    stability:
+      level: development
     unit: "{contributor}"
     gauge:
       value_type: int
@@ -117,6 +129,8 @@ metrics:
   vcs.change.duration:
     enabled: true
     description: The time duration a change (pull request/merge request/changelist) has been in an open state.
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -124,6 +138,8 @@ metrics:
   vcs.change.time_to_merge:
     enabled: true
     description: The amount of time it took a change (pull request) to go from open to merged.
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -131,6 +147,8 @@ metrics:
   vcs.change.time_to_approval:
     enabled: true
     description: The amount of time it took a change (pull request) to go from open to approved.
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -138,6 +156,8 @@ metrics:
   vcs.change.count:
     description: The number of changes (pull requests) in a repository, categorized by their state (either open or merged).
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: "{change}"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
