### PR TITLE
[connector/spanmetrics] move `useSecondAsDefaultMetricsUnit` and `excludeResourceMetrics` feature-gate to beta

### DIFF
--- a/.chloggen/move-spanmetrics-flag-to-beta.yaml
+++ b/.chloggen/move-spanmetrics-flag-to-beta.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/spanmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: move feature gate `useSecondAsDefaultMetricsUnit` and `excludeResourceMetrics` to beta.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43713]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: more detail information please see https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.137.0.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/move-spanmetrics-flag-to-beta.yaml
+++ b/.chloggen/move-spanmetrics-flag-to-beta.yaml
@@ -15,7 +15,10 @@ issues: [43713]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: more detail information please see https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.137.0.
+subtext: |
+  More detail information please see https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.137.0.
+  Existing users who want to retain resource attributes in the generated metrics can use the `add_resource_attributes` configuration option,
+  see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43394 for more detail.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -52,13 +52,13 @@ func init() {
 	)
 	useSecondAsDefaultMetricsUnit = featuregate.GlobalRegistry().MustRegister(
 		useSecondAsDefaultMetricsUnitFeatureGateID,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, connector use second as default unit for duration metrics."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42462"),
 	)
 	excludeResourceMetrics = featuregate.GlobalRegistry().MustRegister(
 		excludeResourceMetricsFeatureGate,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("When enabled, connector will exclude all resource attributes."),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42103"),
 	)


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
See https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.137.0 for more detail.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43713