### PR TITLE
[tailsamplingprocessor] [chore] Remove test coupling on component internal fields

### DIFF
--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -173,13 +173,6 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 	return tsp, nil
 }
 
-// withPolicies sets the sampling policies to be used by the processor.
-func withPolicies(policies []*policy) Option {
-	return func(tsp *tailSamplingSpanProcessor) {
-		tsp.policies = policies
-	}
-}
-
 // WithSampledDecisionCache sets the cache which the processor uses to store recently sampled trace IDs.
 func WithSampledDecisionCache(c cache.Cache[bool]) Option {
 	return func(tsp *tailSamplingSpanProcessor) {

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -56,7 +56,7 @@ type tailSamplingSpanProcessor struct {
 	nextConsumer       consumer.Traces
 	policies           []*policy
 	idToTrace          sync.Map
-	policyTicker       timeutils.TTicker
+	policyTicker       *timeutils.PolicyTicker
 	tickerFrequency    time.Duration
 	decisionBatcher    idbatcher.Batcher
 	sampledIDCache     cache.Cache[bool]
@@ -173,24 +173,10 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 	return tsp, nil
 }
 
-// withDecisionBatcher sets the batcher used to batch trace IDs for policy evaluation.
-func withDecisionBatcher(batcher idbatcher.Batcher) Option {
-	return func(tsp *tailSamplingSpanProcessor) {
-		tsp.decisionBatcher = batcher
-	}
-}
-
 // withPolicies sets the sampling policies to be used by the processor.
 func withPolicies(policies []*policy) Option {
 	return func(tsp *tailSamplingSpanProcessor) {
 		tsp.policies = policies
-	}
-}
-
-// withTickerFrequency sets the frequency at which the processor will evaluate the sampling policies.
-func withTickerFrequency(frequency time.Duration) Option {
-	return func(tsp *tailSamplingSpanProcessor) {
-		tsp.tickerFrequency = frequency
 	}
 }
 

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -54,7 +54,6 @@ type tailSamplingSpanProcessor struct {
 	logger    *zap.Logger
 
 	nextConsumer       consumer.Traces
-	maxNumTraces       uint64
 	policies           []*policy
 	idToTrace          sync.Map
 	policyTicker       timeutils.TTicker
@@ -132,7 +131,6 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 		set:                set,
 		telemetry:          telemetry,
 		nextConsumer:       nextConsumer,
-		maxNumTraces:       cfg.NumTraces,
 		sampledIDCache:     sampledDecisions,
 		nonSampledIDCache:  nonSampledDecisions,
 		logger:             telemetrySettings.Logger,

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -5,6 +5,7 @@ package tailsamplingprocessor
 
 import (
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,685 +22,689 @@ import (
 )
 
 func TestSamplingPolicyTypicalPath(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	mpe1.NextDecision = samplingpolicy.Sampled
+		mpe1.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingPolicyInvertSampled(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	mpe1.NextDecision = samplingpolicy.InvertSampled
+		mpe1.NextDecision = samplingpolicy.InvertSampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingMultiplePolicies(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// InvertNotSampled takes precedence
-	mpe1.NextDecision = samplingpolicy.Sampled
-	mpe2.NextDecision = samplingpolicy.Sampled
+		// InvertNotSampled takes precedence
+		mpe1.NextDecision = samplingpolicy.Sampled
+		mpe2.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
+		require.Equal(t, 0, mpe2.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
-	require.Equal(t, 0, mpe2.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
+		require.Equal(t, 1, mpe2.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-	require.Equal(t, 1, mpe2.EvaluationCount)
-
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	s := setupTestTelemetry()
-	ct := s.newSettings()
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		s := setupTestTelemetry()
+		ct := s.newSettings()
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
-	}
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+		}
 
-	p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
-	require.NoError(t, err)
+		p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// First policy takes precedence
-	mpe1.NextDecision = samplingpolicy.Sampled
-	mpe2.NextDecision = samplingpolicy.Sampled
+		// First policy takes precedence
+		mpe1.NextDecision = samplingpolicy.Sampled
+		mpe2.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
 
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
-
-	// First span should have an attribute that records the policy that sampled it
-	policy, ok := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.policy")
-	if !ok {
-		assert.FailNow(t, "Did not find expected attribute")
-	}
-	require.Equal(t, "mock-policy-1", policy.AsString())
+		// First span should have an attribute that records the policy that sampled it
+		policy, ok := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.policy")
+		if !ok {
+			assert.FailNow(t, "Did not find expected attribute")
+		}
+		require.Equal(t, "mock-policy-1", policy.AsString())
+	})
 }
 
 func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// InvertNotSampled takes precedence
-	mpe1.NextDecision = samplingpolicy.NotSampled
+		// InvertNotSampled takes precedence
+		mpe1.NextDecision = samplingpolicy.NotSampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-
-	// The final decision SHOULD be NotSampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
+		// The final decision SHOULD be NotSampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingPolicyDecisionNotSampled_WithRecordPolicy(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	s := setupTestTelemetry()
-	ct := s.newSettings()
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		s := setupTestTelemetry()
+		ct := s.newSettings()
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
-	}
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+		}
 
-	p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
-	require.NoError(t, err)
+		p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// InvertNotSampled takes precedence
-	mpe1.NextDecision = samplingpolicy.NotSampled
+		// InvertNotSampled takes precedence
+		mpe1.NextDecision = samplingpolicy.NotSampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
-
-	// The final decision SHOULD be NotSampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
+		// The final decision SHOULD be NotSampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// InvertNotSampled takes precedence
-	mpe1.NextDecision = samplingpolicy.InvertNotSampled
-	mpe2.NextDecision = samplingpolicy.Sampled
+		// InvertNotSampled takes precedence
+		mpe1.NextDecision = samplingpolicy.InvertNotSampled
+		mpe2.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
+		require.Equal(t, 0, mpe2.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
-	require.Equal(t, 0, mpe2.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
+		require.Equal(t, 1, mpe2.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-	require.Equal(t, 1, mpe2.EvaluationCount)
-
-	// The final decision SHOULD be NotSampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
+		// The final decision SHOULD be NotSampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
+	})
 }
 
 func TestSamplingPolicyDecisionInvertNotSampled_WithRecordPolicy(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	s := setupTestTelemetry()
-	ct := s.newSettings()
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		s := setupTestTelemetry()
+		ct := s.newSettings()
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
-	}
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+		}
 
-	p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
-	require.NoError(t, err)
+		p, err := newTracesProcessor(t.Context(), ct, nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// InvertNotSampled takes precedence
-	mpe1.NextDecision = samplingpolicy.InvertNotSampled
-	mpe2.NextDecision = samplingpolicy.Sampled
+		// InvertNotSampled takes precedence
+		mpe1.NextDecision = samplingpolicy.InvertNotSampled
+		mpe2.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
-
-	// The final decision SHOULD be NotSampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
+		// The final decision SHOULD be NotSampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
+	})
 }
 
 func TestLateArrivingSpansAssignedOriginalDecision(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+		}
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// We are going to create 2 spans belonging to the same trace
-	traceID := uInt64ToTraceID(1)
+		// We are going to create 2 spans belonging to the same trace
+		traceID := uInt64ToTraceID(1)
 
