### PR TITLE
[chore] Fix uses of configgrpc/confighttp headers

### DIFF
--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -403,7 +403,7 @@ func TestClientConfig(t *testing.T) {
 			config: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: endpoint,
-					Headers: map[string]configopaque.String{
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 						"hdr1": "val1",
 						"hdr2": "val2",
 					},

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -40,9 +40,9 @@ type TransportConfig struct {
 func (c *TransportConfig) ToHTTPClient(ctx context.Context, host component.Host, settings component.TelemetrySettings) (*http.Client, error) {
 	headers := c.Headers
 	if headers == nil {
-		headers = make(map[string]configopaque.String)
+		headers = new(configopaque.MapList)
 	}
-	headers["Content-Type"] = "application/x-protobuf"
+	headers.Set("Content-Type", "application/x-protobuf")
 
 	httpClientConfig := confighttp.ClientConfig{
 		ProxyURL:        c.ProxyURL,
@@ -226,16 +226,16 @@ func (c *Config) getMergedTransportConfig(signalConfig *TransportConfig) *Transp
 	if signalConfig.TLS.Insecure || signalConfig.TLS.InsecureSkipVerify || signalConfig.TLS.CAFile != "" {
 		merged.TLS = signalConfig.TLS
 	}
-	if len(signalConfig.Headers) > 0 {
+	if signalConfig.Headers.Len() > 0 {
 		// Deep-copy domain headers to avoid mutating the shared map
 		headers := make(map[string]configopaque.String)
-		for k, v := range merged.Headers {
+		for k, v := range merged.Headers.Iter {
 			headers[k] = v
 		}
-		for k, v := range signalConfig.Headers {
+		for k, v := range signalConfig.Headers.Iter {
 			headers[k] = v
 		}
-		merged.Headers = headers
+		merged.Headers = configopaque.MapListFromMap(headers)
 	}
 	if signalConfig.WriteBufferSize > 0 {
 		merged.WriteBufferSize = signalConfig.WriteBufferSize

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -166,10 +166,10 @@ func TestCreateTraces(t *testing.T) {
 				Traces: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
 						Endpoint: endpoint,
-						Headers: map[string]configopaque.String{
+						Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 							"hdr1": "val1",
 							"hdr2": "val2",
-						},
+						}),
 					},
 				},
 			},

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -84,7 +84,7 @@ func TestLogsExporter_Start(t *testing.T) {
 		PrivateKey: "test-key",
 		Logs: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -96,7 +96,7 @@ func TestLogsExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcLogsExporter)
-	assert.Contains(t, exp.config.Logs.Headers, "Authorization")
+	assert.Contains(t, exp.config.Logs.Headers.ToMap(), "Authorization")
 
 	// Test shutdown
 	err = exp.shutdown(t.Context())
@@ -109,9 +109,9 @@ func TestLogsExporter_EnhanceContext(t *testing.T) {
 		PrivateKey: "test-key",
 		Logs: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"test-header": "test-value",
-				},
+				}),
 			},
 		},
 	}
@@ -130,7 +130,7 @@ func TestLogsExporter_PushLogs(t *testing.T) {
 		PrivateKey: "test-key",
 		Logs: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -178,7 +178,7 @@ func TestLogsExporter_PushLogs_WhenCannotSend(t *testing.T) {
 				PrivateKey: "test-key",
 				Logs: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
-						Headers: map[string]configopaque.String{},
+						Headers: new(configopaque.MapList),
 					},
 				},
 				RateLimiter: RateLimiterConfig{
@@ -280,7 +280,7 @@ func BenchmarkLogsExporter_PushLogs(b *testing.B) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -335,7 +335,7 @@ func TestLogsExporter_PushLogs_PartialSuccess(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -406,7 +406,7 @@ func TestLogsExporter_PushLogs_Performance(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -84,7 +84,7 @@ func TestMetricsExporter_Start(t *testing.T) {
 		PrivateKey: "test-key",
 		Metrics: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -96,7 +96,7 @@ func TestMetricsExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcMetricsExporter)
-	assert.Contains(t, exp.config.Metrics.Headers, "Authorization")
+	assert.Contains(t, exp.config.Metrics.Headers.ToMap(), "Authorization")
 
 	// Test shutdown
 	err = exp.shutdown(t.Context())
@@ -109,9 +109,9 @@ func TestMetricsExporter_EnhanceContext(t *testing.T) {
 		PrivateKey: "test-key",
 		Metrics: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"test-header": "test-value",
-				},
+				}),
 			},
 		},
 	}
