### PR TITLE
[testbed] Fix failing TestMetric10kDPS

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -34,7 +34,7 @@ func TestMetric10kDPS(t *testing.T) {
 			receiver: datareceivers.NewCarbonDataReceiver(testutil.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 237,
-				ExpectedMaxRAM: 105,
+				ExpectedMaxRAM: 150,
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func TestMetric10kDPS(t *testing.T) {
 			receiver: datareceivers.NewSFxMetricsDataReceiver(testutil.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 120,
-				ExpectedMaxRAM: 98,
+				ExpectedMaxRAM: 150,
 			},
 		},
 		{


### PR DESCRIPTION
The memory limits for Carbon and Signalfx formats are set too low. This bumps the limits to avoid failures.

Here is a failing example:
https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/17718996172/job/50348134333#step:9:176

No changelog is necessary.