-	// The combined decision from the policies is NotSampled
-	mpe1.NextDecision = samplingpolicy.InvertSampled
-	mpe2.NextDecision = samplingpolicy.NotSampled
+		// The combined decision from the policies is NotSampled
+		mpe1.NextDecision = samplingpolicy.InvertSampled
+		mpe2.NextDecision = samplingpolicy.NotSampled
 
-	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
-	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
-		traces := ptrace.NewTraces()
-		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-		span.SetTraceID(traceID)
-		span.SetSpanID(uInt64ToSpanID(spanIndex))
-		return traces
-	}
+		// A function that return a ptrace.Traces containing a single span for the single trace we are using.
+		spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+			traces := ptrace.NewTraces()
+			span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(uInt64ToSpanID(spanIndex))
+			return traces
+		}
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
+		require.Equal(t, 0, mpe2.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
-	require.Equal(t, 0, mpe2.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Both policies should have been evaluated once
+		require.Equal(t, 1, mpe1.EvaluationCount)
+		require.Equal(t, 1, mpe2.EvaluationCount)
 
-	// Both policies should have been evaluated once
-	require.Equal(t, 1, mpe1.EvaluationCount)
-	require.Equal(t, 1, mpe2.EvaluationCount)
+		// The final decision SHOULD be NotSampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
 
-	// The final decision SHOULD be NotSampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
-
-	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
-	// The policies should NOT be evaluated again.
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
-	require.Equal(t, 1, mpe1.EvaluationCount)
-	require.Equal(t, 1, mpe2.EvaluationCount)
-	require.Equal(t, 0, nextConsumer.SpanCount(), "original final decision not honored")
+		// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
+		// The policies should NOT be evaluated again.
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+		require.Equal(t, 1, mpe1.EvaluationCount)
+		require.Equal(t, 1, mpe2.EvaluationCount)
+		require.Equal(t, 0, nextConsumer.SpanCount(), "original final decision not honored")
+	})
 }
 
 func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe := &mockPolicyEvaluator{}
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		mpe := &mockPolicyEvaluator{}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	// Use this instead of the default no-op cache
-	c, err := cache.NewLRUDecisionCache[bool](200)
-	require.NoError(t, err)
+		// Use this instead of the default no-op cache
+		c, err := cache.NewLRUDecisionCache[bool](200)
+		require.NoError(t, err)
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait * 10,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-			WithSampledDecisionCache(c),
-			withRecordPolicy(),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait * 10,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+				WithSampledDecisionCache(c),
+				withRecordPolicy(),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// We are going to create 2 spans belonging to the same trace
-	traceID := uInt64ToTraceID(1)
+		// We are going to create 2 spans belonging to the same trace
+		traceID := uInt64ToTraceID(1)
 
-	// The first span will be sampled, this will later be set to not sampled, but the sampling decision will be cached
-	mpe.NextDecision = samplingpolicy.Sampled
+		// The first span will be sampled, this will later be set to not sampled, but the sampling decision will be cached
+		mpe.NextDecision = samplingpolicy.Sampled
 
-	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
-	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
-		traces := ptrace.NewTraces()
-		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-		span.SetTraceID(traceID)
-		span.SetSpanID(uInt64ToSpanID(spanIndex))
-		return traces
-	}
+		// A function that return a ptrace.Traces containing a single span for the single trace we are using.
+		spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+			traces := ptrace.NewTraces()
+			span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(uInt64ToSpanID(spanIndex))
+			return traces
+		}
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		tsp := p.(*tailSamplingSpanProcessor)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe.EvaluationCount)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe.EvaluationCount)
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// Policy should have been evaluated once
-	require.Equal(t, 1, mpe.EvaluationCount)
+		// Policy should have been evaluated once
+		require.Equal(t, 1, mpe.EvaluationCount)
 
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
 
-	// The trace should have been dropped after its id was added to the decision cache
-	_, ok := tsp.idToTrace.Load(traceID)
-	require.False(t, ok)
+		// The trace should have been dropped after its id was added to the decision cache
+		_, ok := tsp.idToTrace.Load(traceID)
+		require.False(t, ok)
 
-	// Set next decision to not sampled, ensuring the next decision is determined by the decision cache, not the policy
-	mpe.NextDecision = samplingpolicy.NotSampled
+		// Set next decision to not sampled, ensuring the next decision is determined by the decision cache, not the policy
+		mpe.NextDecision = samplingpolicy.NotSampled
 
-	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
-	// The policies should NOT be evaluated again.
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
-	require.Equal(t, 1, mpe.EvaluationCount)
-	require.Equal(t, 2, nextConsumer.SpanCount(), "original final decision not honored")
-	allTraces := nextConsumer.AllTraces()
-	require.Len(t, allTraces, 2)
+		// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
+		// The policies should NOT be evaluated again.
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+		require.Equal(t, 1, mpe.EvaluationCount)
+		require.Equal(t, 2, nextConsumer.SpanCount(), "original final decision not honored")
+		allTraces := nextConsumer.AllTraces()
+		require.Len(t, allTraces, 2)
 
