### PR TITLE
[receiver/azuremonitorreceiver] Scrape also non-default namespaces

### DIFF
--- a/.chloggen/celian-garcia_fix-37220.yaml
+++ b/.chloggen/celian-garcia_fix-37220.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Scrape also non-default namespaces
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37220]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -247,6 +247,7 @@ type Config struct {
 	TenantID                          string                        `mapstructure:"tenant_id"`
 	ResourceGroups                    []string                      `mapstructure:"resource_groups"`
 	Services                          []string                      `mapstructure:"services"`
+	MetricsNamespaces                 map[string][]string           `mapstructure:"namespaces"`
 	Metrics                           NestedListAlias               `mapstructure:"metrics"`
 	CacheResources                    float64                       `mapstructure:"cache_resources"`
 	CacheResourcesDefinitions         float64                       `mapstructure:"cache_resources_definitions"`

--- a/receiver/azuremonitorreceiver/scraper_batch_test.go
+++ b/receiver/azuremonitorreceiver/scraper_batch_test.go
@@ -25,7 +25,7 @@ func getMetricsQueryResponseMockData() []queryResourcesResponseMock {
 		{
 			params: queryResourcesResponseMockParams{
 				subscriptionID:  "subscriptionId3",
-				metricNamespace: "type1",
+				metricNamespace: "namespace1",
 				metricNames:     []string{"metric7"},
 				resourceIDs:     []string{"/subscriptions/subscriptionId3/resourceGroups/group1/resourceId1"},
 			},
@@ -59,7 +59,7 @@ func getMetricsQueryResponseMockData() []queryResourcesResponseMock {
 		{
 			params: queryResourcesResponseMockParams{
 				subscriptionID:  "subscriptionId1",
-				metricNamespace: "type1",
+				metricNamespace: "namespace1",
 				metricNames:     []string{"metric1", "metric2"},
 				resourceIDs: []string{
 					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1",
@@ -106,7 +106,7 @@ func getMetricsQueryResponseMockData() []queryResourcesResponseMock {
 		{
 			params: queryResourcesResponseMockParams{
 				subscriptionID:  "subscriptionId1",
-				metricNamespace: "type1",
+				metricNamespace: "namespace1",
 				metricNames:     []string{"metric3"},
 				resourceIDs: []string{
 					"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1",

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -217,31 +217,35 @@ func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
 			},
 		})
 
-		metricsMockData := newMetricsClientListResponseMockData(map[string]map[string][]metricsClientListResponseMockInput{
+		metricsMockData := newMetricsClientListResponseMockData(map[string]map[string]map[string][]metricsClientListResponseMockInput{
 			id1: {
-				metricName1: {{
-					Name: metricName1,
-					Unit: unit,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
-						{Count: &valueCount},
-					}}},
-				}},
+				metricNamespace1: {
+					metricName1: {{
+						Name: metricName1,
+						Unit: unit,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
+							{Count: &valueCount},
+						}}},
+					}},
+				},
 			},
 			id2: {
-				metricName2: {{
-					Name: metricName2,
-					Unit: unit,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
-						{Average: &valueMaximum, Count: &valueCount, Maximum: &valueMaximum, Minimum: &valueMinimum, Total: &valueCount},
-					}}},
-				}},
-				metricName3: {{
-					Name: metricName3,
-					Unit: unit,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
-						{Maximum: &valueMaximum, Minimum: &valueMinimum},
-					}}},
-				}},
+				metricNamespace1: {
+					metricName2: {{
+						Name: metricName2,
+						Unit: unit,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
+							{Average: &valueMaximum, Count: &valueCount, Maximum: &valueMaximum, Minimum: &valueMinimum, Total: &valueCount},
+						}}},
+					}},
+					metricName3: {{
+						Name: metricName3,
+						Unit: unit,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{Data: []*armmonitor.MetricValue{
+							{Maximum: &valueMaximum, Minimum: &valueMinimum},
+						}}},
+					}},
+				},
 			},
 		})
 
@@ -470,109 +474,117 @@ func getMetricsDefinitionsMockData() map[string][]armmonitor.MetricDefinitionsCl
 	})
 }
 
