### PR TITLE
[chore][activedirectorydsreceiver] Add stability level per metric

### DIFF
--- a/receiver/activedirectorydsreceiver/documentation.md
+++ b/receiver/activedirectorydsreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 The number of binds per second serviced by this domain controller.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {binds}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {binds}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -30,57 +30,57 @@ The number of binds per second serviced by this domain controller.
 
 The amount of time taken for the last successful LDAP bind.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### active_directory.ds.ldap.bind.rate
 
 The number of successful LDAP binds per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {binds}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {binds}/s | Sum | Double | Cumulative | false | development |
 
 ### active_directory.ds.ldap.client.session.count
 
 The number of connected LDAP client sessions.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {sessions} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {sessions} | Sum | Int | Cumulative | false | development |
 
 ### active_directory.ds.ldap.search.rate
 
 The number of LDAP searches per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {searches}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {searches}/s | Sum | Double | Cumulative | false | development |
 
 ### active_directory.ds.name_cache.hit_rate
 
 The percentage of directory object name component lookups that are satisfied by the Directory System Agent's name cache.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| % | Gauge | Double | development |
 
 ### active_directory.ds.notification.queued
 
 The number of pending update notifications that have been queued to push to clients.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {notifications} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {notifications} | Sum | Int | Cumulative | false | development |
 
 ### active_directory.ds.operation.rate
 
 The number of operations performed per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -92,9 +92,9 @@ The number of operations performed per second.
 
 The amount of network data transmitted by the Directory Replication Agent.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -107,9 +107,9 @@ The amount of network data transmitted by the Directory Replication Agent.
 
 The number of objects transmitted by the Directory Replication Agent per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -121,17 +121,17 @@ The number of objects transmitted by the Directory Replication Agent per second.
 
 The number of pending replication operations for the Directory Replication Agent.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operations} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operations} | Sum | Int | Cumulative | false | development |
 
 ### active_directory.ds.replication.property.rate
 
 The number of properties transmitted by the Directory Replication Agent per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {properties}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {properties}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -143,17 +143,17 @@ The number of properties transmitted by the Directory Replication Agent per seco
 
 The number of objects remaining until the full sync completes for the Directory Replication Agent.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {objects} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {objects} | Sum | Int | Cumulative | false | development |
 
 ### active_directory.ds.replication.sync.request.count
 
 The number of sync requests made by the Directory Replication Agent.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -165,9 +165,9 @@ The number of sync requests made by the Directory Replication Agent.
 
 The number of values transmitted by the Directory Replication Agent per second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {values}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {values}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -180,17 +180,17 @@ The number of values transmitted by the Directory Replication Agent per second.
 
 The number of security descriptor propagation events that are queued for processing.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {events} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {events} | Sum | Int | Cumulative | false | development |
 
 ### active_directory.ds.suboperation.rate
 
 The rate of sub-operations performed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {suboperations}/s | Sum | Double | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {suboperations}/s | Sum | Double | Cumulative | false | development |
 
 #### Attributes
 
@@ -202,6 +202,6 @@ The rate of sub-operations performed.
 
 The number of threads in use by the directory service.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {threads} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {threads} | Sum | Int | Cumulative | false | development |

--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -71,6 +71,8 @@ metrics:
       value_type: int
     attributes: [direction, network_data_type]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.sync.object.pending:
     description: "The number of objects remaining until the full sync completes for the Directory Replication Agent."
     unit: "{objects}"
@@ -79,6 +81,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.sync.request.count:
     description: "The number of sync requests made by the Directory Replication Agent."
     unit: "{requests}"
@@ -88,6 +92,8 @@ metrics:
       value_type: int
     attributes: [sync_result]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.object.rate:
     description: "The number of objects transmitted by the Directory Replication Agent per second."
     unit: "{objects}/s"
@@ -97,6 +103,8 @@ metrics:
       value_type: double
     attributes: [direction]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.property.rate:
     description: "The number of properties transmitted by the Directory Replication Agent per second."
     unit: "{properties}/s"
@@ -106,6 +114,8 @@ metrics:
       value_type: double
     attributes: [direction]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.value.rate:
     description: "The number of values transmitted by the Directory Replication Agent per second."
     unit: "{values}/s"
@@ -115,6 +125,8 @@ metrics:
       value_type: double
     attributes: [direction, value_type]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.replication.operation.pending:
     description: "The number of pending replication operations for the Directory Replication Agent."
     unit: "{operations}"
@@ -123,6 +135,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.operation.rate:
     description: "The number of operations performed per second."
     unit: "{operations}/s"
@@ -132,12 +146,16 @@ metrics:
       value_type: double
     attributes: [operation_type]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.name_cache.hit_rate:
     description: "The percentage of directory object name component lookups that are satisfied by the Directory System Agent's name cache."
     unit: "%"
     gauge:
       value_type: double
     enabled: true
+    stability:
+      level: development
   active_directory.ds.notification.queued:
     description: "The number of pending update notifications that have been queued to push to clients."
     unit: "{notifications}"
@@ -146,6 +164,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.security_descriptor_propagations_event.queued:
     description: "The number of security descriptor propagation events that are queued for processing."
     unit: "{events}"
@@ -154,6 +174,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.suboperation.rate:
     description: "The rate of sub-operations performed."
     unit: "{suboperations}/s"
@@ -163,6 +185,8 @@ metrics:
       value_type: double
     attributes: [suboperation_type]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.bind.rate:
     description: "The number of binds per second serviced by this domain controller."
     unit: "{binds}/s"
@@ -172,6 +196,8 @@ metrics:
       value_type: double
     attributes: [bind_type]
     enabled: true
+    stability:
+      level: development
   active_directory.ds.thread.count:
     description: "The number of threads in use by the directory service."
     unit: "{threads}"
@@ -180,6 +206,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.ldap.client.session.count:
     description: "The number of connected LDAP client sessions."
     unit: "{sessions}"
@@ -188,12 +216,16 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.ldap.bind.last_successful.time:
     description: "The amount of time taken for the last successful LDAP bind."
     unit: "ms"
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development
   active_directory.ds.ldap.bind.rate:
     description: "The number of successful LDAP binds per second."
     unit: "{binds}/s"
@@ -202,6 +234,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: double
     enabled: true
+    stability:
+      level: development
   active_directory.ds.ldap.search.rate:
     description: "The number of LDAP searches per second."
     unit: "{searches}/s"
@@ -210,6 +244,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: double
     enabled: true
+    stability:
+      level: development
 
 # TODO: Update the receiver to pass the tests
 tests:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
