### PR TITLE
Revert "[chore] add pull-request write permission to issuegenerator workflow"

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -120,7 +120,6 @@ jobs:
     needs: [arm-unittest-matrix]
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -175,7 +175,6 @@ jobs:
     needs: [windows-unittest-matrix]
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -661,7 +661,6 @@ jobs:
     needs: [unittest-matrix]
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#43500

cc @jelly-afk This seems to be too spammy so I am going to temporarily revert it. I think we can notify users only when a new issue is opened, since at that time it is more likely that the PR will be the culprit