-	// Second trace should have the cached decision attribute
-	cachedAttr, ok := allTraces[1].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.cached_decision")
-	if !ok {
-		assert.FailNow(t, "Did not find expected attribute")
-	}
-	require.True(t, cachedAttr.Bool())
+		// Second trace should have the cached decision attribute
+		cachedAttr, ok := allTraces[1].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.cached_decision")
+		if !ok {
+			assert.FailNow(t, "Did not find expected attribute")
+		}
+		require.True(t, cachedAttr.Bool())
+	})
 }
 
 func TestLateSpanUsesNonSampledDecisionCache(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe := &mockPolicyEvaluator{}
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-	}
+		mpe := &mockPolicyEvaluator{}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		}
 
-	// Use this instead of the default no-op cache
-	c, err := cache.NewLRUDecisionCache[bool](200)
-	require.NoError(t, err)
+		// Use this instead of the default no-op cache
+		c, err := cache.NewLRUDecisionCache[bool](200)
+		require.NoError(t, err)
 
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait * 10,
-		NumTraces:    defaultNumTraces,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-			WithNonSampledDecisionCache(c),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait: defaultTestDecisionWait * 10,
+			NumTraces:    defaultNumTraces,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+				WithNonSampledDecisionCache(c),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// We are going to create 2 spans belonging to the same trace
-	traceID := uInt64ToTraceID(1)
+		// We are going to create 2 spans belonging to the same trace
+		traceID := uInt64ToTraceID(1)
 
-	// The first span will be NOT sampled, this will later be set to sampled, but the sampling decision will be cached
-	mpe.NextDecision = samplingpolicy.NotSampled
+		// The first span will be NOT sampled, this will later be set to sampled, but the sampling decision will be cached
+		mpe.NextDecision = samplingpolicy.NotSampled
 
-	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
-	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
-		traces := ptrace.NewTraces()
-		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-		span.SetTraceID(traceID)
-		span.SetSpanID(uInt64ToSpanID(spanIndex))
-		return traces
-	}
+		// A function that return a ptrace.Traces containing a single span for the single trace we are using.
+		spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+			traces := ptrace.NewTraces()
+			span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetTraceID(traceID)
+			span.SetSpanID(uInt64ToSpanID(spanIndex))
+			return traces
+		}
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(1)))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		tsp := p.(*tailSamplingSpanProcessor)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe.EvaluationCount)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe.EvaluationCount)
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// Policy should have been evaluated once
-	require.Equal(t, 1, mpe.EvaluationCount)
+		// Policy should have been evaluated once
+		require.Equal(t, 1, mpe.EvaluationCount)
 
-	// The final decision SHOULD be NOT Sampled.
-	require.Equal(t, 0, nextConsumer.SpanCount())
+		// The final decision SHOULD be NOT Sampled.
+		require.Equal(t, 0, nextConsumer.SpanCount())
 
-	// The trace should have been dropped after its id was added to the decision cache
-	_, ok := tsp.idToTrace.Load(traceID)
-	require.False(t, ok)
+		// The trace should have been dropped after its id was added to the decision cache
+		_, ok := tsp.idToTrace.Load(traceID)
+		require.False(t, ok)
 
