### PR TITLE
[chore][extension/k8sleaderelector] Fix race in TestExtension

### DIFF
--- a/extension/k8sleaderelector/extension_test.go
+++ b/extension/k8sleaderelector/extension_test.go
@@ -67,9 +67,9 @@ func TestExtension(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, lease)
 		require.Equal(t, expectedLeaseDurationSeconds, lease.Spec.LeaseDurationSeconds)
+		require.True(t, onStartLeadingInvoked.Load())
 	}, 10*time.Second, 100*time.Millisecond)
 
-	require.True(t, onStartLeadingInvoked.Load())
 	require.NoError(t, leaderElection.Shutdown(ctx))
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Moved the check causing race conditions
#### Link to tracking issue
Fixes [43423](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43423)
<!--Describe what testing was performed and which tests were added.-->
#### Testing

You can test this locally running `GOMAXPROCS=1 go test -race -v -run TestExtension -count=100` from main
results in
 ```
Error:          Should be true
                Test:           TestExtension
```
 and then from this pr branch the test PASS
