### PR TITLE
[receiver/azureeventhubreceiver] use `$Default` as default consumer group

### DIFF
--- a/.chloggen/dylan_azure-event-hubs-default-consumer-group.yaml
+++ b/.chloggen/dylan_azure-event-hubs-default-consumer-group.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use `$Default` as the default consumer group with the new azeventhubs SDK
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43049]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -24,10 +24,16 @@ type azPartitionClient interface {
 }
 
 func newAzeventhubWrapper(h *eventhubHandler) (*hubWrapperAzeventhubImpl, error) {
+	consumerGroup := h.config.ConsumerGroup
+	// Default the consumer group to $Default
+	if consumerGroup == "" {
+		consumerGroup = "$Default"
+	}
+
 	hub, newHubErr := azeventhubs.NewConsumerClientFromConnectionString(
 		h.config.Connection,
 		"",
-		h.config.ConsumerGroup,
+		consumerGroup,
 		&azeventhubs.ConsumerClientOptions{},
 	)
 
@@ -124,7 +130,6 @@ func (h *hubWrapperAzeventhubImpl) Receive(ctx context.Context, partitionID stri
 				}
 			}
 		}
-
 		pc, err := h.hub.NewPartitionClient(partitionID, &azeventhubs.PartitionClientOptions{
 			StartPosition: startPos,
 		})

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -23,12 +23,15 @@ type azPartitionClient interface {
 	ReceiveEvents(ctx context.Context, maxBatchSize int, options *azeventhubs.ReceiveEventsOptions) ([]*azeventhubs.ReceivedEventData, error)
 }
 
-func newAzeventhubWrapper(h *eventhubHandler) (*hubWrapperAzeventhubImpl, error) {
-	consumerGroup := h.config.ConsumerGroup
-	// Default the consumer group to $Default
-	if consumerGroup == "" {
-		consumerGroup = "$Default"
+func getConsumerGroup(config *Config) string {
+	if config.ConsumerGroup == "" {
+		return "$Default"
 	}
+	return config.ConsumerGroup
+}
+
+func newAzeventhubWrapper(h *eventhubHandler) (*hubWrapperAzeventhubImpl, error) {
+	consumerGroup := getConsumerGroup(h.config)
 
 	hub, newHubErr := azeventhubs.NewConsumerClientFromConnectionString(
 		h.config.Connection,

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
@@ -226,7 +226,7 @@ func TestPartitionListener_SetErr(t *testing.T) {
 	assert.Equal(t, "test", p.err.Error())
 }
 
-func TestNewAzeventhubWrapper_ConsumerGroupDefault(t *testing.T) {
+func TestGetConsumerGroup(t *testing.T) {
 	testCases := []struct {
 		name          string
 		consumerGroup string
@@ -246,23 +246,12 @@ func TestNewAzeventhubWrapper_ConsumerGroupDefault(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			// Create a mock eventhubHandler with the test consumer group
-			handler := &eventhubHandler{
-				config: &Config{
-					Connection:    "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abcd;EntityPath=main",
-					ConsumerGroup: test.consumerGroup,
-				},
+			config := &Config{
+				ConsumerGroup: test.consumerGroup,
 			}
 
-			// We can't easily test the actual azeventhubs.NewConsumerClientFromConnectionString
-			// since it requires a real connection, but we can test the logic by checking
-			// that the consumer group is properly set in the config before the call
-			consumerGroup := handler.config.ConsumerGroup
-			if consumerGroup == "" {
-				consumerGroup = "$Default"
-			}
-
-			assert.Equal(t, test.expectedGroup, consumerGroup)
+			result := getConsumerGroup(config)
+			assert.Equal(t, test.expectedGroup, result)
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The old SDK sets `$Default` as the consumer group when no consumer groups are set. This is a fix to the new SDK implementation to do the same. This would cause issues when users attempted to use the new SDK and didn't have the consumer group set.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43049 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added tests for the function for getting the consumer group


<!--Please delete paragraphs that you did not use before submitting.-->
