### PR TITLE
[exporter/coralogixexporter] Support for auto configuring PrivateLink endpoint

### DIFF
--- a/.chloggen/coralogixexporter-privatelink-support.yaml
+++ b/.chloggen/coralogixexporter-privatelink-support.yaml
@@ -8,7 +8,7 @@ component: coralogixexporter
 note: Add Automatic AWS PrivateLink set up via new `private_link` configuration option
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [43075]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/coralogixexporter-privatelink-support.yaml
+++ b/.chloggen/coralogixexporter-privatelink-support.yaml
@@ -1,0 +1,27 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Automatic AWS PrivateLink set up via new `private_link` configuration option
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When enabled, the exporter will automatically use the AWS PrivateLink endpoint for the configured domain.
+  If the domain is already set to a PrivateLink one, no further change to the endpoint will be made.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -93,33 +93,20 @@ exporters:
     domain: "coralogix.com"
 ```
 
-### Coralogix's Domain 
+### Coralogix's Domain
 
-Depending on your region, you might need to use a different domain. Here are the available domains:
+Depending on your region and, you might need to use a different domain. For an up-to-date list of domains, please refer to [the official Coralogix's Domain documentation](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/#domains).
 
-| Region  | Domain                  |
-|---------|-------------------------|
-| USA1    | `coralogix.us`          |
-| USA2    | `cx498.coralogix.com`   |
-| APAC1   | `coralogix.in`          |
-| APAC2   | `coralogixsg.com`       |
-| APAC3   | `ap3.coralogix.com`     |
-| EUROPE1 | `coralogix.com`         |
-| EUROPE2 | `eu2.coralogix.com`     |
+Additionally, Coralogix supports AWS PrivateLink, which provides private connectivity between virtual private clouds (VPCs), supported AWS services, and your on-premises networks without exposing your traffic to the public internet. For an up-to-date list of AWS PrivateLink domains, please refer to [Coralogix's official AWS PrivateLink documentation](https://coralogix.com/docs/integrations/aws/aws-privatelink/aws-privatelink/#privatelink-endpoints).
 
-Additionally, Coralogix supports AWS PrivateLink, which provides private connectivity between virtual private clouds (VPCs), supported AWS services, and your on-premises networks without exposing your traffic to the public internet.
+To automatically use the PrivateLink endpoint that corresponds to the configured domain, you can set the `private_link` configuration field to `true`. For example:
 
-Here are available AWS PrivateLink domains:
-
-| Region  | Domain                                              |
-|---------|-----------------------------------------------------|
-| USA1    | `private.us1.coralogix.com`                             |
-| USA2    | `private.us2.coralogix.com` |
-| APAC1   | `private.coralogix.in`                              |
-| APAC2   | `private.coralogixsg.com`                           |
-| EUROPE1 | `private.coralogix.com`                             |
-| EUROPE2 | `private.eu2.coralogix.com`                         |
-Learn more about [AWS PrivateLink in the documentation page](https://coralogix.com/docs/coralogix-amazon-web-services-aws-privatelink-endpoints/).
+```yaml
+exporters:
+  coralogix:
+    domain: "eu2.coralogix.com"
+    private_link: true
+```
 
 ### Application and SubSystem attributes
 

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -6,6 +6,7 @@ package coralogixexporter // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -148,8 +149,9 @@ func (c *Config) getDomainGrpcSettings() *configgrpc.ClientConfig {
 	settings := c.DomainSettings
 	domain := c.Domain
 
-	// If PrivateLink is enabled, use the private link endpoint pattern
-	if c.PrivateLink {
+	// If PrivateLink is enabled, use the private link endpoint.
+	// However, if the domain already contains "private", don't add it again.
+	if c.PrivateLink && !strings.Contains(domain, "private.") {
 		settings.Endpoint = fmt.Sprintf("ingress.private.%s:443", domain)
 	} else {
 		settings.Endpoint = fmt.Sprintf("ingress.%s:443", domain)

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -28,8 +28,12 @@ type Config struct {
 
 	// Coralogix domain
 	Domain string `mapstructure:"domain"`
+
 	// GRPC Settings used with Domain
 	DomainSettings configgrpc.ClientConfig `mapstructure:"domain_settings"`
+
+	// Use AWS PrivateLink for the domain
+	PrivateLink bool `mapstructure:"private_link"`
 
 	// Coralogix traces ingress endpoint
 	Traces configgrpc.ClientConfig `mapstructure:"traces"`
@@ -142,6 +146,14 @@ func (c *Config) getMetadataFromResource(res pcommon.Resource) (appName, subsyst
 
 func (c *Config) getDomainGrpcSettings() *configgrpc.ClientConfig {
 	settings := c.DomainSettings
-	settings.Endpoint = fmt.Sprintf("ingress.%s:443", c.Domain)
+	domain := c.Domain
+
+	// If PrivateLink is enabled, use the private link endpoint pattern
+	if c.PrivateLink {
+		settings.Endpoint = fmt.Sprintf("ingress.private.%s:443", domain)
+	} else {
+		settings.Endpoint = fmt.Sprintf("ingress.%s:443", domain)
+	}
+
 	return &settings
 }

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -341,6 +341,30 @@ func TestGetDomainGrpcSettings(t *testing.T) {
 			privateLink:      true,
 			expectedEndpoint: "ingress.private.coralogix.us:443",
 		},
+		{
+			name:             "Domain already contains private prefix with PrivateLink",
+			domain:           "private.coralogix.com",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.coralogix.com:443",
+		},
+		{
+			name:             "Domain already contains private prefix without PrivateLink",
+			domain:           "private.coralogix.com",
+			privateLink:      false,
+			expectedEndpoint: "ingress.private.coralogix.com:443",
+		},
+		{
+			name:             "EU2 domain already contains private with PrivateLink",
+			domain:           "private.eu2.coralogix.com",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.eu2.coralogix.com:443",
+		},
+		{
+			name:             "Domain contains private in middle with PrivateLink",
+			domain:           "eu2.private.coralogix.com",
+			privateLink:      true,
+			expectedEndpoint: "ingress.eu2.private.coralogix.com:443",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -292,6 +292,73 @@ func TestGetMetadataFromResource(t *testing.T) {
 	assert.Equal(t, "subsystem", subSystemName)
 }
 
+func TestGetDomainGrpcSettings(t *testing.T) {
+	tests := []struct {
+		name             string
+		domain           string
+		privateLink      bool
+		expectedEndpoint string
+	}{
+		{
+			name:             "Standard domain without PrivateLink",
+			domain:           "coralogix.com",
+			privateLink:      false,
+			expectedEndpoint: "ingress.coralogix.com:443",
+		},
+		{
+			name:             "Standard domain with PrivateLink",
+			domain:           "coralogix.com",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.coralogix.com:443",
+		},
+		{
+			name:             "EU2 domain without PrivateLink",
+			domain:           "eu2.coralogix.com",
+			privateLink:      false,
+			expectedEndpoint: "ingress.eu2.coralogix.com:443",
+		},
+		{
+			name:             "EU2 domain with PrivateLink",
+			domain:           "eu2.coralogix.com",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.eu2.coralogix.com:443",
+		},
+		{
+			name:             "AP1 domain without PrivateLink",
+			domain:           "coralogix.in",
+			privateLink:      false,
+			expectedEndpoint: "ingress.coralogix.in:443",
+		},
+		{
+			name:             "AP1 domain with PrivateLink",
+			domain:           "coralogix.in",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.coralogix.in:443",
+		},
+		{
+			name:             "US1 domain with PrivateLink",
+			domain:           "coralogix.us",
+			privateLink:      true,
+			expectedEndpoint: "ingress.private.coralogix.us:443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Domain:      tt.domain,
+				PrivateLink: tt.privateLink,
+				DomainSettings: configgrpc.ClientConfig{
+					Compression: configcompression.TypeGzip,
+				},
+			}
+
+			settings := cfg.getDomainGrpcSettings()
+			assert.Equal(t, tt.expectedEndpoint, settings.Endpoint)
+		})
+	}
+}
+
 func TestCreateExportersWithBatcher(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -244,3 +244,72 @@ func TestCreateLogsWithDomainAndEndpoint(t *testing.T) {
 		assert.Equal(t, "rpc error: code = Canceled desc = grpc: the client connection is closing", err.Error())
 	}
 }
+
+func TestCreateTracesWithPrivateLink(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "coralogix.com"
+	cfg.PrivateLink = true
+	cfg.PrivateKey = "test-key"
+	cfg.AppName = "test-app"
+
+	set := exportertest.NewNopSettings(metadata.Type)
+	consumer, err := factory.CreateTraces(t.Context(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
+
+	// Verify the endpoint is correctly set to private link
+	settings := cfg.getDomainGrpcSettings()
+	assert.Equal(t, "ingress.private.coralogix.com:443", settings.Endpoint)
+
+	err = consumer.Start(t.Context(), componenttest.NewNopHost())
+	assert.NoError(t, err)
+
+	err = consumer.Shutdown(t.Context())
+	if err != nil {
+		// Since the endpoint doesn't actually exist, connection may already be closed
+		assert.Contains(t, err.Error(), "grpc: the client connection is closing")
+	}
+}
+
+func TestCreateMetricsWithPrivateLink(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "eu2.coralogix.com"
+	cfg.PrivateLink = true
+	cfg.PrivateKey = "test-key"
+	cfg.AppName = "test-app"
+
+	set := exportertest.NewNopSettings(metadata.Type)
+	consumer, err := factory.CreateMetrics(t.Context(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
+
+	// Verify the endpoint is correctly set to private link
+	settings := cfg.getDomainGrpcSettings()
+	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", settings.Endpoint)
+
+	err = consumer.Shutdown(t.Context())
+	assert.NoError(t, err)
+}
+
+func TestCreateLogsWithPrivateLink(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "coralogix.us"
+	cfg.PrivateLink = true
+	cfg.PrivateKey = "test-key"
+	cfg.AppName = "test-app"
+
+	set := exportertest.NewNopSettings(metadata.Type)
+	consumer, err := factory.CreateLogs(t.Context(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
+
+	// Verify the endpoint is correctly set to private link
+	settings := cfg.getDomainGrpcSettings()
+	assert.Equal(t, "ingress.private.coralogix.us:443", settings.Endpoint)
+
+	err = consumer.Shutdown(t.Context())
+	assert.NoError(t, err)
+}

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -313,3 +313,51 @@ func TestCreateLogsWithPrivateLink(t *testing.T) {
 	err = consumer.Shutdown(t.Context())
 	assert.NoError(t, err)
 }
+
+func TestCreateTracesWithDomainAlreadyContainingPrivate(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "private.coralogix.com"
+	cfg.PrivateLink = true
+	cfg.PrivateKey = "test-key"
+	cfg.AppName = "test-app"
+
+	set := exportertest.NewNopSettings(metadata.Type)
+	consumer, err := factory.CreateTraces(t.Context(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
+
+	// Verify the endpoint does not duplicate "private"
+	settings := cfg.getDomainGrpcSettings()
+	assert.Equal(t, "ingress.private.coralogix.com:443", settings.Endpoint)
+
+	err = consumer.Start(t.Context(), componenttest.NewNopHost())
+	assert.NoError(t, err)
+
+	err = consumer.Shutdown(t.Context())
+	if err != nil {
+		// Since the endpoint doesn't actually exist, connection may already be closed
+		assert.Contains(t, err.Error(), "grpc: the client connection is closing")
+	}
+}
+
+func TestCreateMetricsWithDomainAlreadyContainingPrivate(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "private.eu2.coralogix.com"
+	cfg.PrivateLink = true
+	cfg.PrivateKey = "test-key"
+	cfg.AppName = "test-app"
+
+	set := exportertest.NewNopSettings(metadata.Type)
+	consumer, err := factory.CreateMetrics(t.Context(), set, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, consumer)
+
+	// Verify the endpoint does not duplicate "private"
+	settings := cfg.getDomainGrpcSettings()
+	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", settings.Endpoint)
+
+	err = consumer.Shutdown(t.Context())
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support for automatically configuring the AWS Private Link endpoint via a new configuration option, which is disabled by default. Example:

```yaml
exporters:
  coralogix:
    domain: "eu2.coralogix.com"
    private_link: true
```

The snippet above ensuring data is sent to the PrivateLink endpoint for EU2 (`ingress.private.eu2.coralogix.com`). 

If by chance the domain already includes the `private.` prefix, it won't end up duplicated.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests (factories & config).

<!--Describe the documentation added.-->
#### Documentation

Updated the README to mention the new feature with an example.
