### PR TITLE
[processor/tailsampling] Change NumericAttribute minValue & maxValue into Optional

### DIFF
--- a/.chloggen/issue-43499-fix-tailsampling-numeric-attribute.yaml
+++ b/.chloggen/issue-43499-fix-tailsampling-numeric-attribute.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "breaking"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "processor/tailsampling"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change the numeric_attribute configuration to use Optional type to distinguish between missing and default values"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43499, 41562]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -98,7 +98,7 @@ processors:
           {
             name: test-policy-3,
             type: numeric_attribute,
-            numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+            numeric_attribute: {key: key1, min_value: {value: 50}, max_value: {value: 100}}
           },
           {
             name: test-policy-4,
@@ -164,7 +164,7 @@ processors:
                 {
                   name: test-and-policy-1,
                   type: numeric_attribute,
-                  numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+                  numeric_attribute: { key: key1, min_value: {value: 50}, max_value: {value: 100} }
                 },
                 {
                     name: test-and-policy-2,
@@ -200,7 +200,7 @@ processors:
                     {
                       name: test-composite-policy-1,
                       type: numeric_attribute,
-                      numeric_attribute: {key: key1, min_value: 50}
+                      numeric_attribute: {key: key1, min_value: {value: 50}}
                     },
                     {
                       name: test-composite-policy-2,

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -6,7 +6,10 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 import (
 	"time"
 
+	"go.opentelemetry.io/collector/config/configoptional"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 // PolicyType indicates the type of sampling policy.
@@ -159,9 +162,9 @@ type NumericAttributeCfg struct {
 	// Tag that the filter is going to be matching against.
 	Key string `mapstructure:"key"`
 	// MinValue is the minimum value of the attribute to be considered a match.
-	MinValue *int64 `mapstructure:"min_value"`
+	MinValue configoptional.Optional[sampling.NumericValue] `mapstructure:"min_value"`
 	// MaxValue is the maximum value of the attribute to be considered a match.
-	MaxValue *int64 `mapstructure:"max_value"`
+	MaxValue configoptional.Optional[sampling.NumericValue] `mapstructure:"max_value"`
 	// InvertMatch indicates that values must not match against attribute values.
 	// If InvertMatch is true and Values is equal to '123', all other values will be sampled except '123'.
 	// Also, if the specified Key does not match any resource or span attributes, data will be sampled.

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -159,9 +159,9 @@ type NumericAttributeCfg struct {
 	// Tag that the filter is going to be matching against.
 	Key string `mapstructure:"key"`
 	// MinValue is the minimum value of the attribute to be considered a match.
-	MinValue int64 `mapstructure:"min_value"`
+	MinValue *int64 `mapstructure:"min_value"`
 	// MaxValue is the maximum value of the attribute to be considered a match.
-	MaxValue int64 `mapstructure:"max_value"`
+	MaxValue *int64 `mapstructure:"max_value"`
 	// InvertMatch indicates that values must not match against attribute values.
 	// If InvertMatch is true and Values is equal to '123', all other values will be sampled except '123'.
 	// Also, if the specified Key does not match any resource or span attributes, data will be sampled.

--- a/processor/tailsamplingprocessor/config_test.go
+++ b/processor/tailsamplingprocessor/config_test.go
@@ -54,7 +54,7 @@ func TestLoadConfig(t *testing.T) {
 					sharedPolicyCfg: sharedPolicyCfg{
 						Name:                "test-policy-3",
 						Type:                NumericAttribute,
-						NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+						NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
 					},
 				},
 				{
@@ -128,7 +128,7 @@ func TestLoadConfig(t *testing.T) {
 								sharedPolicyCfg: sharedPolicyCfg{
 									Name:                "test-and-policy-1",
 									Type:                NumericAttribute,
-									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
 								},
 							},
 							{
@@ -154,7 +154,7 @@ func TestLoadConfig(t *testing.T) {
 								sharedPolicyCfg: sharedPolicyCfg{
 									Name:                "test-composite-policy-1",
 									Type:                NumericAttribute,
-									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
 								},
 							},
 							{
@@ -185,4 +185,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		}, cfg)
+}
+
+func ptr(v int64) *int64 {
+	return &v
 }

--- a/processor/tailsamplingprocessor/config_test.go
+++ b/processor/tailsamplingprocessor/config_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -54,7 +56,7 @@ func TestLoadConfig(t *testing.T) {
 					sharedPolicyCfg: sharedPolicyCfg{
 						Name:                "test-policy-3",
 						Type:                NumericAttribute,
-						NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
+						NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: configoptional.Some(sampling.NumericValue{Value: 50}), MaxValue: configoptional.Some(sampling.NumericValue{Value: 100})},
 					},
 				},
 				{
@@ -128,7 +130,7 @@ func TestLoadConfig(t *testing.T) {
 								sharedPolicyCfg: sharedPolicyCfg{
 									Name:                "test-and-policy-1",
 									Type:                NumericAttribute,
-									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: configoptional.Some(sampling.NumericValue{Value: 50}), MaxValue: configoptional.Some(sampling.NumericValue{Value: 100})},
 								},
 							},
 							{
@@ -154,7 +156,7 @@ func TestLoadConfig(t *testing.T) {
 								sharedPolicyCfg: sharedPolicyCfg{
 									Name:                "test-composite-policy-1",
 									Type:                NumericAttribute,
-									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: ptr(50), MaxValue: ptr(100)},
+									NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: configoptional.Some(sampling.NumericValue{Value: 50}), MaxValue: configoptional.Some(sampling.NumericValue{Value: 100})},
 								},
 							},
 							{
@@ -185,8 +187,4 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		}, cfg)
-}
-
-func ptr(v int64) *int64 {
-	return &v
 }

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
@@ -59,10 +60,10 @@ func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *samplingpol
 
 func TestCompositeEvaluatorNotSampled(t *testing.T) {
 	// Create 2 policies which do not match any trace
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
-	n2 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some(NumericValue{Value: 0})
+	max100 := configoptional.Some(NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
+	n2 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100, "eval-1"}, {n2, 100, "eval-2"}}, FakeTimeProvider{}, false)
 
 	trace := createTrace()
@@ -78,9 +79,9 @@ func TestCompositeEvaluatorNotSampled(t *testing.T) {
 
 func TestCompositeEvaluatorSampled(t *testing.T) {
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some(NumericValue{Value: 0})
+	max100 := configoptional.Some(NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100, "eval-1"}, {n2, 100, "eval-2"}}, FakeTimeProvider{}, false)
 
@@ -96,9 +97,9 @@ func TestCompositeEvaluatorSampled(t *testing.T) {
 
 func TestCompositeEvaluatorSampled_RecordSubPolicy(t *testing.T) {
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some[NumericValue](NumericValue{Value: 0})
+	max100 := configoptional.Some[NumericValue](NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100, "eval-1"}, {n2, 100, "eval-2"}}, FakeTimeProvider{}, true)
 
@@ -119,9 +120,9 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 	timeProvider := &FakeTimeProvider{second: 0}
 
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some(NumericValue{Value: 0})
+	max100 := configoptional.Some(NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 3, []SubPolicyEvalParams{{n1, 1, "eval-1"}, {n2, 1, "eval-2"}}, timeProvider, false)
 
@@ -154,9 +155,9 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 
 func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some(NumericValue{Value: 0})
+	max100 := configoptional.Some(NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 10, []SubPolicyEvalParams{{n1, 20, "eval-1"}, {n2, 20, "eval-2"}}, FakeTimeProvider{}, false)
 
@@ -252,9 +253,9 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 }
 
 func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