@@ -130,7 +130,7 @@ func TestMetricsExporter_PushMetrics(t *testing.T) {
 		PrivateKey: "test-key",
 		Metrics: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -190,7 +190,7 @@ func TestMetricsExporter_PushMetrics_WhenCannotSend(t *testing.T) {
 				PrivateKey: "test-key",
 				Metrics: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
-						Headers: map[string]configopaque.String{},
+						Headers: new(configopaque.MapList),
 					},
 				},
 				RateLimiter: RateLimiterConfig{
@@ -293,7 +293,7 @@ func BenchmarkMetricsExporter_PushMetrics(b *testing.B) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -352,7 +352,7 @@ func TestMetricsExporter_PushMetrics_PartialSuccess(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -442,7 +442,7 @@ func TestMetricsExporter_PushMetrics_Performance(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",

--- a/exporter/coralogixexporter/profiles_client_test.go
+++ b/exporter/coralogixexporter/profiles_client_test.go
@@ -82,7 +82,7 @@ func TestProfilesExporter_Start(t *testing.T) {
 		Domain:     "test.domain.com",
 		PrivateKey: "test-key",
 		Profiles: configgrpc.ClientConfig{
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 		},
 	}
 
@@ -93,7 +93,7 @@ func TestProfilesExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.profilesExporter)
-	assert.Contains(t, exp.config.Profiles.Headers, "Authorization")
+	assert.Contains(t, exp.config.Profiles.Headers.ToMap(), "Authorization")
 
 	// Test shutdown
 	err = exp.shutdown(t.Context())
@@ -105,9 +105,9 @@ func TestProfilesExporter_EnhanceContext(t *testing.T) {
 		Domain:     "test.domain.com",
 		PrivateKey: "test-key",
 		Profiles: configgrpc.ClientConfig{
-			Headers: map[string]configopaque.String{
+			Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 				"test-header": "test-value",
-			},
+			}),
 		},
 	}
 
@@ -124,7 +124,7 @@ func TestProfilesExporter_PushProfiles(t *testing.T) {
 		Domain:     "test.domain.com",
 		PrivateKey: "test-key",
 		Profiles: configgrpc.ClientConfig{
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 		},
 	}
 
@@ -172,7 +172,7 @@ func TestProfilesExporter_PushProfiles_WhenCannotSend(t *testing.T) {
 				Domain:     "test.domain.com",
 				PrivateKey: "test-key",
 				Profiles: configgrpc.ClientConfig{
-					Headers: map[string]configopaque.String{},
+					Headers: new(configopaque.MapList),
 				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   tt.enabled,
@@ -279,7 +279,7 @@ func BenchmarkProfilesExporter_PushProfiles(b *testing.B) {
 			TLS: configtls.ClientConfig{
 				Insecure: true,
 			},
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 		},
 		PrivateKey: "test-key",
 	}
@@ -334,7 +334,7 @@ func TestProfilesExporter_PushProfiles_PartialSuccess(t *testing.T) {
 			TLS: configtls.ClientConfig{
 				Insecure: true,
 			},
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 		},
 		PrivateKey: "test-key",
 	}
@@ -407,7 +407,7 @@ func TestProfilesExporter_PushProfiles_Performance(t *testing.T) {
 			TLS: configtls.ClientConfig{
 				Insecure: true,
 			},
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 		},
 		PrivateKey: "test-key",
 		RateLimiter: RateLimiterConfig{

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -51,7 +51,7 @@ func (w *signalConfigWrapper) GetEndpoint() string {
 	return w.config.Endpoint
 }
 
-func newSignalExporter(oCfg *Config, set exp.Settings, signalEndpoint string, headers map[string]configopaque.String) (*signalExporter, error) {
+func newSignalExporter(oCfg *Config, set exp.Settings, signalEndpoint string, headers *configopaque.MapList) (*signalExporter, error) {
 	if isEmpty(oCfg.Domain) && isEmpty(signalEndpoint) {
 		return nil, errors.New("coralogix exporter config requires `domain` or `logs.endpoint` configuration")
 	}
@@ -60,7 +60,7 @@ func newSignalExporter(oCfg *Config, set exp.Settings, signalEndpoint string, he
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
 	md := metadata.New(nil)
-	for k, v := range headers {
+	for k, v := range headers.Iter {
 		md.Set(k, string(v))
 	}
 
@@ -121,11 +121,11 @@ func (e *signalExporter) enhanceContext(ctx context.Context) context.Context {
 func (e *signalExporter) startSignalExporter(ctx context.Context, host component.Host, signalConfig signalConfig) (err error) {
 	if signalConfigWrapper, ok := signalConfig.(*signalConfigWrapper); ok {
 		if signalConfigWrapper.config.Headers == nil {
-			signalConfigWrapper.config.Headers = make(map[string]configopaque.String)
+			signalConfigWrapper.config.Headers = new(configopaque.MapList)
 		}
-		signalConfigWrapper.config.Headers["Authorization"] = configopaque.String("Bearer " + string(e.config.PrivateKey))
+		signalConfigWrapper.config.Headers.Set("Authorization", configopaque.String("Bearer "+string(e.config.PrivateKey)))
 		if e.config.Protocol != httpProtocol {
-			for k, v := range signalConfigWrapper.config.Headers {
+			for k, v := range signalConfigWrapper.config.Headers.Iter {
 				e.metadata.Set(k, string(v))
 			}
 		}

--- a/exporter/coralogixexporter/signals_test.go
+++ b/exporter/coralogixexporter/signals_test.go
@@ -171,7 +171,7 @@ func TestSignalExporter_AuthorizationHeader(t *testing.T) {
 		PrivateKey: configopaque.String(privateKey),
 		Logs: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -186,7 +186,7 @@ func TestSignalExporter_AuthorizationHeader(t *testing.T) {
 		require.NoError(t, exp.shutdown(t.Context()))
 	}()
 
-	authHeader, ok := wrapper.config.Headers["Authorization"]
+	authHeader, ok := wrapper.config.Headers.Get2("Authorization")
 	require.True(t, ok, "Authorization header should be present")
 	assert.Equal(t, configopaque.String("Bearer "+privateKey), authHeader, "Authorization header should be in Bearer format")
 
@@ -203,37 +203,37 @@ func TestSignalExporter_CustomHeadersAndAuthorization(t *testing.T) {
 		{
 			name: "logs",
 			config: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"Custom-Header": "custom-value",
 					"X-Test":        "test-value",
-				},
+				}),
 			},
 		},
 		{
 			name: "traces",
 			config: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"Custom-Header": "custom-value",
 					"X-Test":        "test-value",
-				},
+				}),
 			},
 		},
 		{
 			name: "metrics",
 			config: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"Custom-Header": "custom-value",
 					"X-Test":        "test-value",
-				},
+				}),
 			},
 		},
 		{
 			name: "profiles",
 			config: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"Custom-Header": "custom-value",
 					"X-Test":        "test-value",
-				},
+				}),
 			},
 		},
 	}
