### PR TITLE
[pkg/datadog] remove previously deprecated logs::dump_payloads

### DIFF
--- a/.chloggen/jackgopack4-remove-datadogexporter-logs-dump_payloads copy.yaml
+++ b/.chloggen/jackgopack4-remove-datadogexporter-logs-dump_payloads copy.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `logs::dump_payloads` config option from `datadogexporter` config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43427]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Please remove the previously deprecated `logs::dump_payloads` config option from your `datadogexporter` config.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/jackgopack4-remove-datadogexporter-logs-dump_payloads copy.yaml
+++ b/.chloggen/jackgopack4-remove-datadogexporter-logs-dump_payloads copy.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: exporter/datadogexporter
+component: exporter/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove `logs::dump_payloads` config option from `datadogexporter` config.

--- a/.chloggen/jackgopack4-remove-pkg-datadog-logs-dump_payloads.yaml
+++ b/.chloggen/jackgopack4-remove-pkg-datadog-logs-dump_payloads.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `logs::dump_payloads` config option from `pkg/datadog` config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43427]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -522,10 +522,6 @@ func (f *factory) createLogsExporter(
 ) (exporter.Logs, error) {
 	cfg := checkAndCastConfig(c, set.Logger)
 
-	if cfg.Logs.DumpPayloads {
-		set.Logger.Warn("logs::dump_payloads is not valid")
-	}
-
 	var pusher consumer.ConsumeLogsFunc
 	var logsAgent logsagentpipeline.LogsAgent
 	hostProvider, err := f.SourceProvider(set.TelemetrySettings, cfg.Hostname, cfg.HostnameDetectionTimeout)

--- a/pkg/datadog/config/logs.go
+++ b/pkg/datadog/config/logs.go
@@ -11,11 +11,6 @@ type LogsConfig struct {
 	// If unset, the value is obtained from the Site.
 	confignet.TCPAddrConfig `mapstructure:",squash"`
 
-	// DumpPayloads report whether payloads should be dumped when logging level is debug.
-	// Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is enabled (now enabled by default).
-	// Deprecated: This config option is not supported in the Datadog Agent logs pipeline.
-	DumpPayloads bool `mapstructure:"dump_payloads"`
-
 	// UseCompression enables the logs agent to compress logs before sending them.
 	// Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is disabled.
 	UseCompression bool `mapstructure:"use_compression"`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
removes `logs::dump_payloads` config from `pkg/datadog` (removing the option from datadogexporter)
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43427

<!--Describe what testing was performed and which tests were added.-->
#### Testing
none, as functionality was already removed
<!--Describe the documentation added.-->
#### Documentation
breaking user changelog, deprecation api changelog
<!--Please delete paragraphs that you did not use before submitting.-->
