### PR TITLE
feat: CloudTrail digest file support

### DIFF
--- a/.chloggen/feat_cloudtrail-digest-file-support.yaml
+++ b/.chloggen/feat_cloudtrail-digest-file-support.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awslogs_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhance CloudTrail log parsing by adding support for digest files
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43403]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/encoding/awslogsencodingextension/README.md
+++ b/extension/encoding/awslogsencodingextension/README.md
@@ -258,11 +258,18 @@ If you're using the old format values you should update the encoding extension c
 | `challengeResponse`           | _Currently not supported_                                                                        |
 | `oversizeFields`              | _Currently not supported_                                                                        |
 
-### CloudTrail log record fields
+### CloudTrail record fields
 
-[CloudTrail log record fields](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html) are mapped this way in the resulting OpenTelemetry log:
+Processed CloudTrail records come in two formats,
 
-| CloudTrail field                                          | Attribute in OpenTelemetry log                                            |
+- CloudTrail event records
+- CloudTrail digest record
+
+#### CloudTrail event records
+
+[CloudTrail event records](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-record-contents.html) get mapped with following attributes in the resulting OpenTelemetry log:
+
+| CloudTrail event field                                    | Attribute in OpenTelemetry log                                            |
 |-----------------------------------------------------------|---------------------------------------------------------------------------|
 | `apiVersion`                                              | `aws.cloudtrail.api_version`                                              |
 | `eventID`                                                 | `aws.cloudtrail.event_id`                                                 |
@@ -306,6 +313,24 @@ If you're using the old format values you should update the encoding extension c
 | `userIdentity.sessionContext.sessionIssuer.arn`           | `aws.user_identity.session_context.issuer.arn`                            |
 | `userIdentity.sessionContext.sessionIssuer.accountId`     | `aws.user_identity.session_context.issuer.account_id`                     |
 | `userIdentity.sessionContext.sessionIssuer.userName`      | `aws.user_identity.session_context.issuer.user_name`                      |
+
+#### CloudTrail digest record
+
+[CloudTrail digest record](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-digest-file-structure.html) get mapped with following attributes in the resulting OpenTelemetry log:
+
+| CloudTrail digest field  | Attribute in OpenTelemetry log                    |
+|--------------------------|---------------------------------------------------|
+| awsAccountId             | cloud.account.id                                  |
+| digestS3Bucket           | aws.cloudtrail.digest.s3_bucket                   |
+| digestS3Object           | aws.cloudtrail.digest.s3_object                   |
+| newestEventTime          | aws.cloudtrail.digest.newest_event                |
+| oldestEventTime          | aws.cloudtrail.digest.oldest_event                |
+| previousDigestS3Bucket   | aws.cloudtrail.digest.previous_s3_bucket          |
+| previousDigestS3Object   | aws.cloudtrail.digest.previous_s3_object          |
+| logFiles.s3Bucket        | aws.cloudtrail.digest.log_files.s3_bucket         |
+| logFiles.s3Object        | aws.cloudtrail.digest.log_files.s3_bucket         |
+| logFiles.newestEventTime | aws.cloudtrail.digest.log_files.newest_event_time |
+| logFiles.oldestEventTime | aws.cloudtrail.digest.log_files.oldest_event_time |
 
 All request parameters and response elements are included directly as nested maps in the attributes, preserving their original structure.
 

--- a/extension/encoding/awslogsencodingextension/README.md
+++ b/extension/encoding/awslogsencodingextension/README.md
@@ -321,6 +321,7 @@ Processed CloudTrail records come in two formats,
 | CloudTrail digest field  | Attribute in OpenTelemetry log                    |
 |--------------------------|---------------------------------------------------|
 | awsAccountId             | cloud.account.id                                  |
+| digestEndTime            | aws.cloudtrail.digest.end_time                    |
 | digestS3Bucket           | aws.cloudtrail.digest.s3_bucket                   |
 | digestS3Object           | aws.cloudtrail.digest.s3_object                   |
 | newestEventTime          | aws.cloudtrail.digest.newest_event                |
