### PR TITLE
[receivers/libhoney] Decompression error fix

### DIFF
--- a/.chloggen/libhoney-decompression-error-fix.yaml
+++ b/.chloggen/libhoney-decompression-error-fix.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: receiver/libhoney
+note: fix panic when decompressing poorly formatted data
+issues: [42272]
+subtext:
+  When decompressing poorly formatted data, the receiver would panic.
+  This has now been fixed.
+change_logs: [user]

--- a/receiver/libhoneyreceiver/factory.go
+++ b/receiver/libhoneyreceiver/factory.go
@@ -42,7 +42,7 @@ func createDefaultConfig() component.Config {
 		HTTP: configoptional.Default(HTTPConfig{
 			ServerConfig: confighttp.ServerConfig{
 				Endpoint: endpointStr,
-				// Disable OTEL decompression middleware - we handle it internally for better error logging
+				// Disable default decompression middleware - we handle it internally for better error logging
 				CompressionAlgorithms: []string{},
 			},
 			TracesURLPaths: defaultTracesURLPaths,

--- a/receiver/libhoneyreceiver/factory.go
+++ b/receiver/libhoneyreceiver/factory.go
@@ -41,8 +41,9 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		HTTP: configoptional.Default(HTTPConfig{
 			ServerConfig: confighttp.ServerConfig{
-				Endpoint:              endpointStr,
-				CompressionAlgorithms: []string{"", "zstd", "gzip", "deflate"},
+				Endpoint: endpointStr,
+				// Disable OTEL decompression middleware - we handle it internally for better error logging
+				CompressionAlgorithms: []string{},
 			},
 			TracesURLPaths: defaultTracesURLPaths,
 		}),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The shared http server, under certain load conditions, would not be able to decompress packets coming from libhoney libraries. This appears to be related to network conditions that slow down or deliver chunks of http bodies awkwardly. 



<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
