### PR TITLE
[chore][mongodbatlasreceiver] Add stability level per metric

### DIFF
--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -18,9 +18,9 @@ Database feature size
 
 Aggregate of MongoDB Metrics DATABASE_EXTENT_COUNT, DATABASE_VIEW_COUNT, DATABASE_COLLECTION_COUNT, DATABASE_OBJECT_COUNT, DATABASE_INDEX_COUNT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {objects} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {objects} | Gauge | Double | development |
 
 #### Attributes
 
@@ -34,9 +34,9 @@ Database feature size
 
 Aggregate of MongoDB Metrics DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_AVERAGE_OBJECT_SIZE
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -50,9 +50,9 @@ Disk partition iops
 
 Aggregate of MongoDB Metrics DISK_PARTITION_IOPS_READ, DISK_PARTITION_IOPS_WRITE, DISK_PARTITION_IOPS_TOTAL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ops}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {ops}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -66,9 +66,9 @@ Disk partition iops
 
 Aggregate of MongoDB Metrics MAX_DISK_PARTITION_IOPS_WRITE, MAX_DISK_PARTITION_IOPS_TOTAL, MAX_DISK_PARTITION_IOPS_READ
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ops}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {ops}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -82,9 +82,9 @@ Disk partition latency
 
 Aggregate of MongoDB Metrics DISK_PARTITION_LATENCY_WRITE, DISK_PARTITION_LATENCY_READ
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Double | development |
 
 #### Attributes
 
@@ -98,9 +98,9 @@ Disk partition latency
 
 Aggregate of MongoDB Metrics MAX_DISK_PARTITION_LATENCY_WRITE, MAX_DISK_PARTITION_LATENCY_READ
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Double | development |
 
 #### Attributes
 
@@ -114,9 +114,9 @@ Disk partition space
 
 Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -130,9 +130,9 @@ Disk partition space
 
 Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -146,9 +146,9 @@ Disk partition usage (%)
 
 Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -162,9 +162,9 @@ Disk partition usage (%)
 
 Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -178,9 +178,9 @@ The percentage of time during which requests are being issued to and serviced by
 
 MongoDB Metrics DISK_PARTITION_UTILIZATION
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### mongodbatlas.disk.partition.utilization.max
 
@@ -188,9 +188,9 @@ The maximum percentage of time during which requests are being issued to and ser
 
 MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### mongodbatlas.process.asserts
 
@@ -198,9 +198,9 @@ Number of assertions per second
 
 Aggregate of MongoDB Metrics ASSERT_REGULAR, ASSERT_USER, ASSERT_MSG, ASSERT_WARNING
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {assertions}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {assertions}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -214,9 +214,9 @@ Amount of data flushed in the background
 
 MongoDB Metric BACKGROUND_FLUSH_AVG
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### mongodbatlas.process.cache.io
 
@@ -224,9 +224,9 @@ Cache throughput (per second)
 
 Aggregate of MongoDB Metrics CACHE_BYTES_READ_INTO, CACHE_BYTES_WRITTEN_FROM
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -240,9 +240,9 @@ Cache sizes
 
 Aggregate of MongoDB Metrics CACHE_USED_BYTES, CACHE_DIRTY_BYTES
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -256,9 +256,9 @@ Number of current connections
 
 MongoDB Metric CONNECTIONS
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Double | Cumulative | false | development |
 
 ### mongodbatlas.process.cpu.children.normalized.usage.average
 
@@ -266,9 +266,9 @@ CPU Usage for child processes, normalized to pct
 
 Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -282,9 +282,9 @@ CPU Usage for child processes, normalized to pct
 
 Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -298,9 +298,9 @@ CPU Usage for child processes (%)
 
 Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -314,9 +314,9 @@ CPU Usage for child processes (%)
 
 Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -330,9 +330,9 @@ CPU Usage, normalized to pct
 
 Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -346,9 +346,9 @@ CPU Usage, normalized to pct
 
 Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -362,9 +362,9 @@ CPU Usage (%)
 
 Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -378,9 +378,9 @@ CPU Usage (%)
 
 Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -394,9 +394,9 @@ Number of cursors
 
 Aggregate of MongoDB Metrics CURSORS_TOTAL_OPEN, CURSORS_TOTAL_TIMED_OUT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {cursors} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {cursors} | Gauge | Double | development |
 
 #### Attributes
 