-	// Set next decision to sampled, ensuring the next decision is determined by the decision cache, not the policy
-	mpe.NextDecision = samplingpolicy.Sampled
+		// Set next decision to sampled, ensuring the next decision is determined by the decision cache, not the policy
+		mpe.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
-	// The policies should NOT be evaluated again.
-	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
-	require.Equal(t, 1, mpe.EvaluationCount)
-	require.Equal(t, 0, nextConsumer.SpanCount(), "original final decision not honored")
+		// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
+		// The policies should NOT be evaluated again.
+		require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+		require.Equal(t, 1, mpe.EvaluationCount)
+		require.Equal(t, 0, nextConsumer.SpanCount(), "original final decision not honored")
+	})
 }
 
 func TestSampleOnFirstMatch(t *testing.T) {
-	nextConsumer := new(consumertest.TracesSink)
-	idb := newSyncIDBatcher()
+	synctest.Test(t, func(t *testing.T) {
+		nextConsumer := new(consumertest.TracesSink)
+		idb := newSyncIDBatcher()
 
-	mpe1 := &mockPolicyEvaluator{}
-	mpe2 := &mockPolicyEvaluator{}
-	mpe3 := &mockPolicyEvaluator{}
+		mpe1 := &mockPolicyEvaluator{}
+		mpe2 := &mockPolicyEvaluator{}
+		mpe3 := &mockPolicyEvaluator{}
 
-	policies := []*policy{
-		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
-		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
-		{name: "mock-policy-3", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-3"))},
-	}
+		policies := []*policy{
+			{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+			{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+			{name: "mock-policy-3", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-3"))},
+		}
 
-	cfg := Config{
-		DecisionWait:       defaultTestDecisionWait,
-		NumTraces:          defaultNumTraces,
-		SampleOnFirstMatch: true,
-		Options: []Option{
-			withDecisionBatcher(idb),
-			withPolicies(policies),
-		},
-	}
-	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			DecisionWait:       defaultTestDecisionWait,
+			NumTraces:          defaultNumTraces,
+			SampleOnFirstMatch: true,
+			Options: []Option{
+				withDecisionBatcher(idb),
+				withPolicies(policies),
+			},
+		}
+		p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+		require.NoError(t, err)
 
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() {
-		require.NoError(t, p.Shutdown(t.Context()))
-	}()
+		require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, p.Shutdown(t.Context()))
+		}()
 
-	// Second policy matches, last policy should not be evaluated
-	mpe1.NextDecision = samplingpolicy.NotSampled
-	mpe2.NextDecision = samplingpolicy.Sampled
+		// Second policy matches, last policy should not be evaluated
+		mpe1.NextDecision = samplingpolicy.NotSampled
+		mpe2.NextDecision = samplingpolicy.Sampled
 
-	// Generate and deliver first span
-	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+		// Generate and deliver first span
+		require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
 
-	tsp := p.(*tailSamplingSpanProcessor)
+		// The first tick won't do anything
+		waitForTick()
+		require.Equal(t, 0, mpe1.EvaluationCount)
+		require.Equal(t, 0, mpe2.EvaluationCount)
+		require.Equal(t, 0, mpe3.EvaluationCount)
 
-	// The first tick won't do anything
-	tsp.policyTicker.OnTick()
-	require.Equal(t, 0, mpe1.EvaluationCount)
-	require.Equal(t, 0, mpe2.EvaluationCount)
-	require.Equal(t, 0, mpe3.EvaluationCount)
+		// This will cause policy evaluations on the first span
+		waitForTick()
 
-	// This will cause policy evaluations on the first span
-	tsp.policyTicker.OnTick()
+		// Only the first policy should have been evaluated
+		require.Equal(t, 1, mpe1.EvaluationCount)
+		require.Equal(t, 1, mpe2.EvaluationCount)
+		require.Equal(t, 0, mpe3.EvaluationCount)
 
-	// Only the first policy should have been evaluated
-	require.Equal(t, 1, mpe1.EvaluationCount)
-	require.Equal(t, 1, mpe2.EvaluationCount)
-	require.Equal(t, 0, mpe3.EvaluationCount)
-
-	// The final decision SHOULD be Sampled.
-	require.Equal(t, 1, nextConsumer.SpanCount())
+		// The final decision SHOULD be Sampled.
+		require.Equal(t, 1, nextConsumer.SpanCount())
+	})
 }

--- a/processor/tailsamplingprocessor/processor_telemetry_test.go
+++ b/processor/tailsamplingprocessor/processor_telemetry_test.go
@@ -6,7 +6,6 @@ package tailsamplingprocessor
 import (
 	"context"
 	"testing"
-	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,303 +27,297 @@ import (
 )
 
 func TestMetricsAfterOneEvaluation(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    100,
-			PolicyCfgs: []PolicyCfg{
-				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "always",
-						Type: AlwaysSample,
-					},
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    100,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "always",
+					Type: AlwaysSample,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
 		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+	}()
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
 
-		// test
-		err = proc.ConsumeTraces(t.Context(), simpleTraces())
-		require.NoError(t, err)
+	// test
+	err = proc.ConsumeTraces(t.Context(), simpleTraces())
+	require.NoError(t, err)
 
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
 
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-		require.Equal(t, 8, s.len(md))
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+	require.Equal(t, 8, s.len(md))
 
-		for _, tt := range []struct {
-			opts []metricdatatest.Option
-			m    metricdata.Metrics
-		}{
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_count_traces_sampled",
-					Description: "Count of traces that were sampled or not per sampling policy",
-					Unit:        "{traces}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Attributes: attribute.NewSet(
-									attribute.String("policy", "always"),
-									attribute.String("sampled", "true"),
-									attribute.String("decision", "sampled"),
-								),
-								Value: 1,
-							},
+	for _, tt := range []struct {
+		opts []metricdatatest.Option
+		m    metricdata.Metrics
+	}{
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_count_traces_sampled",
+				Description: "Count of traces that were sampled or not per sampling policy",
+				Unit:        "{traces}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("policy", "always"),
+								attribute.String("sampled", "true"),
+								attribute.String("decision", "sampled"),
+							),
+							Value: 1,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_global_count_traces_sampled",
-					Description: "Global count of traces that were sampled or not by at least one policy",
-					Unit:        "{traces}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Attributes: attribute.NewSet(
-									attribute.String("sampled", "true"),
-									attribute.String("decision", "sampled"),
-								),
-								Value: 1,
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_global_count_traces_sampled",
+				Description: "Global count of traces that were sampled or not by at least one policy",
+				Unit:        "{traces}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("sampled", "true"),
+								attribute.String("decision", "sampled"),
+							),
+							Value: 1,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
-					Description: "Latency (in microseconds) of a given sampling policy",
-					Unit:        "µs",
-					Data: metricdata.Histogram[int64]{
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.HistogramDataPoint[int64]{
-							{
-								Attributes: attribute.NewSet(
-									attribute.String("policy", "always"),
-								),
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
+				Description: "Latency (in microseconds) of a given sampling policy",
+				Unit:        "µs",
+				Data: metricdata.Histogram[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("policy", "always"),
+							),
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_decision_timer_latency",
-					Description: "Latency (in milliseconds) of each run of the sampling decision timer",
-					Unit:        "ms",
-					Data: metricdata.Histogram[int64]{
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints:  []metricdata.HistogramDataPoint[int64]{{}},
-					},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_decision_timer_latency",
+				Description: "Latency (in milliseconds) of each run of the sampling decision timer",
+				Unit:        "ms",
+				Data: metricdata.Histogram[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints:  []metricdata.HistogramDataPoint[int64]{{}},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_new_trace_id_received",
-					Description: "Counts the arrival of new traces",
-					Unit:        "{traces}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Value: 1,
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_new_trace_id_received",
+				Description: "Counts the arrival of new traces",
+				Unit:        "{traces}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Value: 1,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
-					Description: "Count of sampling policy evaluation errors",
-					Unit:        "{errors}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Value: 0,
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
+				Description: "Count of sampling policy evaluation errors",
+				Unit:        "{errors}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Value: 0,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
-					Description: "Count of traces that needed to be dropped before the configured wait time",
-					Unit:        "{traces}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Value: 0,
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
+				Description: "Count of traces that needed to be dropped before the configured wait time",
+				Unit:        "{traces}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Value: 0,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_traces_on_memory",
-					Description: "Tracks the number of traces current on memory",
-					Unit:        "{traces}",
-					Data: metricdata.Gauge[int64]{
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Value: 1,
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_traces_on_memory",
+				Description: "Tracks the number of traces current on memory",
+				Unit:        "{traces}",
+				Data: metricdata.Gauge[int64]{
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Value: 1,
 						},
 					},
 				},
 			},
-		} {
-			got := s.getMetric(tt.m.Name, md)
-			metricdatatest.AssertEqual(t, tt.m, got, tt.opts...)
-		}
+		},
+	} {
+		got := s.getMetric(tt.m.Name, md)
+		metricdatatest.AssertEqual(t, tt.m, got, tt.opts...)
+	}
 
-		// sanity check
-		assert.Len(t, cs.AllTraces(), 1)
-	})
+	// sanity check
+	assert.Len(t, cs.AllTraces(), 1)
 }
 
 func TestMetricsWithComponentID(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    100,
-			PolicyCfgs: []PolicyCfg{
-				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "always",
-						Type: AlwaysSample,
-					},
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    100,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "always",
+					Type: AlwaysSample,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		ct.ID = component.MustNewIDWithName("tail_sampling", "unique_id") // e.g tail_sampling/unique_id
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	ct.ID = component.MustNewIDWithName("tail_sampling", "unique_id") // e.g tail_sampling/unique_id
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
 		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+	}()
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
 
