### PR TITLE
[chore][ci] Fix `scoped-test` build gostestsum step

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -79,8 +79,8 @@ jobs:
         run: make install-tools
 
       - name: Build gotestsum
-        working-directory: ${{ github.workspace }}
-        run: make .tools/gotestsum
+        shell: bash
+        run: make "$PWD/.tools/gotestsum"
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -20,6 +20,7 @@ import (
 var creationSet = receivertest.NewNopSettings(metadata.Type)
 
 func TestCreateDefaultConfig(t *testing.T) {
+	// Bogus change just to trigger `scoped-test`: must be reverted before merging corresponding PR.
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -20,7 +20,6 @@ import (
 var creationSet = receivertest.NewNopSettings(metadata.Type)
 
 func TestCreateDefaultConfig(t *testing.T) {
-	// Bogus change just to trigger `scoped-test`: must be reverted before merging corresponding PR.
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")


### PR DESCRIPTION
The target for `gotestsum` needs to include the full path, keeping it as a runner OS independent step by ensuring that it always runs on `bash`.

cc @paulojmdias @atoulme 