### PR TITLE
[chore] Set missing enabled field for resource_attributes

### DIFF
--- a/receiver/apachesparkreceiver/metadata.yaml
+++ b/receiver/apachesparkreceiver/metadata.yaml
@@ -24,6 +24,7 @@ resource_attributes:
   spark.stage.attempt.id:
     description: The ID of the stage attempt for which the metric was recorded.
     type: int
+    enabled: false
   spark.executor.id:
     description: The ID of the executor for which the metric was recorded.
     type: string

--- a/receiver/azuremonitorreceiver/metadata.yaml
+++ b/receiver/azuremonitorreceiver/metadata.yaml
@@ -12,12 +12,15 @@ resource_attributes:
   azuremonitor.tenant_id:
     description: Azure tenant ID
     type: string
+    enabled: false
   azuremonitor.subscription_id:
     description: Azure subscription ID
     type: string
+    enabled: false
   azuremonitor.subscription:
     description: Azure subscription name
     type: string
+    enabled: false
 
 tests:
   config:

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -12,6 +12,7 @@ resource_attributes:
   ssh.endpoint:
     description: Full SSH endpoint
     type: string
+    enabled: false
 
 attributes:
   error.message:


### PR DESCRIPTION
If `enabled` is unset in metadata.yaml defaults to false. This commit doesn't change any behavior, it only unblocks the stricter validation https://github.com/open-telemetry/opentelemetry-collector/pull/13921 by setting the false value explicitly.

Likely the enabled fields are missed by mistake here. If so, they should be explicitly fixed separately, cc (code owners of the affected components) @nslaughter, @celian-garcia, @ishleenk17, @Caleb-Hurshman, @mrsillydog.