-		// test
-		err = proc.ConsumeTraces(t.Context(), simpleTraces())
-		require.NoError(t, err)
+	// test
+	err = proc.ConsumeTraces(t.Context(), simpleTraces())
+	require.NoError(t, err)
 
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
 
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-		require.Equal(t, 8, s.len(md))
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+	require.Equal(t, 8, s.len(md))
 
-		for _, tt := range []struct {
-			opts []metricdatatest.Option
-			m    metricdata.Metrics
-		}{
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_count_traces_sampled",
-					Description: "Count of traces that were sampled or not per sampling policy",
-					Unit:        "{traces}",
-					Data: metricdata.Sum[int64]{
-						IsMonotonic: true,
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.DataPoint[int64]{
-							{
-								Attributes: attribute.NewSet(
-									attribute.String("policy", "unique_id.always"),
-									attribute.String("sampled", "true"),
-									attribute.String("decision", "sampled"),
-								),
-								Value: 1,
-							},
+	for _, tt := range []struct {
+		opts []metricdatatest.Option
+		m    metricdata.Metrics
+	}{
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_count_traces_sampled",
+				Description: "Count of traces that were sampled or not per sampling policy",
+				Unit:        "{traces}",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("policy", "unique_id.always"),
+								attribute.String("sampled", "true"),
+								attribute.String("decision", "sampled"),
+							),
+							Value: 1,
 						},
 					},
 				},
 			},
-			{
-				opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
-				m: metricdata.Metrics{
-					Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
-					Description: "Latency (in microseconds) of a given sampling policy",
-					Unit:        "µs",
-					Data: metricdata.Histogram[int64]{
-						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.HistogramDataPoint[int64]{
-							{
-								Attributes: attribute.NewSet(
-									attribute.String("policy", "unique_id.always"),
-								),
-							},
+		},
+		{
+			opts: []metricdatatest.Option{metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue()},
+			m: metricdata.Metrics{
+				Name:        "otelcol_processor_tail_sampling_sampling_decision_latency",
+				Description: "Latency (in microseconds) of a given sampling policy",
+				Unit:        "µs",
+				Data: metricdata.Histogram[int64]{
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.HistogramDataPoint[int64]{
+						{
+							Attributes: attribute.NewSet(
+								attribute.String("policy", "unique_id.always"),
+							),
 						},
 					},
 				},
 			},
-		} {
-			got := s.getMetric(tt.m.Name, md)
-			metricdatatest.AssertEqual(t, tt.m, got, tt.opts...)
-		}
+		},
+	} {
+		got := s.getMetric(tt.m.Name, md)
+		metricdatatest.AssertEqual(t, tt.m, got, tt.opts...)
+	}
 
-		// sanity check
-		assert.Len(t, cs.AllTraces(), 1)
-	})
+	// sanity check
+	assert.Len(t, cs.AllTraces(), 1)
 }
 
 func TestMetricsCountSampled(t *testing.T) {
@@ -563,49 +556,46 @@ func TestMetricsCountSampled(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
+			// prepare
+			s := setupTestTelemetry()
+			controller := newTestTSPController()
+
+			cfg := Config{
+				DecisionWait: 1,
+				NumTraces:    100,
+				PolicyCfgs:   tt.policyCfgs,
+				Options: []Option{
+					withTestController(controller),
+				},
+			}
+			cs := &consumertest.TracesSink{}
+			ct := s.newSettings()
+			proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err = proc.Shutdown(t.Context())
+				require.NoError(t, err)
+			})
+
+			err = proc.Start(t.Context(), componenttest.NewNopHost())
+			require.NoError(t, err)
+
+			// test
+			err = proc.ConsumeTraces(t.Context(), simpleTraces())
+			require.NoError(t, err)
+
+			controller.waitForTick() // the first tick always gets an empty batch
+			controller.waitForTick()
+
+			// verify
+			var md metricdata.ResourceMetrics
+			require.NoError(t, s.reader.Collect(t.Context(), &md))
+			require.Equal(t, 9, s.len(md))
+
 			for _, m := range tt.m {
 				t.Run(m.Name, func(t *testing.T) {
-					synctest.Test(t, func(t *testing.T) {
-						// prepare
-						s := setupTestTelemetry()
-						b := newSyncIDBatcher()
-						syncBatcher := b.(*syncIDBatcher)
-
-						cfg := Config{
-							DecisionWait: 1,
-							NumTraces:    100,
-							PolicyCfgs:   tt.policyCfgs,
-							Options: []Option{
-								withDecisionBatcher(syncBatcher),
-							},
-						}
-						cs := &consumertest.TracesSink{}
-						ct := s.newSettings()
-						proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
-						require.NoError(t, err)
-						t.Cleanup(func() {
-							err = proc.Shutdown(t.Context())
-							require.NoError(t, err)
-						})
-
-						err = proc.Start(t.Context(), componenttest.NewNopHost())
-						require.NoError(t, err)
-
-						// test
-						err = proc.ConsumeTraces(t.Context(), simpleTraces())
-						require.NoError(t, err)
-
-						waitForTick() // the first tick always gets an empty batch
-						waitForTick()
-
-						// verify
-						var md metricdata.ResourceMetrics
-						require.NoError(t, s.reader.Collect(t.Context(), &md))
-						require.Equal(t, 9, s.len(md))
-
-						got := s.getMetric(m.Name, md)
-						metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
-					})
+					got := s.getMetric(m.Name, md)
+					metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
 				})
 			}
 		})
@@ -613,366 +603,351 @@ func TestMetricsCountSampled(t *testing.T) {
 }
 
 func TestProcessorTailSamplingSamplingTraceRemovalAge(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    2,
-			PolicyCfgs: []PolicyCfg{
-				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "always",
-						Type: AlwaysSample,
-					},
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    2,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "always",
+					Type: AlwaysSample,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
 		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+	}()
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// test
+	_, batches := generateIDsAndBatches(3)
+	for _, batch := range batches {
+		err = proc.ConsumeTraces(t.Context(), batch)
 		require.NoError(t, err)
+	}
 
