### PR TITLE
[elasticsearchexporter] Support escape_html parameter when encoding document

### DIFF
--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -268,6 +268,9 @@ type MappingsSettings struct {
 	// If unspecified, all mapping modes are allowed.
 	AllowedModes []string `mapstructure:"allowed_modes"`
 
+	// Configures escaping of HTML strings
+	EsacpeHTML bool `mapstructure:"escape_html"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -122,6 +122,7 @@ func (e *elasticsearchExporter) pushLogsData(ctx context.Context, ld plog.Logs) 
 				resourceSchemaURL: rl.SchemaUrl(),
 				scope:             scope,
 				scopeSchemaURL:    ill.SchemaUrl(),
+				escapeHTML:        e.config.Mapping.EsacpeHTML,
 			}
 
 			for _, lr := range ill.LogRecords().All() {

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -291,9 +291,10 @@ func newJSONVisitor(w io.Writer) *json.Visitor {
 // Serialize writes the document to the given writer. The document fields will be
 // deduplicated and, if dedot is true, turned into nested objects prior to
 // serialization.
-func (doc *Document) Serialize(w io.Writer, dedot bool) error {
+func (doc *Document) Serialize(w io.Writer, dedot bool, escapeHTML bool) error {
 	doc.Dedup()
 	v := newJSONVisitor(w)
+	v.SetEscapeHTML(escapeHTML)
 	return doc.iterJSON(v, dedot)
 }
 

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -283,7 +283,7 @@ func TestDocument_Serialize_Flat(t *testing.T) {
 			assert.NoError(t, m.FromRaw(test.attrs))
 			doc := DocumentFromAttributes(m)
 			doc.Dedup()
-			err := doc.Serialize(&buf, false)
+			err := doc.Serialize(&buf, false, false)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.want, buf.String())
@@ -344,7 +344,7 @@ func TestDocument_Serialize_Dedot(t *testing.T) {
 			assert.NoError(t, m.FromRaw(test.attrs))
 			doc := DocumentFromAttributes(m)
 			doc.Dedup()
-			err := doc.Serialize(&buf, true)
+			err := doc.Serialize(&buf, true, false)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.want, buf.String())

--- a/exporter/elasticsearchexporter/internal/serializer/map.go
+++ b/exporter/elasticsearchexporter/internal/serializer/map.go
@@ -12,11 +12,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-func Map(m pcommon.Map, buf *bytes.Buffer) {
+func Map(m pcommon.Map, buf *bytes.Buffer, escapeHTML bool) {
 	v := json.NewVisitor(buf)
 	// Enable ExplicitRadixPoint such that 1.0 is encoded as 1.0 instead of 1.
 	// This is required to generate the correct dynamic mapping in ES.
 	v.SetExplicitRadixPoint(true)
+	v.SetEscapeHTML(escapeHTML)
 	writeMap(v, m, false)
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds `mapping.escape_html` options which if enabled will esacpe HTML strings. This is important to allow escaping embedded (potentially malicious) HTML scripts in a JSON body. It is also required to be compatible with `elasticsearch` options [Ref](https://www.elastic.co/docs/reference/fleet/elasticsearch-output#output-elasticsearch-data-parsing-settings)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation
TODO

<!--Please delete paragraphs that you did not use before submitting.-->