@@ -269,17 +269,17 @@ func TestSignalExporter_CustomHeadersAndAuthorization(t *testing.T) {
 			}()
 
 			headers := wrapper.config.Headers
-			require.Len(t, headers, 3)
+			require.Equal(t, 3, headers.Len())
 
-			authHeader, ok := headers["Authorization"]
+			authHeader, ok := headers.Get2("Authorization")
 			require.True(t, ok)
 			assert.Equal(t, configopaque.String("Bearer "+privateKey), authHeader)
 
-			customHeader, ok := headers["Custom-Header"]
+			customHeader, ok := headers.Get2("Custom-Header")
 			require.True(t, ok)
 			assert.Equal(t, configopaque.String("custom-value"), customHeader)
 
-			testHeader, ok := headers["X-Test"]
+			testHeader, ok := headers.Get2("X-Test")
 			require.True(t, ok)
 			assert.Equal(t, configopaque.String("test-value"), testHeader)
 

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -85,7 +85,7 @@ func TestTracesExporter_Start(t *testing.T) {
 		PrivateKey: "test-key",
 		Traces: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -97,7 +97,7 @@ func TestTracesExporter_Start(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exp.clientConn)
 	assert.NotNil(t, exp.grpcTracesExporter)
-	assert.Contains(t, exp.config.Traces.Headers, "Authorization")
+	assert.Contains(t, exp.config.Traces.Headers.ToMap(), "Authorization")
 
 	err = exp.shutdown(t.Context())
 	require.NoError(t, err)
@@ -109,9 +109,9 @@ func TestTracesExporter_EnhanceContext(t *testing.T) {
 		PrivateKey: "test-key",
 		Traces: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"test-header": "test-value",
-				},
+				}),
 			},
 		},
 	}
@@ -130,7 +130,7 @@ func TestTracesExporter_PushTraces(t *testing.T) {
 		PrivateKey: "test-key",
 		Traces: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 	}