-		// test
-		_, batches := generateIDsAndBatches(3)
-		for _, batch := range batches {
-			err = proc.ConsumeTraces(t.Context(), batch)
-			require.NoError(t, err)
-		}
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
 
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
 
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-
-		m := metricdata.Metrics{
-			Name:        "otelcol_processor_tail_sampling_sampling_trace_removal_age",
-			Description: "Time (in seconds) from arrival of a new trace until its removal from memory",
-			Unit:        "s",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints:  []metricdata.HistogramDataPoint[int64]{{}},
-			},
-		}
-		got := s.getMetric(m.Name, md)
-		metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
-	})
+	m := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_sampling_trace_removal_age",
+		Description: "Time (in seconds) from arrival of a new trace until its removal from memory",
+		Unit:        "s",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  []metricdata.HistogramDataPoint[int64]{{}},
+		},
+	}
+	got := s.getMetric(m.Name, md)
+	metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreValue())
 }
 
 func TestProcessorTailSamplingSamplingLateSpanAge(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    100,
-			PolicyCfgs: []PolicyCfg{
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    100,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "sample-half",
+					Type: Probabilistic,
+					ProbabilisticCfg: ProbabilisticCfg{
+						SamplingPercentage: 50,
+					},
+				},
+			},
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
+		require.NoError(t, err)
+	}()
+
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// test
+	traceIDs, batches := generateIDsAndBatches(10)
+	for _, batch := range batches {
+		err = proc.ConsumeTraces(t.Context(), batch)
+		require.NoError(t, err)
+	}
+
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
+
+	for _, traceID := range traceIDs {
+		lateSpan := ptrace.NewTraces()
+		lateSpan.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(traceID)
+
+		err = proc.ConsumeTraces(t.Context(), lateSpan)
+		require.NoError(t, err)
+	}
+
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+
+	m := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_sampling_late_span_age",
+		Description: "Time (in seconds) from the sampling decision was taken and the arrival of a late span",
+		Unit:        "s",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.HistogramDataPoint[int64]{
 				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "sample-half",
-						Type: Probabilistic,
-						ProbabilisticCfg: ProbabilisticCfg{
-							SamplingPercentage: 50,
-						},
-					},
+					Count:        10,
+					Bounds:       []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
+					BucketCounts: []uint64{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+					Min:          metricdata.NewExtrema[int64](0),
+					Max:          metricdata.NewExtrema[int64](0),
+					Sum:          0,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
-		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+		},
+	}
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
+	got := s.getMetric(m.Name, md)
 
