### PR TITLE
[chore][kafkametricsreceiver] Add stability level per metric

### DIFF
--- a/receiver/kafkametricsreceiver/documentation.md
+++ b/receiver/kafkametricsreceiver/documentation.md
@@ -16,17 +16,17 @@ metrics:
 
 Number of brokers in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {brokers} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {brokers} | Sum | Int | Cumulative | false | development |
 
 ### kafka.consumer_group.lag
 
 Current approximate lag of consumer group at partition of topic
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -40,9 +40,9 @@ Current approximate lag of consumer group at partition of topic
 
 Current approximate sum of consumer group lag across all partitions of topic
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -55,9 +55,9 @@ Current approximate sum of consumer group lag across all partitions of topic
 
 Count of members in the consumer group
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {members} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {members} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -69,9 +69,9 @@ Count of members in the consumer group
 
 Current offset of the consumer group at partition of topic
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -85,9 +85,9 @@ Current offset of the consumer group at partition of topic
 
 Sum of consumer group offset across partitions of topic
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -100,9 +100,9 @@ Sum of consumer group offset across partitions of topic
 
 Current offset of partition of topic.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -115,9 +115,9 @@ Current offset of partition of topic.
 
 Oldest offset of partition of topic
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 
@@ -130,9 +130,9 @@ Oldest offset of partition of topic
 
 Number of replicas for partition of topic
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {replicas} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {replicas} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -145,9 +145,9 @@ Number of replicas for partition of topic
 
 Number of synchronized replicas of partition
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {replicas} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {replicas} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -160,9 +160,9 @@ Number of synchronized replicas of partition
 
 Number of partitions in topic.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {partitions} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {partitions} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -184,9 +184,9 @@ metrics:
 
 log retention time (s) of a broker.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -198,9 +198,9 @@ log retention time (s) of a broker.
 
 log retention period of a topic (s).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -212,9 +212,9 @@ log retention period of a topic (s).
 
 log retention size of a topic in Bytes, The value (-1) indicates infinite size.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -226,9 +226,9 @@ log retention size of a topic in Bytes, The value (-1) indicates infinite size.
 
 minimum in-sync replicas of a topic.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {replicas} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {replicas} | Gauge | Int | development |
 
 #### Attributes
 
@@ -240,9 +240,9 @@ minimum in-sync replicas of a topic.
 
 replication factor of a topic.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 #### Attributes
 

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -33,6 +33,8 @@ metrics:
   kafka.brokers:
     enabled: true
     description: Number of brokers in the cluster.
+    stability:
+      level: development
     unit: "{brokers}"
     sum:
       monotonic: false
@@ -41,6 +43,8 @@ metrics:
   kafka.broker.log_retention_period:
     enabled: false
     description: log retention time (s) of a broker.
+    stability:
+      level: development
     unit: "s"
     gauge:
       value_type: int
@@ -49,6 +53,8 @@ metrics:
   kafka.topic.partitions:
     enabled: true
     description: Number of partitions in topic.
+    stability:
+      level: development
     unit: "{partitions}"
     sum:
       monotonic: false
@@ -58,6 +64,8 @@ metrics:
   kafka.topic.replication_factor:
     enabled: false
     description: replication factor of a topic.
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -65,6 +73,8 @@ metrics:
   kafka.topic.log_retention_period:
     enabled: false
     description: log retention period of a topic (s).
+    stability:
+      level: development
     unit: s
     gauge:
       value_type: int
@@ -72,6 +82,8 @@ metrics:
   kafka.topic.log_retention_size:
     enabled: false
     description: log retention size of a topic in Bytes, The value (-1) indicates infinite size.
+    stability:
+      level: development
     unit: By
     gauge:
       value_type: int
@@ -79,6 +91,8 @@ metrics:
   kafka.topic.min_insync_replicas:
     enabled: false
     description: minimum in-sync replicas of a topic.
+    stability:
+      level: development
     unit: "{replicas}"
     gauge:
       value_type: int
@@ -86,6 +100,8 @@ metrics:
   kafka.partition.current_offset:
     enabled: true
     description: Current offset of partition of topic.
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -93,6 +109,8 @@ metrics:
   kafka.partition.oldest_offset:
     enabled: true
     description: Oldest offset of partition of topic
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -100,6 +118,8 @@ metrics:
   kafka.partition.replicas:
     enabled: true
     description: Number of replicas for partition of topic
+    stability:
+      level: development
     unit: "{replicas}"
     sum:
       monotonic: false
@@ -109,6 +129,8 @@ metrics:
   kafka.partition.replicas_in_sync:
     enabled: true
     description: Number of synchronized replicas of partition
+    stability:
+      level: development
     unit: "{replicas}"
     sum:
       monotonic: false
@@ -119,6 +141,8 @@ metrics:
   kafka.consumer_group.members:
     enabled: true
     description: Count of members in the consumer group
+    stability:
+      level: development
     unit: "{members}"
     sum:
       monotonic: false
@@ -128,6 +152,8 @@ metrics:
   kafka.consumer_group.offset:
     enabled: true
     description: Current offset of the consumer group at partition of topic
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -135,6 +161,8 @@ metrics:
   kafka.consumer_group.offset_sum:
     enabled: true
     description: Sum of consumer group offset across partitions of topic
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -142,6 +170,8 @@ metrics:
   kafka.consumer_group.lag:
     enabled: true
     description: Current approximate lag of consumer group at partition of topic
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int
@@ -149,6 +179,8 @@ metrics:
   kafka.consumer_group.lag_sum:
     enabled: true
     description: Current approximate sum of consumer group lag across all partitions of topic
+    stability:
+      level: development
     unit: "1"
     gauge:
       value_type: int


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
