### PR TITLE
[receiver/kafkareceiver] try to fix flaky tests for franz-go consumer

### DIFF
--- a/receiver/kafkareceiver/consumer_franz_test.go
+++ b/receiver/kafkareceiver/consumer_franz_test.go
@@ -208,6 +208,11 @@ func TestConsumerShutdownConsuming(t *testing.T) {
 			}, 10*time.Second, 10*time.Millisecond)
 			require.NoError(tb, kafkaClient.ProduceSync(ctx, rs...).FirstErr())
 
+			// Give the consumer a brief moment to poll both records into the same batch.
+			// Without this, on slower CI, one record can land in a later poll,
+			// which gets cut off by Shutdown → called==3 instead of 4.
+			time.Sleep(100 * time.Millisecond)
+
 			select {
 			case consuming <- struct{}{}:
 				close(consuming) // Close the channel so the rest exit.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Tentative fix for the flaky CI tests on TestConsumerShutdownConsuming.
The failures were showing up as `expected=4, actual=3`, which seems tied to timing in slower CI runners. This PR adds a small wait to ensure the expected number of messages is processed before shutting down the consumer.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43022
