### PR TITLE
[connector/signaltometrics]Drop collector service name and namespace from metrics

### DIFF
--- a/.chloggen/signaltometrics-drop-name-namespace.yaml
+++ b/.chloggen/signaltometrics-drop-name-namespace.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signaltometricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop `signaltometrics.service.{name, namespace}` resource attribute from produced metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43148]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/signaltometricsconnector/README.md
+++ b/connector/signaltometricsconnector/README.md
@@ -297,7 +297,7 @@ principle. However, since `signaltometrics` component produces metrics from all 
 types and also allows customizing the resource attributes, there is a possibility
 of violating the single-writer principle. To keep the single-writer principle intact,
 the component adds collector instance information as resource attributes. The following
-resource attribute is added to each produced metrics:
+resource attribute is added to each produced metric:
 
 ```yaml
 signaltometrics.service.instance.id: <service_instance_id_of_the_otel_collector>

--- a/connector/signaltometricsconnector/README.md
+++ b/connector/signaltometricsconnector/README.md
@@ -297,11 +297,9 @@ principle. However, since `signaltometrics` component produces metrics from all 
 types and also allows customizing the resource attributes, there is a possibility
 of violating the single-writer principle. To keep the single-writer principle intact,
 the component adds collector instance information as resource attributes. The following
-resource attributes are added to each produced metrics:
+resource attribute is added to each produced metrics:
 
 ```yaml
