### PR TITLE
[chore][httpcheckreceiver] Add stability level per metric

### DIFF
--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -16,9 +16,9 @@ metrics:
 
 Measures the duration of the HTTP check.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -30,9 +30,9 @@ Measures the duration of the HTTP check.
 
 Records errors occurring during HTTP check.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {error} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {error} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -45,9 +45,9 @@ Records errors occurring during HTTP check.
 
 1 if the check resulted in status_code matching the status_class, otherwise 0.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -72,9 +72,9 @@ metrics:
 
 Time spent establishing TCP connection to the endpoint.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -87,9 +87,9 @@ Time spent establishing TCP connection to the endpoint.
 
 Time spent sending the HTTP request to the endpoint.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -101,9 +101,9 @@ Time spent sending the HTTP request to the endpoint.
 
 Time spent performing DNS lookup for the endpoint.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -115,9 +115,9 @@ Time spent performing DNS lookup for the endpoint.
 
 Time spent receiving the HTTP response from the endpoint.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -129,9 +129,9 @@ Time spent receiving the HTTP response from the endpoint.
 
 Size of response body in bytes.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -143,9 +143,9 @@ Size of response body in bytes.
 
 Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 #### Attributes
 
@@ -160,9 +160,9 @@ Time in seconds until certificate expiry, as specified by `NotAfter` field in th
 
 Time spent performing TLS handshake with the endpoint.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 #### Attributes
 
@@ -174,9 +174,9 @@ Time spent performing TLS handshake with the endpoint.
 
 Number of response validations that failed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {validation} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {validation} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -189,9 +189,9 @@ Number of response validations that failed.
 
 Number of response validations that passed.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {validation} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {validation} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -47,6 +47,8 @@ metrics:
   httpcheck.status:
     description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
     enabled: true
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -56,6 +58,8 @@ metrics:
   httpcheck.duration:
     description: Measures the duration of the HTTP check.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -63,6 +67,8 @@ metrics:
   httpcheck.error:
     description: Records errors occurring during HTTP check.
     enabled: true
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -72,6 +78,8 @@ metrics:
   httpcheck.tls.cert_remaining:
     description: Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: "s"
@@ -79,6 +87,8 @@ metrics:
   httpcheck.dns.lookup.duration:
     description: Time spent performing DNS lookup for the endpoint.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -86,6 +96,8 @@ metrics:
   httpcheck.client.connection.duration:
     description: Time spent establishing TCP connection to the endpoint.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -93,6 +105,8 @@ metrics:
   httpcheck.tls.handshake.duration:
     description: Time spent performing TLS handshake with the endpoint.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -100,6 +114,8 @@ metrics:
   httpcheck.client.request.duration:
     description: Time spent sending the HTTP request to the endpoint.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -107,6 +123,8 @@ metrics:
   httpcheck.response.duration:
     description: Time spent receiving the HTTP response from the endpoint.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: ms
@@ -114,6 +132,8 @@ metrics:
   httpcheck.response.size:
     description: Size of response body in bytes.
     enabled: false
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: "By"
@@ -121,6 +141,8 @@ metrics:
   httpcheck.validation.passed:
     description: Number of response validations that passed.
     enabled: false
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative
@@ -130,6 +152,8 @@ metrics:
   httpcheck.validation.failed:
     description: Number of response validations that failed.
     enabled: false
+    stability:
+      level: development
     sum:
       value_type: int
       aggregation_temporality: cumulative


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
