### PR TITLE
Fix prometheus exporter error log for unknown metric type

### DIFF
--- a/.chloggen/fix-prom-log.yaml
+++ b/.chloggen/fix-prom-log.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes data_type field formatting in the error logs message when exporting  unknown metrics types - e.g. native histograms.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43595]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -92,7 +92,7 @@ func (a *lastValueAccumulator) addMetric(metric pmetric.Metric, scopeName, scope
 		return a.accumulateSummary(metric, scopeName, scopeVersion, scopeSchemaURL, scopeAttributes, resourceAttrs, now)
 	default:
 		a.logger.With(
-			zap.String("data_type", string(metric.Type())),
+			zap.String("data_type", metric.Type().String()),
 			zap.String("metric_name", metric.Name()),
 		).Error("failed to translate metric")
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes the `data_type` field not being properly formatted 

```json
{
  "level": "error",
  "ts": "2025-10-16T10:26:48.992Z",
  "caller": "prometheusexporter@v0.137.0/accumulator.go:97",
  "msg": "failed to translate metric",
  "resource": {
    "service.instance.id": "c2ca81b8-ce73-473d-b897-6b946935260f",
    "service.name": "otelcol-contrib",
    "service.version": "0.137.0"
  },
  "otelcol.component.id": "prometheus",
  "otelcol.component.kind": "exporter",
  "otelcol.signal": "metrics",
  "data_type": "\u0004",
  "metric_name": "prometheus_http_request_duration_seconds",
  "stacktrace": "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*lastValueAccumulator).addMetric\n\tgithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter@v0.137.0/accumulator.go:97\ngithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*lastValueAccumulator).Accumulate\n\tgithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter@v0.137.0/accumulator.go:74\ngithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*collector).processMetrics\n\tgithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter@v0.137.0/collector.go:171\ngithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter.(*prometheusExporter).ConsumeMetrics\n\tgithub.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter@v0.137.0/prometheus.go:93\ngo.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics\n\tgo.opentelemetry.io/collector/consumer@v1.43.0/metrics.go:27\ngo.opentelemetry.io/collector/exporter/exporterhelper.NewMetrics.RequestConsumeFromMetrics.func2\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/queuebatch/metrics.go:134\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal/sender.(*sender[...]).Send\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/sender/sender.go:31\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal.(*timeoutSender[...]).Send\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/timeout_sender.go:54\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal.(*obsReportSender[...]).Send\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/obs_report_sender.go:92\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal.(*BaseExporter).Send\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/base_exporter.go:112\ngo.opentelemetry.io/collector/exporter/exporterhelper/internal.NewMetricsRequest.newConsumeMetrics.func1\n\tgo.opentelemetry.io/collector/exporter/exporterhelper@v0.137.0/internal/new_request.go:176\ngo.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics\n\tgo.opentelemetry.io/collector/consumer@v1.43.0/metrics.go:27\ngo.opentelemetry.io/collector/service/internal/refconsumer.refMetrics.ConsumeMetrics\n\tgo.opentelemetry.io/collector/service@v0.137.0/internal/refconsumer/metrics.go:29\ngo.opentelemetry.io/collector/internal/fanoutconsumer.(*metricsConsumer).ConsumeMetrics\n\tgo.opentelemetry.io/collector/internal/fanoutconsumer@v0.137.0/metrics.go:62\ngo.opentelemetry.io/collector/processor/processorhelper.NewMetrics.func1\n\tgo.opentelemetry.io/collector/processor/processorhelper@v0.137.0/metrics.go:71\ngo.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics\n\tgo.opentelemetry.io/collector/consumer@v1.43.0/metrics.go:27\ngo.opentelemetry.io/collector/service/internal/refconsumer.refMetrics.ConsumeMetrics\n\tgo.opentelemetry.io/collector/service@v0.137.0/internal/refconsumer/metrics.go:29\ngo.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics\n\tgo.opentelemetry.io/collector/consumer@v1.43.0/metrics.go:27\ngithub.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver.(*prometheusRemoteWriteReceiver).handlePRW\n\tgithub.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver@v0.137.0/receiver.go:198\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2322\nnet/http.(*ServeMux).ServeHTTP\n\tnet/http/server.go:2861\ngo.opentelemetry.io/collector/config/confighttp.(*decompressor).ServeHTTP\n\tgo.opentelemetry.io/collector/config/confighttp@v0.137.0/compression.go:272\ngo.opentelemetry.io/collector/config/confighttp.(*ServerConfig).ToServer.maxRequestBodySizeInterceptor.func2\n\tgo.opentelemetry.io/collector/config/confighttp@v0.137.0/server.go:350\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2322\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP\n\tgo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.63.0/handler.go:180\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1\n\tgo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.63.0/handler.go:67\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2322\ngo.opentelemetry.io/collector/config/confighttp.(*clientInfoHandler).ServeHTTP\n\tgo.opentelemetry.io/collector/config/confighttp@v0.137.0/clientinfohandler.go:26\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:3340\nnet/http.(*conn).serve\n\tnet/http/server.go:2109"
}
```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
