### PR TITLE
[chore] Move to goccy-json

### DIFF
--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/json-iterator/go v1.1.12
 	github.com/leodido/go-syslog/v4 v4.2.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.137.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.137.0
@@ -55,6 +54,7 @@ require (
 	github.com/google/go-tpm v0.9.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
 	github.com/knadh/koanf/v2 v2.3.0 // indirect

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	gojson "github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -49,7 +49,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 			// journalctl is an executable that is required for this operator to function
 		},
 		convertMessageBytes: c.ConvertMessageBytes,
-		json:                jsoniter.ConfigFastest,
+		json:                gojson,
 	}, nil
 }
 

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"time"
 
-	gojson "github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -49,7 +48,6 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 			// journalctl is an executable that is required for this operator to function
 		},
 		convertMessageBytes: c.ConvertMessageBytes,
-		json:                gojson,
 	}, nil
 }
 

--- a/pkg/stanza/operator/input/journald/input.go
+++ b/pkg/stanza/operator/input/journald/input.go
@@ -31,7 +31,6 @@ type Input struct {
 	newCmd func(ctx context.Context, cursor []byte) cmd
 
 	persister           operator.Persister
-	json                gojson
 	convertMessageBytes bool
 	cancel              context.CancelFunc
 	wg                  sync.WaitGroup
@@ -208,7 +207,7 @@ func (operator *Input) runJournalctl(ctx context.Context, jctl *journalctl) erro
 
 func (operator *Input) parseJournalEntry(line []byte) (*entry.Entry, string, error) {
 	var body map[string]any
-	err := operator.json.Unmarshal(line, &body)
+	err := gojson.Unmarshal(line, &body)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/stanza/operator/input/journald/input.go
+++ b/pkg/stanza/operator/input/journald/input.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
+	gojson "github.com/goccy/go-json"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -31,7 +31,7 @@ type Input struct {
 	newCmd func(ctx context.Context, cursor []byte) cmd
 
 	persister           operator.Persister
-	json                jsoniter.API
+	json                gojson
 	convertMessageBytes bool
 	cancel              context.CancelFunc
 	wg                  sync.WaitGroup


### PR DESCRIPTION
Description
Moves the stanza operator journald input to goccy-json from jsoniter.

This speeds up execution.

Also jsoniter no new release since 2021...