### PR TITLE
[receiver/azureeventhubreceiver] Omit storage client setup if it is not configured

### DIFF
--- a/.chloggen/dylan_fix-azure-event-hubs-offset.yaml
+++ b/.chloggen/dylan_fix-azure-event-hubs-offset.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: With the new Azure Event Hubs SDK, the offset configuration option is now correctly honored, and the default start position is set to latest.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38487]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/dylan_fix-azure-event-hubs-offset.yaml
+++ b/.chloggen/dylan_fix-azure-event-hubs-offset.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: azureeventhubreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: With the new Azure Event Hubs SDK, the offset configuration option is now correctly honored, and the default start position is set to latest.
+note: Offset configuration option is now correctly honored, and the default start position is set to latest.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [38487]

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -47,10 +47,14 @@ type eventhubHandler struct {
 	storageClient storage.Client
 }
 
+func shouldInitializeStorageClient(storageClient storage.Client, storageID *component.ID) bool {
+	return storageClient == nil && storageID != nil
+}
+
 func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 	ctx, h.cancel = context.WithCancel(ctx)
 
-	if h.storageClient == nil { // set manually for testing.
+	if shouldInitializeStorageClient(h.storageClient, h.config.StorageID) { // set manually for testing.
 		storageClient, err := adapter.GetStorageClient(ctx, host, h.config.StorageID, h.settings.ID)
 		if err != nil {
 			h.settings.Logger.Debug("Error connecting to Storage", zap.Error(err))

--- a/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
@@ -72,7 +72,7 @@ func (h *hubWrapperLegacyImpl) Receive(ctx context.Context, partitionID string, 
 	if h.config.ConsumerGroup != "" {
 		receiverOptions = append(receiverOptions, eventhub.ReceiveWithConsumerGroup(h.config.ConsumerGroup))
 	}
-	if h.config.StorageID == nil && (applyOffset == false || h.config.Offset == "") {
+	if h.config.StorageID == nil && (!applyOffset || h.config.Offset == "") {
 		receiverOptions = append(receiverOptions, eventhub.ReceiveWithLatestOffset())
 	}
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
@@ -69,9 +69,11 @@ func (h *hubWrapperLegacyImpl) Receive(ctx context.Context, partitionID string, 
 	if applyOffset && h.config.Offset != "" {
 		receiverOptions = append(receiverOptions, eventhub.ReceiveWithStartingOffset(h.config.Offset))
 	}
-
 	if h.config.ConsumerGroup != "" {
 		receiverOptions = append(receiverOptions, eventhub.ReceiveWithConsumerGroup(h.config.ConsumerGroup))
+	}
+	if h.config.StorageID == nil && (applyOffset == false || h.config.Offset == "") {
+		receiverOptions = append(receiverOptions, eventhub.ReceiveWithLatestOffset())
 	}
 
 	if h.hub != nil {

--- a/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
@@ -18,14 +18,20 @@ type legacyHubWrapper interface {
 }
 
 func newLegacyHubWrapper(h *eventhubHandler) (*hubWrapperLegacyImpl, error) {
+	options := []eventhub.HubOption{}
+	if h.storageClient != nil {
+		options = append(options,
+			eventhub.HubWithOffsetPersistence(
+				&storageCheckpointPersister[persist.Checkpoint]{
+					storageClient: h.storageClient,
+					defaultValue:  persist.NewCheckpointFromStartOfStream(),
+				},
+			),
+		)
+	}
 	hub, newHubErr := eventhub.NewHubFromConnectionString(
 		h.config.Connection,
-		eventhub.HubWithOffsetPersistence(
-			&storageCheckpointPersister[persist.Checkpoint]{
-				storageClient: h.storageClient,
-				defaultValue:  persist.NewCheckpointFromStartOfStream(),
-			},
-		),
+		options...,
 	)
 	if newHubErr != nil {
 		h.settings.Logger.Debug("Error connecting to Event Hub", zap.Error(newHubErr))

--- a/receiver/azureeventhubreceiver/eventhubhandler_legacy_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_legacy_test.go
@@ -77,7 +77,7 @@ func TestHubWrapperLegacyImpl_Receive(t *testing.T) {
 	}{
 		{
 			name:                "simple",
-			expectedOptionCount: 0,
+			expectedOptionCount: 1, // Default to latest offset when no storage and no offset
 			shouldCallReceive:   true,
 		},
 		{
@@ -85,6 +85,7 @@ func TestHubWrapperLegacyImpl_Receive(t *testing.T) {
 			partitionID:         "partition1",
 			expectedPartitionID: "partition1",
 			shouldCallReceive:   true,
+			expectedOptionCount: 1, // Default to latest offset when no storage and no offset
 		},
 		{
 			name:                "offset with apply",
@@ -98,14 +99,14 @@ func TestHubWrapperLegacyImpl_Receive(t *testing.T) {
 			offset:              "1",
 			applyOffset:         false,
 			shouldCallReceive:   true,
-			expectedOptionCount: 0,
+			expectedOptionCount: 1, // Default to latest offset when no storage and no offset
 		},
 		{
 			name:                "no offset with apply",
 			offset:              "",
 			applyOffset:         true,
 			shouldCallReceive:   true,
-			expectedOptionCount: 0,
+			expectedOptionCount: 1, // Default to latest offset when no storage and no offset
 		},
 		{
 			name:                "offset with partition id",
@@ -120,7 +121,7 @@ func TestHubWrapperLegacyImpl_Receive(t *testing.T) {
 			name:                "consumer group",
 			consumerGroup:       "cg1",
 			shouldCallReceive:   true,
-			expectedOptionCount: 1,
+			expectedOptionCount: 2, // Consumer group + latest offset
 		},
 		{
 			name:                "consumer group and offset",

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -124,14 +124,16 @@ func TestShouldInitializeStorageClient(t *testing.T) {
 			expected:      true,
 		},
 		{
-			name:      "has storage client and storage ID - should not initialize",
-			storageID: &component.ID{},
-			expected:  false,
+			name:          "has storage client and storage ID - should not initialize",
+			storageClient: &mockStorageClient{},
+			storageID:     &component.ID{},
+			expected:      false,
 		},
 		{
-			name:      "has storage client but no storage ID - should not initialize",
-			storageID: nil,
-			expected:  false,
+			name:          "has storage client but no storage ID - should not initialize",
+			storageClient: &mockStorageClient{},
+			storageID:     nil,
+			expected:      false,
 		},
 	}
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -147,23 +147,23 @@ func TestShouldInitializeStorageClient(t *testing.T) {
 
 type mockStorageClient struct{}
 
-func (m *mockStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+func (*mockStorageClient) Get(_ context.Context, _ string) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *mockStorageClient) Set(ctx context.Context, key string, value []byte) error {
+func (*mockStorageClient) Set(_ context.Context, _ string, _ []byte) error {
 	return nil
 }
 
-func (m *mockStorageClient) Delete(ctx context.Context, key string) error {
+func (*mockStorageClient) Delete(_ context.Context, _ string) error {
 	return nil
 }
 
-func (m *mockStorageClient) Batch(ctx context.Context, ops ...*storage.Operation) error {
+func (*mockStorageClient) Batch(_ context.Context, _ ...*storage.Operation) error {
 	return nil
 }
 
-func (m *mockStorageClient) Close(ctx context.Context) error {
+func (*mockStorageClient) Close(_ context.Context) error {
 	return nil
 }
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
@@ -101,6 +102,67 @@ func TestEventhubHandler_Start(t *testing.T) {
 
 	assert.NoError(t, ehHandler.run(t.Context(), componenttest.NewNopHost()))
 	assert.NoError(t, ehHandler.close(t.Context()))
+}
+
+func TestShouldInitializeStorageClient(t *testing.T) {
+	testCases := []struct {
+		name          string
+		storageClient storage.Client
+		storageID     *component.ID
+		expected      bool
+	}{
+		{
+			name:          "no storage client and no storage ID - should not initialize",
+			storageClient: nil,
+			storageID:     nil,
+			expected:      false,
+		},
+		{
+			name:          "no storage client but has storage ID - should initialize",
+			storageClient: nil,
+			storageID:     &component.ID{},
+			expected:      true,
+		},
+		{
+			name:      "has storage client and storage ID - should not initialize",
+			storageID: &component.ID{},
+			expected:  false,
+		},
+		{
+			name:      "has storage client but no storage ID - should not initialize",
+			storageID: nil,
+			expected:  false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			result := shouldInitializeStorageClient(test.storageClient, test.storageID)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+type mockStorageClient struct{}
+
+func (m *mockStorageClient) Get(ctx context.Context, key string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockStorageClient) Set(ctx context.Context, key string, value []byte) error {
+	return nil
+}
+
+func (m *mockStorageClient) Delete(ctx context.Context, key string) error {
+	return nil
+}
+
+func (m *mockStorageClient) Batch(ctx context.Context, ops ...*storage.Operation) error {
+	return nil
+}
+
+func (m *mockStorageClient) Close(ctx context.Context) error {
+	return nil
 }
 
 func TestEventhubHandler_newAzeventhubsMessageHandler(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
A storage client was always being created, which was overriding the user-provided `offset` and not setting the default position to `latest`

The following code in the `Receive` function of the `eventhubhandler_azeventhub.go` file was always getting set to the storage client.
```go
		startPos := azeventhubs.StartPosition{Latest: to.Ptr(true)}
		if applyOffset && h.config.Offset != "" {
			startPos = azeventhubs.StartPosition{Offset: &h.config.Offset}
		}
		if h.storage != nil {
			checkpoint, readErr := h.storage.Read(namespace, pProps.EventHubName, h.config.ConsumerGroup, partitionID)
			if readErr == nil {
				startPos = azeventhubs.StartPosition{
					SequenceNumber: &checkpoint.SeqNumber,
				}
			}
		}
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38487

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a test to validate this going forward

<!--Please delete paragraphs that you did not use before submitting.-->