-func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientListResponse {
+func getMetricsValuesMockData() map[string]map[string]map[string]armmonitor.MetricsClientListResponse {
 	name1, name2, name3, name4, name5, name6, name7, dimension1, dimension2, dimensionValue := "metric1", "metric2",
 		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension1", "dimension2", "dimension value"
 	var unit1 armmonitor.Unit = "unit1"
 	var value1 float64 = 1
 
-	return newMetricsClientListResponseMockData(map[string]map[string][]metricsClientListResponseMockInput{
+	return newMetricsClientListResponseMockData(map[string]map[string]map[string][]metricsClientListResponseMockInput{
 		"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId1": {
-			name1 + "," + name2: {
-				{
-					Name: name1, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-					}},
+			"namespace1": {
+				name1 + "," + name2: {
+					{
+						Name: name1, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+						}},
+					},
+					{
+						Name: name2, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+						}},
+					},
 				},
-				{
-					Name: name2, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-					}},
-				},
-			},
-			name3: {
-				{
-					Name: name3, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-					}},
+				name3: {
+					{
+						Name: name3, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+						}},
+					},
 				},
 			},
 		},
 		"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId2": {
-			name4: {
-				{
-					Name: name4, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-					}},
+			"namespace1": {
+				name4: {
+					{
+						Name: name4, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+						}},
+					},
 				},
-			},
-			name5: {
-				{
-					Name: name5, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-						Metadatavalues: []*armmonitor.MetadataValue{
-							{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
-							{Name: &armmonitor.LocalizableString{Value: &dimension2}, Value: &dimensionValue},
-						},
-					}},
+				name5: {
+					{
+						Name: name5, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+							Metadatavalues: []*armmonitor.MetadataValue{
+								{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
+								{Name: &armmonitor.LocalizableString{Value: &dimension2}, Value: &dimensionValue},
+							},
+						}},
+					},
 				},
-			},
-			name6: {
-				{
-					Name: name6, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
-						},
-						Metadatavalues: []*armmonitor.MetadataValue{
-							{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
-						},
-					}},
+				name6: {
+					{
+						Name: name6, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Average: &value1, Count: &value1, Maximum: &value1, Minimum: &value1, Total: &value1},
+							},
+							Metadatavalues: []*armmonitor.MetadataValue{
+								{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
+							},
+						}},
+					},
 				},
 			},
 		},
 		"/subscriptions/subscriptionId1/resourceGroups/group1/resourceId3": {
-			name7: {
-				{
-					Name: name7, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Count: &value1},
-						},
-						Metadatavalues: []*armmonitor.MetadataValue{
-							{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
-						},
-					}},
+			"namespace2": {
+				name7: {
+					{
+						Name: name7, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Count: &value1},
+							},
+							Metadatavalues: []*armmonitor.MetadataValue{
+								{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
+							},
+						}},
+					},
 				},
 			},
 		},
 		"/subscriptions/subscriptionId3/resourceGroups/group1/resourceId1": {
-			name7: {
-				{
-					Name: name7, Unit: unit1,
-					TimeSeries: []*armmonitor.TimeSeriesElement{{
-						Data: []*armmonitor.MetricValue{
-							{Count: &value1},
-						},
-						Metadatavalues: []*armmonitor.MetadataValue{
-							{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
-						},
-					}},
+			"namespace2": {
+				name7: {
+					{
+						Name: name7, Unit: unit1,
+						TimeSeries: []*armmonitor.TimeSeriesElement{{
+							Data: []*armmonitor.MetricValue{
+								{Count: &value1},
+							},
+							Metadatavalues: []*armmonitor.MetadataValue{
+								{Name: &armmonitor.LocalizableString{Value: &dimension1}, Value: &dimensionValue},
+							},
+						}},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Currently only the default metric namespace by resource type is scraped. But metrics of a resource type can actually be located in several namespaces. (see Isssu desc)
This PR make sure we collect metrics from all available namespaces.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37220 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

TODO: This is where my pain is currently. The tests are not readable enough and I'm pretty sure the code would work but I don't manage to be sure I'm defining correctly the azure mocks. Hence why tests are failing for now.

<!--Describe the documentation added.-->
#### Documentation

TODO

<!--Please delete paragraphs that you did not use before submitting.-->