@@ -410,9 +410,9 @@ Document access rates
 
 Aggregate of MongoDB Metrics DOCUMENT_METRICS_UPDATED, DOCUMENT_METRICS_DELETED, DOCUMENT_METRICS_RETURNED, DOCUMENT_METRICS_INSERTED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {documents}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {documents}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -426,9 +426,9 @@ DB Operation Rates
 
 Aggregate of MongoDB Metrics OPCOUNTER_GETMORE, OPERATIONS_SCAN_AND_ORDER, OPCOUNTER_UPDATE, OPCOUNTER_REPL_UPDATE, OPCOUNTER_CMD, OPCOUNTER_DELETE, OPCOUNTER_REPL_DELETE, OPCOUNTER_REPL_CMD, OPCOUNTER_QUERY, OPCOUNTER_REPL_INSERT, OPCOUNTER_INSERT, OPCOUNTER_TTL_DELETED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {operations}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {operations}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -443,9 +443,9 @@ DB Operation Times
 
 Aggregate of MongoDB Metrics OP_EXECUTION_TIME_WRITES, OP_EXECUTION_TIME_COMMANDS, OP_EXECUTION_TIME_READS
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| ms | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| ms | Sum | Double | Cumulative | true | development |
 
 #### Attributes
 
@@ -459,9 +459,9 @@ Scanned objects
 
 Aggregate of MongoDB Metrics QUERY_EXECUTOR_SCANNED_OBJECTS, QUERY_EXECUTOR_SCANNED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {objects}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {objects}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -475,9 +475,9 @@ Scanned objects per returned
 
 Aggregate of MongoDB Metrics QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED, QUERY_TARGETING_SCANNED_PER_RETURNED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {scanned}/{returned} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {scanned}/{returned} | Gauge | Double | development |
 
 #### Attributes
 
@@ -491,9 +491,9 @@ Storage used by the database
 
 Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, DB_STORAGE_TOTAL, DB_DATA_SIZE_TOTAL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -507,9 +507,9 @@ Number and status of locks
 
 Aggregate of MongoDB Metrics GLOBAL_LOCK_CURRENT_QUEUE_WRITERS, GLOBAL_LOCK_CURRENT_QUEUE_READERS, GLOBAL_LOCK_CURRENT_QUEUE_TOTAL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {locks} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Double | development |
 
 #### Attributes
 
@@ -523,9 +523,9 @@ Index miss ratio (%)
 
 MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### mongodbatlas.process.index.counters
 
@@ -533,9 +533,9 @@ Indexes
 
 Aggregate of MongoDB Metrics INDEX_COUNTERS_BTREE_MISSES, INDEX_COUNTERS_BTREE_ACCESSES, INDEX_COUNTERS_BTREE_HITS
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {indexes} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {indexes} | Gauge | Double | development |
 
 #### Attributes
 
@@ -549,9 +549,9 @@ Journaling commits
 
 MongoDB Metric JOURNALING_COMMITS_IN_WRITE_LOCK
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {commits} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {commits} | Gauge | Double | development |
 
 ### mongodbatlas.process.journaling.data_files
 
@@ -559,9 +559,9 @@ Data file sizes
 
 MongoDB Metric JOURNALING_WRITE_DATA_FILES_MB
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| MiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| MiBy | Gauge | Double | development |
 
 ### mongodbatlas.process.journaling.written
 
@@ -569,9 +569,9 @@ Journals written
 
 MongoDB Metric JOURNALING_MB
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| MiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| MiBy | Gauge | Double | development |
 
 ### mongodbatlas.process.memory.usage
 
