### PR TITLE
[chore][ci-cd] Remove windows-2022 from test matrices

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -92,7 +92,7 @@ jobs:
           - pkg
           - cmd-0
           - other
-        os: [windows-2022, windows-2025, windows-11-arm]
+        os: [windows-2025, windows-11-arm]
     runs-on: ${{ matrix.os }}
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     env:
@@ -170,7 +170,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       matrix:
-        os: [windows-2022, windows-2025, windows-11-arm]
+        os: [windows-2025, windows-11-arm]
     runs-on: ubuntu-24.04
     needs: [windows-unittest-matrix]
     permissions:

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025, windows-11-arm]
+        os: [windows-2025, windows-11-arm]
     runs-on: ${{ matrix.os }}
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     env:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025, windows-11-arm]
+        os: [windows-2025, windows-11-arm]
     runs-on: ${{ matrix.os }}
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     needs: [collector-build]

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -57,7 +57,7 @@ jobs:
     if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
     strategy:
       matrix:
-        runner: [windows-latest, ubuntu-latest]
+        runner: [windows-2022, windows-2025, windows-11-arm, ubuntu-latest]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Echo changed files

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -30,5 +30,5 @@ func createLogsReceiver(
 	_ component.Config,
 	_ consumer.Logs,
 ) (receiver.Logs, error) {
-	return nil, errors.New("windows eventlog receiver is only supported on Windows OS")
+	return nil, errors.New("windows eventlog receiver is only supported on Windows")
 }

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -30,5 +30,5 @@ func createLogsReceiver(
 	_ component.Config,
 	_ consumer.Logs,
 ) (receiver.Logs, error) {
-	return nil, errors.New("windows eventlog receiver is only supported on Windows")
+	return nil, errors.New("windows eventlog receiver is only supported on Windows OS")
 }


### PR DESCRIPTION
Fix #43436

Per issue description removes `windows-2022` from large test matrices. As an extra precaution I'm adding `windows-2022` to the scoped test workflow.