### PR TITLE
[chore][ci] improve Build gotestsum for Windows

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -78,14 +78,9 @@ jobs:
         if: steps.go-setup.outputs.cache-hit != 'true'
         run: make install-tools
 
-      - name: Build gotestsum on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh # Explicitly set the shell to avoid actionlint treating this an attempt to escape single quote
-        run: make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
-
       - name: Build gotestsum
-        if: runner.os != 'Windows'
-        run: make "$PWD/.tools/gotestsum"
+        working-directory: ${{ github.workspace }}
+        run: make .tools/gotestsum
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Seems the CI for `scoped-tests-matrix (windows-latest)` is failing due to the `Build gotestsum on Windows` error.

```sh
Run make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
make: *** No rule to make target 'D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/.tools/gotestsum'.  Stop.
Error: Process completed with exit code 1.
```

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/18048822328/job/51369899669?pr=43018 and https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/18050658515/job/51371803867?pr=43019

I think we can simplify the `Build gotestsum` task into a single one using the `working-directory` definition, and this should fix the issue.

Found the issue in:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43018
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43019