@@ -579,9 +579,9 @@ Memory Usage
 
 Aggregate of MongoDB Metrics MEMORY_MAPPED, MEMORY_VIRTUAL, COMPUTED_MEMORY, MEMORY_RESIDENT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 #### Attributes
 
@@ -595,9 +595,9 @@ Network IO
 
 Aggregate of MongoDB Metrics NETWORK_BYTES_OUT, NETWORK_BYTES_IN
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -611,9 +611,9 @@ Network requests
 
 MongoDB Metric NETWORK_NUM_REQUESTS
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Double | Cumulative | true | development |
 
 ### mongodbatlas.process.oplog.rate
 
@@ -621,9 +621,9 @@ Execution rate by operation
 
 MongoDB Metric OPLOG_RATE_GB_PER_HOUR
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| GiBy/h | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| GiBy/h | Gauge | Double | development |
 
 ### mongodbatlas.process.oplog.time
 
@@ -631,9 +631,9 @@ Execution time by operation
 
 Aggregate of MongoDB Metrics OPLOG_MASTER_TIME, OPLOG_SLAVE_LAG_MASTER_TIME, OPLOG_MASTER_LAG_TIME_DIFF
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Double | development |
 
 #### Attributes
 
@@ -647,9 +647,9 @@ Page faults
 
 Aggregate of MongoDB Metrics GLOBAL_PAGE_FAULT_EXCEPTIONS_THROWN, EXTRA_INFO_PAGE_FAULTS, GLOBAL_ACCESSES_NOT_IN_MEMORY
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {faults}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {faults}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -663,9 +663,9 @@ Restarts in last hour
 
 Aggregate of MongoDB Metrics RESTARTS_IN_LAST_HOUR
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {restarts}/h | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {restarts}/h | Gauge | Double | development |
 
 ### mongodbatlas.process.tickets
 
@@ -673,9 +673,9 @@ Tickets
 
 Aggregate of MongoDB Metrics TICKETS_AVAILABLE_WRITE, TICKETS_AVAILABLE_READS
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {tickets} | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {tickets} | Gauge | Double | development |
 
 #### Attributes
 
@@ -689,9 +689,9 @@ System CPU Normalized to pct
 
 Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -705,9 +705,9 @@ System CPU Normalized to pct
 
 Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -721,9 +721,9 @@ System CPU Usage (%)
 
 Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -737,9 +737,9 @@ System CPU Usage (%)
 
 Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -753,9 +753,9 @@ Full text search disk usage (%)
 
 Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -769,9 +769,9 @@ Full-text search (%)
 
 Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 #### Attributes
 
@@ -785,9 +785,9 @@ Full text search disk usage
 
 MongoDB Metric FTS_DISK_USAGE
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Double | development |
 
 ### mongodbatlas.system.fts.memory.usage
 
@@ -795,9 +795,9 @@ Full-text search
 
 Aggregate of MongoDB Metrics FTS_MEMORY_MAPPED, FTS_PROCESS_SHARED_MEMORY, FTS_PROCESS_RESIDENT_MEMORY, FTS_PROCESS_VIRTUAL_MEMORY
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| MiBy | Sum | Double | Cumulative | true | development |
 
 #### Attributes
 
@@ -811,9 +811,9 @@ System Memory Usage
 
 Aggregate of MongoDB Metrics SYSTEM_MEMORY_AVAILABLE, SYSTEM_MEMORY_BUFFERS, SYSTEM_MEMORY_USED, SYSTEM_MEMORY_CACHED, SYSTEM_MEMORY_SHARED, SYSTEM_MEMORY_FREE
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| KiBy | Gauge | Double | development |
 
 #### Attributes
 
@@ -827,9 +827,9 @@ System Memory Usage
 
 Aggregate of MongoDB Metrics MAX_SYSTEM_MEMORY_CACHED, MAX_SYSTEM_MEMORY_AVAILABLE, MAX_SYSTEM_MEMORY_USED, MAX_SYSTEM_MEMORY_BUFFERS, MAX_SYSTEM_MEMORY_FREE, MAX_SYSTEM_MEMORY_SHARED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| KiBy | Gauge | Double | development |
 
 #### Attributes
 
