### PR TITLE
[exporter/prometheus] Expose native histograms

### DIFF
--- a/.chloggen/feature_33703-prometheus-exporter-support-native-histograms.yaml
+++ b/.chloggen/feature_33703-prometheus-exporter-support-native-histograms.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support to exponential histograms
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33703]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/feature_33703-prometheus-exporter-support-native-histograms.yaml
+++ b/.chloggen/feature_33703-prometheus-exporter-support-native-histograms.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: prometheusexporter
+component: exporter/prometheus
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support to exponential histograms

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -489,14 +489,14 @@ func calculateBucketUpperBound(scale, offset int32, index int) float64 {
 
 // filterBucketsForZeroThreshold filters buckets that fall below the zero threshold
 // and returns the filtered buckets and the additional zero count
-func filterBucketsForZeroThreshold(offset int32, counts []uint64, scale int32, zeroThreshold float64) (int32, []uint64, uint64) {
+func filterBucketsForZeroThreshold(offset int32, counts []uint64, scale int32, zeroThreshold float64) (newOffset int32, filteredCounts []uint64, additionalZeroCount uint64) {
 	if len(counts) == 0 || zeroThreshold <= 0 {
 		return offset, counts, 0
 	}
 
-	additionalZeroCount := uint64(0)
-	filteredCounts := make([]uint64, 0, len(counts))
-	newOffset := offset
+	additionalZeroCount = uint64(0)
+	filteredCounts = make([]uint64, 0, len(counts))
+	newOffset = offset
 
 	// Find the first bucket whose upper bound is > zeroThreshold
 	for i, count := range counts {

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -501,15 +501,13 @@ func filterBucketsForZeroThreshold(offset int32, counts []uint64, scale int32, z
 	// Find the first bucket whose upper bound is > zeroThreshold
 	for i, count := range counts {
 		upperBound := calculateBucketUpperBound(scale, offset, i)
-		if upperBound <= zeroThreshold {
-			// This bucket's range falls entirely below the zero threshold
-			additionalZeroCount += count
-			newOffset = offset + int32(i) + 1 // Move offset to next bucket
-		} else {
-			// This bucket and all subsequent buckets should be kept
+		if upperBound > zeroThreshold {
 			filteredCounts = append(filteredCounts, counts[i:]...)
 			break
 		}
+		// This bucket's range falls entirely below the zero threshold
+		additionalZeroCount += count
+		newOffset = offset + int32(i) + 1 // Move offset to next bucket
 	}
 
 	// If all buckets were filtered out, return empty buckets
@@ -617,7 +615,6 @@ func downscaleBucketSide(offset int32, counts []uint64, fromScale, targetScale i
 		} else {
 			counts[nk-newOffset] += counts[i]
 		}
-
 	}
 	return newOffset, counts[:newLen]
 }

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -370,6 +370,9 @@ func (a *lastValueAccumulator) accumulateNativeHistogram(metric pmetric.Metric, 
 			continue
 		}
 
+		// Store the updated metric and advance count
+		a.registeredMetrics.Store(signature, &accumulatedValue{value: m, resourceAttrs: resourceAttrs, scopeName: scopeName, scopeVersion: scopeVersion, scopeSchemaURL: scopeSchemaURL, scopeAttributes: scopeAttributes, updated: now})
+		n++
 	}
 	return
 }

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -367,7 +367,8 @@ func (a *lastValueAccumulator) accumulateExponentialHistogram(metric pmetric.Met
 		a.registeredMetrics.Store(signature, &accumulatedValue{value: m, resourceAttrs: resourceAttrs, scopeName: scopeName, scopeVersion: scopeVersion, scopeSchemaURL: scopeSchemaURL, scopeAttributes: scopeAttributes, updated: now})
 		n++
 	}
-	return
+
+	return n
 }
 
 // Collect returns a slice with relevant aggregated metrics and their resource attributes.

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -481,13 +481,13 @@ func accumulateHistogramValues(prev, current, dest pmetric.HistogramDataPoint) {
 
 func accumulateExponentialHistogramValues(prev, current, dest pmetric.ExponentialHistogramDataPoint) {
 	if current.Timestamp().AsTime().Before(prev.Timestamp().AsTime()) {
-		dest.SetStartTimestamp(prev.StartTimestamp())
-		current.Attributes().CopyTo(dest.Attributes())
-		dest.SetTimestamp(current.Timestamp())
-	} else {
 		dest.SetStartTimestamp(current.StartTimestamp())
 		prev.Attributes().CopyTo(dest.Attributes())
 		dest.SetTimestamp(prev.Timestamp())
+	} else {
+		dest.SetStartTimestamp(prev.StartTimestamp())
+		current.Attributes().CopyTo(dest.Attributes())
+		dest.SetTimestamp(current.Timestamp())
 	}
 
 	targetScale := min(current.Scale(), prev.Scale())

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -550,13 +550,17 @@ func downscaleBucketSide(offset int32, counts []uint64, fromScale, targetScale i
 	newOffset := floorDivInt32(first, factor)
 	newLast := floorDivInt32(last, factor)
 	newLen := int(newLast - newOffset + 1)
-	out := make([]uint64, newLen)
 	for i := range counts {
 		k := offset + int32(i)
 		nk := floorDivInt32(k, factor)
-		out[nk-newOffset] += counts[i]
+		if k%factor == 0 {
+			counts[nk-newOffset] = counts[i]
+		} else {
+			counts[nk-newOffset] += counts[i]
+		}
+
 	}
-	return newOffset, out
+	return newOffset, counts[:newLen]
 }
 
 func mergeBuckets(offsetA int32, countsA []uint64, offsetB int32, countsB []uint64) (int32, []uint64) {

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -567,16 +567,16 @@ func mergeBuckets(offsetA int32, countsA []uint64, offsetB int32, countsB []uint
 	if len(countsA) == 0 && len(countsB) == 0 {
 		return 0, nil
 	}
-	minOffset := offsetA
-	if len(countsB) > 0 && (len(countsA) == 0 || offsetB < minOffset) {
-		minOffset = offsetB
+	if len(countsA) == 0 {
+		return offsetB, countsB
 	}
+	if len(countsB) == 0 {
+		return offsetA, countsA
+	}
+	minOffset := min(offsetB, offsetA)
 	lastA := offsetA + int32(len(countsA)) - 1
 	lastB := offsetB + int32(len(countsB)) - 1
-	maxLast := lastA
-	if len(countsB) > 0 && (len(countsA) == 0 || lastB > maxLast) {
-		maxLast = lastB
-	}
+	maxLast := max(lastB, lastA)
 	newBucketLen := int(maxLast - minOffset + 1)
 	newBucketCount := make([]uint64, newBucketLen)
 	for i := range countsA {

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -809,6 +809,218 @@ func TestAccumulateDeltaToCumulativeExponentialHistogram(t *testing.T) {
 	})
 }
 
+func TestAccumulateExponentialHistogramZeroThresholds(t *testing.T) {
+	appendDeltaNativeWithZeroThreshold := func(startTs, ts time.Time, scale, posOff int32, pos []uint64, negOff int32, neg []uint64,
+		zeroCount, count uint64, sum, zeroThreshold float64, metrics pmetric.MetricSlice,
+	) pmetric.Metric {
+		metric := metrics.AppendEmpty()
+		metric.SetName("test_native_hist_zero_threshold")
+		metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+		dp.SetScale(scale)
+		dp.Positive().SetOffset(posOff)
+		dp.Positive().BucketCounts().FromRaw(pos)
+		dp.Negative().SetOffset(negOff)
+		dp.Negative().BucketCounts().FromRaw(neg)
+		dp.SetZeroCount(zeroCount)
+		dp.SetCount(count)
+		dp.SetZeroThreshold(zeroThreshold)
+		dp.SetSum(sum)
+		dp.Attributes().PutStr("label_1", "1")
+		dp.Attributes().PutStr("label_2", "2")
+		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTs))
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+		return metric
+	}
+
+	t.Run("MergeWithHigherZeroThreshold", func(t *testing.T) {
+		// Test merging two histograms where one has a higher zero threshold
+		// Some buckets from the histogram with lower threshold should be moved to zero count
+		startTs := time.Now().Add(-6 * time.Second)
+		ts1 := time.Now().Add(-5 * time.Second)
+		ts2 := time.Now().Add(-4 * time.Second)
+
+		rm := pmetric.NewResourceMetrics()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		ilm.Scope().SetName("test")
+
+		// First histogram: scale=0, offset=0, zeroThreshold=0.5, buckets representing ranges [1,2), [2,4), [4,8)
+		// Bucket 0: [2^0, 2^1) = [1,2), count=2
+		// Bucket 1: [2^1, 2^2) = [2,4), count=3
+		// Bucket 2: [2^2, 2^3) = [4,8), count=1
+		appendDeltaNativeWithZeroThreshold(startTs, ts1, 0, 0, []uint64{2, 3, 1}, 0, nil, 1, 7, 15.0, 0.5, ilm.Metrics())
+
+		// Second histogram: scale=0, offset=0, zeroThreshold=3.0, buckets representing same ranges
+		// With new zero threshold of 3.0, bucket 0 [1,2) should be moved to zero count
+		// Only buckets [2,4) and [4,8) should remain
+		m2 := appendDeltaNativeWithZeroThreshold(ts1, ts2, 0, 0, []uint64{1, 2, 4}, 0, nil, 2, 9, 20.0, 3.0, ilm.Metrics())
+
+		a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
+		n := a.Accumulate(rm)
+		require.Equal(t, 2, n)
+
+		sig := timeseriesSignature(ilm.Scope().Name(), ilm.Scope().Version(), ilm.SchemaUrl(), ilm.Scope().Attributes(), ilm.Metrics().At(0), m2.ExponentialHistogram().DataPoints().At(0).Attributes(), pcommon.NewMap())
+		got, ok := a.registeredMetrics.Load(sig)
+		require.True(t, ok)
+		dp := got.(*accumulatedValue).value.ExponentialHistogram().DataPoints().At(0)
+
+		// Expect zero threshold to be the maximum (3.0)
+		require.InDelta(t, 3.0, dp.ZeroThreshold(), 1e-12)
+
+		// Zero count should include original zero counts plus bucket 0 from first histogram
+		// Original zero counts: 1 + 2 = 3, plus bucket 0 from first histogram: 2
+		require.Equal(t, uint64(3+2), dp.ZeroCount())
+
+		// After filtering first histogram: offset=1, counts=[3,1] (bucket 0 removed)
+		// Second histogram: offset=0, counts=[1,2,4]
+		// Merged result: offset=0, counts=[1, 3+2, 1+4] = [1, 5, 5]
+		require.Equal(t, int32(0), dp.Positive().Offset())
+		require.Equal(t, 3, dp.Positive().BucketCounts().Len())
+		require.Equal(t, uint64(1), dp.Positive().BucketCounts().At(0)) // bucket 0: [1,2) from second histogram
+		require.Equal(t, uint64(5), dp.Positive().BucketCounts().At(1)) // bucket 1: [2,4) = 3+2
+		require.Equal(t, uint64(5), dp.Positive().BucketCounts().At(2)) // bucket 2: [4,8) = 1+4
+
+		// Total count should remain the same
+		require.Equal(t, uint64(16), dp.Count())
+
+		// Sum should be sum of both histograms
+		require.InDelta(t, 35.0, dp.Sum(), 1e-12)
+	})
+
+	t.Run("MergeSameZeroThreshold", func(t *testing.T) {
+		// Test merging two histograms with the same zero threshold
+		// No buckets should be moved to zero count
+		startTs := time.Now().Add(-6 * time.Second)
+		ts1 := time.Now().Add(-5 * time.Second)
+		ts2 := time.Now().Add(-4 * time.Second)
+
+		rm := pmetric.NewResourceMetrics()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		ilm.Scope().SetName("test")
+
+		appendDeltaNativeWithZeroThreshold(startTs, ts1, 0, 0, []uint64{2, 3}, 0, nil, 1, 6, 10.0, 1.0, ilm.Metrics())
+		m2 := appendDeltaNativeWithZeroThreshold(ts1, ts2, 0, 0, []uint64{1, 2}, 0, nil, 2, 5, 8.0, 1.0, ilm.Metrics())
+
+		a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
+		n := a.Accumulate(rm)
+		require.Equal(t, 2, n)
+
+		sig := timeseriesSignature(ilm.Scope().Name(), ilm.Scope().Version(), ilm.SchemaUrl(), ilm.Scope().Attributes(), ilm.Metrics().At(0), m2.ExponentialHistogram().DataPoints().At(0).Attributes(), pcommon.NewMap())
+		got, ok := a.registeredMetrics.Load(sig)
+		require.True(t, ok)
+		dp := got.(*accumulatedValue).value.ExponentialHistogram().DataPoints().At(0)
+
+		// Zero threshold should remain 1.0
+		require.InDelta(t, 1.0, dp.ZeroThreshold(), 1e-12)
+
+		// Zero count should just be the sum of original zero counts
+		require.Equal(t, uint64(1+2), dp.ZeroCount())
+
+		// Positive buckets should be merged normally
+		require.Equal(t, int32(0), dp.Positive().Offset())
+		require.Equal(t, 2, dp.Positive().BucketCounts().Len())
+		require.Equal(t, uint64(3), dp.Positive().BucketCounts().At(0)) // 2+1
+		require.Equal(t, uint64(5), dp.Positive().BucketCounts().At(1)) // 3+2
+
+		// Total count
+		require.Equal(t, uint64(11), dp.Count())
+
+		// Sum
+		require.InDelta(t, 18.0, dp.Sum(), 1e-12)
+	})
+
+	t.Run("AllBucketsMovedToZeroCount", func(t *testing.T) {
+		// Test case where all buckets from one histogram get moved to zero count
+		startTs := time.Now().Add(-6 * time.Second)
+		ts1 := time.Now().Add(-5 * time.Second)
+		ts2 := time.Now().Add(-4 * time.Second)
+
+		rm := pmetric.NewResourceMetrics()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		ilm.Scope().SetName("test")
+
+		// First histogram: small buckets, zero threshold = 0.1
+		// Buckets: [1,2), [2,4) with counts [3, 2]
+		appendDeltaNativeWithZeroThreshold(startTs, ts1, 0, 0, []uint64{3, 2}, 0, nil, 1, 6, 5.0, 0.1, ilm.Metrics())
+
+		// Second histogram: higher zero threshold = 10.0, which is greater than all bucket upper bounds from first histogram
+		// Buckets: [4,8), [8,16) with counts [1, 1]
+		m2 := appendDeltaNativeWithZeroThreshold(ts1, ts2, 0, 2, []uint64{1, 1}, 0, nil, 5, 7, 12.0, 10.0, ilm.Metrics())
+
+		a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
+		n := a.Accumulate(rm)
+		require.Equal(t, 2, n)
+
+		sig := timeseriesSignature(ilm.Scope().Name(), ilm.Scope().Version(), ilm.SchemaUrl(), ilm.Scope().Attributes(), ilm.Metrics().At(0), m2.ExponentialHistogram().DataPoints().At(0).Attributes(), pcommon.NewMap())
+		got, ok := a.registeredMetrics.Load(sig)
+		require.True(t, ok)
+		dp := got.(*accumulatedValue).value.ExponentialHistogram().DataPoints().At(0)
+
+		// Zero threshold should be 10.0
+		require.InDelta(t, 10.0, dp.ZeroThreshold(), 1e-12)
+
+		// Zero count should include all buckets from first histogram plus original zero counts
+		// Original zero counts: 1 + 5 = 6, plus all buckets from first histogram: 3 + 2 = 5
+		require.Equal(t, uint64(6+5), dp.ZeroCount())
+
+		// Positive buckets should only include buckets from second histogram that weren't filtered
+		require.Equal(t, int32(2), dp.Positive().Offset())
+		require.Equal(t, 2, dp.Positive().BucketCounts().Len())
+		require.Equal(t, uint64(1), dp.Positive().BucketCounts().At(0)) // bucket 2: [4,8)
+		require.Equal(t, uint64(1), dp.Positive().BucketCounts().At(1)) // bucket 3: [8,16)
+
+		// Total count
+		require.Equal(t, uint64(13), dp.Count())
+
+		// Sum
+		require.InDelta(t, 17.0, dp.Sum(), 1e-12)
+	})
+
+	t.Run("LowerZeroThresholdHasNoBuckets", func(t *testing.T) {
+		// Test edge case where histogram with lower zero threshold has no positive buckets
+		startTs := time.Now().Add(-6 * time.Second)
+		ts1 := time.Now().Add(-5 * time.Second)
+		ts2 := time.Now().Add(-4 * time.Second)
+
+		rm := pmetric.NewResourceMetrics()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		ilm.Scope().SetName("test")
+
+		// First histogram: only zero count, no positive buckets
+		appendDeltaNativeWithZeroThreshold(startTs, ts1, 0, 0, nil, 0, nil, 5, 5, 0.0, 0.1, ilm.Metrics())
+
+		// Second histogram: has buckets, higher zero threshold
+		m2 := appendDeltaNativeWithZeroThreshold(ts1, ts2, 0, 1, []uint64{2, 3}, 0, nil, 3, 8, 15.0, 2.0, ilm.Metrics())
+
+		a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
+		n := a.Accumulate(rm)
+		require.Equal(t, 2, n)
+
+		sig := timeseriesSignature(ilm.Scope().Name(), ilm.Scope().Version(), ilm.SchemaUrl(), ilm.Scope().Attributes(), ilm.Metrics().At(0), m2.ExponentialHistogram().DataPoints().At(0).Attributes(), pcommon.NewMap())
+		got, ok := a.registeredMetrics.Load(sig)
+		require.True(t, ok)
+		dp := got.(*accumulatedValue).value.ExponentialHistogram().DataPoints().At(0)
+
+		// Zero threshold should be 2.0
+		require.InDelta(t, 2.0, dp.ZeroThreshold(), 1e-12)
+
+		// Zero count should be sum of original zero counts
+		require.Equal(t, uint64(5+3), dp.ZeroCount())
+
+		// Positive buckets should be from second histogram only
+		require.Equal(t, int32(1), dp.Positive().Offset())
+		require.Equal(t, 2, dp.Positive().BucketCounts().Len())
+		require.Equal(t, uint64(2), dp.Positive().BucketCounts().At(0))
+		require.Equal(t, uint64(3), dp.Positive().BucketCounts().At(1))
+
+		// Total count
+		require.Equal(t, uint64(13), dp.Count())
+
+		// Sum
+		require.InDelta(t, 15.0, dp.Sum(), 1e-12)
+	})
+}
+
 func TestTimeseriesSignatureNotMutating(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutStr("label_2", "2")

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -644,8 +644,9 @@ func TestAccumulateDroppedMetrics(t *testing.T) {
 }
 
 func TestAccumulateDeltaToCumulativeExponentialHistogram(t *testing.T) {
-	appendDeltaNative := func(startTs, ts time.Time, scale int32, posOff int32, pos []uint64, negOff int32, neg []uint64,
-		zeroCount uint64, count uint64, sum float64, minSet bool, minim float64, maxSet bool, maxim float64, metrics pmetric.MetricSlice) pmetric.Metric {
+	appendDeltaNative := func(startTs, ts time.Time, scale, posOff int32, pos []uint64, negOff int32, neg []uint64,
+		zeroCount, count uint64, sum float64, minSet bool, minim float64, maxSet bool, maxim float64, metrics pmetric.MetricSlice,
+	) pmetric.Metric {
 		metric := metrics.AppendEmpty()
 		metric.SetName("test_native_hist")
 		metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -645,7 +645,7 @@ func TestAccumulateDroppedMetrics(t *testing.T) {
 
 func TestAccumulateDeltaToCumulativeExponentialHistogram(t *testing.T) {
 	appendDeltaNative := func(startTs, ts time.Time, scale int32, posOff int32, pos []uint64, negOff int32, neg []uint64,
-		zeroCount uint64, count uint64, sum float64, minSet bool, min float64, maxSet bool, max float64, metrics pmetric.MetricSlice) pmetric.Metric {
+		zeroCount uint64, count uint64, sum float64, minSet bool, minim float64, maxSet bool, maxim float64, metrics pmetric.MetricSlice) pmetric.Metric {
 		metric := metrics.AppendEmpty()
 		metric.SetName("test_native_hist")
 		metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
@@ -659,10 +659,10 @@ func TestAccumulateDeltaToCumulativeExponentialHistogram(t *testing.T) {
 		dp.SetCount(count)
 		dp.SetZeroThreshold(0)
 		if minSet {
-			dp.SetMin(min)
+			dp.SetMin(minim)
 		}
 		if maxSet {
-			dp.SetMax(max)
+			dp.SetMax(maxim)
 		}
 		dp.SetSum(sum)
 		dp.Attributes().PutStr("label_1", "1")

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -194,8 +194,10 @@ func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.M
 
 // defaultZeroThreshold matches the remote-write translator's default for native histograms
 // when an explicit zero threshold is not provided in the datapoint.
-const defaultZeroThreshold = 1e-128
-const CBNHScale = -53
+const (
+	defaultZeroThreshold = 1e-128
+	CBNHScale            = -53
+)
 
 func bucketsToNativeMap(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) map[int]int64 {
 	counts := buckets.BucketCounts()

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -195,6 +195,7 @@ func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.M
 // defaultZeroThreshold matches the remote-write translator's default for native histograms
 // when an explicit zero threshold is not provided in the datapoint.
 const defaultZeroThreshold = 1e-128
+const CBNHScale = -53
 
 func bucketsToNativeMap(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) map[int]int64 {
 	counts := buckets.BucketCounts()
@@ -222,6 +223,11 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 	}
 
 	schema := dp.Scale()
+
+	// TODO: implement custom bucket native histograms
+	if schema == CBNHScale {
+		return nil, fmt.Errorf("custom bucket native histograms (CBNH) are still not implemented")
+	}
 	if schema < -4 {
 		return nil, fmt.Errorf("cannot convert exponential to native histogram: scale must be >= -4, was %d", schema)
 	}

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -183,11 +183,93 @@ func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.M
 		return c.convertSum(metric, resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
 	case pmetric.MetricTypeHistogram:
 		return c.convertDoubleHistogram(metric, resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
+	case pmetric.MetricTypeExponentialHistogram:
+		return c.convertExponentialHistogram(metric, resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
 	case pmetric.MetricTypeSummary:
 		return c.convertSummary(metric, resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
 	}
 
 	return nil, errUnknownMetricType
+}
+
+// defaultZeroThreshold matches the remote-write translator's default for native histograms
+// when an explicit zero threshold is not provided in the datapoint.
+const defaultZeroThreshold = 1e-128
+
+func bucketsToNativeMap(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) map[int]int64 {
+	counts := buckets.BucketCounts()
+	if counts.Len() == 0 {
+		return nil
+	}
+	out := make(map[int]int64, counts.Len())
+	baseOffset := buckets.Offset()
+	for i := 0; i < counts.Len(); i++ {
+		// Effective bucket index after downscaling: ((offset + i) >> scaleDown) + 1
+		idx := (int32(i) + baseOffset) >> scaleDown
+		idx++
+		out[int(idx)] += int64(counts.At(i))
+	}
+	return out
+}
+
+func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (prometheus.Metric, error) {
+	dp := metric.ExponentialHistogram().DataPoints().At(0)
+
+	// Build metadata/labels first.
+	desc, attributes, err := c.getMetricMetadata(metric, dto.MetricType_HISTOGRAM.Enum(), dp.Attributes(), resourceAttrs, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes)
+	if err != nil {
+		return nil, err
+	}
+
+	schema := dp.Scale()
+	if schema < -4 {
+		return nil, fmt.Errorf("cannot convert exponential to native histogram: scale must be >= -4, was %d", schema)
+	}
+	var scaleDown int32
+	if schema > 8 {
+		scaleDown = schema - 8
+		schema = 8
+	}
+
+	pos := bucketsToNativeMap(dp.Positive(), scaleDown)
+	neg := bucketsToNativeMap(dp.Negative(), scaleDown)
+
+	zeroThresh := dp.ZeroThreshold()
+	if zeroThresh == 0 {
+		zeroThresh = defaultZeroThreshold
+	}
+
+	// Use created timestamp if start time is set (> 0), else zero value.
+	created := time.Time{}
+	if dp.StartTimestamp().AsTime().Unix() > 0 {
+		created = dp.StartTimestamp().AsTime()
+	}
+
+	sumVal := 0.0
+	if dp.HasSum() {
+		sumVal = dp.Sum()
+	}
+
+	m, err := prometheus.NewConstNativeHistogram(
+		desc,
+		dp.Count(),
+		sumVal,
+		pos,
+		neg,
+		dp.ZeroCount(),
+		schema,
+		zeroThresh,
+		created,
+		attributes...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.sendTimestamps {
+		return prometheus.NewMetricWithTimestamp(dp.Timestamp().AsTime(), m), nil
+	}
+	return m, nil
 }
 
 func (c *collector) getMetricMetadata(metric pmetric.Metric, mType *dto.MetricType, attributes, resourceAttrs pcommon.Map, scopeName, scopeVersion, scopeSchemaURL string, scopeAttributes pcommon.Map) (*prometheus.Desc, []string, error) {

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -196,7 +196,7 @@ func (c *collector) convertMetric(metric pmetric.Metric, resourceAttrs pcommon.M
 // when an explicit zero threshold is not provided in the datapoint.
 const (
 	defaultZeroThreshold = 1e-128
-	CBNHScale            = -53
+	cbnhScale            = -53
 )
 
 func bucketsToNativeMap(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) map[int]int64 {
@@ -227,7 +227,7 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 	schema := dp.Scale()
 
 	// TODO: implement custom bucket native histograms #43981
-	if schema == CBNHScale {
+	if schema == cbnhScale {
 		return nil, errors.New("custom bucket native histograms (CBNH) are still not implemented")
 	}
 	if schema < -4 {

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -224,7 +224,7 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 
 	schema := dp.Scale()
 
-	// TODO: implement custom bucket native histograms
+	// TODO: implement custom bucket native histograms #43981
 	if schema == CBNHScale {
 		return nil, fmt.Errorf("custom bucket native histograms (CBNH) are still not implemented")
 	}

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -228,7 +228,7 @@ func (c *collector) convertExponentialHistogram(metric pmetric.Metric, resourceA
 
 	// TODO: implement custom bucket native histograms #43981
 	if schema == CBNHScale {
-		return nil, fmt.Errorf("custom bucket native histograms (CBNH) are still not implemented")
+		return nil, errors.New("custom bucket native histograms (CBNH) are still not implemented")
 	}
 	if schema < -4 {
 		return nil, fmt.Errorf("cannot convert exponential to native histogram: scale must be >= -4, was %d", schema)

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -792,6 +792,154 @@ func TestAccumulateHistograms(t *testing.T) {
 	}
 }
 
+func TestAccumulateExponentialHistograms(t *testing.T) {
+	tests := []struct {
+		name           string
+		metric         func(time.Time, bool) pmetric.Metric
+		wantCount      uint64
+		wantSum        float64
+		wantSchema     int32
+		wantZeroCount  uint64
+		wantZeroThresh float64
+	}{
+		{
+			name:           "NativeHistogram basic (default zero threshold)",
+			wantCount:      10,
+			wantSum:        42.0,
+			wantSchema:     0,
+			wantZeroCount:  4,
+			wantZeroThresh: defaultZeroThreshold,
+			metric: func(ts time.Time, withStartTime bool) (metric pmetric.Metric) {
+				metric = pmetric.NewMetric()
+				metric.SetName("test_native_hist")
+				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				dp.SetScale(0)
+				dp.Positive().SetOffset(0)
+				dp.Positive().BucketCounts().FromRaw([]uint64{1, 2})
+				dp.Negative().SetOffset(0)
+				dp.Negative().BucketCounts().FromRaw([]uint64{3})
+				dp.SetZeroCount(4)
+				dp.SetCount(10)
+				dp.SetSum(42.0)
+				dp.SetZeroThreshold(0) // trigger defaultZeroThreshold
+				dp.Attributes().PutStr("label_1", "1")
+				dp.Attributes().PutStr("label_2", "2")
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+				if withStartTime {
+					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(ts))
+				}
+				return
+			},
+		},
+		{
+			name:           "NativeHistogram scale down (>8 to 8)",
+			wantCount:      6,
+			wantSum:        5.5,
+			wantSchema:     8,
+			wantZeroCount:  1,
+			wantZeroThresh: 0.25,
+			metric: func(ts time.Time, withStartTime bool) (metric pmetric.Metric) {
+				metric = pmetric.NewMetric()
+				metric.SetName("test_native_hist_scaled")
+				metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+				dp.SetScale(10) // will be downscaled to 8
+				dp.Positive().SetOffset(0)
+				dp.Positive().BucketCounts().FromRaw([]uint64{2, 3})
+				dp.Negative().SetOffset(-1)
+				dp.Negative().BucketCounts().FromRaw([]uint64{0, 0})
+				dp.SetZeroCount(1)
+				dp.SetCount(6)
+				dp.SetSum(5.5)
+				dp.SetZeroThreshold(0.25)
+				dp.Attributes().PutStr("label_1", "1")
+				dp.Attributes().PutStr("label_2", "2")
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+				if withStartTime {
+					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(ts))
+				}
+				return
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, sendTimestamp := range []bool{true, false} {
+			name := tt.name
+			if sendTimestamp {
+				name += "/WithTimestamp"
+			}
+			t.Run(name, func(t *testing.T) {
+				ts := time.Now()
+				metric := tt.metric(ts, sendTimestamp)
+				c := newCollector(&Config{SendTimestamps: sendTimestamp}, zap.NewNop())
+				// Replace accumulator with mock for test control
+				c.accumulator = &mockAccumulator{
+					[]pmetric.Metric{metric},
+					pcommon.NewMap(),
+					[]string{""},
+					[]string{""},
+					[]string{""},
+					[]pcommon.Map{pcommon.NewMap()},
+				}
+
+				ch := make(chan prometheus.Metric, 1)
+				go func() {
+					c.Collect(ch)
+					close(ch)
+				}()
+
+				n := 0
+				for m := range ch {
+					n++
+					require.Contains(t, m.Desc().String(), "fqName: \""+metric.Name()+"\"")
+
+					pbMetric := io_prometheus_client.Metric{}
+					require.NoError(t, m.Write(&pbMetric))
+
+					// Assert timestamp behavior
+					if sendTimestamp {
+						require.Equal(t, ts.UnixNano()/1e6, *(pbMetric.TimestampMs))
+						// withStartTime is tied to sendTimestamp in this test
+						require.Equal(t, timestamppb.New(ts), pbMetric.Histogram.CreatedTimestamp)
+					} else {
+						require.Nil(t, pbMetric.TimestampMs)
+						// Native histograms always include CreatedTimestamp; when no start
+						// time is set, it encodes the zero time (0001-01-01) rather than nil.
+						require.NotNil(t, pbMetric.Histogram.CreatedTimestamp)
+						require.True(t, pbMetric.Histogram.CreatedTimestamp.AsTime().IsZero())
+					}
+
+					h := pbMetric.Histogram
+					require.NotNil(t, h)
+					require.Equal(t, tt.wantCount, h.GetSampleCount())
+					require.InDelta(t, tt.wantSum, h.GetSampleSum(), 1e-12)
+					require.Equal(t, tt.wantSchema, h.GetSchema())
+					require.Equal(t, tt.wantZeroCount, h.GetZeroCount())
+					require.InDelta(t, tt.wantZeroThresh, h.GetZeroThreshold(), 0)
+				}
+				require.Equal(t, 1, n)
+			})
+		}
+	}
+}
+
+func TestConvertExponentialHistogramInvalidScale(t *testing.T) {
+	metric := pmetric.NewMetric()
+	metric.SetName("invalid_native_hist")
+	metric.SetEmptyExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dp := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+	dp.SetScale(-5) // invalid: must be >= -4
+	dp.SetCount(0)
+	dp.SetZeroThreshold(0)
+
+	c := newCollector(&Config{}, zap.NewNop())
+	_, err := c.convertExponentialHistogram(metric, pcommon.NewMap(), "", "", "", pcommon.NewMap())
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "scale must be >= -4"))
+}
+
 func TestAccumulateSummary(t *testing.T) {
 	fillQuantileValue := func(pN, value float64, dest pmetric.SummaryDataPointValueAtQuantile) {
 		dest.SetQuantile(pN)

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -937,7 +937,7 @@ func TestConvertExponentialHistogramInvalidScale(t *testing.T) {
 	c := newCollector(&Config{}, zap.NewNop())
 	_, err := c.convertExponentialHistogram(metric, pcommon.NewMap(), "", "", "", pcommon.NewMap())
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "scale must be >= -4"))
+	require.Contains(t, err.Error(), "scale must be >= -4")
 }
 
 func TestAccumulateSummary(t *testing.T) {

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -829,7 +829,8 @@ func TestAccumulateExponentialHistograms(t *testing.T) {
 				if withStartTime {
 					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(ts))
 				}
-				return
+
+				return metric
 			},
 		},
 		{
@@ -859,7 +860,7 @@ func TestAccumulateExponentialHistograms(t *testing.T) {
 				if withStartTime {
 					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(ts))
 				}
-				return
+				return metric
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

This PR adds support for OpenTelemetry ExponentialHistogram metrics in the prometheusexporter.
Before this change, the Collector could ingest Prometheus native histograms through prometheusreceiver, convert them into OTel ExponentialHistogram internally, and then fail when re-exposing them through prometheusexporter. In practice, pipelines like:prometheusreceiver -> processors -> prometheusexporter would log translation errors and drop those metrics at export time.
With this PR, prometheusexporter can now handle ExponentialHistogram metrics instead of rejecting them as unsupported, allowing native histogram data to flow end to end through the Collector.

## Problem

The gap fixed here was not on ingestion, but on export. prometheusreceiver already supports scraping Prometheus native histograms and maps them to OTel ExponentialHistogram data points. However, prometheusexporter did not support exporting that metric type, which resulted in errors similar to:

  - unsupported metric type: ExponentialHistogram

That meant users could successfully scrape native histograms into the Collector, but could not expose them again from the Collector using the Prometheus exporter.

## Changes in this PR

  This PR updates prometheusexporter so it can process and expose ExponentialHistogram metrics.

  Concretely, the change does the following:

  - adds handling for pmetric.ExponentialHistogram in the Prometheus exporter translation/export path
  - removes the previous failure mode where exponential histograms were treated as unsupported
  - enables end-to-end support for Prometheus native histogram ingestion followed by Prometheus re-exposition
  - aligns exporter behavior with the metric types that can already be produced internally by the Collector from Prometheus native histogram input

## Behavior Before

  Before this PR:

  - Prometheus native histograms could be scraped by prometheusreceiver
  - those metrics were converted into OTel ExponentialHistogram
  - prometheusexporter failed to translate them
  - the exporter logged errors and the metrics were not exposed

## Behavior After

  After this PR:

  - Prometheus native histograms can still be scraped by prometheusreceiver
  - the resulting OTel ExponentialHistogram metrics are now accepted by prometheusexporter
  - the exporter exposes those metrics instead of failing translation
  - pipelines using native histograms no longer lose those metrics at the exporter boundary

## Why this matters

This closes an interoperability gap in Collector pipelines that both ingest and expose Prometheus metrics. Without this change, native histogram support was only partial: ingestion worked, but re-export did not. This PR makes that flow consistent and allows users to preserve histogram data across Collector pipelines.

## Compatibility / Scope

  This change is additive.

  - Existing supported metric types are unaffected.
  - The behavior changes only for ExponentialHistogram metrics, which previously failed export.
  - Users not using Prometheus native histograms should see no behavior change.
  - Users ingesting native histograms should see failed exports become successful exports.

## Important Note

Prometheus native histogram support depends on protocol/exposition compatibility on the scraping side as well. This PR adds exporter support for the metric type; it does not change the broader Prometheus protocol constraints around how native histograms are represented and negotiated.

## Follow-ups

This PR focuses on enabling support in prometheusexporter. Follow-up work may still be useful in these areas:

  - add or expand end-to-end tests covering prometheusreceiver -> prometheusexporter with native histograms
  - document any protocol/exposition expectations for consumers scraping native histograms from the exporter
  - clarify fallback behavior, if any, when the scraping side does not support native histogram-capable exposition
  - validate and document behavior for edge cases such as sparse buckets, zero bucket handling, exemplars, and schema/scale conversion details

Closes #33703 
