### PR TITLE
[chore] Fix stall in Datadog connector after downstream error

### DIFF
--- a/.chloggen/connector-dont-bail-on-downstream-error.yaml
+++ b/.chloggen/connector-dont-bail-on-downstream-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/datadogconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Datadog connector no longer stalls after a downstream component errors
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/connector-dont-bail-on-downstream-error.yaml
+++ b/.chloggen/connector-dont-bail-on-downstream-error.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: connector/datadogconnector
+component: connector/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Datadog connector no longer stalls after a downstream component errors

--- a/connector/datadogconnector/connector_native.go
+++ b/connector/datadogconnector/connector_native.go
@@ -201,7 +201,7 @@ func (c *traceToMetricConnectorNative) run() {
 			// send metrics to the consumer or next component in pipeline
 			if err := c.metricsConsumer.ConsumeMetrics(ctx, mx); err != nil {
 				c.logger.Error("Failed ConsumeMetrics", zap.Error(err))
-				return
+				continue
 			}
 		case <-c.exit:
 			return


### PR DESCRIPTION
#### Description

Single line change to avoid bailing out of the forwarding goroutine after receiving an error from the downstream consumer, with accompanying regression test.

#### Link to tracking issue
Fixes #43661
