### PR TITLE
fix(receiver/k8s_cluster): Include non-ready containers

### DIFF
--- a/.chloggen/k8sclusterreceiver-emtpy-containterid.yaml
+++ b/.chloggen/k8sclusterreceiver-emtpy-containterid.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix for k8sclusterreceiver to handle empty containerID in ContainerStatus
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43147]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/k8sclusterreceiver-emtpy-containterid.yaml
+++ b/.chloggen/k8sclusterreceiver-emtpy-containterid.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: k8sclusterreceiver
+component: receiver/k8s_cluster
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix for k8sclusterreceiver to handle empty containerID in ContainerStatus

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -51,9 +51,6 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 	}
 	for i := range pod.Status.ContainerStatuses {
 		cs := &pod.Status.ContainerStatuses[i]
-		if cs.ContainerID == "" {
-			continue
-		}
 		newPod.Status.ContainerStatuses = append(newPod.Status.ContainerStatuses, corev1.ContainerStatus{
 			Name:                 cs.Name,
 			Image:                cs.Image,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fixes an issue where the receiver was ignoring non-ready containers with an empty ContainerID, resulting in incomplete data collection for the newly introduced metrics `k8s.container.status.state` and `k8s.container.status.reason`.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43147 
<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated `TestTransform`
<!--Describe the documentation added.-->
#### Documentation
<!--Please delete paragraphs that you did not use before submitting.-->