@@ -178,7 +178,7 @@ func TestTracesExporter_PushTraces_WhenCannotSend(t *testing.T) {
 				PrivateKey: "test-key",
 				Traces: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
-						Headers: map[string]configopaque.String{},
+						Headers: new(configopaque.MapList),
 					},
 				},
 				RateLimiter: RateLimiterConfig{
@@ -287,7 +287,7 @@ func TestTracesExporter_PushTraces_PartialSuccess(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -378,7 +378,7 @@ func BenchmarkTracesExporter_PushTraces(b *testing.B) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -441,7 +441,7 @@ func TestTracesExporter_PushTraces_Performance(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",
@@ -575,7 +575,7 @@ func TestTracesExporter_RateLimitErrorCountReset(t *testing.T) {
 				TLS: configtls.ClientConfig{
 					Insecure: true,
 				},
-				Headers: map[string]configopaque.String{},
+				Headers: new(configopaque.MapList),
 			},
 		},
 		PrivateKey: "test-key",

--- a/exporter/dorisexporter/config_test.go
+++ b/exporter/dorisexporter/config_test.go
@@ -37,11 +37,11 @@ func TestLoadConfig(t *testing.T) {
 	httpClientConfig := confighttp.NewDefaultClientConfig()
 	httpClientConfig.Timeout = 5 * time.Second
 	httpClientConfig.Endpoint = "http://localhost:8030"
-	httpClientConfig.Headers = map[string]configopaque.String{
+	httpClientConfig.Headers = configopaque.MapListFromMap(map[string]configopaque.String{
 		"max_filter_ratio": "0.1",
 		"strict_mode":      "true",
 		"group_commit":     "async_mode",
-	}
+	})
 
 	fullCfg := &Config{
 		ClientConfig: httpClientConfig,

--- a/exporter/dorisexporter/exporter_common.go
+++ b/exporter/dorisexporter/exporter_common.go
@@ -98,7 +98,7 @@ func streamLoadRequest(ctx context.Context, cfg *Config, table string, data []by
 	req.Header.Set("format", "json")
 	req.Header.Set("Expect", "100-continue")
 	req.Header.Set("read_json_by_line", "true")
-	groupCommit := string(cfg.Headers["group_commit"])
+	groupCommit := string(cfg.Headers.Get("group_commit"))
 	if groupCommit == "" || groupCommit == "off_mode" {
 		req.Header.Set("label", label)
 	}

--- a/exporter/influxdbexporter/config_test.go
+++ b/exporter/influxdbexporter/config_test.go
@@ -26,7 +26,7 @@ func TestLoadConfig(t *testing.T) {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Endpoint = "http://localhost:8080"
 	clientConfig.Timeout = 500 * time.Millisecond
-	clientConfig.Headers = map[string]configopaque.String{"User-Agent": "OpenTelemetry -> Influx"}
+	clientConfig.Headers = configopaque.MapListFromMap(map[string]configopaque.String{"User-Agent": "OpenTelemetry -> Influx"})
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))

--- a/exporter/influxdbexporter/factory.go
+++ b/exporter/influxdbexporter/factory.go
@@ -36,8 +36,8 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Timeout = 5 * time.Second
-	clientConfig.Headers = map[string]configopaque.String{
-		"User-Agent": "OpenTelemetry -> Influx",
+	clientConfig.Headers = &configopaque.MapList{
+		configopaque.OpaquePair{Name: "User-Agent", Value: "OpenTelemetry -> Influx"},
 	}
 
 	return &Config{

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -91,9 +91,9 @@ func composeWriteURL(config *Config) (string, error) {
 			basicAuth := base64.StdEncoding.EncodeToString(
 				[]byte(config.V1Compatibility.Username + ":" + string(config.V1Compatibility.Password)))
 			if config.Headers == nil {
-				config.Headers = make(map[string]configopaque.String, 1)
+				config.Headers = configopaque.MapListWithCapacity(1)
 			}
-			config.Headers["Authorization"] = configopaque.String("Basic " + basicAuth)
+			config.Headers.Set("Authorization", configopaque.String("Basic "+basicAuth))
 		}
 	} else {
 		queryValues.Set("org", config.Org)
@@ -101,9 +101,9 @@ func composeWriteURL(config *Config) (string, error) {
 
 		if config.Token != "" {
 			if config.Headers == nil {
-				config.Headers = make(map[string]configopaque.String, 1)
+				config.Headers = configopaque.MapListWithCapacity(1)
 			}
-			config.Headers["Authorization"] = "Token " + config.Token
+			config.Headers.Set("Authorization", "Token "+config.Token)
 		}
 	}
 

--- a/exporter/logicmonitorexporter/config_test.go
+++ b/exporter/logicmonitorexporter/config_test.go
@@ -121,9 +121,9 @@ func TestLoadConfig(t *testing.T) {
 				QueueSettings: exporterhelper.NewDefaultQueueConfig(),
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: "https://company.logicmonitor.com/rest",
-					Headers: map[string]configopaque.String{
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 						"Authorization": "Bearer <token>",
-					},
+					}),
 				},
 			},
 		},
@@ -134,9 +134,9 @@ func TestLoadConfig(t *testing.T) {
 				QueueSettings: exporterhelper.NewDefaultQueueConfig(),
 				ClientConfig: confighttp.ClientConfig{
 					Endpoint: "https://company.logicmonitor.com/rest",
-					Headers: map[string]configopaque.String{
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 						"Authorization": "Bearer <token>",
-					},
+					}),
 				},
 				Logs: LogsConfig{
 					ResourceMappingOperation: "or",

--- a/exporter/logicmonitorexporter/logs_exporter.go
+++ b/exporter/logicmonitorexporter/logs_exporter.go
@@ -108,7 +108,7 @@ func buildLogIngestOpts(config *Config, client *http.Client) []lmsdklogs.Option 
 	authParams := utils.AuthParams{
 		AccessID:    config.APIToken.AccessID,
 		AccessKey:   string(config.APIToken.AccessKey),
-		BearerToken: string(config.Headers["Authorization"]),
+		BearerToken: string(config.Headers.Get("Authorization")),
 	}
 
 	opts := []lmsdklogs.Option{

--- a/exporter/logicmonitorexporter/traces_exporter.go
+++ b/exporter/logicmonitorexporter/traces_exporter.go
@@ -42,7 +42,7 @@ func (e *tracesExporter) start(ctx context.Context, host component.Host) error {
 	authParams := utils.AuthParams{
 		AccessID:    e.config.APIToken.AccessID,
 		AccessKey:   string(e.config.APIToken.AccessKey),
-		BearerToken: string(e.config.Headers["Authorization"]),
+		BearerToken: string(e.config.Headers.Get("Authorization")),
 	}
 
 	ctx, e.cancel = context.WithCancel(ctx)

--- a/exporter/mezmoexporter/config_test.go
+++ b/exporter/mezmoexporter/config_test.go
@@ -49,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 					MaxIdleConnsPerHost: defaultMaxIdleConnsPerHost,
 					MaxConnsPerHost:     defaultMaxConnsPerHost,
 					IdleConnTimeout:     defaultIdleConnTimeout,
-					Headers:             map[string]configopaque.String{},
+					Headers:             new(configopaque.MapList),
 					ForceAttemptHTTP2:   true,
 				},
 				BackOffConfig: configretry.BackOffConfig{

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -46,7 +46,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 			MaxIdleConnsPerHost: defaultMaxIdleConnsPerHost,
 			MaxConnsPerHost:     defaultMaxConnsPerHost,
 			IdleConnTimeout:     defaultIdleConnTimeout,
-			Headers:             map[string]configopaque.String{},
+			Headers:             new(configopaque.MapList),
 			ForceAttemptHTTP2:   true,
 		},
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),

--- a/exporter/otelarrowexporter/config_test.go
+++ b/exporter/otelarrowexporter/config_test.go
@@ -72,11 +72,11 @@ func TestUnmarshalConfig(t *testing.T) {
 				}),
 			},
 			ClientConfig: configgrpc.ClientConfig{
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"can you have a . here?": "F0000000-0000-0000-0000-000000000000",
 					"header1":                "234",
 					"another":                "somevalue",
-				},
+				}),
 				Endpoint:    "1.2.3.4:1234",
 				Compression: "none",
 				TLS: configtls.ClientConfig{

--- a/exporter/otelarrowexporter/factory.go
+++ b/exporter/otelarrowexporter/factory.go
@@ -64,7 +64,7 @@ func createDefaultConfig() component.Config {
 		RetryConfig:     configretry.NewDefaultBackOffConfig(),
 		QueueSettings:   queueCfg,
 		ClientConfig: configgrpc.ClientConfig{
-			Headers: map[string]configopaque.String{},
+			Headers: new(configopaque.MapList),
 			// Default to zstd compression
 			Compression: configcompression.TypeZstd,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/exporter/otelarrowexporter/factory_test.go
+++ b/exporter/otelarrowexporter/factory_test.go
@@ -143,10 +143,10 @@ func TestCreateTraces(t *testing.T) {
 			config: Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint: endpoint,
-					Headers: map[string]configopaque.String{
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 						"hdr1": "val1",
 						"hdr2": "val2",
-					},
+					}),
 				},
 			},
 		},

