### PR TITLE
fix jmx-scraper update URL + fix bogus 1.49.0 hash

### DIFF
--- a/.chloggen/fix-scraper-url.yaml
+++ b/.chloggen/fix-scraper-url.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'jmxreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the jmx-scraper hash for version 1.49.0
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [121332]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: ['user']

--- a/.github/workflows/auto-update-jmx-component.yml
+++ b/.github/workflows/auto-update-jmx-component.yml
@@ -194,7 +194,7 @@ jobs:
             exit 1
           fi
 
-          hash=$(curl -L "https://repo1.maven.org/maven2/io/opentelemetry/contrib/opentelemetry-jmx-scraper/${VERSION//-alpha/}/opentelemetry-jmx-scraper-$VERSION.jar" \
+          hash=$(curl -L "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v${VERSION//-alpha/}/opentelemetry-jmx-scraper.jar" \
                          | sha256sum \
                          | cut -d ' ' -f 1)
 

--- a/receiver/jmxreceiver/supported_jars.go
+++ b/receiver/jmxreceiver/supported_jars.go
@@ -32,7 +32,7 @@ func oldFormatProperties(c *Config, j supportedJar) error {
 }
 
 var jmxScraperVersions = map[string]supportedJar{
-	"e791ccfcfee9c0d299d07474d9bfcbfcbebf1181323be601220c8a823062ab99": {
+	"b821f96df239d1e1078c0f51f07977bc375e56e92c2d96eb7954ad30e617c677": {
 		version: "1.49.0-alpha",
 		jar:     "JMX scraper",
 	},


### PR DESCRIPTION
#### Description

When support for the jmx-scraper component was added to the `jmxreceiver`, it was not yet available in github release assets, hence for automatic update automation it was downloaded from maven central.

Unfortunately, the URL pattern for maven central artifacts was bogus and returned a 404, which in turn produced a constant hash, this failure was silent for the update to 1.49.0, at least for the CI, as any user would have not been able to use it.

We can now use the github release assets URL as `jmx-scraper` artifact is now available, and thus the URL is consistent with the one used for `jmx-metrics` artifact.

This was only caught when the update for 1.50.0 triggered a duplicate hash because the same 404 page was hashed and added to the dictionary in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43024.

cc @rogercoll 