### PR TITLE
[chore] add unkeyed literal initialization prevention for public structs

### DIFF
--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -97,6 +97,8 @@ func (s Supervisor) Validate() error {
 type Storage struct {
 	// Directory is the directory where the Supervisor will store its data.
 	Directory string `mapstructure:"directory"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // Capabilities is the set of capabilities that the Supervisor supports.
@@ -167,6 +169,8 @@ type OpAMPServer struct {
 	Endpoint string                 `mapstructure:"endpoint"`
 	Headers  http.Header            `mapstructure:"headers"`
 	TLS      configtls.ClientConfig `mapstructure:"tls,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (o OpAMPServer) Validate() error {
@@ -266,6 +270,8 @@ var SpecialConfigFiles = []SpecialConfigFile{
 type AgentDescription struct {
 	IdentifyingAttributes    map[string]string `mapstructure:"identifying_attributes"`
 	NonIdentifyingAttributes map[string]string `mapstructure:"non_identifying_attributes"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type Telemetry struct {
@@ -276,10 +282,14 @@ type Telemetry struct {
 	Traces  otelconftelemetry.TracesConfig `mapstructure:"traces"`
 
 	Resource map[string]*string `mapstructure:"resource"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type HealthCheck struct {
 	confighttp.ServerConfig `mapstructure:",squash"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 func (h HealthCheck) Port() int64 {
@@ -314,6 +324,8 @@ type Logs struct {
 type Metrics struct {
 	Level   configtelemetry.Level `mapstructure:"level"`
 	Readers []config.MetricReader `mapstructure:"readers"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // DefaultSupervisor returns the default supervisor config

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -54,6 +54,8 @@ type APIConfig struct {
 	// FailOnInvalidKey states whether to exit at startup on invalid API key.
 	// The default value is false.
 	FailOnInvalidKey bool `mapstructure:"fail_on_invalid_key"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // TagsConfig defines the tag-related configuration
@@ -66,6 +68,8 @@ type TagsConfig struct {
 	// Prefer using the `datadog.host.name` resource attribute over using this setting.
 	// See https://docs.datadoghq.com/opentelemetry/schema_semantics/hostname/?tab=datadogexporter#general-hostname-semantic-conventions for details.
 	Hostname string `mapstructure:"hostname"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // Config defines configuration for the Datadog exporter.

--- a/pkg/datadog/config/metrics.go
+++ b/pkg/datadog/config/metrics.go
@@ -195,6 +195,8 @@ type SummaryConfig struct {
 	// The default is 'gauges'.
 	// See https://docs.datadoghq.com/metrics/otlp/?tab=summary#mapping for details and examples.
 	Mode SummaryMode `mapstructure:"mode"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // MetricsExporterConfig provides options for a user to customize the behavior of the
@@ -207,6 +209,8 @@ type MetricsExporterConfig struct {
 	// InstrumentationScopeMetadataAsTags, if set to true, adds the name and version of the
 	// instrumentation scope that created a metric to the metric tags
 	InstrumentationScopeMetadataAsTags bool `mapstructure:"instrumentation_scope_metadata_as_tags"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // ToTranslatorOpts returns a list of metrics translator options from the metrics config

--- a/pkg/stanza/operator/helper/trace.go
+++ b/pkg/stanza/operator/helper/trace.go
@@ -34,18 +34,26 @@ type TraceParser struct {
 	TraceID    *TraceIDConfig    `mapstructure:"trace_id,omitempty"`
 	SpanID     *SpanIDConfig     `mapstructure:"span_id,omitempty"`
 	TraceFlags *TraceFlagsConfig `mapstructure:"trace_flags,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type TraceIDConfig struct {
 	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type SpanIDConfig struct {
 	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type TraceFlagsConfig struct {
 	ParseFrom *entry.Field `mapstructure:"parse_from,omitempty"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // Validate validates a TraceParser, and reconfigures it if necessary

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -102,11 +102,15 @@ type TraceStateCfg struct {
 // AndCfg holds the common configuration to all and policies.
 type AndCfg struct {
 	SubPolicyCfg []AndSubPolicyCfg `mapstructure:"and_sub_policy"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // DropCfg holds the common configuration to all policies under drop policy.
 type DropCfg struct {
 	SubPolicyCfg []AndSubPolicyCfg `mapstructure:"drop_sub_policy"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // CompositeCfg holds the configurable settings to create a composite
@@ -122,6 +126,8 @@ type CompositeCfg struct {
 type RateAllocationCfg struct {
 	Policy  string `mapstructure:"policy"`
 	Percent int64  `mapstructure:"percent"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // PolicyCfg holds the common configuration to all policies.
@@ -143,6 +149,8 @@ type LatencyCfg struct {
 	ThresholdMs int64 `mapstructure:"threshold_ms"`
 	// Upper bound in milliseconds.
 	UpperThresholdMs int64 `mapstructure:"upper_threshold_ms"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // NumericAttributeCfg holds the configurable settings to create a numeric attribute filter
@@ -170,12 +178,16 @@ type ProbabilisticCfg struct {
 	// SamplingPercentage is the percentage rate at which traces are going to be sampled. Defaults to zero, i.e.: no sample.
 	// Values greater or equal 100 are treated as "sample all traces".
 	SamplingPercentage float64 `mapstructure:"sampling_percentage"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // StatusCodeCfg holds the configurable settings to create a status code filter sampling
 // policy evaluator.
 type StatusCodeCfg struct {
 	StatusCodes []string `mapstructure:"status_codes"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // StringAttributeCfg holds the configurable settings to create a string attribute filter
@@ -203,6 +215,8 @@ type StringAttributeCfg struct {
 type RateLimitingCfg struct {
 	// SpansPerSecond sets the limit on the maximum number of spans that can be processed each second.
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // SpanCountCfg holds the configurable settings to create a Span Count filter sampling
@@ -211,6 +225,8 @@ type SpanCountCfg struct {
 	// Minimum number of spans in a Trace
 	MinSpans int32 `mapstructure:"min_spans"`
 	MaxSpans int32 `mapstructure:"max_spans"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // BooleanAttributeCfg holds the configurable settings to create a boolean attribute filter
@@ -233,6 +249,8 @@ type OTTLConditionCfg struct {
 	ErrorMode           ottl.ErrorMode `mapstructure:"error_mode"`
 	SpanConditions      []string       `mapstructure:"span"`
 	SpanEventConditions []string       `mapstructure:"spanevent"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type DecisionCacheConfig struct {
@@ -246,6 +264,8 @@ type DecisionCacheConfig struct {
 	// For effective use, this value should be at least an order of magnitude greater than Config.NumTraces.
 	// If left as default 0, a no-op DecisionCache will be used.
 	NonSampledCacheSize int `mapstructure:"non_sampled_cache_size"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 // Config holds the configuration for tail-based sampling.

--- a/receiver/statsdreceiver/protocol/protocol.go
+++ b/receiver/statsdreceiver/protocol/protocol.go
@@ -29,11 +29,15 @@ type TimerHistogramMapping struct {
 	ObserverType ObserverType    `mapstructure:"observer_type"`
 	Histogram    HistogramConfig `mapstructure:"histogram"`
 	Summary      SummaryConfig   `mapstructure:"summary"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type HistogramConfig struct {
 	MaxSize         int32            `mapstructure:"max_size"`
 	ExplicitBuckets []ExplicitBucket `mapstructure:"explicit_buckets"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type ExplicitBucket struct {
@@ -44,4 +48,6 @@ type ExplicitBucket struct {
 
 type SummaryConfig struct {
 	Percentiles []float64 `mapstructure:"percentiles"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43134 - this is addressing unkeyed literal initialization for public structs across components, to help upgrade checkapi.