### PR TITLE
[chore] Pass runCtx into supervisor Health check test

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2189,6 +2189,7 @@ func TestSupervisor_HealthCheckServer(t *testing.T) {
 
 	t.Run("Health check server errors out if port is in-use", func(t *testing.T) {
 		newSupervisor := &Supervisor{
+			runCtx:            t.Context(),
 			telemetrySettings: newNopTelemetrySettings(),
 			persistentState:   &persistentState{InstanceID: testUUID},
 			cfgState:          &atomic.Value{},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Without a valid `runCtx`, anything that attempts to use the context segfaults. In
https://github.com/open-telemetry/opentelemetry-collector/pull/14058 I am using the context, so this test borks. This adds the runCtx to fix it.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector/pull/14058

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