@@ -843,9 +843,9 @@ System Network IO
 
 Aggregate of MongoDB Metrics SYSTEM_NETWORK_IN, SYSTEM_NETWORK_OUT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -859,9 +859,9 @@ System Network IO
 
 Aggregate of MongoDB Metrics MAX_SYSTEM_NETWORK_OUT, MAX_SYSTEM_NETWORK_IN
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -875,9 +875,9 @@ Swap IO
 
 Aggregate of MongoDB Metrics SWAP_IO_IN, SWAP_IO_OUT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {pages}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {pages}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -891,9 +891,9 @@ Swap IO
 
 Aggregate of MongoDB Metrics MAX_SWAP_IO_IN, MAX_SWAP_IO_OUT
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {pages}/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {pages}/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -907,9 +907,9 @@ Swap usage
 
 Aggregate of MongoDB Metrics SWAP_USAGE_FREE, SWAP_USAGE_USED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| KiBy | Gauge | Double | development |
 
 #### Attributes
 
@@ -923,9 +923,9 @@ Swap usage
 
 Aggregate of MongoDB Metrics MAX_SWAP_USAGE_FREE, MAX_SWAP_USAGE_USED
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| KiBy | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| KiBy | Gauge | Double | development |
 
 #### Attributes
 
@@ -949,9 +949,9 @@ Disk queue depth
 
 Aggregate of MongoDB Metrics DISK_QUEUE_DEPTH
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Double | development |
 
 ### mongodbatlas.disk.partition.throughput
 
@@ -959,9 +959,9 @@ Disk throughput
 
 Aggregate of MongoDB Metrics DISK_PARTITION_THROUGHPUT_READ, DISK_PARTITION_THROUGHPUT_WRITE
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By/s | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By/s | Gauge | Double | development |
 
 #### Attributes
 
@@ -975,9 +975,9 @@ Cache ratios represented as (%)
 
 Aggregate of MongoDB Metrics CACHE_FILL_RATIO, DIRTY_FILL_RATIO
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| % | Gauge | Double | development |
 
 #### Attributes
 

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -244,6 +244,8 @@ attributes:
 metrics:
   mongodbatlas.process.asserts:
     enabled: true
+    stability:
+      level: development
     description: Number of assertions per second
     extended_documentation: Aggregate of MongoDB Metrics ASSERT_REGULAR, ASSERT_USER, ASSERT_MSG, ASSERT_WARNING
     unit: "{assertions}/s"
@@ -252,6 +254,8 @@ metrics:
       value_type: double
   mongodbatlas.process.background_flush:
     enabled: true
+    stability:
+      level: development
     description: Amount of data flushed in the background
     extended_documentation: MongoDB Metric BACKGROUND_FLUSH_AVG
     unit: "1"
@@ -259,6 +263,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cache.io:
     enabled: true
+    stability:
+      level: development
     description: Cache throughput (per second)
     extended_documentation: Aggregate of MongoDB Metrics CACHE_BYTES_READ_INTO, CACHE_BYTES_WRITTEN_FROM
     unit: By
@@ -267,6 +273,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cache.ratio:
     enabled: false
+    stability:
+      level: development
     description: Cache ratios represented as (%)
     extended_documentation: Aggregate of MongoDB Metrics CACHE_FILL_RATIO, DIRTY_FILL_RATIO
     unit: "%"
@@ -275,6 +283,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cache.size:
     enabled: true
+    stability:
+      level: development
     description: Cache sizes
     extended_documentation: Aggregate of MongoDB Metrics CACHE_USED_BYTES, CACHE_DIRTY_BYTES
     unit: By
@@ -285,6 +295,8 @@ metrics:
       aggregation_temporality: cumulative
   mongodbatlas.process.connections:
     enabled: true
