### PR TITLE
[chore] add namco1992 as the codeowner of journald receiver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,7 +171,7 @@ pkg/resourcetotelemetry/                                         @open-telemetry
 pkg/sampling/                                                    @open-telemetry/collector-contrib-approvers @kentquirk @jmacd
 pkg/stanza/                                                      @open-telemetry/collector-contrib-approvers @andrzej-stencel
 pkg/stanza/fileconsumer/                                         @open-telemetry/collector-contrib-approvers @andrzej-stencel
-pkg/stanza/operator/input/journald/                              @open-telemetry/collector-contrib-approvers @belimawr
+pkg/stanza/operator/input/journald/                              @open-telemetry/collector-contrib-approvers @belimawr @namco1992
 pkg/status/                                                      @open-telemetry/collector-contrib-approvers @mwear
 pkg/translator/azure/                                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
 pkg/translator/azurelogs/                                        @open-telemetry/collector-contrib-approvers @atoulme @cparkins @MikeGoldsmith @constanca-m
@@ -279,7 +279,7 @@ receiver/iisreceiver/                                            @open-telemetry
 receiver/influxdbreceiver/                                       @open-telemetry/collector-contrib-approvers @jacobmarble
 receiver/jaegerreceiver/                                         @open-telemetry/collector-contrib-approvers @yurishkuro
 receiver/jmxreceiver/                                            @open-telemetry/collector-contrib-approvers @atoulme @rogercoll
-receiver/journaldreceiver/                                       @open-telemetry/collector-contrib-approvers @belimawr
+receiver/journaldreceiver/                                       @open-telemetry/collector-contrib-approvers @belimawr @namco1992
 receiver/k8sclusterreceiver/                                     @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth @povilasv @ChrsMark
 receiver/k8seventsreceiver/                                      @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth @ChrsMark
 receiver/k8slogreceiver/                                         @open-telemetry/collector-contrib-approvers @h0cheung @TylerHelmuth

--- a/pkg/stanza/operator/input/journald/metadata.yaml
+++ b/pkg/stanza/operator/input/journald/metadata.yaml
@@ -6,6 +6,6 @@ status:
   stability:
     alpha: [logs]
   codeowners:
-    active: [belimawr]
+    active: [belimawr, namco1992]
     emeritus: [djaglowski, sumo-drosiek]
   unsupported_platforms: [darwin, windows]

--- a/receiver/journaldreceiver/README.md
+++ b/receiver/journaldreceiver/README.md
@@ -8,7 +8,7 @@
 | Distributions | [contrib], [k8s] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fjournald%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fjournald) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fjournald%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fjournald) |
 | Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_journald)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_journald&displayType=list) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@belimawr](https://www.github.com/belimawr) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@belimawr](https://www.github.com/belimawr), [@namco1992](https://www.github.com/namco1992) |
 | Emeritus      | [@djaglowski](https://www.github.com/djaglowski), [@sumo-drosiek](https://www.github.com/sumo-drosiek) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha

--- a/receiver/journaldreceiver/metadata.yaml
+++ b/receiver/journaldreceiver/metadata.yaml
@@ -6,6 +6,6 @@ status:
     alpha: [logs]
   distributions: [contrib, k8s]
   codeowners:
-    active: [belimawr]
+    active: [belimawr, namco1992]
     emeritus: [djaglowski, sumo-drosiek]
   unsupported_platforms: [darwin, windows]


### PR DESCRIPTION
**Description**

Add myself as codeowner for the journaldreceiver. Journald receiver was [looking for maintainers](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42597) and I'd really appreciate the opportunity to collaborate with @belimawr. I've been trying to make improvements on the journald receiver, and we are managing a large fleet of otel collectors where journald is the main source of logs. I also meet the codeowner [requirements](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md?rgh-link-date=2025-10-08T22%3A07%3A40Z#requirements):

- [Be a member of the OpenTelemetry organization.](https://github.com/orgs/open-telemetry/people?query=namco1992)
- (Code Owner Discretion) It is best to have resolved an issue related to the component, contributed directly to the component, and/or review component PRs. How much interaction with the component is required before becoming a Code Owner is up to any existing Code Owners.

My recent contribution to journaldreceiver is https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35635.


cc @belimawr 
