### PR TITLE
[chore][iisreceiver] Add stability level per metric

### DIFF
--- a/receiver/iisreceiver/documentation.md
+++ b/receiver/iisreceiver/documentation.md
@@ -16,57 +16,57 @@ metrics:
 
 The current status of the application pool (1 - Uninitialized, 2 - Initialized, 3 - Running, 4 - Disabling, 5 - Disabled, 6 - Shutdown Pending, 7 - Delete Pending).
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {state} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {state} | Gauge | Int | development |
 
 ### iis.application_pool.uptime
 
 The application pools uptime period since the last restart.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {ms} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {ms} | Gauge | Int | development |
 
 ### iis.connection.active
 
 Number of active connections.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | false | development |
 
 ### iis.connection.anonymous
 
 Number of connections established anonymously.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {connections} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {connections} | Sum | Int | Cumulative | true | development |
 
 ### iis.connection.attempt.count
 
 Total number of attempts to connect to the server.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {attempts} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {attempts} | Sum | Int | Cumulative | true | development |
 
 ### iis.network.blocked
 
 Number of bytes blocked due to bandwidth throttling.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### iis.network.file.count
 
 Number of transmitted files.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {files} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {files} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -78,9 +78,9 @@ Number of transmitted files.
 
 Total amount of bytes sent and received.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -92,9 +92,9 @@ Total amount of bytes sent and received.
 
 Total number of requests of a given type.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -106,41 +106,41 @@ Total number of requests of a given type.
 
 Age of oldest request in the queue.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | development |
 
 ### iis.request.queue.count
 
 Current number of requests in the queue.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | false | development |
 
 ### iis.request.rejected
 
 Total number of requests rejected.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | development |
 
 ### iis.thread.active
 
 Current number of active threads.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {threads} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {threads} | Sum | Int | Cumulative | false | development |
 
 ### iis.uptime
 
 The amount of time the server has been up.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| s | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| s | Gauge | Int | development |
 
 ## Resource Attributes
 

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -52,6 +52,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [ request ]
   iis.request.rejected:
     description: Total number of requests rejected.
@@ -61,6 +63,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.request.queue.count:
     description: Current number of requests in the queue.
     unit: "{requests}"
@@ -69,12 +73,16 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.request.queue.age.max:
     description: Age of oldest request in the queue.
     unit: ms
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.network.file.count:
     description: Number of transmitted files.
     unit: "{files}"
@@ -83,6 +91,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [ direction ]
   iis.network.blocked:
     description: Number of bytes blocked due to bandwidth throttling.
@@ -92,6 +102,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.network.io:
     description: Total amount of bytes sent and received.
     unit: By
@@ -100,6 +112,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [ direction ]
   iis.connection.attempt.count:
     description: Total number of attempts to connect to the server.
@@ -109,6 +123,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.connection.active:
     description: Number of active connections.
     unit: "{connections}"
@@ -117,6 +133,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.connection.anonymous:
     description: Number of connections established anonymously.
     unit: "{connections}"
@@ -125,6 +143,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.thread.active:
     description: Current number of active threads.
     unit: "{threads}"
@@ -133,21 +153,29 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.uptime:
     description: The amount of time the server has been up.
     unit: s
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.application_pool.state:
     description: The current status of the application pool (1 - Uninitialized, 2 - Initialized, 3 - Running, 4 - Disabling, 5 - Disabled, 6 - Shutdown Pending, 7 - Delete Pending).
     unit: "{state}"
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development
   iis.application_pool.uptime:
     description: The application pools uptime period since the last restart.
     unit: "{ms}"
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