+    stability:
+      level: development
     description: Number of current connections
     extended_documentation: MongoDB Metric CONNECTIONS
     unit: "{connections}"
@@ -294,6 +306,8 @@ metrics:
       aggregation_temporality: cumulative
   mongodbatlas.process.cpu.usage.max:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
     unit: "1"
@@ -302,6 +316,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.usage.average:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
     unit: "1"
@@ -310,6 +326,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.children.usage.max:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
     unit: "1"
@@ -318,6 +336,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.children.usage.average:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
     unit: "1"
@@ -326,6 +346,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.children.normalized.usage.max:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: "1"
@@ -334,6 +356,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.children.normalized.usage.average:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: "1"
@@ -342,6 +366,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.normalized.usage.max:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
     unit: "1"
@@ -350,6 +376,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cpu.normalized.usage.average:
     enabled: true
+    stability:
+      level: development
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
     unit: "1"
@@ -358,6 +386,8 @@ metrics:
       value_type: double
   mongodbatlas.process.cursors:
     enabled: true
+    stability:
+      level: development
     description: Number of cursors
     extended_documentation: Aggregate of MongoDB Metrics CURSORS_TOTAL_OPEN, CURSORS_TOTAL_TIMED_OUT
     unit: "{cursors}"
@@ -366,6 +396,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.storage:
     enabled: true
+    stability:
+      level: development
     description: Storage used by the database
     extended_documentation: Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, DB_STORAGE_TOTAL, DB_DATA_SIZE_TOTAL
     unit: By
@@ -374,6 +406,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.document.rate:
     enabled: true
+    stability:
+      level: development
     description: Document access rates
     extended_documentation: Aggregate of MongoDB Metrics DOCUMENT_METRICS_UPDATED, DOCUMENT_METRICS_DELETED, DOCUMENT_METRICS_RETURNED, DOCUMENT_METRICS_INSERTED
     unit: "{documents}/s"
@@ -382,6 +416,8 @@ metrics:
       value_type: double
   mongodbatlas.process.global_lock:
     enabled: true
+    stability:
+      level: development
     description: Number and status of locks
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_LOCK_CURRENT_QUEUE_WRITERS, GLOBAL_LOCK_CURRENT_QUEUE_READERS, GLOBAL_LOCK_CURRENT_QUEUE_TOTAL
     unit: "{locks}"
@@ -390,6 +426,8 @@ metrics:
       value_type: double
   mongodbatlas.process.index.btree_miss_ratio:
     enabled: true
+    stability:
+      level: development
     description: Index miss ratio (%)
     extended_documentation: MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
     unit: "1"
@@ -397,6 +435,8 @@ metrics:
       value_type: double
   mongodbatlas.process.index.counters:
     enabled: true
+    stability:
+      level: development
     description: Indexes
     extended_documentation: Aggregate of MongoDB Metrics INDEX_COUNTERS_BTREE_MISSES, INDEX_COUNTERS_BTREE_ACCESSES, INDEX_COUNTERS_BTREE_HITS
     unit: "{indexes}"
@@ -405,6 +445,8 @@ metrics:
       value_type: double
   mongodbatlas.process.journaling.commits:
     enabled: true
+    stability:
+      level: development
     description: Journaling commits
     extended_documentation: MongoDB Metric JOURNALING_COMMITS_IN_WRITE_LOCK
     unit: "{commits}"
@@ -412,6 +454,8 @@ metrics:
       value_type: double
   mongodbatlas.process.journaling.data_files:
     enabled: true
+    stability:
+      level: development
     description: Data file sizes
     extended_documentation: MongoDB Metric JOURNALING_WRITE_DATA_FILES_MB
     unit: MiBy
@@ -419,6 +463,8 @@ metrics:
       value_type: double
   mongodbatlas.process.journaling.written:
     enabled: true
+    stability:
+      level: development
     description: Journals written
     extended_documentation: MongoDB Metric JOURNALING_MB
     unit: MiBy
@@ -426,6 +472,8 @@ metrics:
       value_type: double
   mongodbatlas.process.memory.usage:
     enabled: true
