### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1668,7 +1668,7 @@ The frequency of recording pipeline lag can be configured with `lag_record_frequ
 - `elasticsearchexporter`: Enable native frame symbolization for Universal Profiling via the symbolization queue indices. (#38577)
 - `hostmetricsreceiver`: Reduced the cost of retrieving number of threads and parent process ID on Windows. Disable the featuregate `hostmetrics.process.onWindowsUseNewGetProcesses` to fallback to the previous implementation.
  (#32947, #38589)
-- `prometheusremotewritereciever`: Add help ref attribute to metric (#37277)
+- `prometheusremotewritereceiver`: Add help ref attribute to metric (#37277)
 - `hostmetricsreceiver`: Reduced the CPU cost of collecting the `process.handles` metric on Windows. (#38886)
   Instead of using WMI to retrieve the number of opened handles by each process
   the scraper now uses the GetProcessHandleCount Win32 API which results in
@@ -1678,7 +1678,7 @@ The frequency of recording pipeline lag can be configured with `lag_record_frequ
 - `rabbitmqreceiver`: Enhance the RabbitMQ receiver to collect and report additional node-level metrics: `rabbitmq.node.disk_free`, `rabbitmq.node.disk_free_limit`, `rabbitmq.node.disk_free_alarm`, `rabbitmq.node.disk_free_details.rate`, `rabbitmq.node.mem_used`, `rabbitmq.node.mem_limit`, `rabbitmq.node.mem_alarm`, `rabbitmq.node.mem_used_details.rate`, `rabbitmq.node.fd_used`, `rabbitmq.node.fd_total`, `rabbitmq.node.fd_used_details.rate`, `rabbitmq.node.sockets_used`, `rabbitmq.node.sockets_total`, `rabbitmq.node.sockets_used_details.rate`, `rabbitmq.node.proc_used`, `rabbitmq.node.proc_total`, `rabbitmq.node.proc_used_details.rate`. These provide additional observability into the state and resource usage of RabbitMQ nodes. (#38976)
 - `rabbitmqreceiver`: Enhance the RabbitMQ receiver to collect and report additional node-level metrics across multiple categories. These include metrics related to memory, file descriptors, sockets, processes, disk, uptime, scheduling, garbage collection (GC), I/O, message store, connections, clustering, configuration, application info, and context switches. This significantly improves visibility into the performance, state, and resource usage of RabbitMQ nodes. (#38997)
 - `resourcedetection`: Adding the os.version resource attribute to system resourcedetection processor (#38087)
-- `prometheusremotewritereciever`: Separate timeseries with the same labels are now translated into the same OTLP metric. (#37791)
+- `prometheusremotewritereceiver`: Separate timeseries with the same labels are now translated into the same OTLP metric. (#37791)
   timeseries that belongs to the same metric should be added to the same datapoints slice.
 - `prometheusremotewritereceiver`: Use Created Timestamps to populate Datapoint's StartTimeUnixNano (#37277)
 - `workflow`: Remove path parts from component label suffixes (#38527)
@@ -1835,7 +1835,7 @@ The frequency of recording pipeline lag can be configured with `lag_record_frequ
 - `pkg/ottl`: Enhance flatten() editor to resolve attribute key conflicts by adding a number suffix to the conflicting keys. (#35793)
 - `geoipprocessor`: Add the `attributes` parameter and consider both `source.address` and `client.address` by default (#37008)
 - `githubreceiver`: add GitHub workflow job spans (#38016)
-- `prometheusremotewritereciever`: Handle `otel_scope_name` and `otel_scope_version` labels in Prometheus Remote Write receiver properly if not present (#37791)
+- `prometheusremotewritereceiver`: Handle `otel_scope_name` and `otel_scope_version` labels in Prometheus Remote Write receiver properly if not present (#37791)
   if otel_scope_name or otel_scope_name is missing, use collector’s version and description according to the otel spec.
 - `exporter/loadbalancing`: Add support for route with composite keys (#35320)
 - `kafka`: Upgrading to aws sdk v2 (#38478)

--- a/exporter/azuremonitorexporter/testdata/config.yaml
+++ b/exporter/azuremonitorexporter/testdata/config.yaml
@@ -2,7 +2,7 @@ azuremonitor:
 azuremonitor/2:
   # endpoint is the uri used to communicate with Azure Monitor
   endpoint: "https://dc.services.visualstudio.com/v2/track"
-  # instrumentation_key is the unique identifer for your Application Insights resource
+  # instrumentation_key is the unique identifier for your Application Insights resource
   instrumentation_key: 00000000-0000-0000-0000-000000000000
   # connection string specifies Application Insights InstrumentationKey and IngestionEndpoint
   connection_string: InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/

--- a/exporter/rabbitmqexporter/README.md
+++ b/exporter/rabbitmqexporter/README.md
@@ -30,7 +30,7 @@ The following settings can be configured:
       - `username` (required): username for authentication
       - `password`: password for authentication
   - `tls` (optional): [TLS configuration](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/configtls.go#L32)
-  - `name` (optional): The name of the connection, visible in in RabbitMQ management interface
+  - `name` (optional): The name of the connection, visible in RabbitMQ management interface
 - `routing`:
   - `routing_key` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): Routing key used to route exported messages to RabbitMQ consumers
   - `exchange`: Name of the exchange used to route messages. If omitted, the [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts#exchange-default) is used which routes to a queue with the same as the routing key. Only [direct exchanges](https://www.rabbitmq.com/tutorials/amqp-concepts#exchange-direct) are currently supported. Note that this component does not handle queue creation or binding.

--- a/internal/coreinternal/goldendataset/traces_generator.go
+++ b/internal/coreinternal/goldendataset/traces_generator.go
@@ -15,7 +15,7 @@ import (
 
 // GenerateTraces generates a slice of OTLP ResourceSpans objects based on the PICT-generated pairwise
 // parameters defined in the parameters file specified by the tracePairsFile parameter. The pairs to generate
-// spans for for defined in the file specified by the spanPairsFile parameter.
+// spans for defined in the file specified by the spanPairsFile parameter.
 // The slice of ResourceSpans are returned. If an err is returned, the slice elements will be nil.
 func GenerateTraces(tracePairsFile, spanPairsFile string) ([]ptrace.Traces, error) {
 	random := (*randReader)(rand.New(rand.NewPCG(42, 0)))

--- a/internal/e2e/examples/collector.yaml
+++ b/internal/e2e/examples/collector.yaml
@@ -257,8 +257,8 @@ exporters:
       ## @param resource_attributes_as_tags - string - optional - default: false
       ## Set to true to add resource attributes of a metric to its metric tags.
       ## Please note that any of the subset of resource attributes in this
-      ## list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/ are 
-      ## converted to datadog conventions and set to to metric tags whether this option
+      ## list https://docs.datadoghq.com/opentelemetry/guide/semantic_mapping/ are
+      ## converted to datadog conventions and set to metric tags whether this option
       ## is enabled or not.
       #
       # resource_attributes_as_tags: false

--- a/pkg/datadog/config/metrics.go
+++ b/pkg/datadog/config/metrics.go
@@ -187,7 +187,7 @@ func (sm *SummaryMode) UnmarshalText(in []byte) error {
 
 // SummaryConfig customizes export of OTLP Summaries.
 type SummaryConfig struct {
-	// Mode is the the mode for exporting OTLP Summaries.
+	// Mode is the mode for exporting OTLP Summaries.
 	// Valid values are 'noquantiles' or 'gauges'.
 	//  - 'noquantiles' sends no `.quantile` metrics. `.sum` and `.count` metrics will still be sent.
 	//  - 'gauges' sends `.quantile` metrics as gauges tagged by the quantile.

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -265,7 +265,7 @@ func (c *ProducerConfig) Unmarshal(conf *confmap.Conf) error {
 	return conf.Unmarshal(c)
 }
 
-// RequiredAcks defines record acknowledgement behavior for for producers.
+// RequiredAcks defines record acknowledgement behavior for producers.
 type RequiredAcks int
 
 const (

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -468,7 +468,7 @@ func TestMultipleEmpty(t *testing.T) {
 	sink.ExpectNoCallsUntil(t, time.Second)
 }
 
-// TestLeadingEmpty tests that the the operator handles a leading
+// TestLeadingEmpty tests that the operator handles a leading
 // newline, and does not read the file multiple times
 func TestLeadingEmpty(t *testing.T) {
 	t.Parallel()

--- a/pkg/translator/azurelogs/category_logs.go
+++ b/pkg/translator/azurelogs/category_logs.go
@@ -40,7 +40,7 @@ const (
 	// request to the time the first byte gets sent to the client.
 	attributeTimeToFirstByte = "azure.time_to_first_byte"
 
-	// attributeDuration holds the the length of time from first byte of
+	// attributeDuration holds the length of time from first byte of
 	// request to last byte of response out, in seconds.
 	attributeDuration = "duration"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
@@ -217,7 +217,7 @@ func init() {
 //	\\LogicalDisk(C:)\% Free Space
 //
 // To view all (internationalized...) counters on a system, there are three non-programmatic ways: perfmon utility,
-// the typeperf command, and the the registry editor. perfmon.exe is perhaps the easiest way, because it's basically a
+// the typeperf command, and the registry editor. perfmon.exe is perhaps the easiest way, because it's basically a
 // full implemention of the pdh.dll API, except with a GUI and all that. The registry setting also provides an
 // interface to the available counters, and can be found at the following key:
 //

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -71,11 +71,11 @@ type DeltaValue struct {
 	HistogramValue *HistogramPoint
 }
 
-func NewMetricTracker(ctx context.Context, logger *zap.Logger, maxStaleness time.Duration, initalValue InitialValue) *MetricTracker {
+func NewMetricTracker(ctx context.Context, logger *zap.Logger, maxStaleness time.Duration, initialValue InitialValue) *MetricTracker {
 	t := &MetricTracker{
 		logger:       logger,
 		maxStaleness: maxStaleness,
-		initialValue: initalValue,
+		initialValue: initialValue,
 		startTime:    pcommon.NewTimestampFromTime(time.Now()),
 	}
 	if maxStaleness > 0 {

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -598,7 +598,7 @@ Supported aggregation functions are:
 - median
 - count
 
-**NOTE:** Only the `sum` agregation function is supported for histogram and exponential histogram datatypes.
+**NOTE:** Only the `sum` aggregation function is supported for histogram and exponential histogram datatypes.
 
 Examples:
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
@@ -222,7 +222,7 @@ func getCGroupMountPoint(mountConfigPath string) (string, error) {
 			return "", fmt.Errorf("Found no fields post '-' in %q", text)
 		}
 		if postSeparatorFields[0] == "cgroup" {
-			// check that the mount is properly formated.
+			// check that the mount is properly formatted.
 			if numPostFields < 3 {
 				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
 			}

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
@@ -138,7 +138,7 @@ func TestGetCGroupMountPoint(t *testing.T) {
 			err:     errors.New(""),
 		},
 		{
-			name:    "the mount is not properly formated",
+			name:    "the mount is not properly formatted",
 			input:   "test/mountinfo_err3",
 			wantRes: "",
 			err:     errors.New(""),

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -219,7 +219,7 @@ func TestAzureScraperScrape(t *testing.T) {
 func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
 	fakeSubID := "azuremonitor-receiver"
 	metricNamespace1, metricNamespace2 := "Microsoft.ServiceA/namespace1", "Microsoft.ServiceB/namespace2"
-	metricName1, metricName2, metricName3 := "ConnectionsTotal", "IncommingMessages", "TransferedBytes"
+	metricName1, metricName2, metricName3 := "ConnectionsTotal", "IncomingMessages", "TransferredBytes"
 	metricAggregation1, metricAggregation2, metricAggregation3 := "Count", "Maximum", "Minimum"
 	cfgLimitedMertics := createDefaultTestConfig()
 	cfgLimitedMertics.SubscriptionIDs = []string{fakeSubID}

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
@@ -53,7 +53,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_incommingmessages_average
+            name: azure_incomingmessages_average
             unit: u
           - gauge:
               dataPoints:
@@ -76,7 +76,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_incommingmessages_count
+            name: azure_incomingmessages_count
             unit: u
           - gauge:
               dataPoints:
@@ -99,7 +99,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_incommingmessages_maximum
+            name: azure_incomingmessages_maximum
             unit: u
           - gauge:
               dataPoints:
@@ -122,7 +122,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_incommingmessages_minimum
+            name: azure_incomingmessages_minimum
             unit: u
           - gauge:
               dataPoints:
@@ -145,7 +145,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_incommingmessages_total
+            name: azure_incomingmessages_total
             unit: u
           - gauge:
               dataPoints:
@@ -168,7 +168,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_transferedbytes_maximum
+            name: azure_transferredbytes_maximum
             unit: u
           - gauge:
               dataPoints:
@@ -191,7 +191,7 @@ resourceMetrics:
                         stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_transferedbytes_minimum
+            name: azure_transferredbytes_minimum
             unit: u
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver

--- a/receiver/carbonreceiver/testdata/config.yaml
+++ b/receiver/carbonreceiver/testdata/config.yaml
@@ -9,7 +9,7 @@ carbon/receiver_settings:
   # new data. This value is ignored is the transport is not "tcp". The default
   # value is 30 seconds.
   tcp_idle_timeout: 5s
-  # parser section is used to to configure the actual parser to handle the
+  # parser section is used to configure the actual parser to handle the
   # received data. The default is "plaintext", see
   # https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol.
   parser:

--- a/receiver/githubreceiver/internal/scraper/githubscraper/schema.graphql
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/schema.graphql
@@ -22376,7 +22376,7 @@ enum ThreadSubscriptionState {
   SUBSCRIBED_TO_THREAD_TYPE
   "The User is notified because they are subscribed to the thread"
   SUBSCRIBED_TO_THREAD
-  "The User is not recieving notifications from this thread"
+  "The User is not receiving notifications from this thread"
   NONE
 }
 "Reason that the suggested topic is declined."

--- a/receiver/githubreceiver/trace_receiver.go
+++ b/receiver/githubreceiver/trace_receiver.go
@@ -129,7 +129,7 @@ func (gtr *githubTracesReceiver) Shutdown(_ context.Context) error {
 	return err
 }
 
-// handleReq handles incoming request sent to the webhook endoint. On success
+// handleReq handles incoming request sent to the webhook endpoint. On success
 // returns a 200 response code.
 func (gtr *githubTracesReceiver) handleReq(w http.ResponseWriter, req *http.Request) {
 	ctx := gtr.obsrecv.StartTracesOp(req.Context())

--- a/receiver/gitlabreceiver/traces_receiver.go
+++ b/receiver/gitlabreceiver/traces_receiver.go
@@ -150,7 +150,7 @@ func (gtr *gitlabTracesReceiver) handleHealthCheck(w http.ResponseWriter, r *htt
 	_, _ = w.Write([]byte(healthyResponse))
 }
 
-// handleReq handles incoming request sent to the webhook endoint
+// handleReq handles incoming request sent to the webhook endpoint
 func (gtr *gitlabTracesReceiver) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	ctx := gtr.obsrecv.StartTracesOp(r.Context())
 

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -53,7 +53,7 @@ type messageHandler[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 
 	// startObsReport starts an observation report for the unmarshaled data.
 	//
-	// This simply calls the the signal-specific receiverhelper.ObsReport.Start*Op method.
+	// This simply calls the signal-specific receiverhelper.ObsReport.Start*Op method.
 	startObsReport(ctx context.Context) context.Context
 
 	// endObsReport ends the observation report for the unmarshaled data.

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -35,7 +35,7 @@ In order to collect access logs, the requesting API key needs the appropriate pe
 
 MongoDB Atlas [Documentation](https://www.mongodb.com/docs/atlas/reference/api/logs/#logs) recommends a polling interval of 5 minutes.
 
-- `base_url` (default https://cloud.mongodb.com/) set the base URL to connect to to Atlas Cloud
+- `base_url` (default https://cloud.mongodb.com/) set the base URL to connect to Atlas Cloud
 - `public_key` (required for metrics, logs, or alerts in `poll` mode)
 - `private_key` (required for metrics, logs, or alerts in `poll` mode)
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))

--- a/testbed/testbed/options.go
+++ b/testbed/testbed/options.go
@@ -49,10 +49,10 @@ func WithSkipResults() TestCaseOption {
 	}
 }
 
-// WithResourceLimits sets expected limits for resource consmption.
+// WithResourceLimits sets expected limits for resource consumption.
 // Error is signaled if consumption during ResourceCheckPeriod exceeds the limits.
 // Limits are modified only for non-zero fields of resourceSpec, all zero-value fields
-// fo resourceSpec are ignored and their previous values remain in effect.
+// of resourceSpec are ignored and their previous values remain in effect.
 func WithResourceLimits(resourceSpec ResourceSpec) TestCaseOption {
 	return func(tc *TestCase) {
 		if resourceSpec.ExpectedMaxCPU > 0 {


### PR DESCRIPTION
#### Description

Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help


