### PR TITLE
[chore] add pull-request write permission to issuegenerator workflow

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -120,6 +120,7 @@ jobs:
     needs: [arm-unittest-matrix]
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -175,6 +175,7 @@ jobs:
     needs: [windows-unittest-matrix]
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -661,6 +661,7 @@ jobs:
     needs: [unittest-matrix]
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Added pull-request write permission to issuegenerator workflow, currently workflow fails to comment on pr because workflow does not have required permission.

Link to workflow: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/18347481850/job/52259572883

Discussion: https://github.com/open-telemetry/opentelemetry-go-build-tools/pull/1267#issuecomment-3381976134

cc @mx-psi 

