### PR TITLE
[chore][pkg/stanza] Removed an unncessary printing in a unittest

### DIFF
--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -137,7 +137,6 @@ func TestShutdownFlush(t *testing.T) {
 			select {
 			case <-closeCh:
 				assert.NoError(t, logsReceiver.Shutdown(t.Context()))
-				fmt.Println(">> Shutdown called")
 				return
 			default:
 				err := stanzaReceiver.emitter.Process(t.Context(), entry.New())


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Looks like the printing message is unnecessary, but it shows up everytime I run benchmarks(`go test -bench=.`) in the package.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
```
cd pkg/stanza/adapter
go test -run Shutdown
```
