### PR TITLE
[chore][oracledbreceiver] Add stability level per metric

### DIFF
--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -16,153 +16,153 @@ metrics:
 
 Cumulative CPU time, in seconds
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| s | Sum | Double | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| s | Sum | Double | Cumulative | true | development |
 
 ### oracledb.dml_locks.limit
 
 Maximum limit of active DML (Data Manipulation Language) locks, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {locks} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | development |
 
 ### oracledb.dml_locks.usage
 
 Current count of active DML (Data Manipulation Language) locks.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {locks} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | development |
 
 ### oracledb.enqueue_deadlocks
 
 Total number of deadlocks between table or row locks in different sessions.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {deadlocks} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {deadlocks} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.enqueue_locks.limit
 
 Maximum limit of active enqueue locks, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {locks} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | development |
 
 ### oracledb.enqueue_locks.usage
 
 Current count of active enqueue locks.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {locks} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {locks} | Gauge | Int | development |
 
 ### oracledb.enqueue_resources.limit
 
 Maximum limit of active enqueue resources, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {resources} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {resources} | Gauge | Int | development |
 
 ### oracledb.enqueue_resources.usage
 
 Current count of active enqueue resources.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {resources} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {resources} | Gauge | Int | development |
 
 ### oracledb.exchange_deadlocks
 
 Number of times that a process detected a potential deadlock when exchanging two buffers and raised an internal, restartable error. Index scans are the only operations that perform exchanges.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {deadlocks} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {deadlocks} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.executions
 
 Total number of calls (user and recursive) that executed SQL statements
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.hard_parses
 
 Number of hard parses
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {parses} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {parses} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.logical_reads
 
 Number of logical reads
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {reads} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {reads} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parse_calls
 
 Total number of parse calls.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {parses} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {parses} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.pga_memory
 
 Session PGA (Program Global Area) memory
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_reads
 
 Number of physical reads
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {reads} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {reads} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.processes.limit
 
 Maximum limit of active processes, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {processes} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {processes} | Gauge | Int | development |
 
 ### oracledb.processes.usage
 
 Current count of active processes.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {processes} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {processes} | Gauge | Int | development |
 
 ### oracledb.sessions.limit
 
 Maximum limit of active sessions, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {sessions} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {sessions} | Gauge | Int | development |
 
 ### oracledb.sessions.usage
 
 Count of active sessions.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {sessions} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {sessions} | Gauge | Int | development |
 
 #### Attributes
 
@@ -175,9 +175,9 @@ Count of active sessions.
 
 Maximum size of tablespace in bytes, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -189,9 +189,9 @@ Maximum size of tablespace in bytes, -1 if unlimited.
 
 Used tablespace in bytes.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| By | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | development |
 
 #### Attributes
 
@@ -203,33 +203,33 @@ Used tablespace in bytes.
 
 Maximum limit of active transactions, -1 if unlimited.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {transactions} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions} | Gauge | Int | development |
 
 ### oracledb.transactions.usage
 
 Current count of active transactions.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {transactions} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {transactions} | Gauge | Int | development |
 
 ### oracledb.user_commits
 
 Number of user commits. When a user commits a transaction, the redo generated that reflects the changes made to database blocks must be written to disk. Commits often represent the closest thing to a user transaction rate.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {commits} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {commits} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.user_rollbacks
 
 Number of times users manually issue the ROLLBACK statement or an error occurs during a user's transactions
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| 1 | Sum | Int | Cumulative | true | development |
 
 ## Optional Metrics
 
