### PR TITLE
[chore]Fix flaky test for lruset due to time mismatch

### DIFF
--- a/exporter/elasticsearchexporter/internal/lru/lruset_test.go
+++ b/exporter/elasticsearchexporter/internal/lru/lruset_test.go
@@ -47,8 +47,8 @@ func TestLRUSetLifeTime(t *testing.T) {
 	// Wait until cache item is expired.
 	time.Sleep(lifetime)
 	err = cache.WithLock(func(lock LockedLRUSet) error {
-		assert.False(t, lock.CheckAndAdd("a"))
 		timeSet = time.Now()
+		assert.False(t, lock.CheckAndAdd("a"))
 		assert.True(t, lock.CheckAndAdd("a"))
 		return nil
 	})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Attempts to fix the flaky test `TestLRUSetLifeTime ` due to time mismatch.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42874

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
