### PR TITLE
Fix invalid configuration example in PostgreSQL receiver README

### DIFF
--- a/.chloggen/fix-postgresql-readme-config-42838.yaml
+++ b/.chloggen/fix-postgresql-readme-config-42838.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "receiver/postgresql"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix invalid configuration example in README by correctly placing `max_rows_per_query` under `query_sample_collection` and `top_query_collection` sections instead of `events` section"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42838]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/postgresqlreceiver/README.md
+++ b/receiver/postgresqlreceiver/README.md
@@ -125,8 +125,10 @@ receivers:
         enabled: true
       db.server.top_query:
         enabled: true
-      max_rows_per_query: 100 
+    query_sample_collection:
+      max_rows_per_query: 100
     top_query_collection:
+      max_rows_per_query: 100
       top_n_query: 100
 ```
 


### PR DESCRIPTION
## Description

This PR fixes the invalid configuration example in the PostgreSQL receiver README that was causing configuration validation errors.

## Problem

The `max_rows_per_query` parameter was incorrectly placed under the `events` section, causing the error: `'events' has invalid keys: max_rows_per_query`

## Solution

Moved `max_rows_per_query` to the correct sections:
- Added `query_sample_collection.max_rows_per_query` for query sample configuration
- Added `top_query_collection.max_rows_per_query` for top query configuration

This aligns the documentation with the actual struct definitions in config.go (lines 41, 31, 57-58).

## Testing

- Verified configuration structure matches config.go
- All existing tests pass: `go test -short ./...`
- Configuration can now be parsed without errors

## Related Issues

Fixes #42838

## Checklist

- [x] Documentation updated
- [x] Changelog entry added
- [x] Tests passing
- [x] Follows contributing guidelines