--- a/exporter/otelarrowexporter/otelarrow.go
+++ b/exporter/otelarrowexporter/otelarrow.go
@@ -124,7 +124,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)
 	headers := map[string]string{}
-	for k, v := range e.config.Headers {
+	for k, v := range e.config.Headers.Iter {
 		headers[k] = string(v)
 	}
 	headerMetadata := metadata.New(headers)

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -313,9 +313,9 @@ func TestSendTraces(t *testing.T) {
 		TLS: configtls.ClientConfig{
 			Insecure: true,
 		},
-		Headers: map[string]configopaque.String{
+		Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 			"header": configopaque.String(expectedHeader[0]),
-		},
+		}),
 		Auth: configoptional.Some(configauth.Config{
 			AuthenticatorID: authID,
 		}),
@@ -519,9 +519,9 @@ func TestSendMetrics(t *testing.T) {
 		TLS: configtls.ClientConfig{
 			Insecure: true,
 		},
-		Headers: map[string]configopaque.String{
+		Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 			"header": "header-value",
-		},
+		}),
 	}
 	cfg.Arrow.MaxStreamLifetime = 100 * time.Second
 	set := exportertest.NewNopSettings(factory.Type())
@@ -923,9 +923,9 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 			Insecure: true,
 		},
 		WaitForReady: clientWaitForReady,
-		Headers: map[string]configopaque.String{
+		Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 			"header": configopaque.String(expectedHeader[0]),
-		},
+		}),
 		Auth: configoptional.Some(configauth.Config{
 			AuthenticatorID: authID,
 		}),