@@ -331,6 +332,15 @@ Processed CloudTrail records come in two formats,
 | logFiles.s3Object        | aws.cloudtrail.digest.log_files.s3_bucket         |
 | logFiles.newestEventTime | aws.cloudtrail.digest.log_files.newest_event_time |
 | logFiles.oldestEventTime | aws.cloudtrail.digest.log_files.oldest_event_time |
+
+Following fields are not included in the derived OpenTelemetry log:
+- digestPublicKeyFingerprint
+- digestSignatureAlgorithm
+- previousDigestHashValue
+- previousDigestHashAlgorithm
+- previousDigestSignature
+- logFiles.hashValue
+- logFiles.hashAlgorithm
 
 All request parameters and response elements are included directly as nested maps in the attributes, preserving their original structure.
 

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest.json
@@ -1,0 +1,26 @@
+{
+  "awsAccountId": "111122223333",
+  "digestStartTime": "2025-10-21T00:00:00Z",
+  "digestEndTime": "2025-10-21T01:00:00Z",
+  "digestS3Bucket": "amzn-s3-demo-bucket",
+  "digestS3Object": "AWSLogs/111122223333/CloudTrail-Digest/us-east-1/2025/10/21/digest.json.gz",
+  "digestPublicKeyFingerprint": "31e8b5433410dfb61a9dc45cc65b22ff",
+  "digestSignatureAlgorithm": "SHA256withRSA",
+  "newestEventTime": "2025-10-21T00:59:58Z",
+  "oldestEventTime": "2025-10-21T00:00:01Z",
+  "previousDigestS3Bucket": "amzn-s3-demo-bucket",
+  "previousDigestS3Object": "AWSLogs/123456789012/CloudTrail-Digest/us-east-1/2025/10/21/digest-previous.json.gz",
+  "previousDigestHashValue": "97fb791cf91ffc440d274f8190dbdd9aa09c34432aba82739df18b6d3c13df2d",
+  "previousDigestHashAlgorithm": "SHA-256",
+  "previousDigestSignature": "hash-of-previous-digest",
+  "logFiles": [
+    {
+      "s3Bucket": "amzn-s3-demo-bucket",
+      "s3Object": "AWSLogs/123456789012/CloudTrail/us-east-1/2025/10/21/obj1.json.gz",
+      "hashValue": "7aab8a1f04f32adf1113c9acdd894f10a2b5fa4039fcb4dd1cbd40b13e482b8a",
+      "hashAlgorithm": "SHA-256",
+      "newestEventTime": "2025-10-21TT00:52:27Z",
+      "oldestEventTime": "2025-10-21TT00:42:27Z"
+    }
+  ]
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty.json
@@ -1,0 +1,17 @@
+{
+  "awsAccountId": "111122223333",
+  "digestStartTime": "2015-08-20T17:01:31Z",
+  "digestEndTime": "2015-08-20T18:01:31Z",
+  "digestS3Bucket": "amzn-s3-demo-bucket",
+  "digestS3Object": "AWSLogs/111122223333/CloudTrail-Digest/us-east-2/2015/08/20/111122223333_CloudTrail-Digest_us-east-2_example-trail-name_us-east-2_20150820T180131Z.json.gz",
+  "digestPublicKeyFingerprint": "31e8b5433410dfb61a9dc45cc65b22ff",
+  "digestSignatureAlgorithm": "SHA256withRSA",
+  "newestEventTime": null,
+  "oldestEventTime": null,
+  "previousDigestS3Bucket": "amzn-s3-demo-bucket",
+  "previousDigestS3Object": "AWSLogs/111122223333/CloudTrail-Digest/us-east-2/2015/08/20/111122223333_CloudTrail-Digest_us-east-2_example-trail-name_us-east-2_20150820T170131Z.json.gz",
+  "previousDigestHashValue": "ed96c4bac9eaa8fe9716ca0e515da51938be651b1db31d781956416a9d05cdfa",
+  "previousDigestHashAlgorithm": "SHA-256",
+  "previousDigestSignature": "82705525fb0fe7f919f9434e5b7138cb41793c776c7414f3520c0242902daa8cc8286b29263d2627f2f259471c745b1654af76e2073264b2510fd45236b3aea4d80c0e8e6455223d7bd54ff80af0edf22a5f14fa856626daec919f0591479aa4f213787ba1e1076328dcf8ff624e03a977fa5612dcf58594c590fd8c1c5b48bddf43fc84ecc00b41bedd0ff7f293c3e2de8dcdc78f98b03e17577f5822ba842399d69eb79921c0429773509520e08c8b518702d987dfbb3a4e5d8c5f17673ce1f989dfff82d4becf24e452f20d3bcac94ad50131f93e57f10155536acb54c60efbe9d57228c2b930bc6082b2318e3ccd36834a8e835b8d112dbf32145f445c11",
+  "logFiles": []
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty_expected.yaml
@@ -1,0 +1,29 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: cloud.account.id
+                value:
+                  stringValue: "111122223333"
+              - key: aws.cloudtrail.digest.s3_bucket
+                value:
+                  stringValue: amzn-s3-demo-bucket
+              - key: aws.cloudtrail.digest.s3_object
+                value:
+                  stringValue: AWSLogs/111122223333/CloudTrail-Digest/us-east-2/2015/08/20/111122223333_CloudTrail-Digest_us-east-2_example-trail-name_us-east-2_20150820T180131Z.json.gz
+              - key: aws.cloudtrail.digest.previous_s3_bucket
+                value:
+                  stringValue: amzn-s3-demo-bucket
+              - key: aws.cloudtrail.digest.previous_s3_object
+                value:
+                  stringValue: AWSLogs/111122223333/CloudTrail-Digest/us-east-2/2015/08/20/111122223333_CloudTrail-Digest_us-east-2_example-trail-name_us-east-2_20150820T170131Z.json.gz
+            body: {}
+            timeUnixNano: "1440090091000000000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: aws.cloudtrail
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
+          version: test-version

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_empty_expected.yaml
@@ -6,6 +6,9 @@ resourceLogs:
               - key: cloud.account.id
                 value:
                   stringValue: "111122223333"
+              - key: aws.cloudtrail.digest.end_time
+                value:
+                  stringValue: "2015-08-20T18:01:31Z"
               - key: aws.cloudtrail.digest.s3_bucket
                 value:
                   stringValue: amzn-s3-demo-bucket

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_expected.yaml
@@ -6,6 +6,9 @@ resourceLogs:
               - key: cloud.account.id
                 value:
                   stringValue: "111122223333"
+              - key: aws.cloudtrail.digest.end_time
+                value:
+                  stringValue: "2025-10-21T01:00:00Z"
               - key: aws.cloudtrail.digest.s3_bucket
                 value:
                   stringValue: amzn-s3-demo-bucket

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/testdata/cloudtrail_digest_expected.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: cloud.account.id
+                value:
+                  stringValue: "111122223333"
+              - key: aws.cloudtrail.digest.s3_bucket
+                value:
+                  stringValue: amzn-s3-demo-bucket
+              - key: aws.cloudtrail.digest.s3_object
+                value:
+                  stringValue: AWSLogs/111122223333/CloudTrail-Digest/us-east-1/2025/10/21/digest.json.gz
+              - key: aws.cloudtrail.digest.newest_event
+                value:
+                  stringValue: "2025-10-21T00:59:58Z"
+              - key: aws.cloudtrail.digest.oldest_event
+                value:
+                  stringValue: "2025-10-21T00:00:01Z"
+              - key: aws.cloudtrail.digest.previous_s3_bucket
+                value:
+                  stringValue: amzn-s3-demo-bucket
+              - key: aws.cloudtrail.digest.previous_s3_object
+                value:
+                  stringValue: AWSLogs/123456789012/CloudTrail-Digest/us-east-1/2025/10/21/digest-previous.json.gz
+              - key: aws.cloudtrail.digest.log_files
+                value:
+                  arrayValue:
+                    values:
+                      - kvlistValue:
+                          values:
+                            - key: s3_bucket
+                              value:
+                                stringValue: amzn-s3-demo-bucket
+                            - key: s3_object
+                              value:
+                                stringValue: AWSLogs/123456789012/CloudTrail/us-east-1/2025/10/21/obj1.json.gz
+                            - key: newest_event_time
+                              value:
+                                stringValue: 2025-10-21TT00:52:27Z
+                            - key: oldest_event_time
+                              value:
+                                stringValue: 2025-10-21TT00:42:27Z
+            body: {}
+            timeUnixNano: "1761004800000000000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: aws.cloudtrail
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
+          version: test-version

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
@@ -151,7 +151,7 @@ func (u *CloudTrailLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs
 		return plog.Logs{}, fmt.Errorf("failed to unmarshal payload as CloudTrail logs: %w", err)
 	}
 
-	if len(cloudTrailLog.Records) > 0 {
+	if cloudTrailLog.Records != nil {
 		return u.processRecords(cloudTrailLog.Records)
 	}
 

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
@@ -148,7 +148,7 @@ func (u *CloudTrailLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs
 
 	var cloudTrailLog CloudTrailLog
 	if err := gojson.Unmarshal(decompressedBuf, &cloudTrailLog); err != nil {
-		return plog.Logs{}, fmt.Errorf("failed to unmarshal payload as a CloudTrail logs: %w", err)
+		return plog.Logs{}, fmt.Errorf("failed to unmarshal payload as CloudTrail logs: %w", err)
 	}
 
 	if len(cloudTrailLog.Records) > 0 {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
@@ -207,6 +207,7 @@ func (u *CloudTrailLogUnmarshaler) processDigestRecord(record CloudTrailDigest) 
 
 	attributes := logRecord.Attributes()
 	attributes.PutStr(string(conventions.CloudAccountIDKey), record.AWSAccountID)
+	attributes.PutStr("aws.cloudtrail.digest.end_time", record.DigestEndTime)
 	attributes.PutStr("aws.cloudtrail.digest.s3_bucket", record.DigestS3Bucket)
 	attributes.PutStr("aws.cloudtrail.digest.s3_object", record.DigestS3Object)
 

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler.go
@@ -108,6 +108,28 @@ type CloudTrailRecord struct {
 	SharedEventID                string         `json:"sharedEventID"`
 }
 
+// logFiles represents log file information in a CloudTrail digest file
+type logFiles struct {
+	S3Bucket        string `json:"s3Bucket"`
+	S3Object        string `json:"s3Object"`
+	NewestEventTime string `json:"newestEventTime"`
+	OldestEventTime string `json:"oldestEventTime"`
+}
+
+// CloudTrailDigest represents a CloudTrail digest file
+type CloudTrailDigest struct {
+	AWSAccountID           string     `json:"awsAccountId"`
+	DigestStartTime        string     `json:"digestStartTime"`
+	DigestEndTime          string     `json:"digestEndTime"`
+	DigestS3Bucket         string     `json:"digestS3Bucket"`
+	DigestS3Object         string     `json:"digestS3Object"`
+	NewestEventTime        string     `json:"newestEventTime"`
+	OldestEventTime        string     `json:"oldestEventTime"`
+	PreviousDigestS3Bucket string     `json:"previousDigestS3Bucket"`
+	PreviousDigestS3Object string     `json:"previousDigestS3Object"`
+	LogFiles               []logFiles `json:"logFiles"`
+}
+
 type CloudTrailLog struct {
 	Records []CloudTrailRecord `json:"Records"`
 }
@@ -126,10 +148,20 @@ func (u *CloudTrailLogUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs
 
 	var cloudTrailLog CloudTrailLog
 	if err := gojson.Unmarshal(decompressedBuf, &cloudTrailLog); err != nil {
-		return plog.Logs{}, fmt.Errorf("failed to unmarshal CloudTrail logs: %w", err)
+		return plog.Logs{}, fmt.Errorf("failed to unmarshal payload as a CloudTrail logs: %w", err)
 	}
 
-	return u.processRecords(cloudTrailLog.Records)
+	if len(cloudTrailLog.Records) > 0 {
+		return u.processRecords(cloudTrailLog.Records)
+	}
+
+	// Try to parse as a CloudTrail digest record
+	var cloudTrailDigest CloudTrailDigest
+	if err := gojson.Unmarshal(decompressedBuf, &cloudTrailDigest); err != nil {
+		return plog.Logs{}, fmt.Errorf("failed to unmarshal payload as a CloudTrail digest: %w", err)
+	}
+
+	return u.processDigestRecord(cloudTrailDigest)
 }
 
 func (u *CloudTrailLogUnmarshaler) processRecords(records []CloudTrailRecord) (plog.Logs, error) {
@@ -142,9 +174,7 @@ func (u *CloudTrailLogUnmarshaler) processRecords(records []CloudTrailRecord) (p
 	// Create a single resource logs entry for all records
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
-	scopeLogs.Scope().SetName(metadata.ScopeName)
-	scopeLogs.Scope().SetVersion(u.buildInfo.Version)
-	scopeLogs.Scope().Attributes().PutStr(constants.FormatIdentificationTag, "aws."+constants.FormatCloudTrailLog)
+	u.setCommonScopeAttributes(scopeLogs)
 
 	// Set resource attributes based on the first record
 	// (all records have the same account ID and region)
@@ -159,6 +189,62 @@ func (u *CloudTrailLogUnmarshaler) processRecords(records []CloudTrailRecord) (p
 	}
 
 	return logs, nil
+}
+
+func (u *CloudTrailLogUnmarshaler) processDigestRecord(record CloudTrailDigest) (plog.Logs, error) {
+	logs := plog.NewLogs()
+
+	resourceLog := logs.ResourceLogs().AppendEmpty()
+	scopeLog := resourceLog.ScopeLogs().AppendEmpty()
+	u.setCommonScopeAttributes(scopeLog)
+
+	logRecord := scopeLog.LogRecords().AppendEmpty()
+	t, err := time.Parse(time.RFC3339, record.DigestStartTime)
+	if err != nil {
+		return plog.Logs{}, fmt.Errorf("failed to parse start time: %w", err)
+	}
+	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(t))
+
+	attributes := logRecord.Attributes()
+	attributes.PutStr(string(conventions.CloudAccountIDKey), record.AWSAccountID)
+	attributes.PutStr("aws.cloudtrail.digest.s3_bucket", record.DigestS3Bucket)
+	attributes.PutStr("aws.cloudtrail.digest.s3_object", record.DigestS3Object)
+
+	// following attributes may be empty (null)
+	if record.NewestEventTime != "" {
+		attributes.PutStr("aws.cloudtrail.digest.newest_event", record.NewestEventTime)
+	}
+
+	if record.OldestEventTime != "" {
+		attributes.PutStr("aws.cloudtrail.digest.oldest_event", record.OldestEventTime)
+	}
+
+	if record.PreviousDigestS3Bucket != "" {
+		attributes.PutStr("aws.cloudtrail.digest.previous_s3_bucket", record.PreviousDigestS3Bucket)
+	}
+
+	if record.PreviousDigestS3Object != "" {
+		attributes.PutStr("aws.cloudtrail.digest.previous_s3_object", record.PreviousDigestS3Object)
+	}
+
+	if len(record.LogFiles) > 0 {
+		logFilesArray := attributes.PutEmptySlice("aws.cloudtrail.digest.log_files")
+		for _, logFile := range record.LogFiles {
+			logFileMap := logFilesArray.AppendEmpty().SetEmptyMap()
+			logFileMap.PutStr("s3_bucket", logFile.S3Bucket)
+			logFileMap.PutStr("s3_object", logFile.S3Object)
+			logFileMap.PutStr("newest_event_time", logFile.NewestEventTime)
+			logFileMap.PutStr("oldest_event_time", logFile.OldestEventTime)
+		}
+	}
+
+	return logs, nil
+}
+
+func (u *CloudTrailLogUnmarshaler) setCommonScopeAttributes(scope plog.ScopeLogs) {
+	scope.Scope().SetName(metadata.ScopeName)
+	scope.Scope().SetVersion(u.buildInfo.Version)
+	scope.Scope().Attributes().PutStr(constants.FormatIdentificationTag, "aws."+constants.FormatCloudTrailLog)
 }
 
 func (*CloudTrailLogUnmarshaler) setResourceAttributes(attrs pcommon.Map, record CloudTrailRecord) {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
@@ -96,7 +96,7 @@ func TestCloudTrailLogUnmarshaler_UnmarshalAWSLogs_InvalidJSON(t *testing.T) {
 	unmarshaler := NewCloudTrailLogUnmarshaler(component.BuildInfo{Version: "test-version"})
 	reader := bytes.NewReader([]byte(`{invalid-json}`))
 	_, err := unmarshaler.UnmarshalAWSLogs(reader)
-	require.ErrorContains(t, err, "failed to unmarshal CloudTrail logs")
+	require.ErrorContains(t, err, "failed to unmarshal payload as CloudTrail logs")
 }
 
 func TestCloudTrailLogUnmarshaler_UnmarshalAWSLogs_InvalidTimestamp(t *testing.T) {

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/cloudtraillog/unmarshaler_test.go
@@ -40,6 +40,26 @@ func TestCloudTrailLogUnmarshaler_UnmarshalAWSLogs_Valid(t *testing.T) {
 	require.NoError(t, plogtest.CompareLogs(expectedLogs, logs, compareOptions...))
 }
 
+func TestCloudtrailLogUnmarshaler_UnmarshalAWSDigest_valid(t *testing.T) {
+	t.Parallel()
+	unmarshaler := NewCloudTrailLogUnmarshaler(component.BuildInfo{Version: "test-version"})
+
+	content := readLogFile(t, filesDirectory, "cloudtrail_digest.json")
+	logs, err := unmarshaler.UnmarshalAWSLogs(content)
+	require.NoError(t, err)
+
+	expectedLogs, err := golden.ReadLogs(filepath.Join(filesDirectory, "cloudtrail_digest_expected.yaml"))
+	require.NoError(t, err)
+
+	compareLogsOptions := []plogtest.CompareLogsOption{
+		plogtest.IgnoreResourceLogsOrder(),
+		plogtest.IgnoreScopeLogsOrder(),
+		plogtest.IgnoreLogRecordsOrder(),
+	}
+
+	require.NoError(t, plogtest.CompareLogs(expectedLogs, logs, compareLogsOptions...))
+}
+
 func TestCloudTrailLogUnmarshaler_UnmarshalAWSLogs_EmptyRecords(t *testing.T) {
 	t.Parallel()
 	unmarshaler := NewCloudTrailLogUnmarshaler(component.BuildInfo{Version: "test-version"})


### PR DESCRIPTION
#### Description

Adds support to the parsing of CloudTrail digest log [^1] through CloudTrail unmarshaler. 

Table below highlight the digest fields to OTel log attributed mapping (extracted from updated documentation),

| CloudTrail digest field  | Attribute in OpenTelemetry log                    |
|--------------------------|---------------------------------------------------|
| awsAccountId             | cloud.account.id                                  |
| digestEndTime            | aws.cloudtrail.digest.end_time                    |
| digestS3Bucket           | aws.cloudtrail.digest.s3_bucket                   |
| digestS3Object           | aws.cloudtrail.digest.s3_object                   |
| newestEventTime          | aws.cloudtrail.digest.newest_event                |
| oldestEventTime          | aws.cloudtrail.digest.oldest_event                |
| previousDigestS3Bucket   | aws.cloudtrail.digest.previous_s3_bucket          |
| previousDigestS3Object   | aws.cloudtrail.digest.previous_s3_object          |
| logFiles.s3Bucket        | aws.cloudtrail.digest.log_files.s3_bucket         |
| logFiles.s3Object        | aws.cloudtrail.digest.log_files.s3_bucket         |
| logFiles.newestEventTime | aws.cloudtrail.digest.log_files.newest_event_time |
| logFiles.oldestEventTime | aws.cloudtrail.digest.log_files.oldest_event_time |

Note that I have not included the digest signature, algorithm, and related hash values, given usage of these requires extra metadata that's only present at the S3 object [^2]. But having unmarshaled digest file information (ex:- bucket, object and timing) allows consuming system to implement custom validation workflows. 

`DigestStartTime` is used as the log record timestamp. 

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43403

#### Testing

I have added unit tests for the digest file parsing

#### Documentation

I have updated the documentation with the resulting fields

[^1]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-validation-digest-file-structure.html
[^2]: https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-log-file-custom-validation.html