-		// test
-		traceIDs, batches := generateIDsAndBatches(10)
-		for _, batch := range batches {
-			err = proc.ConsumeTraces(t.Context(), batch)
-			require.NoError(t, err)
-		}
-
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
-
-		for _, traceID := range traceIDs {
-			lateSpan := ptrace.NewTraces()
-			lateSpan.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(traceID)
-
-			err = proc.ConsumeTraces(t.Context(), lateSpan)
-			require.NoError(t, err)
-		}
-
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-
-		m := metricdata.Metrics{
-			Name:        "otelcol_processor_tail_sampling_sampling_late_span_age",
-			Description: "Time (in seconds) from the sampling decision was taken and the arrival of a late span",
-			Unit:        "s",
-			Data: metricdata.Histogram[int64]{
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{
-					{
-						Count:        10,
-						Bounds:       []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
-						BucketCounts: []uint64{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-						Min:          metricdata.NewExtrema[int64](0),
-						Max:          metricdata.NewExtrema[int64](0),
-						Sum:          0,
-					},
-				},
-			},
-		}
-
-		got := s.getMetric(m.Name, md)
-
-		metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
-	})
+	metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
 }
 
 func TestProcessorTailSamplingSamplingTraceDroppedTooEarly(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    2,
-			PolicyCfgs: []PolicyCfg{
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    2,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "always",
+					Type: AlwaysSample,
+				},
+			},
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
+		require.NoError(t, err)
+	}()
+
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// test
+	_, batches := generateIDsAndBatches(3)
+	for _, batch := range batches {
+		err = proc.ConsumeTraces(t.Context(), batch)
+		require.NoError(t, err)
+	}
+
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
+
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+
+	m := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
+		Description: "Count of traces that needed to be dropped before the configured wait time",
+		Unit:        "{traces}",
+		Data: metricdata.Sum[int64]{
+			IsMonotonic: true,
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.DataPoint[int64]{
 				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "always",
-						Type: AlwaysSample,
-					},
+					Value: 1,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
-		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+		},
+	}
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
-
-		// test
-		_, batches := generateIDsAndBatches(3)
-		for _, batch := range batches {
-			err = proc.ConsumeTraces(t.Context(), batch)
-			require.NoError(t, err)
-		}
-
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
-
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-
-		m := metricdata.Metrics{
-			Name:        "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
-			Description: "Count of traces that needed to be dropped before the configured wait time",
-			Unit:        "{traces}",
-			Data: metricdata.Sum[int64]{
-				IsMonotonic: true,
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value: 1,
-					},
-				},
-			},
-		}
-
-		got := s.getMetric(m.Name, md)
-		metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
-	})
+	got := s.getMetric(m.Name, md)
+	metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
 }
 
 func TestProcessorTailSamplingSamplingPolicyEvaluationError(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    100,
-			PolicyCfgs: []PolicyCfg{
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    100,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "ottl",
+					Type: OTTLCondition,
+					OTTLConditionCfg: OTTLConditionCfg{
+						ErrorMode:      ottl.PropagateError,
+						SpanConditions: []string{"attributes[1] == \"test\""},
+					},
+				},
+			},
+		},
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
+		require.NoError(t, err)
+	}()
+
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// test
+	_, batches := generateIDsAndBatches(2)
+	for _, batch := range batches {
+		err = proc.ConsumeTraces(t.Context(), batch)
+		require.NoError(t, err)
+	}
+
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick()
+
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+
+	m := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
+		Description: "Count of sampling policy evaluation errors",
+		Unit:        "{errors}",
+		Data: metricdata.Sum[int64]{
+			IsMonotonic: true,
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.DataPoint[int64]{
 				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "ottl",
-						Type: OTTLCondition,
-						OTTLConditionCfg: OTTLConditionCfg{
-							ErrorMode:      ottl.PropagateError,
-							SpanConditions: []string{"attributes[1] == \"test\""},
-						},
-					},
+					Value: 2,
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
-		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+		},
+	}
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
-
-		// test
-		_, batches := generateIDsAndBatches(2)
-		for _, batch := range batches {
-			err = proc.ConsumeTraces(t.Context(), batch)
-			require.NoError(t, err)
-		}
-
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick()
-
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-
-		m := metricdata.Metrics{
-			Name:        "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
-			Description: "Count of sampling policy evaluation errors",
-			Unit:        "{errors}",
-			Data: metricdata.Sum[int64]{
-				IsMonotonic: true,
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value: 2,
-					},
-				},
-			},
-		}
-
-		got := s.getMetric(m.Name, md)
-		metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
-	})
+	got := s.getMetric(m.Name, md)
+	metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
 }
 
 func TestProcessorTailSamplingEarlyReleasesFromCacheDecision(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		// prepare
-		s := setupTestTelemetry()
-		b := newSyncIDBatcher()
-		syncBatcher := b.(*syncIDBatcher)
+	// prepare
+	s := setupTestTelemetry()
+	controller := newTestTSPController()
 
-		// Use this instead of the default no-op cache
-		c, err := cache.NewLRUDecisionCache[bool](200)
+	// Use this instead of the default no-op cache
+	c, err := cache.NewLRUDecisionCache[bool](200)
+	require.NoError(t, err)
+
+	cfg := Config{
+		DecisionWait: 1,
+		NumTraces:    100,
+		PolicyCfgs: []PolicyCfg{
+			{
+				sharedPolicyCfg: sharedPolicyCfg{
+					Name: "always",
+					Type: AlwaysSample,
+				},
+			},
+		},
+		Options: []Option{
+			withTestController(controller),
+			WithSampledDecisionCache(c),
+		},
+	}
+	cs := &consumertest.TracesSink{}
+	ct := s.newSettings()
+	proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
+	require.NoError(t, err)
+	defer func() {
+		err = proc.Shutdown(t.Context())
 		require.NoError(t, err)
+	}()
 
-		cfg := Config{
-			DecisionWait: 1,
-			NumTraces:    100,
-			PolicyCfgs: []PolicyCfg{
+	err = proc.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// test
+	err = proc.ConsumeTraces(t.Context(), simpleTraces())
+	require.NoError(t, err)
+
+	controller.waitForTick() // the first tick always gets an empty batch
+	controller.waitForTick() // ensure a sampling decision was made and cached
+
+	err = proc.ConsumeTraces(t.Context(), simpleTraces())
+	require.NoError(t, err)
+	controller.waitForTick()
+
+	// verify
+	var md metricdata.ResourceMetrics
+	require.NoError(t, s.reader.Collect(t.Context(), &md))
+
+	m := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_early_releases_from_cache_decision",
+		Description: "Number of spans that were able to be immediately released due to a decision cache hit.",
+		Unit:        "{spans}",
+		Data: metricdata.Sum[int64]{
+			IsMonotonic: true,
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints: []metricdata.DataPoint[int64]{
 				{
-					sharedPolicyCfg: sharedPolicyCfg{
-						Name: "always",
-						Type: AlwaysSample,
-					},
+					Value: 1,
+					Attributes: attribute.NewSet(
+						attribute.String("sampled", "true"),
+					),
 				},
 			},
-			Options: []Option{
-				withDecisionBatcher(syncBatcher),
-				WithSampledDecisionCache(c),
-			},
-		}
-		cs := &consumertest.TracesSink{}
-		ct := s.newSettings()
-		proc, err := newTracesProcessor(t.Context(), ct, cs, cfg)
-		require.NoError(t, err)
-		defer func() {
-			err = proc.Shutdown(t.Context())
-			require.NoError(t, err)
-		}()
+		},
+	}
 
-		err = proc.Start(t.Context(), componenttest.NewNopHost())
-		require.NoError(t, err)
-
-		// test
-		err = proc.ConsumeTraces(t.Context(), simpleTraces())
-		require.NoError(t, err)
-
-		waitForTick() // the first tick always gets an empty batch
-		waitForTick() // ensure a sampling decision was made and cached
-
-		err = proc.ConsumeTraces(t.Context(), simpleTraces())
-		require.NoError(t, err)
-		waitForTick()
-
-		// verify
-		var md metricdata.ResourceMetrics
-		require.NoError(t, s.reader.Collect(t.Context(), &md))
-
-		m := metricdata.Metrics{
-			Name:        "otelcol_processor_tail_sampling_early_releases_from_cache_decision",
-			Description: "Number of spans that were able to be immediately released due to a decision cache hit.",
-			Unit:        "{spans}",
-			Data: metricdata.Sum[int64]{
-				IsMonotonic: true,
-				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.DataPoint[int64]{
-					{
-						Value: 1,
-						Attributes: attribute.NewSet(
-							attribute.String("sampled", "true"),
-						),
-					},
-				},
-			},
-		}
-
-		got := s.getMetric(m.Name, md)
-		metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
-	})
+	got := s.getMetric(m.Name, md)
+	metricdatatest.AssertEqual(t, m, got, metricdatatest.IgnoreTimestamp())
 }
 
 type testTelemetry struct {

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -448,15 +448,15 @@ func TestConsumptionDuringPolicyEvaluation(t *testing.T) {
 			// dropped too early errors.
 			SampledCacheSize: numBatches * 2,
 		},
+		Options: []Option{
+			withTickerFrequency(5 * time.Millisecond),
+		},
 	}
 	settings := processortest.NewNopSettings(metadata.Type)
 	reader := sdkmetric.NewManualReader()
 	settings.MeterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	tsp, err := newTracesProcessor(t.Context(), settings, msp, cfg)
 	require.NoError(t, err)