-signaltometrics.service.name: <service_name_of_the_otel_collector>
-signaltometrics.service.namespace: <service_namespace_of_the_otel_collector>
 signaltometrics.service.instance.id: <service_instance_id_of_the_otel_collector>
 ```
 

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo.go
@@ -20,8 +20,6 @@ var prefix = metadata.Type.String()
 type CollectorInstanceInfo struct {
 	size              int
 	serviceInstanceID string
-	serviceName       string
-	serviceNamespace  string
 }
 
 func NewCollectorInstanceInfo(
@@ -29,20 +27,9 @@ func NewCollectorInstanceInfo(
 ) CollectorInstanceInfo {
 	var info CollectorInstanceInfo
 	for k, v := range set.Resource.Attributes().All() {
-		switch k {
-		case string(semconv.ServiceInstanceIDKey):
+		if k == string(semconv.ServiceInstanceIDKey) {
 			if str := v.Str(); str != "" {
-				info.serviceInstanceID = str
-				info.size++
-			}
-		case string(semconv.ServiceNameKey):
-			if str := v.Str(); str != "" {
-				info.serviceName = str
-				info.size++
-			}
-		case string(semconv.ServiceNamespaceKey):
-			if str := v.Str(); str != "" {
-				info.serviceNamespace = str
+				info.serviceInstanceID = v.Str()
 				info.size++
 			}
 		}
@@ -60,12 +47,6 @@ func (info CollectorInstanceInfo) Copy(to pcommon.Map) {
 	to.EnsureCapacity(info.Size())
 	if info.serviceInstanceID != "" {
 		to.PutStr(keyWithPrefix(string(semconv.ServiceInstanceIDKey)), info.serviceInstanceID)
-	}
-	if info.serviceName != "" {
-		to.PutStr(keyWithPrefix(string(semconv.ServiceNameKey)), info.serviceName)
-	}
-	if info.serviceNamespace != "" {
-		to.PutStr(keyWithPrefix(string(semconv.ServiceNamespaceKey)), info.serviceNamespace)
 	}
 }
 

--- a/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
+++ b/connector/signaltometricsconnector/internal/model/collectorinstanceinfo_test.go
@@ -42,32 +42,6 @@ func TestCollectorInstanceInfo(t *testing.T) {
 				return m
 			}(),
 		},
-		{
-			name: "with_all_values",
-			input: func() component.TelemetrySettings {
-				ts := componenttest.NewNopTelemetrySettings()
-				ts.Resource.Attributes().PutStr(string(semconv.ServiceInstanceIDKey), "627cc493-f310-47de-96bd-71410b7dec09")
-				ts.Resource.Attributes().PutStr(string(semconv.ServiceNameKey), "signaltometrics")
-				ts.Resource.Attributes().PutStr(string(semconv.ServiceNamespaceKey), "test")
-				return ts
-			}(),
-			expected: func() pcommon.Map {
-				m := pcommon.NewMap()
-				m.PutStr(
-					"signaltometrics."+string(semconv.ServiceInstanceIDKey),
-					"627cc493-f310-47de-96bd-71410b7dec09",
-				)
-				m.PutStr(
-					"signaltometrics."+string(semconv.ServiceNameKey),
-					"signaltometrics",
-				)
-				m.PutStr(
-					"signaltometrics."+string(semconv.ServiceNamespaceKey),
-					"test",
-				)
-				return m
-			}(),
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ci := NewCollectorInstanceInfo(tc.input)

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -18,8 +18,6 @@ import (
 
 const (
 	testServiceInstanceID = "627cc493-f310-47de-96bd-71410b7dec09"
-	testServiceName       = "testsignaltometrics"
-	testNamespace         = "test"
 )
 
 func TestFilterResourceAttributes(t *testing.T) {
@@ -45,8 +43,6 @@ func TestFilterResourceAttributes(t *testing.T) {
 				"key.4": "val.4",
 				// Collector instance info will be added
 				"signaltometrics.service.instance.id": testServiceInstanceID,
-				"signaltometrics.service.name":        testServiceName,
-				"signaltometrics.service.namespace":   testNamespace,
 			},
 		},
 		{
@@ -80,8 +76,6 @@ func TestFilterResourceAttributes(t *testing.T) {
 				"key.302": "anything",
 				// Collector instance info will be added
 				"signaltometrics.service.instance.id": testServiceInstanceID,
-				"signaltometrics.service.name":        testServiceName,
-				"signaltometrics.service.namespace":   testNamespace,
 			},
 		},
 	} {
@@ -175,8 +169,6 @@ func testCollectorInstanceInfo(t *testing.T) CollectorInstanceInfo {
 
 	set := componenttest.NewNopTelemetrySettings()
 	set.Resource.Attributes().PutStr(string(semconv.ServiceInstanceIDKey), testServiceInstanceID)
-	set.Resource.Attributes().PutStr(string(semconv.ServiceNameKey), testServiceName)
-	set.Resource.Attributes().PutStr(string(semconv.ServiceNamespaceKey), testNamespace)
 	return NewCollectorInstanceInfo(set)
 }
 

--- a/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/exponential_histograms/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Logrecords as exponential histogram with log.duration from attributes
@@ -339,12 +333,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Logrecords with resource attribute foo as exponential histogram with log.duration from attributes

--- a/connector/signaltometricsconnector/testdata/logs/gauge/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/gauge/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Extract memory_mb from log records
@@ -54,12 +48,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Extract memory_mb from log records with attribute foo

--- a/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/histograms/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Logrecords as histogram with log.duration from attributes
@@ -139,12 +133,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Logrecords with resource attribute foo as histogram with log.duration from attributes

--- a/connector/signaltometricsconnector/testdata/logs/metric_identity/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/metric_identity/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Logrecords as histogram with log.duration from attributes

--- a/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/logs/sum/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Count total number of log records
@@ -69,12 +63,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Count total number of log records with resource attribute foo

--- a/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/exponential_histograms/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: An exponential histogram created from gauge values

--- a/connector/signaltometricsconnector/testdata/metrics/gauge/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/gauge/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Last gauge as per datapoint.bar attribute

--- a/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/histograms/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: A histogram created from gauge values

--- a/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/metrics/sum/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Count total number of datapoints

--- a/connector/signaltometricsconnector/testdata/profiles/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/exponential_histograms/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Profiles as exponential histogram with duration
@@ -58,12 +52,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Profiles with resource attribute foo as exponential histogram with duration

--- a/connector/signaltometricsconnector/testdata/profiles/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/histograms/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Profiles as histogram with duration
@@ -74,12 +68,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Profiles with resource attribute foo as histogram with duration

--- a/connector/signaltometricsconnector/testdata/profiles/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/sum/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Count total number of profiles
@@ -46,12 +40,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Count total number of profiles with resource attribute foo

--- a/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/exponential_histograms/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.foo as a exponential histogram metric
@@ -147,12 +141,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.bar as a exponential histogram metric
@@ -290,12 +278,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with custom count OTTL expression as a exponential histogram metric

--- a/connector/signaltometricsconnector/testdata/traces/gauge/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/gauge/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.foo as a int gauge metric
@@ -35,12 +29,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Adjusted count for the span as a int gauge metric

--- a/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/histograms/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.foo as a histogram metric
@@ -197,12 +191,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.bar as a histogram metric
@@ -262,12 +250,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with custom count OTTL expression as a histogram metric

--- a/connector/signaltometricsconnector/testdata/traces/metric_identity/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/metric_identity/output.yaml
@@ -10,12 +10,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.foo as a histogram metric

--- a/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/traces/sum/output.yaml
@@ -7,12 +7,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Spans with resource attribute including resource.foo as a int sum metric
@@ -36,12 +30,6 @@ resourceMetrics:
         - key: signaltometrics.service.instance.id
           value:
             stringValue: 627cc493-f310-47de-96bd-71410b7dec09
-        - key: signaltometrics.service.name
-          value:
-            stringValue: signaltometrics
-        - key: signaltometrics.service.namespace
-          value:
-            stringValue: test
     scopeMetrics:
       - metrics:
           - description: Adjusted count for the span as a sum metric


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`signaltometrics.service.*` fields were added to the metrics produced from signaltometrics component to ensure single-writer is obeyed ([ref](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/signaltometricsconnector#single-writer)). However, we don't require all the fields to ensure this. Based on the description of `service.instance.id` it is alone enough to ensure single-writer ([ref](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/)). The other fields leak information about the service which is not desirable and also unnecessary for our purpose.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43148

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated in PR

<!--Describe the documentation added.-->
#### Documentation
Updated

<!--Please delete paragraphs that you did not use before submitting.-->