+    stability:
+      level: development
     description: Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MEMORY_MAPPED, MEMORY_VIRTUAL, COMPUTED_MEMORY, MEMORY_RESIDENT
     unit: By
@@ -434,6 +482,8 @@ metrics:
       value_type: double
   mongodbatlas.process.network.io:
     enabled: true
+    stability:
+      level: development
     description: Network IO
     extended_documentation: Aggregate of MongoDB Metrics NETWORK_BYTES_OUT, NETWORK_BYTES_IN
     unit: By/s
@@ -442,6 +492,8 @@ metrics:
       value_type: double
   mongodbatlas.process.network.requests:
     enabled: true
+    stability:
+      level: development
     description: Network requests
     extended_documentation: MongoDB Metric NETWORK_NUM_REQUESTS
     unit: "{requests}"
@@ -451,6 +503,8 @@ metrics:
       aggregation_temporality: cumulative
   mongodbatlas.process.oplog.time:
     enabled: true
+    stability:
+      level: development
     description: Execution time by operation
     extended_documentation: Aggregate of MongoDB Metrics OPLOG_MASTER_TIME, OPLOG_SLAVE_LAG_MASTER_TIME, OPLOG_MASTER_LAG_TIME_DIFF
     unit: s
@@ -459,6 +513,8 @@ metrics:
       value_type: double
   mongodbatlas.process.oplog.rate:
     enabled: true
+    stability:
+      level: development
     description: Execution rate by operation
     extended_documentation: MongoDB Metric OPLOG_RATE_GB_PER_HOUR
     unit: GiBy/h
@@ -466,6 +522,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.operations.rate:
     enabled: true
+    stability:
+      level: development
     description: DB Operation Rates
     extended_documentation: Aggregate of MongoDB Metrics OPCOUNTER_GETMORE, OPERATIONS_SCAN_AND_ORDER, OPCOUNTER_UPDATE, OPCOUNTER_REPL_UPDATE, OPCOUNTER_CMD, OPCOUNTER_DELETE, OPCOUNTER_REPL_DELETE, OPCOUNTER_REPL_CMD, OPCOUNTER_QUERY, OPCOUNTER_REPL_INSERT, OPCOUNTER_INSERT, OPCOUNTER_TTL_DELETED
     unit: "{operations}/s"
@@ -474,6 +532,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.operations.time:
     enabled: true
+    stability:
+      level: development
     description: DB Operation Times
     extended_documentation: Aggregate of MongoDB Metrics OP_EXECUTION_TIME_WRITES, OP_EXECUTION_TIME_COMMANDS, OP_EXECUTION_TIME_READS
     unit: ms
@@ -484,6 +544,8 @@ metrics:
       aggregation_temporality: cumulative
   mongodbatlas.process.page_faults:
     enabled: true
+    stability:
+      level: development
     description: Page faults
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_PAGE_FAULT_EXCEPTIONS_THROWN, EXTRA_INFO_PAGE_FAULTS, GLOBAL_ACCESSES_NOT_IN_MEMORY
     unit: "{faults}/s"
@@ -492,6 +554,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.query_executor.scanned:
     enabled: true
+    stability:
+      level: development
     description: Scanned objects
     extended_documentation: Aggregate of MongoDB Metrics QUERY_EXECUTOR_SCANNED_OBJECTS, QUERY_EXECUTOR_SCANNED
     attributes: [scanned_type]
@@ -500,6 +564,8 @@ metrics:
       value_type: double
   mongodbatlas.process.db.query_targeting.scanned_per_returned:
     enabled: true
+    stability:
+      level: development
     description: Scanned objects per returned
     extended_documentation: Aggregate of MongoDB Metrics QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED, QUERY_TARGETING_SCANNED_PER_RETURNED
     unit: "{scanned}/{returned}"
@@ -508,6 +574,8 @@ metrics:
       value_type: double
   mongodbatlas.process.restarts:
     enabled: true
