### PR TITLE
[chore][ci] only run codeowners workflow when related files are changed

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -2,9 +2,15 @@ name: codeowners
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/CODEOWNERS"
+      - "**/metadata.yaml"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request_target:
+    paths:
+      - ".github/CODEOWNERS"
+      - "**/metadata.yaml"
     types:
       - opened
       - synchronize


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Based on the discussion we had on the following [Slack thread](https://cloud-native.slack.com/archives/C07CCCMRXBK/p1758785169835369), we decided to propose adding the ability to skip the `codeowners` workflow if the related files are not changed at all. This will improve the CI performance a bit.