### PR TITLE
[receiver/k8seventsreceiver] avoid panic on non-Event objects in informer handler

### DIFF
--- a/.chloggen/fix_panic_event_filter.yaml
+++ b/.chloggen/fix_panic_event_filter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "receiver/k8seventsreceiver"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Prevent potential panic in the events receiver by safely checking that informer objects are *corev1.Event before handling them."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43014]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8seventsreceiver/receiver.go
+++ b/receiver/k8seventsreceiver/receiver.go
@@ -96,12 +96,14 @@ func (kr *k8seventsReceiver) startWatch(ns string, client k8s.Interface) {
 	kr.stopperChanList = append(kr.stopperChanList, stopperChan)
 	kr.startWatchingNamespace(client, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
-			ev := obj.(*corev1.Event)
-			kr.handleEvent(ev)
+			if ev, ok := obj.(*corev1.Event); ok {
+				kr.handleEvent(ev)
+			}
 		},
 		UpdateFunc: func(_, obj any) {
-			ev := obj.(*corev1.Event)
-			kr.handleEvent(ev)
+			if ev, ok := obj.(*corev1.Event); ok {
+				kr.handleEvent(ev)
+			}
 		},
 	}, ns, stopperChan)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

As discussed in the following [thread](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42330#discussion_r2380455710), I decided to open a dedicated PR for this.

The change just makes the code safer, as before we were assuming the object was always an Event, which could panic if it wasn’t. Now we check first, and skip anything that isn’t an Event.