@@ -245,137 +245,137 @@ metrics:
 
 Number of times a consistent read was requested for a block from the buffer cache.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {gets} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {gets} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.db_block_gets
 
 Number of times a current block was requested from the buffer cache.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {gets} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {gets} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.ddl_statements_parallelized
 
 Number of DDL statements that were executed in parallel
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {statements} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {statements} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.dml_statements_parallelized
 
 Number of DML statements that were executed in parallel
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {statements} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {statements} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.logons
 
 Number of logon operations
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_downgraded_1_to_25_pct
 
 Number of times parallel execution was requested and the degree of parallelism was reduced down to 1-25% because of insufficient parallel execution servers
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_downgraded_25_to_50_pct
 
 Number of times parallel execution was requested and the degree of parallelism was reduced down to 25-50% because of insufficient parallel execution servers
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_downgraded_50_to_75_pct
 
 Number of times parallel execution was requested and the degree of parallelism was reduced down to 50-75% because of insufficient parallel execution servers
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_downgraded_75_to_99_pct
 
 Number of times parallel execution was requested and the degree of parallelism was reduced down to 75-99% because of insufficient parallel execution servers
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_downgraded_to_serial
 
 Number of times parallel execution was requested but execution was serial because of insufficient parallel execution servers
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.parallel_operations_not_downgraded
 
 Number of times parallel execution was executed at the requested degree of parallelism
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {executions} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {executions} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_read_io_requests
 
 Number of read requests for application activity
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_reads_direct
 
 Number of reads directly from disk, bypassing the buffer cache
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {reads} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {reads} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_write_io_requests
 
 Number of write requests for application activity
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {requests} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {requests} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_writes
 
 Number of physical writes
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {writes} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {writes} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.physical_writes_direct
 
 Number of writes directly to disk, bypassing the buffer cache
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {writes} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {writes} | Sum | Int | Cumulative | true | development |
 
 ### oracledb.queries_parallelized
 
 Number of SELECT statements executed in parallel
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {queries} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {queries} | Sum | Int | Cumulative | true | development |
 
 ## Default Events
 

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -226,6 +226,8 @@ metrics:
   oracledb.cpu_time:
     description: Cumulative CPU time, in seconds
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -235,6 +237,8 @@ metrics:
     description: Total number of deadlocks between table or row locks in different
       sessions.
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -246,6 +250,8 @@ metrics:
       exchanging two buffers and raised an internal, restartable error. Index scans
       are the only operations that perform exchanges.
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -255,6 +261,8 @@ metrics:
   oracledb.executions:
     description: Total number of calls (user and recursive) that executed SQL statements
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -264,6 +272,8 @@ metrics:
   oracledb.logical_reads:
     description: Number of logical reads
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -273,6 +283,8 @@ metrics:
   oracledb.hard_parses:
     description: Number of hard parses
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -282,6 +294,8 @@ metrics:
   oracledb.parse_calls:
     description: Total number of parse calls.
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -291,6 +305,8 @@ metrics:
   oracledb.pga_memory:
     description: Session PGA (Program Global Area) memory
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -300,6 +316,8 @@ metrics:
   oracledb.physical_reads:
     description: Number of physical reads
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -309,6 +327,8 @@ metrics:
   oracledb.physical_reads_direct:
     description: Number of reads directly from disk, bypassing the buffer cache
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -318,6 +338,8 @@ metrics:
   oracledb.physical_read_io_requests:
     description: Number of read requests for application activity
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -327,6 +349,8 @@ metrics:
   oracledb.physical_writes:
     description: Number of physical writes
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -336,6 +360,8 @@ metrics:
   oracledb.physical_writes_direct:
     description: Number of writes directly to disk, bypassing the buffer cache
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -345,6 +371,8 @@ metrics:
   oracledb.physical_write_io_requests:
     description: Number of write requests for application activity
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -356,6 +384,8 @@ metrics:
       generated that reflects the changes made to database blocks must be written
       to disk. Commits often represent the closest thing to a user transaction rate.
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -366,6 +396,8 @@ metrics:
     description: Number of times users manually issue the ROLLBACK statement or an
       error occurs during a user's transactions
     enabled: true
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -378,6 +410,8 @@ metrics:
       - session_status
     description: Count of active sessions.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -385,6 +419,8 @@ metrics:
   oracledb.processes.usage:
     description: Current count of active processes.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -392,6 +428,8 @@ metrics:
   oracledb.processes.limit:
     description: Maximum limit of active processes, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -399,6 +437,8 @@ metrics:
   oracledb.sessions.limit:
     description: Maximum limit of active sessions, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -406,6 +446,8 @@ metrics:
   oracledb.enqueue_locks.usage:
     description: Current count of active enqueue locks.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -413,6 +455,8 @@ metrics:
   oracledb.enqueue_locks.limit:
     description: Maximum limit of active enqueue locks, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -420,6 +464,8 @@ metrics:
   oracledb.dml_locks.usage:
     description: Current count of active DML (Data Manipulation Language) locks.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -427,6 +473,8 @@ metrics:
   oracledb.dml_locks.limit:
     description: Maximum limit of active DML (Data Manipulation Language) locks, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -434,6 +482,8 @@ metrics:
   oracledb.enqueue_resources.usage:
     description: Current count of active enqueue resources.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -441,6 +491,8 @@ metrics:
   oracledb.enqueue_resources.limit:
     description: Maximum limit of active enqueue resources, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -448,6 +500,8 @@ metrics:
   oracledb.transactions.usage:
     description: Current count of active transactions.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -455,6 +509,8 @@ metrics:
   oracledb.transactions.limit:
     description: Maximum limit of active transactions, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
       input_type: string
@@ -464,6 +520,8 @@ metrics:
       - tablespace_name
     description: Maximum size of tablespace in bytes, -1 if unlimited.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: By
@@ -472,12 +530,16 @@ metrics:
       - tablespace_name
     description: Used tablespace in bytes.
     enabled: true
+    stability:
+      level: development
     gauge:
       value_type: int
     unit: By
   oracledb.db_block_gets:
     description: Number of times a current block was requested from the buffer cache.
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -487,6 +549,8 @@ metrics:
   oracledb.consistent_gets:
     description: Number of times a consistent read was requested for a block from the buffer cache.
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -496,6 +560,8 @@ metrics:
   oracledb.queries_parallelized:
     description: Number of SELECT statements executed in parallel
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -505,6 +571,8 @@ metrics:
   oracledb.ddl_statements_parallelized:
     description: Number of DDL statements that were executed in parallel
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -514,6 +582,8 @@ metrics:
   oracledb.dml_statements_parallelized:
     description: Number of DML statements that were executed in parallel
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -524,6 +594,8 @@ metrics:
     description: Number of times parallel execution was executed at the
       requested degree of parallelism
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -534,6 +606,8 @@ metrics:
     description: Number of times parallel execution was requested but execution
       was serial because of insufficient parallel execution servers
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -545,6 +619,8 @@ metrics:
       degree of parallelism was reduced down to 1-25% because of insufficient
       parallel execution servers
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -556,6 +632,8 @@ metrics:
       degree of parallelism was reduced down to 25-50% because of insufficient
       parallel execution servers
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -567,6 +645,8 @@ metrics:
       degree of parallelism was reduced down to 50-75% because of insufficient
       parallel execution servers
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -578,6 +658,8 @@ metrics:
       degree of parallelism was reduced down to 75-99% because of insufficient
       parallel execution servers
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true
@@ -587,6 +669,8 @@ metrics:
   oracledb.logons:
     description: Number of logon operations
     enabled: false
+    stability:
+      level: development
     sum:
       aggregation_temporality: cumulative
       monotonic: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
