### PR TITLE
[chore][sumologicextension]: fix flaky test

### DIFF
--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -372,7 +372,10 @@ func TestStoreCredentials_PreexistingCredentialsAreUsed(t *testing.T) {
 	require.NoError(t, se.Shutdown(t.Context()))
 	require.FileExists(t, credsPath)
 
-	require.EqualValues(t, 2, atomic.LoadInt32(&reqCount))
+	// Depending on timing, the periodic heartbeat can result in more than
+	// two requests being made. Testing that at least two requests were made
+	// should be sufficient to satisfy this test.
+	require.GreaterOrEqual(t, atomic.LoadInt32(&reqCount), int32(2))
 }
 
 func TestStoreCredentials_V2CredentialsAreUsed(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
A test was flaky due to depending on timing and an exact count of a periodic condition. By asserting instead that a minimum count was achieved instead, the problem can be sidestepped.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42867

<!--Describe what testing was performed and which tests were added.-->
#### Testing
`go test -count 100 -run TestStoreCredentials_PreexistingCredentialsAreUsed` will fail before this change is applied, and succeed after.