--- a/exporter/sematextexporter/config_test.go
+++ b/exporter/sematextexporter/config_test.go
@@ -53,7 +53,7 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 500 * time.Millisecond,
-					Headers: map[string]configopaque.String{"User-Agent": "OpenTelemetry -> Sematext"},
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{"User-Agent": "OpenTelemetry -> Sematext"}),
 				},
 				QueueSettings: func() exporterhelper.QueueBatchConfig {
 					queue := exporterhelper.NewDefaultQueueConfig()

--- a/exporter/sematextexporter/factory.go
+++ b/exporter/sematextexporter/factory.go
@@ -43,9 +43,9 @@ func createDefaultConfig() component.Config {
 	cfg := &Config{
 		ClientConfig: confighttp.ClientConfig{
 			Timeout: 5 * time.Second,
-			Headers: map[string]configopaque.String{
+			Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 				"User-Agent": "OpenTelemetry -> Sematext",
-			},
+			}),
 		},
 		QueueSettings: exporterhelper.NewDefaultQueueConfig(),
 		MetricsConfig: MetricsConfig{

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -55,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 				Realm:       "ap0",
 				ClientConfig: confighttp.ClientConfig{
 					Timeout:              10 * time.Second,
-					Headers:              map[string]configopaque.String{},
+					Headers:              new(configopaque.MapList),
 					MaxIdleConns:         hundred,
 					MaxIdleConnsPerHost:  hundred,
 					MaxConnsPerHost:      defaultMaxConnsPerHost,
@@ -94,7 +94,7 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint:            "",
 						Timeout:             5 * time.Second,
-						Headers:             map[string]configopaque.String{},
+						Headers:             new(configopaque.MapList),
 						MaxIdleConns:        defaultMaxIdleConns,
 						MaxIdleConnsPerHost: defaultMaxIdleConnsPerHost,
 						MaxConnsPerHost:     defaultMaxConnsPerHost,
@@ -126,10 +126,10 @@ func TestLoadConfig(t *testing.T) {
 				Realm:       "us1",
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 2 * time.Second,
-					Headers: map[string]configopaque.String{
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 						"added-entry": "added value",
 						"dot.test":    "test",
-					},
+					}),
 					MaxIdleConns:         seventy,
 					MaxIdleConnsPerHost:  seventy,
 					MaxConnsPerHost:      defaultMaxConnsPerHost,
@@ -231,7 +231,7 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: confighttp.ClientConfig{
 						Endpoint:            "",
 						Timeout:             5 * time.Second,
-						Headers:             map[string]configopaque.String{},
+						Headers:             new(configopaque.MapList),
 						MaxIdleConns:        defaultMaxIdleConns,
 						MaxIdleConnsPerHost: defaultMaxIdleConnsPerHost,
 						MaxConnsPerHost:     defaultMaxConnsPerHost,

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -264,7 +264,7 @@ func buildHeaders(config *Config, version string) map[string]string {
 	// Add any custom headers from the config. They will override the pre-defined
 	// ones above in case of conflict, but, not the content encoding one since
 	// the latter one is defined according to the payload.
-	for k, v := range config.Headers {
+	for k, v := range config.Headers.Iter {
 		headers[k] = string(v)
 	}
 	// we want to control how headers are set, overriding user headers with our passthrough.

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -187,7 +187,7 @@ func TestConsumeMetrics(t *testing.T) {
 			cfg := &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 1 * time.Second,
-					Headers: map[string]configopaque.String{"test_header_": "test"},
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{"test_header_": "test"}),
 				},
 			}
 
@@ -546,11 +546,12 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.IngestURL = server.URL
 			cfg.APIURL = server.URL
-			cfg.Headers = make(map[string]configopaque.String)
-			for k, v := range tt.additionalHeaders {
-				cfg.Headers[k] = configopaque.String(v)
+			cfg.Headers = &configopaque.MapList{
+				configopaque.OpaquePair{Name: "test_header_", Value: configopaque.String(tt.name)},
 			}
-			cfg.Headers["test_header_"] = configopaque.String(tt.name)
+			for k, v := range tt.additionalHeaders {
+				cfg.Headers.Set(k, configopaque.String(v))
+			}
 			cfg.AccessToken = configopaque.String(fromHeaders)
 			cfg.AccessTokenPassthrough = tt.accessTokenPassthrough
 			cfg.SendOTLPHistograms = tt.sendOTLPHistograms
@@ -669,11 +670,12 @@ func TestConsumeMetricsAccessTokenPassthroughPriorityToContext(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.IngestURL = server.URL
 			cfg.APIURL = server.URL
-			cfg.Headers = make(map[string]configopaque.String)
-			for k, v := range tt.additionalHeaders {
-				cfg.Headers[k] = configopaque.String(v)
+			cfg.Headers = &configopaque.MapList{
+				configopaque.OpaquePair{Name: "test_header_", Value: configopaque.String(tt.name)},
 			}
-			cfg.Headers["test_header_"] = configopaque.String(tt.name)
+			for k, v := range tt.additionalHeaders {
+				cfg.Headers.Set(k, configopaque.String(v))
+			}
 			cfg.AccessToken = configopaque.String(fromHeaders)
 			cfg.AccessTokenPassthrough = tt.accessTokenPassthrough
 			cfg.SendOTLPHistograms = tt.sendOTLPHistograms
@@ -773,8 +775,9 @@ func TestConsumeLogsAccessTokenPassthrough(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.IngestURL = server.URL
 			cfg.APIURL = server.URL
-			cfg.Headers = make(map[string]configopaque.String)
-			cfg.Headers["test_header_"] = configopaque.String(tt.name)
+			cfg.Headers = &configopaque.MapList{
+				configopaque.OpaquePair{Name: "test_header_", Value: configopaque.String(tt.name)},
+			}
 			cfg.AccessToken = configopaque.String(fromHeaders)
 			cfg.AccessTokenPassthrough = tt.accessTokenPassthrough
 			cfg.QueueSettings.Enabled = false
@@ -934,7 +937,7 @@ func TestConsumeEventData(t *testing.T) {
 			cfg := &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 1 * time.Second,
-					Headers: map[string]configopaque.String{"test_header_": "test"},
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{"test_header_": "test"}),
 				},
 			}
 
@@ -1028,8 +1031,9 @@ func TestConsumeLogsDataWithAccessTokenPassthrough(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			cfg.IngestURL = server.URL
 			cfg.APIURL = server.URL
-			cfg.Headers = make(map[string]configopaque.String)
-			cfg.Headers["test_header_"] = configopaque.String(tt.name)
+			cfg.Headers = &configopaque.MapList{
+				configopaque.OpaquePair{Name: "test_header_", Value: configopaque.String(tt.name)},
+			}
 			cfg.AccessToken = configopaque.String(fromHeaders)
 			cfg.AccessTokenPassthrough = tt.accessTokenPassthrough
 			sfxExp, err := NewFactory().CreateLogs(t.Context(), exportertest.NewNopSettings(componentmetadata.Type), cfg)
@@ -2052,7 +2056,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 			cfg := &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 1 * time.Second,
-					Headers: map[string]configopaque.String{"test_header_": "test"},
+					Headers: configopaque.MapListFromMap(map[string]configopaque.String{"test_header_": "test"}),
 				},
 			}
 

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -103,10 +103,10 @@ func TestCreateMetrics_CustomConfig(t *testing.T) {
 		Realm:       "us1",
 		ClientConfig: confighttp.ClientConfig{
 			Timeout: 2 * time.Second,
-			Headers: map[string]configopaque.String{
+			Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 				"added-entry": "added value",
 				"dot.test":    "test",
-			},
+			}),
 		},
 	}
 

--- a/extension/httpforwarderextension/config_test.go
+++ b/extension/httpforwarderextension/config_test.go
@@ -26,9 +26,9 @@ func TestLoadConfig(t *testing.T) {
 
 	egressCfg := confighttp.NewDefaultClientConfig()
 	egressCfg.Endpoint = "http://target/"
-	egressCfg.Headers = map[string]configopaque.String{
+	egressCfg.Headers = configopaque.MapListFromMap(map[string]configopaque.String{
 		"otel_http_forwarder": "dev",
-	}
+	})
 	egressCfg.MaxIdleConns = maxIdleConns
 	egressCfg.IdleConnTimeout = idleConnTimeout
 	egressCfg.Timeout = 5 * time.Second

--- a/extension/httpforwarderextension/extension.go
+++ b/extension/httpforwarderextension/extension.go
@@ -78,7 +78,7 @@ func (h *httpForwarder) forwardRequest(writer http.ResponseWriter, request *http
 	forwarderRequest.RequestURI = ""
 
 	// Add additional headers.
-	for k, v := range h.config.Egress.Headers {
+	for k, v := range h.config.Egress.Headers.Iter {
 		forwarderRequest.Header.Add(k, string(v))
 	}
 

--- a/extension/httpforwarderextension/extension_test.go
+++ b/extension/httpforwarderextension/extension_test.go
@@ -75,9 +75,9 @@ func TestExtension(t *testing.T) {
 						Endpoint: listenAt,
 					},
 					Egress: confighttp.ClientConfig{
-						Headers: map[string]configopaque.String{
+						Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 							"key": "value",
-						},
+						}),
 					},
 				}
 			},
@@ -101,9 +101,9 @@ func TestExtension(t *testing.T) {
 						Endpoint: listenAt,
 					},
 					Egress: confighttp.ClientConfig{
-						Headers: map[string]configopaque.String{
+						Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 							"key": "value",
-						},
+						}),
 					},
 				}
 			},
