### PR TITLE
[chore][chronyreceiver] Add stability level per metric

### DIFF
--- a/receiver/chronyreceiver/documentation.md
+++ b/receiver/chronyreceiver/documentation.md
@@ -16,17 +16,17 @@ metrics:
 
 This is the estimated error bound on the frequency.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ppm | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ppm | Gauge | Double | development |
 
 ### ntp.time.correction
 
 The number of seconds difference between the system's clock and the reference clock
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| seconds | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| seconds | Gauge | Double | development |
 
 #### Attributes
 
@@ -38,9 +38,9 @@ The number of seconds difference between the system's clock and the reference cl
 
 The estimated local offset on the last clock update
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| seconds | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| seconds | Gauge | Double | development |
 
 #### Attributes
 
@@ -64,9 +64,9 @@ The frequency is the rate by which the system s clock would be wrong if chronyd 
 
 It is expressed in ppm (parts per million). For example, a value of 1 ppm would mean that when the system’s clock thinks it has advanced 1 second, it has actually advanced by 1.000001 seconds relative to true time.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ppm | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ppm | Gauge | Double | development |
 
 #### Attributes
 
@@ -80,17 +80,17 @@ The number of hops away from the reference system keeping the reference time
 
 To read further, refer to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-Checking_chrony_tracking
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {count} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {count} | Gauge | Int | development |
 
 ### ntp.time.rms_offset
 
 the long term average of the offset value
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| seconds | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| seconds | Gauge | Double | development |
 
 #### Attributes
 
@@ -102,9 +102,9 @@ the long term average of the offset value
 
 This is the total of the network path delays to the stratum-1 system from which the system is ultimately synchronised.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| seconds | Gauge | Double |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| seconds | Gauge | Double | development |
 
 #### Attributes
 

--- a/receiver/chronyreceiver/metadata.yaml
+++ b/receiver/chronyreceiver/metadata.yaml
@@ -21,6 +21,8 @@ attributes:
 metrics:
   ntp.frequency.offset:
     enabled: false
+    stability:
+      level: development
     description: The frequency is the rate by which the system s clock would be wrong if chronyd was not correcting it.
     extended_documentation: "It is expressed in ppm (parts per million). For example, a value of 1 ppm would mean that when the system’s clock thinks it has advanced 1 second, it has actually advanced by 1.000001 seconds relative to true time."
     unit: "ppm"
@@ -30,12 +32,16 @@ metrics:
     - leap.status
   ntp.skew:
     enabled: true
+    stability:
+      level: development
     description: This is the estimated error bound on the frequency.
     unit: "ppm"
     gauge:
       value_type: double
   ntp.stratum:
     enabled: false
+    stability:
+      level: development
     description: The number of hops away from the reference system keeping the reference time
     extended_documentation: To read further, refer to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-Checking_chrony_tracking
     unit: "{count}"
@@ -43,6 +49,8 @@ metrics:
       value_type: int
   ntp.time.correction:
     enabled: true
+    stability:
+      level: development
     description: The number of seconds difference between the system's clock and the reference clock
     unit: seconds
     gauge:
@@ -51,6 +59,8 @@ metrics:
     - leap.status
   ntp.time.last_offset:
     enabled: true
+    stability:
+      level: development
     description: The estimated local offset on the last clock update
     unit: seconds
     gauge:
@@ -59,6 +69,8 @@ metrics:
     - leap.status
   ntp.time.rms_offset:
     enabled: false
+    stability:
+      level: development
     description: the long term average of the offset value
     unit: seconds
     gauge:
@@ -67,6 +79,8 @@ metrics:
     - leap.status
   ntp.time.root_delay:
     enabled: false
+    stability:
+      level: development
     description: This is the total of the network path delays to the stratum-1 system from which the system is ultimately synchronised.
     unit: seconds
     gauge:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