-
-	// speed up the test a bit
-	tsp.(*tailSamplingSpanProcessor).tickerFrequency = 5 * time.Millisecond
 
 	require.NoError(t, tsp.Start(t.Context(), componenttest.NewNopHost()))
 	defer func() {
@@ -723,11 +723,11 @@ func TestSubSecondDecisionTime(t *testing.T) {
 		DecisionWait: 500 * time.Millisecond,
 		NumTraces:    defaultNumTraces,
 		PolicyCfgs:   testPolicy,
+		Options: []Option{
+			withTickerFrequency(10 * time.Millisecond),
+		},
 	})
 	require.NoError(t, err)
-
-	// speed up the test a bit
-	tsp.(*tailSamplingSpanProcessor).tickerFrequency = 10 * time.Millisecond
 
 	require.NoError(t, tsp.Start(t.Context(), componenttest.NewNopHost()))
 	defer func() {

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -107,9 +107,18 @@ func withTestController(t *testTSPController) Option {
 	}
 }
 
+// withTickerFrequency sets the frequency at which the processor will evaluate
+// the sampling policies.
 func withTickerFrequency(frequency time.Duration) Option {
 	return func(tsp *tailSamplingSpanProcessor) {
 		tsp.tickerFrequency = frequency
+	}
+}
+
+// withPolicies sets the sampling policies to be used by the processor.
+func withPolicies(policies []*policy) Option {
+	return func(tsp *tailSamplingSpanProcessor) {
+		tsp.policies = policies
 	}
 }
 

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -279,13 +279,13 @@ func TestSequentialTraceArrival(t *testing.T) {
 	for _, trace := range allSampledTraces {
 		sampledTraceIDs[trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID()] = struct{}{}
 	}
-	require.Equal(t, 128, len(sampledTraceIDs))
+	require.Len(t, sampledTraceIDs, 128)
 	for _, expectedTrace := range traceIDs {
 		_, ok := sampledTraceIDs[expectedTrace]
 		require.True(t, ok, "Expected trace %v to be sampled", expectedTrace)
 		delete(sampledTraceIDs, expectedTrace)
 	}
-	require.Equal(t, 0, len(sampledTraceIDs), "No extra traces should be sampled")
+	require.Empty(t, sampledTraceIDs, "No extra traces should be sampled")
 }
 
 func TestConcurrentTraceArrival(t *testing.T) {
@@ -346,14 +346,13 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	for _, trace := range allSampledTraces {
 		sampledTraceIDs[trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID()] = struct{}{}
 	}
-	require.Equal(t, 128, len(sampledTraceIDs))
+	require.Len(t, sampledTraceIDs, 128)
 	for _, expectedTrace := range traceIDs {
 		_, ok := sampledTraceIDs[expectedTrace]
 		require.True(t, ok, "Expected trace %v to be sampled", expectedTrace)
 		delete(sampledTraceIDs, expectedTrace)
 	}
-	require.Equal(t, 0, len(sampledTraceIDs), "No extra traces should be sampled")
-
+	require.Empty(t, sampledTraceIDs, "No extra traces should be sampled")
 }
 
 func TestConcurrentArrivalAndEvaluation(t *testing.T) {
@@ -446,14 +445,14 @@ func TestSequentialTraceMapSize(t *testing.T) {
 		sampledTraceIDs[trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID()] = struct{}{}
 	}
 
-	require.Equal(t, int(cfg.NumTraces), len(sampledTraceIDs))
+	require.Len(t, sampledTraceIDs, int(cfg.NumTraces))
 	for _, expectedTrace := range traceIDs[len(traceIDs)-int(cfg.NumTraces):] {
 		_, ok := sampledTraceIDs[expectedTrace]
 		require.True(t, ok, "Expected trace %v to be sampled", expectedTrace)
 		delete(sampledTraceIDs, expectedTrace)
 	}
 
-	require.Equal(t, 0, len(sampledTraceIDs), "No extra traces should be sampled")
+	require.Empty(t, sampledTraceIDs, "No extra traces should be sampled")
 }
 
 func TestConsumptionDuringPolicyEvaluation(t *testing.T) {


### PR DESCRIPTION
While working on a fix for #41656, I've noticed many tests are strongly coupled to the tsp internals. This PR refactors all such coupling to exist in a small number of test helpers, instead of being duplicated across all tests. Those helpers are:

* `withPolicies` - allows directly setting the policy evaluators which is useful for fine grained decision logic tests
* `withTickerLatency` - allows speeding up the decision ticker which is useful for speeding up tests
* `withTestController` - makes the decision tick blocking until triggered. This allows deterministic tests of otherwise non-deterministic behavior.

A few tests were mostly rewritten to make them test externally observable behavior. For example:

* TestLateArrivingSpanUsesDecisionCache - used to inspect idToTrace state to ensure traces are cleared from memory. Now the tsp is destroyed and recreated with the same cache to ensure the cache is the only state available.
* TestSequentialTraceMapSize et al - these used to inspect idToTrace state to ensure trace data is properly tracked. Now they trigger sampling decisions and assert that the output is complete.
* TestSetSamplingPolicy et al - these used to inspect policies state to ensure policies are reloaded. Now they observe sampled traces only.

### Instead of invoking the TSP tick loop directly

Instead of directly calling the tsp tick loop, I've added code to wrap the tick loop and make it blocking until called. This still involves some coupling, but since it's encapsulated in one place, it will be easier to change when refactoring the tsp in #41656. I took the opportunity to consolidate the sync batcher into this controller as well. In all cases with a manual tick loop, we also want a synchronous batcher for the same reason. Again this makes it simpler to update later without modifying every test at once.

### Instead of accessing the idToTrace map

In all cases where we were directly inspecting the idToTrace map, we could instead just let the tsp sample those traces and inspect the output.

### Instead of setting tickerFrequency directly

I've moved these tests to use `withTickerFrequency`, which is still a coupling, but since it's delegated to the option func, there's a central place to change how it works.

### other

I included a final commit: 7bfab91d5921e981d8bfb6bc9b3221da69f41958. This just removes an unused field.

I've decided to remove two tests:

* TestConcurrentTraceMapSize - this one writes traces concurrently then asserts on the size of the idToTrace map. We have overlapping tests which write concurrently then assert complete sampled output, which IMO is a better test.
* TestDecisionPolicyMetrics - this one calls the internal `makeDecision` method and then asserts on the returned metrics, which are only used in debug logging. This feels like over testing to me and makes the tests overly coupled.
