### PR TITLE
Add propagation of EnableOpenMetricsTextCreatedSamples to prometheus handler

### DIFF
--- a/.chloggen/openmetrics-created-timestamp.yaml
+++ b/.chloggen/openmetrics-created-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for OpenMetrics created timestamp"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -31,6 +31,7 @@ The following settings can be optionally configured:
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `enable_open_metrics`: (default = `false`): If true, metrics will be exported using the OpenMetrics format. Exemplars are only exported in the OpenMetrics format, and only for histogram and monotonic sum (i.e. counter) metrics.
+- `enable_open_metrics_text_created_samples`: (default = `false`): If true, and if `enable_open_metrics` is also true, the new metric `*_created` with the timestamp of the metric creation will additionally be added to counters, histograms, and summaries. See the [OpenMetrics created timestamp documentation](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#counter-1) for more details.
 - `add_metric_suffixes`: (default = `true`): If false, addition of type and unit suffixes is disabled. **Deprecated**: Use `translation_strategy` instead. This setting is ignored when `translation_strategy` is explicitly set.
 - `translation_strategy`: Controls how OTLP metric and attribute names are translated into Prometheus metric and label names. When set, this takes precedence over `add_metric_suffixes`. Available options:
   - `UnderscoreEscapingWithSuffixes`: Fully escapes metric names for classic Prometheus metric name compatibility, and includes appending type and unit suffixes.

--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -41,6 +41,9 @@ type Config struct {
 	// EnableOpenMetrics enables the use of the OpenMetrics encoding option for the prometheus exporter.
 	EnableOpenMetrics bool `mapstructure:"enable_open_metrics"`
 
+	// EnableOpenMetricsTextCreatedSamples controls whether the created timestamp is added to metrics.
+	EnableOpenMetricsTextCreatedSamples bool `mapstructure:"enable_open_metrics_text_created_samples"`
+
 	// AddMetricSuffixes controls whether suffixes are added to metric names. Defaults to true.
 	// Deprecated: Use TranslationStrategy instead. This setting is ignored when TranslationStrategy is explicitly set.
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -30,6 +30,7 @@ func createDefaultConfig() component.Config {
 		SendTimestamps:    false,
 		MetricExpiration:  time.Minute * 5,
 		EnableOpenMetrics: false,
+		EnableOpenMetricsTextCreatedSamples: false,
 		AddMetricSuffixes: true,
 	}
 }

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -54,9 +54,10 @@ func newPrometheusExporter(config *Config, set exporter.Settings) (*prometheusEx
 		handler: promhttp.HandlerFor(
 			registry,
 			promhttp.HandlerOpts{
-				ErrorHandling:     promhttp.ContinueOnError,
-				ErrorLog:          newPromLogger(set.Logger),
-				EnableOpenMetrics: config.EnableOpenMetrics,
+				ErrorHandling:                       promhttp.ContinueOnError,
+				ErrorLog:                            newPromLogger(set.Logger),
+				EnableOpenMetrics:                   config.EnableOpenMetrics,
+				EnableOpenMetricsTextCreatedSamples: config.EnableOpenMetricsTextCreatedSamples,
 			},
 		),
 		settings: set.TelemetrySettings,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This change adds support of Created timestamps

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43501 

<!--Describe what testing was performed and which tests were added.-->
#### Testing


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
