### PR TITLE
[chore]Remove flaky test TestLRUSetLifeTime

### DIFF
--- a/exporter/elasticsearchexporter/internal/lru/lruset_test.go
+++ b/exporter/elasticsearchexporter/internal/lru/lruset_test.go
@@ -30,45 +30,6 @@ func TestLRUSet(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestLRUSetLifeTime(t *testing.T) {
-	const lifetime = 100 * time.Millisecond
-	cache, err := NewLRUSet(5, lifetime)
-	require.NoError(t, err)
-
-	err = cache.WithLock(func(lock LockedLRUSet) error {
-		assert.False(t, lock.CheckAndAdd("a"))
-		assert.True(t, lock.CheckAndAdd("a"))
-		return nil
-	})
-	require.NoError(t, err)
-
-	var timeSet time.Time
-
-	// Wait until cache item is expired.
-	time.Sleep(lifetime)
-	err = cache.WithLock(func(lock LockedLRUSet) error {
-		timeSet = time.Now()
-		assert.False(t, lock.CheckAndAdd("a"))
-		assert.True(t, lock.CheckAndAdd("a"))
-		return nil
-	})
-	require.NoError(t, err)
-
-	// Keep checking for expiry and assert that first expiry happens after at least lifetime
-	assert.EventuallyWithT(t, func(tt *assert.CollectT) {
-		var val bool
-		err = cache.WithLock(func(lock LockedLRUSet) error {
-			val = lock.CheckAndAdd("a")
-			return nil
-		})
-		require.NoError(tt, err)
-		assert.False(tt, val)
-	}, lifetime*2, lifetime/100) // tick is kept at 1% of lifetime
-	// Assert with epsilon to somewhat account for NTP adjustments.
-	// Also see: https://github.com/elastic/go-freelru/issues/1
-	assert.InEpsilon(t, lifetime, time.Since(timeSet), 0.015) // epsilon is kept at 1.5%
-}
-
 func BenchmarkLRUSetCheck(b *testing.B) {
 	cache, err := NewLRUSet(5, time.Minute)
 	require.NoError(b, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

`TestLRUSetLifeTime` is a flaky test, and the root cause seems to be that the expire feature uses the wall clock to remove items. Prior attempts to fix this test haven't been successful. Taking a step back and looking into the test, it seems we are testing the `lifetime` feature of the go-freelru library more than our own usage of the library. Creating this PR to drop the test, as I feel it is out of scope of the exporter. Happy to discuss if others feel this is a required test.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43153

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
