### PR TITLE
[chore][receiver/filestatsreceiver] sort metadata.yaml entries

### DIFF
--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -9,7 +9,6 @@ status:
     active: [atoulme]
     seeking_new: true
 
-
 resource_attributes:
   file.name:
     description: The name of the file
@@ -26,30 +25,6 @@ attributes:
     type: string
 
 metrics:
-  file.mtime:
-    description: Elapsed time since the last modification of the file or folder, in seconds since Epoch.
-    enabled: true
-    stability:
-      level: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: false
-      value_type: int
-      
-    unit: "s"
-  file.ctime:
-    description: Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.
-    enabled: false
-    stability:
-      level: development
-    sum:
-      aggregation_temporality: cumulative
-      monotonic: false
-      value_type: int
-      
-    unit: "s"
-    attributes:
-      - file.permissions
   file.atime:
     description: Elapsed time since last access of the file or folder, in seconds since Epoch.
     enabled: false
@@ -59,7 +34,40 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: false
       value_type: int
-      
+
+    unit: "s"
+  file.count:
+    description: The number of files matched
+    enabled: false
+    stability:
+      level: development
+    gauge:
+      value_type: int
+
+    unit: "{file}"
+  file.ctime:
+    description: Elapsed time since the last change of the file or folder, in seconds since Epoch. In addition to `file.mtime`, this metric tracks metadata changes such as permissions or renaming the file.
+    enabled: false
+    stability:
+      level: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+
+    unit: "s"
+    attributes:
+      - file.permissions
+  file.mtime:
+    description: Elapsed time since the last modification of the file or folder, in seconds since Epoch.
+    enabled: true
+    stability:
+      level: development
+    sum:
+      aggregation_temporality: cumulative
+      monotonic: false
+      value_type: int
+
     unit: "s"
   file.size:
     description: The size of the file or folder, in bytes.
@@ -68,14 +76,5 @@ metrics:
       level: development
     gauge:
       value_type: int
-      
+
     unit: "b"
-  file.count:
-    description: The number of files matched
-    enabled: false
-    stability:
-      level: development
-    gauge:
-      value_type: int
-      
-    unit: "{file}"


### PR DESCRIPTION
#### Description

Sort metadata.yaml file in preparation for sort validation using mdatagen. Context: https://github.com/open-telemetry/opentelemetry-collector/pull/13782