+    stability:
+      level: development
     description: Restarts in last hour
     extended_documentation: Aggregate of MongoDB Metrics RESTARTS_IN_LAST_HOUR
     unit: "{restarts}/h"
@@ -515,6 +583,8 @@ metrics:
       value_type: double
   mongodbatlas.system.paging.usage.max:
     enabled: true
+    stability:
+      level: development
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_USAGE_FREE, MAX_SWAP_USAGE_USED
     unit: KiBy
@@ -523,6 +593,8 @@ metrics:
       value_type: double
   mongodbatlas.system.paging.usage.average:
     enabled: true
+    stability:
+      level: development
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics SWAP_USAGE_FREE, SWAP_USAGE_USED
     unit: KiBy
@@ -531,6 +603,8 @@ metrics:
       value_type: double
   mongodbatlas.system.paging.io.max:
     enabled: true
+    stability:
+      level: development
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_IO_IN, MAX_SWAP_IO_OUT
     unit: "{pages}/s"
@@ -539,6 +613,8 @@ metrics:
       value_type: double
   mongodbatlas.system.paging.io.average:
     enabled: true
+    stability:
+      level: development
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics SWAP_IO_IN, SWAP_IO_OUT
     unit: "{pages}/s"
@@ -547,6 +623,8 @@ metrics:
       value_type: double
   mongodbatlas.system.cpu.usage.max:
     enabled: true
+    stability:
+      level: development
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
     attributes: [cpu_state]
@@ -555,6 +633,8 @@ metrics:
       value_type: double
   mongodbatlas.system.cpu.usage.average:
     enabled: true
+    stability:
+      level: development
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
     attributes: [cpu_state]
@@ -563,6 +643,8 @@ metrics:
       value_type: double
   mongodbatlas.system.memory.usage.max:
     enabled: true
+    stability:
+      level: development
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_MEMORY_CACHED, MAX_SYSTEM_MEMORY_AVAILABLE, MAX_SYSTEM_MEMORY_USED, MAX_SYSTEM_MEMORY_BUFFERS, MAX_SYSTEM_MEMORY_FREE, MAX_SYSTEM_MEMORY_SHARED
     unit: KiBy
@@ -571,6 +653,8 @@ metrics:
       value_type: double
   mongodbatlas.system.memory.usage.average:
     enabled: true
+    stability:
+      level: development
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_MEMORY_AVAILABLE, SYSTEM_MEMORY_BUFFERS, SYSTEM_MEMORY_USED, SYSTEM_MEMORY_CACHED, SYSTEM_MEMORY_SHARED, SYSTEM_MEMORY_FREE
     unit: KiBy
@@ -579,6 +663,8 @@ metrics:
       value_type: double
   mongodbatlas.system.network.io.max:
     enabled: true
+    stability:
+      level: development
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NETWORK_OUT, MAX_SYSTEM_NETWORK_IN
     unit: By/s
@@ -587,6 +673,8 @@ metrics:
       value_type: double
   mongodbatlas.system.network.io.average:
     enabled: true
+    stability:
+      level: development
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NETWORK_IN, SYSTEM_NETWORK_OUT
     unit: By/s
@@ -595,6 +683,8 @@ metrics:
       value_type: double
   mongodbatlas.system.cpu.normalized.usage.max:
     enabled: true
+    stability:
+      level: development
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
     attributes: [cpu_state]
@@ -603,6 +693,8 @@ metrics:
       value_type: double
   mongodbatlas.system.cpu.normalized.usage.average:
     enabled: true
+    stability:
+      level: development
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
     attributes: [cpu_state]
@@ -611,6 +703,8 @@ metrics:
       value_type: double
   mongodbatlas.process.tickets:
     enabled: true
+    stability:
+      level: development
     description: Tickets
     extended_documentation: Aggregate of MongoDB Metrics TICKETS_AVAILABLE_WRITE, TICKETS_AVAILABLE_READS
     unit: "{tickets}"
