### PR TITLE
[tiny][chore] Remove `actionlint` label for `windows-11-arm`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,6 @@
 self-hosted-runner:
   labels:
     - oracle-bare-metal-64cpu-512gb-x86-64
-    - windows-11-arm
 
 config-variables: null
 


### PR DESCRIPTION
Latest version of `actionlint`, see [release notes](https://github.com/rhysd/actionlint/releases/tag/v1.7.8), natively recognizes `windows-11-arm` runners.