### PR TITLE
[chore][sshcheckreceiver] Add stability level per metric

### DIFF
--- a/receiver/sshcheckreceiver/documentation.md
+++ b/receiver/sshcheckreceiver/documentation.md
@@ -16,17 +16,17 @@ metrics:
 
 Measures the duration of SSH connection.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### sshcheck.error
 
 Records errors occurring during SSH check.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {error} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {error} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -38,9 +38,9 @@ Records errors occurring during SSH check.
 
 1 if the SSH client successfully connected, otherwise 0.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 ## Optional Metrics
 
@@ -56,17 +56,17 @@ metrics:
 
 Measures SFTP request duration.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### sshcheck.sftp_error
 
 Records errors occurring during SFTP check.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {error} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {error} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -78,9 +78,9 @@ Records errors occurring during SFTP check.
 
 1 if the SFTP server replied to request, otherwise 0.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 ## Resource Attributes
 

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -22,6 +22,8 @@ metrics:
   sshcheck.status:
     description: 1 if the SSH client successfully connected, otherwise 0.
     enabled: true
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -30,12 +32,16 @@ metrics:
   sshcheck.duration:
     description: Measures the duration of SSH connection.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
   sshcheck.error:
     description: Records errors occurring during SSH check.
     enabled: true
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -45,6 +51,8 @@ metrics:
   sshcheck.sftp_status:
     description: 1 if the SFTP server replied to request, otherwise 0.
     enabled: false
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -53,12 +61,16 @@ metrics:
   sshcheck.sftp_duration:
     description: Measures SFTP request duration.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
   sshcheck.sftp_error:
     description: Records errors occurring during SFTP check.
     enabled: false
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
