### PR TITLE
[chore][prometheusremotewriteexporter] Add stability level per metric

### DIFF
--- a/exporter/prometheusremotewriteexporter/documentation.md
+++ b/exporter/prometheusremotewriteexporter/documentation.md
@@ -8,128 +8,128 @@ The following telemetry is emitted by this component.
 
 ### otelcol_exporter_prometheusremotewrite_consumers
 
-Number of configured workers to use to fan out the outgoing requests
+Number of configured workers to use to fan out the outgoing requests [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {consumer} | Sum | Int | false |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {consumer} | Sum | Int | false | development |
 
 ### otelcol_exporter_prometheusremotewrite_failed_translations
 
-Number of translation operations that failed to translate metrics from Otel to Prometheus
+Number of translation operations that failed to translate metrics from Otel to Prometheus [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_sent_batches
 
-Number of remote write request batches sent to the remote write endpoint regardless of success or failure
+Number of remote write request batches sent to the remote write endpoint regardless of success or failure [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {batch} | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {batch} | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_translated_time_series
 
-Number of Prometheus time series that were translated from OTel metrics
+Number of Prometheus time series that were translated from OTel metrics [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_bytes_read
 
-Total number of bytes read from the WAL
+Total number of bytes read from the WAL [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| By | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| By | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_bytes_written
 
-Total number of bytes written to the WAL
+Total number of bytes written to the WAL [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| By | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| By | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_lag
 
-WAL lag
+WAL lag [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Gauge | Int | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_read_latency
 
-Response latency in ms for the WAL reads.
+Response latency in ms for the WAL reads. [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Histogram | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Histogram | Int | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_reads
 
-Number of WAL reads
+Number of WAL reads [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_reads_failures
 
-Number of WAL reads that failed
+Number of WAL reads that failed [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_write_latency
 
-Response latency in ms for the WAL writes.
+Response latency in ms for the WAL writes. [development]
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| ms | Histogram | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Histogram | Int | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_writes
 
-Number of WAL writes
+Number of WAL writes [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_wal_writes_failures
 
-Number of WAL writes that failed
+Number of WAL writes that failed [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| 1 | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_written_exemplars
 
-Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2)
+Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2) [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {exemplar} | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {exemplar} | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_written_histograms
 
-Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2)
+Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2) [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {histogram} | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {histogram} | Sum | Int | true | development |
 
 ### otelcol_exporter_prometheusremotewrite_written_samples
 
-Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2)
+Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2) [development]
 
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| {sample} | Sum | Int | true |
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {sample} | Sum | Int | true | development |

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
@@ -75,99 +75,99 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.ExporterPrometheusremotewriteConsumers, err = builder.meter.Int64UpDownCounter(
 		"otelcol_exporter_prometheusremotewrite_consumers",
-		metric.WithDescription("Number of configured workers to use to fan out the outgoing requests"),
+		metric.WithDescription("Number of configured workers to use to fan out the outgoing requests [development]"),
 		metric.WithUnit("{consumer}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteFailedTranslations, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_failed_translations",
-		metric.WithDescription("Number of translation operations that failed to translate metrics from Otel to Prometheus"),
+		metric.WithDescription("Number of translation operations that failed to translate metrics from Otel to Prometheus [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteSentBatches, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_sent_batches",
-		metric.WithDescription("Number of remote write request batches sent to the remote write endpoint regardless of success or failure"),
+		metric.WithDescription("Number of remote write request batches sent to the remote write endpoint regardless of success or failure [development]"),
 		metric.WithUnit("{batch}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteTranslatedTimeSeries, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_translated_time_series",
-		metric.WithDescription("Number of Prometheus time series that were translated from OTel metrics"),
+		metric.WithDescription("Number of Prometheus time series that were translated from OTel metrics [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalBytesRead, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_bytes_read",
-		metric.WithDescription("Total number of bytes read from the WAL"),
+		metric.WithDescription("Total number of bytes read from the WAL [development]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalBytesWritten, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_bytes_written",
-		metric.WithDescription("Total number of bytes written to the WAL"),
+		metric.WithDescription("Total number of bytes written to the WAL [development]"),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalLag, err = builder.meter.Int64Gauge(
 		"otelcol_exporter_prometheusremotewrite_wal_lag",
-		metric.WithDescription("WAL lag"),
+		metric.WithDescription("WAL lag [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalReadLatency, err = builder.meter.Int64Histogram(
 		"otelcol_exporter_prometheusremotewrite_wal_read_latency",
-		metric.WithDescription("Response latency in ms for the WAL reads."),
+		metric.WithDescription("Response latency in ms for the WAL reads. [development]"),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries([]float64{5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalReads, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_reads",
-		metric.WithDescription("Number of WAL reads"),
+		metric.WithDescription("Number of WAL reads [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalReadsFailures, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_reads_failures",
-		metric.WithDescription("Number of WAL reads that failed"),
+		metric.WithDescription("Number of WAL reads that failed [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalWriteLatency, err = builder.meter.Int64Histogram(
 		"otelcol_exporter_prometheusremotewrite_wal_write_latency",
-		metric.WithDescription("Response latency in ms for the WAL writes."),
+		metric.WithDescription("Response latency in ms for the WAL writes. [development]"),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries([]float64{5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000}...),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalWrites, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_writes",
-		metric.WithDescription("Number of WAL writes"),
+		metric.WithDescription("Number of WAL writes [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWalWritesFailures, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_wal_writes_failures",
-		metric.WithDescription("Number of WAL writes that failed"),
+		metric.WithDescription("Number of WAL writes that failed [development]"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWrittenExemplars, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_written_exemplars",
-		metric.WithDescription("Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2)"),
+		metric.WithDescription("Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2) [development]"),
 		metric.WithUnit("{exemplar}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWrittenHistograms, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_written_histograms",
-		metric.WithDescription("Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2)"),
+		metric.WithDescription("Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2) [development]"),
 		metric.WithUnit("{histogram}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ExporterPrometheusremotewriteWrittenSamples, err = builder.meter.Int64Counter(
 		"otelcol_exporter_prometheusremotewrite_written_samples",
-		metric.WithDescription("Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2)"),
+		metric.WithDescription("Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2) [development]"),
 		metric.WithUnit("{sample}"),
 	)
 	errs = errors.Join(errs, err)

--- a/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadatatest/generated_telemetrytest.go
@@ -24,7 +24,7 @@ func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
 func AssertEqualExporterPrometheusremotewriteConsumers(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_consumers",
-		Description: "Number of configured workers to use to fan out the outgoing requests",
+		Description: "Number of configured workers to use to fan out the outgoing requests [development]",
 		Unit:        "{consumer}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -40,7 +40,7 @@ func AssertEqualExporterPrometheusremotewriteConsumers(t *testing.T, tt *compone
 func AssertEqualExporterPrometheusremotewriteFailedTranslations(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_failed_translations",
-		Description: "Number of translation operations that failed to translate metrics from Otel to Prometheus",
+		Description: "Number of translation operations that failed to translate metrics from Otel to Prometheus [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -56,7 +56,7 @@ func AssertEqualExporterPrometheusremotewriteFailedTranslations(t *testing.T, tt
 func AssertEqualExporterPrometheusremotewriteSentBatches(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_sent_batches",
-		Description: "Number of remote write request batches sent to the remote write endpoint regardless of success or failure",
+		Description: "Number of remote write request batches sent to the remote write endpoint regardless of success or failure [development]",
 		Unit:        "{batch}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -72,7 +72,7 @@ func AssertEqualExporterPrometheusremotewriteSentBatches(t *testing.T, tt *compo
 func AssertEqualExporterPrometheusremotewriteTranslatedTimeSeries(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_translated_time_series",
-		Description: "Number of Prometheus time series that were translated from OTel metrics",
+		Description: "Number of Prometheus time series that were translated from OTel metrics [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -88,7 +88,7 @@ func AssertEqualExporterPrometheusremotewriteTranslatedTimeSeries(t *testing.T, 
 func AssertEqualExporterPrometheusremotewriteWalBytesRead(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_bytes_read",
-		Description: "Total number of bytes read from the WAL",
+		Description: "Total number of bytes read from the WAL [development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -104,7 +104,7 @@ func AssertEqualExporterPrometheusremotewriteWalBytesRead(t *testing.T, tt *comp
 func AssertEqualExporterPrometheusremotewriteWalBytesWritten(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_bytes_written",
-		Description: "Total number of bytes written to the WAL",
+		Description: "Total number of bytes written to the WAL [development]",
 		Unit:        "By",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -120,7 +120,7 @@ func AssertEqualExporterPrometheusremotewriteWalBytesWritten(t *testing.T, tt *c
 func AssertEqualExporterPrometheusremotewriteWalLag(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_lag",
-		Description: "WAL lag",
+		Description: "WAL lag [development]",
 		Unit:        "1",
 		Data: metricdata.Gauge[int64]{
 			DataPoints: dps,
@@ -134,7 +134,7 @@ func AssertEqualExporterPrometheusremotewriteWalLag(t *testing.T, tt *componentt
 func AssertEqualExporterPrometheusremotewriteWalReadLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_read_latency",
-		Description: "Response latency in ms for the WAL reads.",
+		Description: "Response latency in ms for the WAL reads. [development]",
 		Unit:        "ms",
 		Data: metricdata.Histogram[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -149,7 +149,7 @@ func AssertEqualExporterPrometheusremotewriteWalReadLatency(t *testing.T, tt *co
 func AssertEqualExporterPrometheusremotewriteWalReads(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_reads",
-		Description: "Number of WAL reads",
+		Description: "Number of WAL reads [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -165,7 +165,7 @@ func AssertEqualExporterPrometheusremotewriteWalReads(t *testing.T, tt *componen
 func AssertEqualExporterPrometheusremotewriteWalReadsFailures(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_reads_failures",
-		Description: "Number of WAL reads that failed",
+		Description: "Number of WAL reads that failed [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -181,7 +181,7 @@ func AssertEqualExporterPrometheusremotewriteWalReadsFailures(t *testing.T, tt *
 func AssertEqualExporterPrometheusremotewriteWalWriteLatency(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_write_latency",
-		Description: "Response latency in ms for the WAL writes.",
+		Description: "Response latency in ms for the WAL writes. [development]",
 		Unit:        "ms",
 		Data: metricdata.Histogram[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -196,7 +196,7 @@ func AssertEqualExporterPrometheusremotewriteWalWriteLatency(t *testing.T, tt *c
 func AssertEqualExporterPrometheusremotewriteWalWrites(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_writes",
-		Description: "Number of WAL writes",
+		Description: "Number of WAL writes [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -212,7 +212,7 @@ func AssertEqualExporterPrometheusremotewriteWalWrites(t *testing.T, tt *compone
 func AssertEqualExporterPrometheusremotewriteWalWritesFailures(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_wal_writes_failures",
-		Description: "Number of WAL writes that failed",
+		Description: "Number of WAL writes that failed [development]",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -228,7 +228,7 @@ func AssertEqualExporterPrometheusremotewriteWalWritesFailures(t *testing.T, tt 
 func AssertEqualExporterPrometheusremotewriteWrittenExemplars(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_written_exemplars",
-		Description: "Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2)",
+		Description: "Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2) [development]",
 		Unit:        "{exemplar}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -244,7 +244,7 @@ func AssertEqualExporterPrometheusremotewriteWrittenExemplars(t *testing.T, tt *
 func AssertEqualExporterPrometheusremotewriteWrittenHistograms(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_written_histograms",
-		Description: "Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2)",
+		Description: "Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2) [development]",
 		Unit:        "{histogram}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,
@@ -260,7 +260,7 @@ func AssertEqualExporterPrometheusremotewriteWrittenHistograms(t *testing.T, tt 
 func AssertEqualExporterPrometheusremotewriteWrittenSamples(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_exporter_prometheusremotewrite_written_samples",
-		Description: "Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2)",
+		Description: "Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2) [development]",
 		Unit:        "{sample}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -20,6 +20,8 @@ telemetry:
   metrics:
     exporter_prometheusremotewrite_failed_translations:
       enabled: true
+      stability:
+        level: development
       description: Number of translation operations that failed to translate metrics from Otel to Prometheus
       unit: "1"
       sum:
@@ -27,6 +29,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_translated_time_series:
       enabled: true
+      stability:
+        level: development
       description: Number of Prometheus time series that were translated from OTel metrics
       unit: "1"
       sum:
@@ -34,6 +38,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_written_samples:
       enabled: true
+      stability:
+        level: development
       description: Number of Prometheus Samples that were successfully written to the remote write endpoint (only available when using remote write v2)
       unit: "{sample}"
       sum:
@@ -41,6 +47,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_written_histograms:
       enabled: true
+      stability:
+        level: development
       description: Number of Prometheus Histograms that were successfully written to the remote write endpoint (only available when using remote write v2)
       unit: "{histogram}"
       sum:
@@ -48,6 +56,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_written_exemplars:
       enabled: true
+      stability:
+        level: development
       description: Number of Prometheus Exemplars that were successfully written to the remote write endpoint (only available when using remote write v2)
       unit: "{exemplar}"
       sum:
@@ -55,6 +65,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_consumers:
       enabled: true
+      stability:
+        level: development
       description: Number of configured workers to use to fan out the outgoing requests
       unit: "{consumer}"
       sum:
@@ -62,6 +74,8 @@ telemetry:
         monotonic: false
     exporter_prometheusremotewrite_sent_batches:
       enabled: true
+      stability:
+        level: development
       description: Number of remote write request batches sent to the remote write endpoint regardless of success or failure
       unit: "{batch}"
       sum:
@@ -69,6 +83,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_writes:
       enabled: true
+      stability:
+        level: development
       description: Number of WAL writes
       unit: "1"
       sum:
@@ -76,6 +92,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_writes_failures:
       enabled: true
+      stability:
+        level: development
       description: Number of WAL writes that failed
       unit: "1"
       sum:
@@ -83,6 +101,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_reads:
       enabled: true
+      stability:
+        level: development
       description: Number of WAL reads
       unit: "1"
       sum:
@@ -90,6 +110,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_reads_failures:
       enabled: true
+      stability:
+        level: development
       description: Number of WAL reads that failed
       unit: "1"
       sum:
@@ -97,6 +119,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_write_latency:
       enabled: true
+      stability:
+        level: development
       description: Response latency in ms for the WAL writes.
       unit: ms
       histogram:
@@ -104,6 +128,8 @@ telemetry:
         bucket_boundaries: [5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
     exporter_prometheusremotewrite_wal_read_latency:
       enabled: true
+      stability:
+        level: development
       description: Response latency in ms for the WAL reads.
       unit: ms
       histogram:
@@ -111,6 +137,8 @@ telemetry:
         bucket_boundaries: [5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000]
     exporter_prometheusremotewrite_wal_bytes_written:
       enabled: true
+      stability:
+        level: development
       description: Total number of bytes written to the WAL
       unit: "By"
       sum:
@@ -118,6 +146,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_bytes_read:
       enabled: true
+      stability:
+        level: development
       description: Total number of bytes read from the WAL
       unit: "By"
       sum:
@@ -125,6 +155,8 @@ telemetry:
         monotonic: true
     exporter_prometheusremotewrite_wal_lag:
       enabled: true
+      stability:
+        level: development
       description: WAL lag
       unit: "1"
       gauge:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13756 added support for exposing metrics' stability level  in the generated documentation. This PR makes use of this functionality.

We start by setting the stability of all metrics to `development`. More info about levels can be found at https://github.com/open-telemetry/opentelemetry-specification/blob/v1.49.0/oteps/0232-maturity-of-otel.md#maturity-levels. 

Related to:
- https://github.com/open-telemetry/opentelemetry-collector/issues/11878
- https://github.com/open-telemetry/opentelemetry-collector/issues/13297
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42809

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes ~

<!--Describe what testing was performed and which tests were added.-->
#### Testing
~

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
