### PR TITLE
[chore][receiver/couchdbreceiver] sort metadata.yaml entries

### DIFF
--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -20,18 +20,18 @@ attributes:
   http.method:
     description: An HTTP request method.
     type: string
-    enum: [ COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT ]
+    enum: [COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT]
   http.status_code:
     description: An HTTP status code.
     type: string
-  view:
-    description: The view type.
-    type: string
-    enum: [ temporary_view_reads, view_reads ]
   operation:
     description: The operation type.
     type: string
-    enum: [ writes, reads ]
+    enum: [writes, reads]
+  view:
+    description: The view type.
+    type: string
+    enum: [temporary_view_reads, view_reads]
 
 metrics:
   couchdb.average_request_time:
@@ -42,6 +42,37 @@ metrics:
     unit: ms
     gauge:
       value_type: double
+  couchdb.database.open:
+    enabled: true
+    description: The number of open databases.
+    stability:
+      level: development
+    unit: "{databases}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
+  couchdb.database.operations:
+    enabled: true
+    description: The number of database operations.
+    stability:
+      level: development
+    unit: "{operations}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation_temporality: cumulative
+    attributes: [operation]
+  couchdb.file_descriptor.open:
+    enabled: true
+    description: The number of open file descriptors.
+    stability:
+      level: development
+    unit: "{files}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation_temporality: cumulative
   couchdb.httpd.bulk_requests:
     enabled: true
     description: The number of bulk requests.
@@ -62,7 +93,7 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
-    attributes: [ http.method ]
+    attributes: [http.method]
   couchdb.httpd.responses:
     enabled: true
     description: The number of each HTTP status code.
@@ -73,7 +104,7 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
-    attributes: [ http.status_code ]
+    attributes: [http.status_code]
   couchdb.httpd.views:
     enabled: true
     description: The number of views read.
@@ -84,35 +115,4 @@ metrics:
       value_type: int
       monotonic: true
       aggregation_temporality: cumulative
-    attributes: [ view ]
-  couchdb.database.open:
-    enabled: true
-    description: The number of open databases.
-    stability:
-      level: development
-    unit: "{databases}"
-    sum:
-      value_type: int
-      monotonic: false
-      aggregation_temporality: cumulative
-  couchdb.file_descriptor.open:
-    enabled: true
-    description: The number of open file descriptors.
-    stability:
-      level: development
-    unit: "{files}"
-    sum:
-      value_type: int
-      monotonic: false
-      aggregation_temporality: cumulative
-  couchdb.database.operations:
-    enabled: true
-    description: The number of database operations.
-    stability:
-      level: development
-    unit: "{operations}"
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation_temporality: cumulative
-    attributes: [ operation ]
+    attributes: [view]


### PR DESCRIPTION
#### Description

Sort metadata.yaml file in preparation for sort validation using mdatagen. Context: https://github.com/open-telemetry/opentelemetry-collector/pull/13782
