### PR TITLE
[chore][chloggen template] Update example component

### DIFF
--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -3,7 +3,7 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type:
 
-# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component:
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The example component given does not pass chloggen component validation. The required format is `receiver/filelog`, as valid entries must be part of [the given list](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/41300d4e0bacacc31ff6535c1eeec42aa1d1e637/.chloggen/config.yaml#L9). Updated the example to not mislead users.