### PR TITLE
[chore][pkg/stanza] Fixed a benchmark failure in the adapter package

### DIFF
--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -126,36 +126,24 @@ func BenchmarkFromPdataConverter(b *testing.B) {
 	for _, wc := range workerCounts {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for b.Loop() {
+				b.StopTimer()
 				converter := NewFromPdataConverter(componenttest.NewNopTelemetrySettings(), wc)
 				converter.Start()
 				defer converter.Stop()
-				b.ResetTimer()
+				b.StartTimer()
 
 				go func() {
 					assert.NoError(b, converter.Batch(pLogs))
 				}()
 
-				var (
-					timeoutTimer = time.NewTimer(10 * time.Second)
-					ch           = converter.OutChannel()
-				)
-				defer timeoutTimer.Stop()
-
-				var n int
-			forLoop:
-				for n != entryCount {
-					select {
-					case entries, ok := <-ch:
-						if !ok {
-							break forLoop
-						}
-
-						require.Len(b, entries, 250_000)
-						n += len(entries)
-
-					case <-timeoutTimer.C:
-						break forLoop
+				ch := converter.OutChannel()
+				n := 0
+				for n < entryCount {
+					entries, ok := <-ch
+					if !ok {
+						break
 					}
+					n += len(entries)
 				}
 
 				assert.Equal(b, entryCount, n,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This is another fix for #43044 (oh, never ending). This change fixes the following error:
```
--- FAIL: BenchmarkFromPdataConverter/worker_count=1
    frompdataconverter_test.go:153: 
                Error Trace:    /Users/ray.kang/github.com/gnak-yar/opentelemetry-collector-contrib/pkg/stanza/adapter/frompdataconverter_test.go:153
                                                        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/benchmark.go:219
                                                        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/benchmark.go:245
                                                        /opt/homebrew/Cellar/go/1.24.4/libexec/src/runtime/asm_arm64.s:1223
                Error:          "[0x140f228bec0]" should have 250000 item(s), but has 1
                Test:           BenchmarkFromPdataConverter/worker_count=1
```

- Removes `require.Len(b, entries, 250_000)`, line 153, as the test fails here. There's nothing related to `250_000` in the test cases, and it looks like outdated. The channel receives entry slices that only contain a single element, and it's because the inputs(`plog.Logs`) have only a single log record for each. Maybe we should add more tests that cover multi-log-records cases separately if needed
- Fixes misuse of`ResetTimer`  as  it should not be called in`b.Loop()`
- Eliminates a timeout check since I think someone who runs the benchmark should notice something's going wrong if It takes too long.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
#43044 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
```
cd pkg/stanza/adapter
go test -bench='^BenchmarkFromPdata'
```