### PR TITLE
[chore][exporter/signalfx] Fix README documentation for sync_host_metadata option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -100,7 +100,7 @@ The following configuration options can also be configured:
   IMPORTANT: Host metadata synchronization relies on `resourcedetection`
   processor. If this option is enabled make sure that `resourcedetection`
   processor is enabled in the pipeline with one of the cloud provider detectors
-  or environment variable detector setting a unique value to `host.name` attribute
+  or environment variable detector setting a unique value to `host.id` attribute
   within your k8s cluster. And keep `override=true` in resourcedetection config.
 - `root_path`: Used by the host metadata to identify the root filesystem.
   This is needed when running in a containerized environment and the host root


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fix documentation for `host.name` -> `host.id` attribute for metadata synchronization. ([Functionality being referenced](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/462322b4334c73de056a64af820812eca522ba8f/exporter/signalfxexporter/internal/hostmetadata/metadata.go#L51))