-	min0 := int64(0)
-	max100 := int64(100)
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", &min0, &max100, false)
+	min0 := configoptional.Some(NumericValue{Value: 0})
+	max100 := configoptional.Some(NumericValue{Value: 100})
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", min0, max100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	timeProvider := &FakeTimeProvider{second: 0}
 	const totalSPS = 10

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -32,6 +32,9 @@ func NewNumericAttributeFilter(settings component.TelemetrySettings, key string,
 	if minValue == nil && maxValue == nil {
 		settings.Logger.Error("At least one of minValue or maxValue must be set")
 		return nil
+	} else if minValue != nil && maxValue != nil && *minValue > *maxValue {
+		settings.Logger.Error("minValue must be less than or equal to maxValue")
+		return nil
 	}
 	return &numericAttributeFilter{
 		key:         key,

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -8,6 +8,7 @@ import (
 	"math"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
@@ -15,10 +16,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
+type NumericValue struct {
+	Value int64 `mapstructure:"value"`
+}
+
 type numericAttributeFilter struct {
 	key         string
-	minValue    *int64
-	maxValue    *int64
+	minValue    configoptional.Optional[NumericValue]
+	maxValue    configoptional.Optional[NumericValue]
 	logger      *zap.Logger
 	invertMatch bool
 }
@@ -28,11 +33,11 @@ var _ samplingpolicy.Evaluator = (*numericAttributeFilter)(nil)
 // NewNumericAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range. If minValue is nil, it will use math.MinInt64.
 // If maxValue is nil, it will use math.MaxInt64. At least one of minValue or maxValue must be set.
-func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue *int64, invertMatch bool) samplingpolicy.Evaluator {
-	if minValue == nil && maxValue == nil {
+func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue configoptional.Optional[NumericValue], invertMatch bool) samplingpolicy.Evaluator {
+	if !minValue.HasValue() && !maxValue.HasValue() {
 		settings.Logger.Error("At least one of minValue or maxValue must be set")
 		return nil
-	} else if minValue != nil && maxValue != nil && *minValue > *maxValue {
+	} else if minValue.HasValue() && maxValue.HasValue() && minValue.Get().Value > maxValue.Get().Value {
 		settings.Logger.Error("minValue must be less than or equal to maxValue")
 		return nil
 	}
@@ -53,12 +58,12 @@ func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID
 
 	// Get the effective min/max values
 	minVal := int64(math.MinInt64)
-	if naf.minValue != nil {
-		minVal = *naf.minValue
+	if naf.minValue.HasValue() {
+		minVal = naf.minValue.Get().Value
 	}
 	maxVal := int64(math.MaxInt64)
-	if naf.maxValue != nil {
-		maxVal = *naf.maxValue
+	if naf.maxValue.HasValue() {
+		maxVal = naf.maxValue.Get().Value
 	}
 
 	if naf.invertMatch {

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -217,14 +217,7 @@ func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedP
 		return sampling.NewLatency(settings, lfCfg.ThresholdMs, lfCfg.UpperThresholdMs), nil
 	case NumericAttribute:
 		nafCfg := cfg.NumericAttributeCfg
-		var minValuePtr, maxValuePtr *int64
-		if nafCfg.MinValue != 0 {
-			minValuePtr = &nafCfg.MinValue
-		}
-		if nafCfg.MaxValue != 0 {
-			maxValuePtr = &nafCfg.MaxValue
-		}
-		return sampling.NewNumericAttributeFilter(settings, nafCfg.Key, minValuePtr, maxValuePtr, nafCfg.InvertMatch), nil
+		return sampling.NewNumericAttributeFilter(settings, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue, nafCfg.InvertMatch), nil
 	case Probabilistic:
 		pCfg := cfg.ProbabilisticCfg
 		return sampling.NewProbabilisticSampler(settings, pCfg.HashSalt, pCfg.SamplingPercentage), nil

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -981,56 +981,56 @@ func simpleTracesWithID(traceID pcommon.TraceID) ptrace.Traces {
 func TestNumericAttributeCases(t *testing.T) {
 	tests := []struct {
 		name           string
-		minValue       int64
-		maxValue       int64
+		minValue       *int64
+		maxValue       *int64
 		testValue      int64
 		expectedResult samplingpolicy.Decision
 		description    string
 	}{
 		{
 			name:           "Only min_value set (positive)",
-			minValue:       400,
-			maxValue:       0, // not set (default)
+			minValue:       ptr(400),
+			maxValue:       nil, // not set (default)
 			testValue:      500,
 			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value >= min_value and max_value not set",
 		},
 		{
 			name:           "Only min_value set (negative value)",
-			minValue:       -100,
-			maxValue:       0, // not set (default)
+			minValue:       ptr(-100),
+			maxValue:       nil, // not set (default)
 			testValue:      50,
 			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value >= min_value (negative) and max_value not set",
 		},
 		{
 			name:           "Only max_value set (positive)",
-			minValue:       0, // not set (default)
-			maxValue:       1000,
+			minValue:       nil, // not set (default)
+			maxValue:       ptr(1000),
 			testValue:      500,
 			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when value <= max_value and min_value not set",
 		},
 		{
 			name:           "Both min and max set",
-			minValue:       100,
-			maxValue:       200,
+			minValue:       ptr(100),
+			maxValue:       ptr(200),
 			testValue:      150,
 			expectedResult: samplingpolicy.Sampled,
 			description:    "Should sample when min_value <= value <= max_value",
 		},
 		{
 			name:           "Value below min_value",
-			minValue:       400,
-			maxValue:       0, // not set (default)
+			minValue:       ptr(400),
+			maxValue:       nil, // not set (default)
 			testValue:      300,
 			expectedResult: samplingpolicy.NotSampled,
 			description:    "Should not sample when value < min_value",
 		},
 		{
 			name:           "Value above max_value",
-			minValue:       0, // not set (default)
-			maxValue:       100,
+			minValue:       nil, // not set (default)
+			maxValue:       ptr(100),
 			testValue:      200,
 			expectedResult: samplingpolicy.NotSampled,
 			description:    "Should not sample when value > max_value",

--- a/processor/tailsamplingprocessor/testdata/numeric_attribute_with_minvalue_greather_than_maxvalue.yaml
+++ b/processor/tailsamplingprocessor/testdata/numeric_attribute_with_minvalue_greather_than_maxvalue.yaml
@@ -1,0 +1,15 @@
+tail_sampling:
+  decision_wait: 10s
+  num_traces: 100
+  expected_new_traces_per_sec: 10
+  decision_cache:
+    sampled_cache_size: 1000
+    non_sampled_cache_size: 10000
+  policies:
+    [
+        {
+          name: test-policy-3,
+          type: numeric_attribute,
+          numeric_attribute: {key: key1, min_value: 500, max_value: 100}
+        },
+    ]

--- a/processor/tailsamplingprocessor/testdata/numeric_attribute_without_minvalue_or_maxvalue.yaml
+++ b/processor/tailsamplingprocessor/testdata/numeric_attribute_without_minvalue_or_maxvalue.yaml
@@ -1,0 +1,15 @@
+tail_sampling:
+  decision_wait: 10s
+  num_traces: 100
+  expected_new_traces_per_sec: 10
+  decision_cache:
+    sampled_cache_size: 1000
+    non_sampled_cache_size: 10000
+  policies:
+    [
+        {
+          name: test-policy-3,
+          type: numeric_attribute,
+          numeric_attribute: {key: key1}
+        },
+    ]

--- a/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -19,7 +19,7 @@ tail_sampling:
         {
           name: test-policy-3,
           type: numeric_attribute,
-          numeric_attribute: {key: key1, min_value: 50, max_value: 100}
+          numeric_attribute: {key: key1, min_value: {value: 50}, max_value: {value: 100}}
         },
         {
           name: test-policy-4,
@@ -80,7 +80,7 @@ tail_sampling:
               {
                 name: test-and-policy-1,
                 type: numeric_attribute,
-                numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+                numeric_attribute: { key: key1, min_value: {value: 50}, max_value: {value: 100} }
               },
               {
                   name: test-and-policy-2,
@@ -102,7 +102,7 @@ tail_sampling:
                 {
                   name: test-composite-policy-1,
                   type: numeric_attribute,
-                  numeric_attribute: { key: key1, min_value: 50, max_value: 100 }
+                  numeric_attribute: { key: key1, min_value: {value: 50}, max_value: {value: 100} }
                 },
                 {
                   name: test-composite-policy-2,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Initially there was a problem in the `numeric_attribute` configuration where we didn't distinguish between not set (nil) and the default value 0.
This lead to situations like the current issue where setting the `minValue` to 0 was treated as not set and raised an error, and there was a previous [related issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41562).

This PR makes the distinction between not set and 0 explicit, by changing the types of the `minVal` & `maxVal` from `int64` into `Optional[int64]`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43499

<!--Describe what testing was performed and which tests were added.-->
#### Testing

