### PR TITLE
[chore] Move Vihas Makwana to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ For more information about the maintainer role, see the [community repository](h
 - [Matt Wear](https://github.com/mwear), Lightstep
 - [Paulo Janotti](https://github.com/pjanotti), Splunk
 - [Sam DeHaan](https://github.com/dehaansa), Grafana Labs
+- [Vihas Makwana](https://github.com/VihasMakwana), Elastic
 - [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
@@ -111,7 +112,6 @@ For more information about the approver role, see the [community repository](htt
 - [Murphy Chen](https://github.com/Frapschen), DaoCloud
 - [Ondrej Dubaj](https://github.com/odubajDT), Dynatrace
 - [Roger Coll](https://github.com/rogercoll), Elastic
-- [Vihas Makwana](https://github.com/VihasMakwana), Elastic
 - Actively seeking contributors to triage issues
 
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).


### PR DESCRIPTION
Vihas is an active triager for the last 11 months. This PR offers to elevate him to the status of approver.

Vihas has been a consistent active member of this community. Below is a snapshot of his activity:

Issues interacted with: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue%20state%3Aopen%20commenter%3AVihasMakwana
PRs reviewed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+reviewed-by%3AVihasMakwana+

It is my pleasure to open this proposal, and I want to thank Vihas for his contributions so far, and I look forward to his impact  in this new role.

@VihasMakwana please confirm that you would like to be considered for this role.

@open-telemetry/collector-contrib-approvers please review and approve in support.