### PR TITLE
[chore][podmanreceiver] Add stability level per metric

### DIFF
--- a/receiver/podmanreceiver/documentation.md
+++ b/receiver/podmanreceiver/documentation.md
@@ -18,9 +18,9 @@ Number of bytes transferred from the disk by the container
 
 [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt).
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 ### container.blockio.io_service_bytes_recursive.write
 
@@ -28,25 +28,25 @@ Number of bytes transferred to the disk by the container
 
 [More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt).
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | true | development |
 
 ### container.cpu.percent
 
 Percent of CPU used by the container.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### container.cpu.usage.percpu
 
 Total CPU time consumed per CPU-core.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -58,57 +58,57 @@ Total CPU time consumed per CPU-core.
 
 System CPU usage.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 ### container.cpu.usage.total
 
 Total CPU time consumed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Int | Cumulative | true | development |
 
 ### container.memory.percent
 
 Percentage of memory used.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### container.memory.usage.limit
 
 Memory limit of the container.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### container.memory.usage.total
 
 Memory usage of the container.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### container.network.io.usage.rx_bytes
 
 Bytes received by the container.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### container.network.io.usage.tx_bytes
 
 Bytes sent by the container.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ## Resource Attributes
 

--- a/receiver/podmanreceiver/metadata.yaml
+++ b/receiver/podmanreceiver/metadata.yaml
@@ -37,6 +37,8 @@ metrics:
   container.cpu.usage.system:
     enabled: true
     description: "System CPU usage."
+    stability:
+      level: development
     unit: s
     sum:
       value_type: int
@@ -45,6 +47,8 @@ metrics:
   container.cpu.usage.total:
     enabled: true
     description: "Total CPU time consumed."
+    stability:
+      level: development
     unit: s
     sum:
       value_type: int
@@ -53,6 +57,8 @@ metrics:
   container.cpu.usage.percpu:
     enabled: true
     description: "Total CPU time consumed per CPU-core."
+    stability:
+      level: development
     unit: s
     sum:
       value_type: int
@@ -63,6 +69,8 @@ metrics:
   container.cpu.percent:
     enabled: true
     description: "Percent of CPU used by the container."
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -70,6 +78,8 @@ metrics:
   container.memory.usage.limit:
     enabled: true
     description: "Memory limit of the container."
+    stability:
+      level: development
     unit: By
     sum:
       value_type: int
@@ -78,6 +88,8 @@ metrics:
   container.memory.usage.total:
     enabled: true
     description: "Memory usage of the container."
+    stability:
+      level: development
     unit: By
     sum:
       value_type: int
@@ -86,6 +98,8 @@ metrics:
   container.memory.percent:
     enabled: true
     description: "Percentage of memory used."
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: double
@@ -93,6 +107,8 @@ metrics:
   container.network.io.usage.rx_bytes:
     enabled: true
     description: "Bytes received by the container."
+    stability:
+      level: development
     unit: By
     sum:
       value_type: int
@@ -101,6 +117,8 @@ metrics:
   container.network.io.usage.tx_bytes:
     enabled: true
     description: "Bytes sent by the container."
+    stability:
+      level: development
     unit: By
     sum:
       value_type: int
@@ -111,6 +129,8 @@ metrics:
     enabled: true
     description: "Number of bytes transferred from the disk by the container"
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       value_type: int
@@ -120,6 +140,8 @@ metrics:
     enabled: true
     description: "Number of bytes transferred to the disk by the container"
     extended_documentation: "[More docs](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)."
+    stability:
+      level: development
     unit: "{operations}"
     sum:
       value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
