### PR TITLE
[chore][ci-cd] Fix `mod-integration-test` target

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -167,7 +167,7 @@ INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES), $(shell cat $(INTEGRATION_T
 .PHONY: mod-integration-test
 mod-integration-test: $(GOTESTSUM)
 	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"
-	@if [ -n "$(INTEGRATION_TESTS)" ]; then \
+	if [ -n "$(INTEGRATION_TESTS)" ]; then \
 		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
 	else \
         echo "No integration tests in `pwd`"; \

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -163,11 +163,11 @@ ifneq (,$(wildcard ./builtunitetest.test))
 endif
 
 INTEGRATION_TEST_FILES := $(shell find . -name *integration_test.go)
-INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES), $(shell cat $(INTEGRATION_TEST_FILES) | sed -n "s/func \(Test[A-Za-z0-9_]*\).*/\1/p" | xargs | sed "s/ /|/g"))
+INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES),$(shell cat $(INTEGRATION_TEST_FILES) | sed -n "s/func \(Test[A-Za-z0-9_]*\).*/\1/p" | xargs | sed "s/ /|/g"))
 .PHONY: mod-integration-test
 mod-integration-test: $(GOTESTSUM)
-	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"
-	if [ -n "$(INTEGRATION_TESTS)" ]; then \
+	@echo "running $(GOCMD) integration test "$(INTEGRATION_TESTS)" in `pwd`"
+	@if [ -n "$(INTEGRATION_TESTS)" ]; then \
 		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
 	else \
         echo "No integration tests in `pwd`"; \

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -166,7 +166,7 @@ INTEGRATION_TEST_FILES := $(shell find . -name *integration_test.go)
 INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES),$(shell cat $(INTEGRATION_TEST_FILES) | sed -n "s/func \(Test[A-Za-z0-9_]*\).*/\1/p" | xargs | sed "s/ /|/g"))
 .PHONY: mod-integration-test
 mod-integration-test: $(GOTESTSUM)
-	@echo "running $(GOCMD) integration test "$(INTEGRATION_TESTS)" in `pwd`"
+	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"
 	@if [ -n "$(INTEGRATION_TESTS)" ]; then \
 		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
 	else \


### PR DESCRIPTION
Thanks to @jkoronaAtCisco for calling my attention to this issue.

The expression building the name of the tests has an extra white-space and this caused the integration tests to not run the first integration test captured in the expression. For packages with a single integration test this means that they didn't run at all since the issue was introduced. It is possible that with this fix some integration test surface.

The issue is just an extra space in the make file that should be removed.
