### PR TITLE
[receiver/statsd] fix data race in TCP server shutdown

### DIFF
--- a/.chloggen/fix-statsd-tcp-server-data-race.yaml
+++ b/.chloggen/fix-statsd-tcp-server-data-race.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a data race that can occur during shutdown of the statsdreceiver's TCP server implementation.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42986]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes a data race that occurs when shutdown is called while a new connection is created. `ListenAndServe` runs in a goroutine created [here](https://github.com/asweet-confluent/opentelemetry-collector-contrib/blob/458eaabe6f759bccf38deaae0f945ffa49ec9d07/receiver/statsdreceiver/receiver.go#L121), and apparently WaitGroups [aren't safe to use in this way](https://github.com/golang/go/issues/23842).

The UDP and UDS implementations don't use a WaitGroup and are unaffected.

<details>
<summary>Race detector log</summary

```
==================
WARNING: DATA RACE
Write at 0x00c0000f8c08 by goroutine 15:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.(*tcpServer).Close()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/tcp_server.go:114 +0x48
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.Test_Server_ListenAndServe.func1()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/server_test.go:112 +0xb64
  testing.tRunner()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x44

Previous read at 0x00c0000f8c08 by goroutine 17:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.(*tcpServer).ListenAndServe()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/tcp_server.go:72 +0x2ae
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.Test_Server_ListenAndServe.func1.1()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/server_test.go:84 +0x105

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x8f2
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.Test_Server_ListenAndServe()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/server_test.go:58 +0x28b
  testing.tRunner()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x44

Goroutine 17 (running) created at:
  github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport.Test_Server_ListenAndServe.func1()
      /home/semaphore/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/server_test.go:82 +0x7bc
  testing.tRunner()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /home/semaphore/.local/share/mise/installs/go/1.23.11/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x44
==================
    testing.go:1490: race detected during execution of test

=== [31mFAIL[0m: internal/transport Test_Server_ListenAndServe (1.01s)
```
</summary>

