### PR TITLE
[chore][riakreceiver] Add stability level per metric

### DIFF
--- a/receiver/riakreceiver/documentation.md
+++ b/receiver/riakreceiver/documentation.md
@@ -16,17 +16,17 @@ metrics:
 
 The amount of memory allocated to the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| By | Sum | Int | Cumulative | false | development |
 
 ### riak.node.operation.count
 
 The number of operations performed by the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 
@@ -38,9 +38,9 @@ The number of operations performed by the node.
 
 The mean time between request and response for operations performed by the node over the last minute.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| us | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| us | Gauge | Int | development |
 
 #### Attributes
 
@@ -52,17 +52,17 @@ The mean time between request and response for operations performed by the node 
 
 The number of read repairs performed by the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {read_repair} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {read_repair} | Sum | Int | Cumulative | true | development |
 
 ### riak.vnode.index.operation.count
 
 The number of index operations performed by vnodes on the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | false |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | false | development |
 
 #### Attributes
 
@@ -74,9 +74,9 @@ The number of index operations performed by vnodes on the node.
 
 The number of operations performed by vnodes on the node.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {operation} | Sum | Int | Cumulative | true |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {operation} | Sum | Int | Cumulative | true | development |
 
 #### Attributes
 

--- a/receiver/riakreceiver/metadata.yaml
+++ b/receiver/riakreceiver/metadata.yaml
@@ -39,6 +39,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [request]
   riak.node.operation.time.mean:
     description: The mean time between request and response for operations performed by the node over the last minute.
@@ -46,6 +48,8 @@ metrics:
     gauge:
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [request]
   riak.node.read_repair.count:
     description: The number of read repairs performed by the node.
@@ -55,6 +59,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   riak.memory.limit:
     description: The amount of memory allocated to the node.
     unit: By
@@ -63,6 +69,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
   riak.vnode.operation.count:
     description: The number of operations performed by vnodes on the node.
     unit: "{operation}"
@@ -71,6 +79,8 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     enabled: true
+    stability:
+      level: development
     attributes: [request]
   riak.vnode.index.operation.count:
     description: The number of index operations performed by vnodes on the node.
@@ -81,3 +91,5 @@ metrics:
       value_type: int
     attributes: [operation]
     enabled: true
+    stability:
+      level: development


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
