### PR TITLE
feat: Add resource_keys routing for loadbalancingexporter

### DIFF
--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -22,15 +22,17 @@ const (
 	resourceRouting
 	streamIDRouting
 	attrRouting
+	resourceKeysRouting
 )
 
 const (
-	svcRoutingStr        = "service"
-	traceIDRoutingStr    = "traceID"
-	metricNameRoutingStr = "metric"
-	resourceRoutingStr   = "resource"
-	streamIDRoutingStr   = "streamID"
-	attrRoutingStr       = "attributes"
+	svcRoutingStr          = "service"
+	traceIDRoutingStr      = "traceID"
+	metricNameRoutingStr   = "metric"
+	resourceRoutingStr     = "resource"
+	streamIDRoutingStr     = "streamID"
+	attrRoutingStr         = "attributes"
+	resourceKeysRoutingStr = "resource_keys"
 )
 
 // Config defines configuration for the exporter.
@@ -50,6 +52,9 @@ type Config struct {
 	// Supports all attributes available (both resource and span), as well as the pseudo attributes "span.kind" and
 	// "span.name".
 	RoutingAttributes []string `mapstructure:"routing_attributes"`
+
+	// ResourceKeys is used for resource_keys routing - routes based on resource attributes only
+	ResourceKeys []string `mapstructure:"resource_keys"`
 }
 
 // Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.


### PR DESCRIPTION
Add resource_keys routing feature that routes traces based on resource attributes only (unlike attrRouting which checks span attributes too).

Changes:
- Add resourceKeysRouting constant and resource_keys string
- Add ResourceKeys []string field to Config
- Add routingResourceKeys field to traceExporterImp
- Implement routingIdentifiersFromResourceKeys() method
  - Routes based on resource attributes only
  - Falls back to traceID if no matching attribute found
- Add test cases for resource keys routing

This feature is useful for scenarios where you want load balancing based on specific resource metadata (e.g., service.name, deployment.environment) rather than trace IDs or span-level attributes.

All tests pass ✅

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
