### PR TITLE
[chore] skip github.com/vmware/govmomi to v0.51.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -229,6 +229,12 @@
       "matchPackageNames": [
         "github.com/splunk/stef{/,}**"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "github.com/vmware/govmomi"
+      ],
+      "allowedVersions": "!/v0.51.0$/"
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
As indicated by @schmikei, the plan is to hold off on upgrading this dependency.

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41040