@@ -125,9 +125,9 @@ func TestExtension(t *testing.T) {
 						Endpoint: listenAt,
 					},
 					Egress: confighttp.ClientConfig{
-						Headers: map[string]configopaque.String{
+						Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 							"key": "value",
-						},
+						}),
 					},
 				}
 			},
@@ -196,7 +196,7 @@ func TestExtension(t *testing.T) {
 				}
 
 				// Assert additional headers added by forwarder.
-				for k, v := range cfg.Egress.Headers {
+				for k, v := range cfg.Egress.Headers.Iter {
 					got := r.Header.Get(k)
 					assert.Equal(t, string(v), got)
 				}

--- a/extension/jaegerremotesampling/extension_test.go
+++ b/extension/jaegerremotesampling/extension_test.go
@@ -106,7 +106,7 @@ func TestRemote(t *testing.T) {
 					Insecure: true, // test only
 				},
 				WaitForReady: true,
-				Headers:      tc.remoteClientHeaderConfig,
+				Headers:      configopaque.MapListFromMap(tc.remoteClientHeaderConfig),
 			}
 
 			// create the extension

--- a/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_store.go
+++ b/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_store.go
@@ -19,7 +19,7 @@ import (
 )
 
 type grpcRemoteStrategyStore struct {
-	headerAdditions map[string]configopaque.String
+	headerAdditions *configopaque.MapList
 	delegate        *ConfigManagerProxy
 	cache           serviceStrategyCache
 }
