### PR TITLE
Update pkg/sampling docs

### DIFF
--- a/.chloggen/pkg-sampling-stable.yaml
+++ b/.chloggen/pkg-sampling-stable.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: enhancement
+
+component: pkg/sampling
+
+note: Note that pkg/sampling implements the new OpenTelemetry specification
+
+issues: [43396]
+
+subtext:
+
+change_logs: [user]

--- a/pkg/sampling/README.md
+++ b/pkg/sampling/README.md
@@ -7,17 +7,18 @@ This package contains utilities for parsing and interpreting the W3C
 and all sampling-relevant fields specified by OpenTelemetry that may
 be found in the OpenTelemetry section of the W3C TraceState.
 
-This package implements the draft specification in [OTEP
-235](https://github.com/open-telemetry/oteps/pull/235), which
-specifies two fields used by the OpenTelemetry consistent probability
-sampling scheme.
+See the associated OpenTelemetry specifications:
 
-These are:
+- [Consistent probability sampling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/)
+- [OpenTelemetry TraceState handling](https://opentelemetry.io/docs/specs/otel/trace/tracestate-handling/#pre-defined-opentelemetry-sub-keys)
+
+This package supports sampler components that apply sampling on the
+collection path through reading and writing the OpenTelemetry (`ot`)
+TraceState sub-keys:
 
 - `th`: the Threshold used to determine whether a TraceID is sampled
 - `rv`: an explicit randomness value, which overrides randomness in the TraceID
 
-[OTEP 235](https://github.com/open-telemetry/oteps/pull/235) contains
-details on how to interpret these fields.  The are not meant to be
-human readable, with a few exceptions.  The tracestate entry `ot=th:0`
-indicates 100% sampling.
+See
+[probabilisticsamplerprocessor](../../processor/probabilisticsamplerprocessor/README.md)
+for an example application.


### PR DESCRIPTION
#### Description

This code was used as a prototype for the new OpenTelemetry specifications on sampling.

#### Documentation

Update links to the finished specifications, which this now supports.
