### PR TITLE
[chore][mongodbreceiver] Add stability level per metric

### DIFF
--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 The number of cache operations of the instance.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -30,17 +30,17 @@ The number of cache operations of the instance.
 
 The number of collections.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {collections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {collections} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.connection.count
 
 The number of connections.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -52,41 +52,41 @@ The number of connections.
 
 The number of open cursors maintained for clients.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {cursors} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {cursors} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.cursor.timeout.count
 
 The number of cursors that have timed out.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {cursors} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {cursors} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.data.size
 
 The size of the collection. Data compression does not affect this value.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### mongodb.database.count
 
 The number of existing databases.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {databases} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {databases} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.document.operation.count
 
 The number of document operations executed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {documents} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -98,25 +98,25 @@ The number of document operations executed.
 
 The number of extents.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {extents} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {extents} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.global_lock.time
 
 The time the global lock has been held.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 ### mongodb.index.access.count
 
 The number of times an index has been accessed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {accesses} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {accesses} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -128,25 +128,25 @@ The number of times an index has been accessed.
 
 The number of indexes.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {indexes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {indexes} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.index.size
 
 Sum of the space allocated to all indexes in the database, including free index space.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### mongodb.memory.usage
 
 The amount of memory used.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -158,41 +158,41 @@ The amount of memory used.
 
 The number of bytes received.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### mongodb.network.io.transmit
 
 The number of by transmitted.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### mongodb.network.request.count
 
 The number of requests received by the server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.object.count
 
 The number of objects.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.operation.count
 
 The number of operations executed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -204,9 +204,9 @@ The number of operations executed.
 
 The total time spent performing operations.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -218,9 +218,9 @@ The total time spent performing operations.
 
 The total number of active sessions.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {sessions} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {sessions} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.storage.size
 
@@ -228,9 +228,9 @@ The total amount of storage allocated to this collection.
 
 If collection data is compressed it reflects the compressed size.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ## Optional Metrics
 
@@ -246,49 +246,49 @@ metrics:
 
 The number of read operations currently being processed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {reads} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {reads} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.active.writes
 
 The number of write operations currently being processed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {writes} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {writes} | Sum | Int | Cumulative | false | development |
 
 ### mongodb.commands.rate
 
 The number of commands executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {command}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {command}/s | Gauge | Double | development |
 
 ### mongodb.deletes.rate
 
 The number of deletes executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {delete}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {delete}/s | Gauge | Double | development |
 
 ### mongodb.flushes.rate
 
 The number of flushes executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {flush}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {flush}/s | Gauge | Double | development |
 
 ### mongodb.getmores.rate
 
 The number of getmores executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {getmore}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {getmore}/s | Gauge | Double | development |
 
 ### mongodb.health
 
@@ -296,25 +296,25 @@ The health status of the server.
 
 A value of '1' indicates healthy. A value of '0' indicates unhealthy.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### mongodb.inserts.rate
 
 The number of insertions executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {insert}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {insert}/s | Gauge | Double | development |
 
 ### mongodb.lock.acquire.count
 
 Number of times the lock was acquired in the specified mode.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {count} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {count} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -327,9 +327,9 @@ Number of times the lock was acquired in the specified mode.
 
 Cumulative wait time for the lock acquisitions.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| microseconds | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| microseconds | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -342,9 +342,9 @@ Cumulative wait time for the lock acquisitions.
 
 Number of times the lock acquisitions encountered waits because the locks were held in a conflicting mode.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {count} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {count} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -357,9 +357,9 @@ Number of times the lock acquisitions encountered waits because the locks were h
 
 Number of times the lock acquisitions encountered deadlocks.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {count} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {count} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -372,9 +372,9 @@ Number of times the lock acquisitions encountered deadlocks.
 
 The latency of operations.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| us | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| us | Gauge | Int | development |
 
 #### Attributes
 
@@ -386,9 +386,9 @@ The latency of operations.
 
 The number of replicated operations executed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -400,89 +400,89 @@ The number of replicated operations executed.
 
 The number of page faults.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {faults} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {faults} | Sum | Int | Cumulative | true | development |
 
 ### mongodb.queries.rate
 
 The number of queries executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {query}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {query}/s | Gauge | Double | development |
 
 ### mongodb.repl_commands_per_sec
 
 The number of replicated commands executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {command}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {command}/s | Gauge | Double | development |
 
 ### mongodb.repl_deletes_per_sec
 
 The number of replicated deletes executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {delete}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {delete}/s | Gauge | Double | development |
 
 ### mongodb.repl_getmores_per_sec
 
 The number of replicated getmores executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {getmore}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {getmore}/s | Gauge | Double | development |
 
 ### mongodb.repl_inserts_per_sec
 
 The number of replicated insertions executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {insert}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {insert}/s | Gauge | Double | development |
 
 ### mongodb.repl_queries_per_sec
 
 The number of replicated queries executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {query}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {query}/s | Gauge | Double | development |
 
 ### mongodb.repl_updates_per_sec
 
 The number of replicated updates executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {update}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {update}/s | Gauge | Double | development |
 
 ### mongodb.updates.rate
 
 The number of updates executed per second.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {update}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {update}/s | Gauge | Double | development |
 
 ### mongodb.uptime
 
 The amount of time that the server has been running.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Int | Cumulative | true | development |
 
 ### mongodb.wtcache.bytes.read
 
 The number of bytes read into the WiredTiger cache.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ## Resource Attributes
 

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -90,6 +90,8 @@ attributes:
 metrics:
   mongodb.cache.operations:
     description: The number of cache operations of the instance.
+    stability:
+      level: development
     unit: "{operations}"
     enabled: true
     sum:
@@ -99,6 +101,8 @@ metrics:
     attributes: [type]
   mongodb.collection.count:
     description: The number of collections.
+    stability:
+      level: development
     unit: "{collections}"
     enabled: true
     sum:
@@ -108,6 +112,8 @@ metrics:
     attributes: []
   mongodb.data.size:
     description: The size of the collection. Data compression does not affect this value.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -117,6 +123,8 @@ metrics:
     attributes: []
   mongodb.connection.count:
     description: The number of connections.
+    stability:
+      level: development
     unit: "{connections}"
     enabled: true
     sum:
@@ -126,6 +134,8 @@ metrics:
     attributes: [connection_type]
   mongodb.extent.count:
     description: The number of extents.
+    stability:
+      level: development
     unit: "{extents}"
     enabled: true
     sum:
@@ -135,6 +145,8 @@ metrics:
     attributes: []
   mongodb.global_lock.time:
     description: The time the global lock has been held.
+    stability:
+      level: development
     unit: ms
     enabled: true
     sum:
@@ -144,6 +156,8 @@ metrics:
     attributes: []
   mongodb.index.count:
     description: The number of indexes.
+    stability:
+      level: development
     unit: "{indexes}"
     enabled: true
     sum:
@@ -153,6 +167,8 @@ metrics:
     attributes: []
   mongodb.index.size:
     description: Sum of the space allocated to all indexes in the database, including free index space.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -162,6 +178,8 @@ metrics:
     attributes: []
   mongodb.memory.usage:
     description: The amount of memory used.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -171,6 +189,8 @@ metrics:
     attributes: [memory_type]
   mongodb.object.count:
     description: The number of objects.
+    stability:
+      level: development
     unit: "{objects}"
     enabled: true
     sum:
@@ -180,6 +200,8 @@ metrics:
     attributes: []
   mongodb.operation.latency.time:
     description: The latency of operations.
+    stability:
+      level: development
     unit: us
     enabled: false
     gauge:
@@ -187,6 +209,8 @@ metrics:
     attributes: [operation_latency]
   mongodb.operation.count:
     description: The number of operations executed.
+    stability:
+      level: development
     unit: "{operations}"
     enabled: true
     sum:
@@ -196,6 +220,8 @@ metrics:
     attributes: [operation]
   mongodb.operation.repl.count:
     description: The number of replicated operations executed.
+    stability:
+      level: development
     unit: "{operations}"
     enabled: false
     sum:
@@ -206,6 +232,8 @@ metrics:
   mongodb.storage.size:
     description: The total amount of storage allocated to this collection.
     extended_documentation: If collection data is compressed it reflects the compressed size.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -215,6 +243,8 @@ metrics:
     attributes: []
   mongodb.database.count:
     description: The number of existing databases.
+    stability:
+      level: development
     unit: "{databases}"
     enabled: true
     sum:
@@ -224,6 +254,8 @@ metrics:
     attributes: []
   mongodb.index.access.count:
     description: The number of times an index has been accessed.
+    stability:
+      level: development
     unit: "{accesses}"
     enabled: true
     sum:
@@ -233,6 +265,8 @@ metrics:
     attributes: [collection]
   mongodb.document.operation.count:
     description: The number of document operations executed.
+    stability:
+      level: development
     unit: "{documents}"
     enabled: true
     sum:
@@ -242,6 +276,8 @@ metrics:
     attributes: [operation]
   mongodb.network.io.receive:
     description: The number of bytes received.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -251,6 +287,8 @@ metrics:
     attributes: []
   mongodb.network.io.transmit:
     description: The number of by transmitted.
+    stability:
+      level: development
     unit: By
     enabled: true
     sum:
@@ -260,6 +298,8 @@ metrics:
     attributes: []
   mongodb.network.request.count:
     description: The number of requests received by the server.
+    stability:
+      level: development
     unit: "{requests}"
     enabled: true
     sum:
@@ -269,6 +309,8 @@ metrics:
     attributes: []
   mongodb.operation.time:
     description: The total time spent performing operations.
+    stability:
+      level: development
     unit: ms
     enabled: true
     sum:
@@ -278,6 +320,8 @@ metrics:
     attributes: [operation]
   mongodb.session.count:
     description: The total number of active sessions.
+    stability:
+      level: development
     unit: "{sessions}"
     enabled: true
     sum:
@@ -287,6 +331,8 @@ metrics:
     attributes: []
   mongodb.cursor.count:
     description: The number of open cursors maintained for clients.
+    stability:
+      level: development
     unit: "{cursors}"
     enabled: true
     sum:
@@ -296,6 +342,8 @@ metrics:
     attributes: []
   mongodb.cursor.timeout.count:
     description: The number of cursors that have timed out.
+    stability:
+      level: development
     unit: "{cursors}"
     enabled: true
     sum:
@@ -305,6 +353,8 @@ metrics:
     attributes: []
   mongodb.lock.acquire.count:
     description: Number of times the lock was acquired in the specified mode.
+    stability:
+      level: development
     unit: "{count}"
     enabled: false
     sum:
@@ -314,6 +364,8 @@ metrics:
     attributes: [lock_type, lock_mode]
   mongodb.lock.acquire.wait_count:
     description: Number of times the lock acquisitions encountered waits because the locks were held in a conflicting mode.
+    stability:
+      level: development
     unit: "{count}"
     enabled: false
     sum:
@@ -323,6 +375,8 @@ metrics:
     attributes: [lock_type, lock_mode]
   mongodb.lock.acquire.time:
     description: Cumulative wait time for the lock acquisitions.
+    stability:
+      level: development
     unit: "microseconds"
     enabled: false
     sum:
@@ -332,6 +386,8 @@ metrics:
     attributes: [lock_type, lock_mode]
   mongodb.lock.deadlock.count:
     description: Number of times the lock acquisitions encountered deadlocks.
+    stability:
+      level: development
     unit: "{count}"
     enabled: false
     sum:
@@ -344,6 +400,8 @@ metrics:
     description: The health status of the server.
     extended_documentation: A value of '1' indicates healthy.
       A value of '0' indicates unhealthy.
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -351,6 +409,8 @@ metrics:
   mongodb.uptime:
     enabled: false
     description: The amount of time that the server has been running.
+    stability:
+      level: development
     unit: ms
     sum:
       value_type: int
@@ -359,6 +419,8 @@ metrics:
     attributes: []
   mongodb.repl_queries_per_sec:
     description: The number of replicated queries executed per second.
+    stability:
+      level: development
     unit: "{query}/s"
     enabled: false
     gauge:
@@ -367,6 +429,8 @@ metrics:
       monotonic: false
   mongodb.repl_inserts_per_sec:
     description: The number of replicated insertions executed per second.
+    stability:
+      level: development
     unit: "{insert}/s"
     enabled: false
     gauge:
@@ -375,6 +439,8 @@ metrics:
       monotonic: false
   mongodb.repl_commands_per_sec:
     description: The number of replicated commands executed per second.
+    stability:
+      level: development
     unit: "{command}/s"
     enabled: false
     gauge:
@@ -383,6 +449,8 @@ metrics:
       monotonic: false
   mongodb.repl_getmores_per_sec:
     description: The number of replicated getmores executed per second.
+    stability:
+      level: development
     unit: "{getmore}/s"
     enabled: false
     gauge:
@@ -391,6 +459,8 @@ metrics:
       monotonic: false
   mongodb.repl_deletes_per_sec:
     description: The number of replicated deletes executed per second.
+    stability:
+      level: development
     unit: "{delete}/s"
     enabled: false
     gauge:
@@ -399,6 +469,8 @@ metrics:
       monotonic: false
   mongodb.repl_updates_per_sec:
     description: The number of replicated updates executed per second.
+    stability:
+      level: development
     unit: "{update}/s"
     enabled: false
     gauge:
@@ -407,6 +479,8 @@ metrics:
       monotonic: false
   mongodb.queries.rate:
     description: The number of queries executed per second.
+    stability:
+      level: development
     unit: "{query}/s"
     enabled: false
     gauge:
@@ -415,6 +489,8 @@ metrics:
       monotonic: false
   mongodb.inserts.rate:
     description: The number of insertions executed per second.
+    stability:
+      level: development
     unit: "{insert}/s"
     enabled: false
     gauge:
@@ -423,6 +499,8 @@ metrics:
       monotonic: false
   mongodb.commands.rate:
     description: The number of commands executed per second.
+    stability:
+      level: development
     unit: "{command}/s"
     enabled: false
     gauge:
@@ -431,6 +509,8 @@ metrics:
       monotonic: false
   mongodb.getmores.rate:
     description: The number of getmores executed per second.
+    stability:
+      level: development
     unit: "{getmore}/s"
     enabled: false
     gauge:
@@ -439,6 +519,8 @@ metrics:
       monotonic: false
   mongodb.deletes.rate:
     description: The number of deletes executed per second.
+    stability:
+      level: development
     unit: "{delete}/s"
     enabled: false
     gauge:
@@ -447,6 +529,8 @@ metrics:
       monotonic: false
   mongodb.updates.rate:
     description: The number of updates executed per second.
+    stability:
+      level: development
     unit: "{update}/s"
     enabled: false
     gauge:
@@ -455,6 +539,8 @@ metrics:
       monotonic: false
   mongodb.flushes.rate:
     description: The number of flushes executed per second.
+    stability:
+      level: development
     unit: "{flush}/s"
     enabled: false
     gauge:
@@ -463,6 +549,8 @@ metrics:
       monotonic: false
   mongodb.active.writes:
     description: The number of write operations currently being processed.
+    stability:
+      level: development
     unit: "{writes}"
     enabled: false
     sum:
@@ -472,6 +560,8 @@ metrics:
     attributes: []
   mongodb.active.reads:
     description: The number of read operations currently being processed.
+    stability:
+      level: development
     unit: "{reads}"
     enabled: false
     sum:
@@ -481,6 +571,8 @@ metrics:
     attributes: []
   mongodb.wtcache.bytes.read:
     description: The number of bytes read into the WiredTiger cache.
+    stability:
+      level: development
     unit: "By"
     enabled: false
     sum:
@@ -490,6 +582,8 @@ metrics:
     attributes: []
   mongodb.page_faults:
     description: The number of page faults.
+    stability:
+      level: development
     unit: "{faults}"
     enabled: false
     sum:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