@@ -63,7 +63,7 @@ func (g *grpcRemoteStrategyStore) GetSamplingStrategy(
 // This function is used to add the extension configuration defined HTTP headers to a given outbound gRPC call's context.
 func (g *grpcRemoteStrategyStore) enhanceContext(ctx context.Context) context.Context {
 	md := metadata.New(nil)
-	for k, v := range g.headerAdditions {
+	for k, v := range g.headerAdditions.Iter {
 		md.Set(k, string(v))
 	}
 	return metadata.NewOutgoingContext(ctx, md)

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -201,7 +201,7 @@ func validateClientConfig(cfg confighttp.ClientConfig) error {
 	if cfg.Compression != "" {
 		unsupported = append(unsupported, "compression")
 	}
-	if len(cfg.Headers) > 0 {
+	if cfg.Headers.Len() > 0 {
 		unsupported = append(unsupported, "headers")
 	}
 	if cfg.HTTP2ReadIdleTimeout != 0 {

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -182,7 +182,7 @@ func TestValidate(t *testing.T) {
 					Endpoint:             "endpoint",
 					Compression:          "gzip",
 					Auth:                 someAuth,
-					Headers:              map[string]configopaque.String{"key": "val"},
+					Headers:              configopaque.MapListFromMap(map[string]configopaque.String{"key": "val"}),
 					HTTP2ReadIdleTimeout: 250,
 					HTTP2PingTimeout:     200,
 				},

--- a/receiver/elasticsearchreceiver/config_test.go
+++ b/receiver/elasticsearchreceiver/config_test.go
@@ -174,7 +174,7 @@ func TestLoadConfig(t *testing.T) {
 					client := confighttp.NewDefaultClientConfig()
 					client.Timeout = 10000000000
 					client.Endpoint = "http://example.com:9200"
-					client.Headers = map[string]configopaque.String{}
+					client.Headers = new(configopaque.MapList)
 					return client
 				}(),
 			},

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -305,7 +305,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 			}
 
 			// Add headers to the request
-			for key, value := range h.cfg.Targets[targetIndex].Headers {
+			for key, value := range h.cfg.Targets[targetIndex].Headers.Iter {
 				req.Header.Set(key, value.String()) // Convert configopaque.String to string
 			}
 

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -688,10 +688,10 @@ func TestRequestBodyWithCustomHeaders(t *testing.T) {
 		{
 			ClientConfig: confighttp.ClientConfig{
 				Endpoint: server.URL,
-				Headers: map[string]configopaque.String{
+				Headers: configopaque.MapListFromMap(map[string]configopaque.String{
 					"Content-Type":    configopaque.String("application/custom+json"),
 					"X-Custom-Header": configopaque.String("custom-value"),
-				},
+				}),
 			},
 			Method: "POST",
 			Body:   `{"data": "test"}`,

--- a/receiver/splunkenterprisereceiver/factory.go
+++ b/receiver/splunkenterprisereceiver/factory.go
@@ -26,8 +26,8 @@ const (
 func createDefaultConfig() component.Config {
 	// Default HttpClient settings
 	httpCfg := confighttp.NewDefaultClientConfig()
-	httpCfg.Headers = map[string]configopaque.String{
-		"Content-Type": "application/x-www-form-urlencoded",
+	httpCfg.Headers = &configopaque.MapList{
+		configopaque.OpaquePair{Name: "Content-Type", Value: "application/x-www-form-urlencoded"},
 	}
 	httpCfg.Timeout = defaultMaxSearchWaitTime
 

--- a/receiver/splunkenterprisereceiver/factory_test.go
+++ b/receiver/splunkenterprisereceiver/factory_test.go
@@ -24,9 +24,9 @@ func TestFactoryCreate(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := confighttp.NewDefaultClientConfig()
-	cfg.Headers = map[string]configopaque.String{
+	cfg.Headers = configopaque.MapListFromMap(map[string]configopaque.String{
 		"Content-Type": "application/x-www-form-urlencoded",
-	}
+	})
 	cfg.Timeout = 60 * time.Second
 
 	expectedConf := &Config{


### PR DESCRIPTION
#### Description

Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/13996, which introduces a breaking change in configgrpc and confighttp.
