### PR TITLE
[chore][pkg/stanza] Fixed goleak errors on recombine benchmarks

### DIFF
--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -791,8 +791,8 @@ func BenchmarkRecombine(b *testing.B) {
 	require.NoError(b, op.SetOutputs([]operator.Operator{fake}))
 
 	go func() {
-		for {
-			<-fake.Received
+		for range fake.Received {
+			// Nothing to do
 		}
 	}()
 
@@ -818,6 +818,10 @@ func BenchmarkRecombine(b *testing.B) {
 		}
 		op.(*Transformer).flushAllSources(ctx)
 	}
+	b.StopTimer()
+
+	require.NoError(b, op.Stop())
+	close(fake.Received)
 }
 
 func BenchmarkRecombineLimitTrigger(b *testing.B) {
@@ -835,8 +839,8 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 	require.NoError(b, op.Start(nil))
 
 	go func() {
-		for {
-			<-fake.Received
+		for range fake.Received {
+			// Nothing to do
 		}
 	}()
 
@@ -855,6 +859,10 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 		require.NoError(b, op.ProcessBatch(ctx, []*entry.Entry{start, next}))
 		op.(*Transformer).flushAllSources(ctx)
 	}
+	b.StopTimer()
+
+	require.NoError(b, op.Stop())
+	close(fake.Received)
 }
 
 func TestTimeout(t *testing.T) {

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -791,7 +791,7 @@ func BenchmarkRecombine(b *testing.B) {
 	require.NoError(b, op.SetOutputs([]operator.Operator{fake}))
 
 	go func() {
-		for range fake.Received {
+		for range fake.Received { //nolint:revive
 			// Nothing to do
 		}
 	}()
@@ -839,7 +839,7 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 	require.NoError(b, op.Start(nil))
 
 	go func() {
-		for range fake.Received {
+		for range fake.Received { //nolint:revive
 			// Nothing to do
 		}
 	}()


### PR DESCRIPTION
#### Description
Fixed one of the errors reported in #43044

Two goleak errors I faced from the `recombine` package.

One of the errors indicates that `flushLoop` is still running on a goroutine after test finished. This is due to the benchmark tests never call operator's `Stop()`(More precisely,  `Transformer.chClose` is never closed), so `flushLoop()` indefinitely runs. Calling `op.Stop()` makes it silent.
```
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 61 in state select, with github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.(*Transformer).flushLoop on top of the stack:
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.(*Transformer).flushLoop(0x14000188a80)
        /Users/ray.kang/github.com/gnak-yar/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer.go:62 +0x64
created by github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.(*Transformer).Start in goroutine 104
        /Users/ray.kang/github.com/gnak-yar/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer.go:56 +0x5c
```


The other error occurs because there's an infinite loop receiving from a channel of `FakeOutput`. Closing the channel resolves the error.
```
 Goroutine 103 in state chan receive, with github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.BenchmarkRecombine.func1 on top of the stack:
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.BenchmarkRecombine.func1()
        /Users/ray.kang/github.com/gnak-yar/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:795 +0x2c
created by github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine.BenchmarkRecombine in goroutine 21
        /Users/ray.kang/github.com/gnak-yar/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:793 +0x498
```



<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
#43044

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests
