### PR TITLE
internal/kafka: log a hint on broker connect failure if TLS isn't configured

### DIFF
--- a/.chloggen/kafka-broker-connect-tls.yaml
+++ b/.chloggen/kafka-broker-connect-tls.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log a hint when broker connections fail due to possible TLS misconfiguration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40145]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -5,8 +5,11 @@ package kafka // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -241,6 +244,11 @@ func commonOpts(ctx context.Context, clientCfg configkafka.ClientConfig,
 		if tlsCfg != nil {
 			opts = append(opts, kgo.DialTLSConfig(tlsCfg))
 		}
+	} else {
+		// Add a hook that gives a hint that TLS is not configured
+		// in case we try to connect to a TLS-only broker.
+		var hook kgo.HookBrokerConnect = hookBrokerConnectPlaintext{logger: logger}
+		opts = append(opts, kgo.WithHooks(hook))
 	}
 	// Configure authentication
 	if clientCfg.Authentication.PlainText != nil {
@@ -368,4 +376,25 @@ func saramaHashFn(b []byte) uint32 {
 	h.Reset()
 	h.Write(b)
 	return h.Sum32()
+}
+
+type hookBrokerConnectPlaintext struct {
+	logger *zap.Logger
+}
+
+func (h hookBrokerConnectPlaintext) OnBrokerConnect(
+	meta kgo.BrokerMetadata, _ time.Duration, conn net.Conn, err error,
+) {
+	if conn == nil {
+		// Could not make a network connection, this is not related to TLS.
+		return
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		h.logger.Warn(
+			"failed to connect to broker, it may require TLS but TLS is not configured",
+			zap.String("host", meta.Host),
+			zap.Error(err),
+		)
+		return
+	}
 }


### PR DESCRIPTION
#### Description

Add a franz-go hook that will log a warning that hints that TLS may need to be configured in case broker connection fails with EOF or unexpected EOF, but a network connection could be established. This can happen if the broker expects TLS, but the client has not been configured appropriately.

#### Link to tracking issue

Fixes #40145

#### Testing

Updated unit tests which exercise this scenario already.

#### Documentation

N/A