### PR TITLE
[chore] Remove deprecated macos-13 runner, Add macos-14 runner

### DIFF
--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-15-intel]
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15-intel]
+        os: [macos-14]
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
#### Description

Similarly done in the past, see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/38337

Ref: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
n/a

<!--Describe what testing was performed and which tests were added.-->
#### Testing
n/a

<!--Describe the documentation added.-->
#### Documentation
n/a
<!--Please delete paragraphs that you did not use before submitting.-->
