### PR TITLE
[chore] add Bogdan Stancu as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For more information about the approver role, see the [community repository](htt
 ### Triagers
 
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
+- [Bogdan Stancu](https://github.com/bogdan-st), Adobe
 - [Constança Manteigas](https://github.com/constanca-m), Elastic
 - [Douglas Camata](https://github.com/douglascamata), Coralogix
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace


### PR DESCRIPTION
This PR adds [Bogdan Stancu](https://github.com/bogdan-st) as a new triager to the project.

@open-telemetry/collector-contrib-approvers please review his involvement with the project below, and consider approving this PR in support.

* [Issues filed](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20state%3Aopen%20author%3Abogdan-st)
* [PRs](https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls/bogdan-st)
* [PR comments](https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+commenter%3Abogdan-st+is%3Aclosed) 