@@ -619,6 +713,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.iops.max:
     enabled: true
+    stability:
+      level: development
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_IOPS_WRITE, MAX_DISK_PARTITION_IOPS_TOTAL, MAX_DISK_PARTITION_IOPS_READ
     unit: "{ops}/s"
@@ -627,6 +723,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.iops.average:
     enabled: true
+    stability:
+      level: development
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_IOPS_READ, DISK_PARTITION_IOPS_WRITE, DISK_PARTITION_IOPS_TOTAL
     unit: "{ops}/s"
@@ -635,6 +733,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.throughput:
     enabled: false
+    stability:
+      level: development
     description: Disk throughput
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_THROUGHPUT_READ, DISK_PARTITION_THROUGHPUT_WRITE
     unit: By/s
@@ -643,6 +743,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.usage.max:
     enabled: true
+    stability:
+      level: development
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
     unit: "1"
@@ -651,6 +753,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.usage.average:
     enabled: true
+    stability:
+      level: development
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
     unit: "1"
@@ -659,6 +763,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.utilization.max:
     enabled: true
+    stability:
+      level: development
     description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
     unit: "1"
@@ -666,6 +772,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.utilization.average:
     enabled: true
+    stability:
+      level: development
     description: The percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
     unit: "1"
@@ -673,6 +781,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.latency.max:
     enabled: true
+    stability:
+      level: development
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_LATENCY_WRITE, MAX_DISK_PARTITION_LATENCY_READ
     unit: ms
@@ -681,6 +791,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.latency.average:
     enabled: true
+    stability:
+      level: development
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_LATENCY_WRITE, DISK_PARTITION_LATENCY_READ
     unit: ms
@@ -689,6 +801,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.space.max:
     enabled: true
+    stability:
+      level: development
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
@@ -697,6 +811,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.space.average:
     enabled: true
+    stability:
+      level: development
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
@@ -705,6 +821,8 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.queue.depth:
     enabled: false
+    stability:
+      level: development
     description: Disk queue depth
     extended_documentation: Aggregate of MongoDB Metrics DISK_QUEUE_DEPTH
     unit: "1"
@@ -713,6 +831,8 @@ metrics:
       value_type: double
   mongodbatlas.db.size:
     enabled: true
+    stability:
+      level: development
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_AVERAGE_OBJECT_SIZE
     unit: By
@@ -721,6 +841,8 @@ metrics:
       value_type: double
   mongodbatlas.db.counts:
     enabled: true
+    stability:
+      level: development
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_EXTENT_COUNT, DATABASE_VIEW_COUNT, DATABASE_COLLECTION_COUNT, DATABASE_OBJECT_COUNT, DATABASE_INDEX_COUNT
     unit: "{objects}"
@@ -729,6 +851,8 @@ metrics:
       value_type: double
   mongodbatlas.system.fts.memory.usage:
     enabled: true
+    stability:
+      level: development
     description: Full-text search
     extended_documentation: Aggregate of MongoDB Metrics FTS_MEMORY_MAPPED, FTS_PROCESS_SHARED_MEMORY, FTS_PROCESS_RESIDENT_MEMORY, FTS_PROCESS_VIRTUAL_MEMORY
     unit: MiBy
@@ -739,6 +863,8 @@ metrics:
       aggregation_temporality: cumulative
   mongodbatlas.system.fts.disk.used:
     enabled: true
+    stability:
+      level: development
     description: Full text search disk usage
     extended_documentation: MongoDB Metric FTS_DISK_USAGE
     unit: By
@@ -746,6 +872,8 @@ metrics:
       value_type: double
   mongodbatlas.system.fts.cpu.usage:
     enabled: true
+    stability:
+      level: development
     description: Full-text search (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
     unit: "1"
@@ -754,6 +882,8 @@ metrics:
       value_type: double
   mongodbatlas.system.fts.cpu.normalized.usage:
     enabled: true
+    stability:
+      level: development
     description: Full text search disk usage (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
     unit: "1"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
