### PR TITLE
[connector/datadog] Add NewFactoryForAgent constructor

### DIFF
--- a/.chloggen/connector-dont-bail-on-downstream-error.yaml
+++ b/.chloggen/connector-dont-bail-on-downstream-error.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: connector/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add "NewFactoryForAgent" to support additional tagging and hostname functionality in DDOT, as well as injecting shared components into the connector.
+note: Datadog connector no longer stalls after a downstream component errors
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [43755]

--- a/.chloggen/ibraheem_update-ddconnector-for-ddot.yaml
+++ b/.chloggen/ibraheem_update-ddconnector-for-ddot.yaml
@@ -12,7 +12,7 @@ note: |
   Bugfix: Datadog connector no longer stalls after a downstream component errors
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [43755]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ibraheem_update-ddconnector-for-ddot.yaml
+++ b/.chloggen/ibraheem_update-ddconnector-for-ddot.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Add "NewFactoryForAgent" to support additional tagging and hostname functionality in DDOT, as well as injecting shared components into the connector.
+  Bugfix: Datadog connector no longer stalls after a downstream component errors
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/datadogconnector/benchmark_test.go
+++ b/connector/datadogconnector/benchmark_test.go
@@ -40,11 +40,7 @@ func genTrace() ptrace.Traces {
 	return traces
 }
 
-func BenchmarkPeerTags_Native(b *testing.B) {
-	benchmarkPeerTags(b)
-}
-
-func benchmarkPeerTags(b *testing.B) {
+func BenchmarkPeerTags(b *testing.B) {
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
 	cfg.Traces.ComputeStatsBySpanKind = true
 	cfg.Traces.PeerTagsAggregation = true

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -9,14 +9,14 @@ import (
 	"sync"
 	"time"
 
+	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/featuregates"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor"
-	"github.com/DataDog/datadog-agent/pkg/obfuscate"
-	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
-	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -24,12 +24,17 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap"
 
-	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/featuregates"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 )
 
-// traceToMetricConnectorNative is the schema for connector
-type traceToMetricConnectorNative struct {
+// traceToMetricConnector is the schema for connector
+type traceToMetricConnector struct {
 	metricsConsumer consumer.Metrics // the next component in the pipeline to ingest metrics after connector
 	logger          *zap.Logger
 
@@ -66,13 +71,12 @@ type traceToMetricConnectorNative struct {
 	isStarted bool
 }
 
-var _ component.Component = (*traceToMetricConnectorNative)(nil) // testing that the connectorImp properly implements the type Component interface
+var _ component.Component = (*traceToMetricConnector)(nil) // testing that the connectorImp properly implements the type Component interface
 
-// newTraceToMetricConnectorNative creates a new connector with native OTel span ingestion
-func newTraceToMetricConnectorNative(set component.TelemetrySettings, cfg component.Config, metricsConsumer consumer.Metrics, metricsClient statsd.ClientInterface) (*traceToMetricConnectorNative, error) {
+// newTraceToMetricConnector creates a new connector with native OTel span ingestion
+func newTraceToMetricConnector(set component.TelemetrySettings, cfg component.Config, metricsConsumer consumer.Metrics, metricsClient statsd.ClientInterface, concentrator *stats.Concentrator, tagger types.TaggerClient, hostnameOpt option.Option[string]) (*traceToMetricConnector, error) {
 	set.Logger.Info("Building datadog connector for traces to metrics")
 	statsout := make(chan *pb.StatsPayload, 100)
-	statsWriter := statsprocessor.NewOtelStatsWriter(statsout)
 	set.MeterProvider = noop.NewMeterProvider() // disable metrics for the connector
 	attributesTranslator, err := attributes.NewTranslator(set)
 	if err != nil {
@@ -83,18 +87,23 @@ func newTraceToMetricConnectorNative(set component.TelemetrySettings, cfg compon
 		return nil, fmt.Errorf("failed to create metrics translator: %w", err)
 	}
 
-	tcfg := getTraceAgentCfg(set.Logger, cfg.(*Config).Traces, attributesTranslator)
+	tcfg := getTraceAgentCfg(set.Logger, cfg.(*Config).Traces, attributesTranslator, tagger, hostnameOpt)
 	oconf := tcfg.Obfuscation.Export(tcfg)
 	oconf.Statsd = metricsClient
 	oconf.Redis.Enabled = true
 
-	return &traceToMetricConnectorNative{
+	if concentrator == nil {
+		statsWriter := statsprocessor.NewOtelStatsWriter(statsout)
+		concentrator = stats.NewConcentrator(tcfg, statsWriter, time.Now(), metricsClient)
+	}
+
+	return &traceToMetricConnector{
 		logger:          set.Logger,
 		translator:      trans,
 		tcfg:            tcfg,
 		ctagKeys:        cfg.(*Config).Traces.ResourceAttributesAsContainerTags,
 		peerTagKeys:     tcfg.ConfiguredPeerTags(),
-		concentrator:    stats.NewConcentrator(tcfg, statsWriter, time.Now(), metricsClient),
+		concentrator:    concentrator,
 		statsout:        statsout,
 		metricsConsumer: metricsConsumer,
 		obfuscator:      obfuscate.NewObfuscator(oconf),
@@ -102,19 +111,30 @@ func newTraceToMetricConnectorNative(set component.TelemetrySettings, cfg compon
 	}, nil
 }
 
-func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfig, attributesTranslator *attributes.Translator) *config.AgentConfig {
+func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfig, attributesTranslator *attributes.Translator, tagger types.TaggerClient, hostnameOpt option.Option[string]) *config.AgentConfig {
 	acfg := config.New()
 	acfg.OTLPReceiver.AttributesTranslator = attributesTranslator
 	acfg.OTLPReceiver.SpanNameRemappings = cfg.SpanNameRemappings
 	acfg.OTLPReceiver.SpanNameAsResourceName = cfg.SpanNameAsResourceName
+	acfg.OTLPReceiver.IgnoreMissingDatadogFields = cfg.IgnoreMissingDatadogFields
 	acfg.Ignore["resource"] = cfg.IgnoreResources
 	acfg.ComputeStatsBySpanKind = cfg.ComputeStatsBySpanKind
 	acfg.PeerTagsAggregation = cfg.PeerTagsAggregation
 	acfg.PeerTags = cfg.PeerTags
+
+	if hostname, found := hostnameOpt.Get(); found {
+		acfg.Hostname = hostname
+	}
+	if tagger != nil {
+		acfg.ContainerTags = func(cid string) ([]string, error) {
+			return tagger.Tag(types.NewEntityID(types.ContainerID, cid), types.HighCardinality)
+		}
+	}
 	if len(cfg.ResourceAttributesAsContainerTags) > 0 {
 		acfg.Features["enable_cid_stats"] = struct{}{}
 		delete(acfg.Features, "disable_cid_stats")
 	}
+
 	if v := cfg.TraceBuffer; v > 0 {
 		acfg.TraceBuffer = v
 	}
@@ -127,6 +147,8 @@ func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfi
 	}
 	if !featuregates.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 		acfg.Features["disable_operation_and_resource_name_logic_v2"] = struct{}{}
+	} else {
+		logger.Info("Please enable feature gate datadog.EnableOperationAndResourceNameV2 for improved operation and resource name logic. The v1 logic will be deprecated in the future - if you have Datadog monitors or alerts set on operation/resource names, you may need to migrate them to the new convention. See the migration guide at https://docs.datadoghq.com/opentelemetry/guide/migrate/migrate_operation_names/")
 	}
 	if v := cfg.BucketInterval; v > 0 {
 		acfg.BucketInterval = v
@@ -135,7 +157,7 @@ func getTraceAgentCfg(logger *zap.Logger, cfg datadogconfig.TracesConnectorConfi
 }
 
 // Start implements the component.Component interface.
-func (c *traceToMetricConnectorNative) Start(context.Context, component.Host) error {
+func (c *traceToMetricConnector) Start(context.Context, component.Host) error {
 	c.logger.Info("Starting datadogconnector")
 	c.concentrator.Start()
 	c.wg.Add(1)
@@ -145,7 +167,7 @@ func (c *traceToMetricConnectorNative) Start(context.Context, component.Host) er
 }
 
 // Shutdown implements the component.Component interface.
-func (c *traceToMetricConnectorNative) Shutdown(context.Context) error {
+func (c *traceToMetricConnector) Shutdown(context.Context) error {
 	if !c.isStarted {
 		// Note: it is not necessary to manually close c.exit, c.in and c.concentrator.exit channels as these are unused.
 		c.logger.Info("Requested shutdown, but not started, ignoring.")
@@ -163,11 +185,11 @@ func (c *traceToMetricConnectorNative) Shutdown(context.Context) error {
 
 // Capabilities implements the consumer interface.
 // tells use whether the component(connector) will mutate the data passed into it. if set to true the connector does modify the data
-func (*traceToMetricConnectorNative) Capabilities() consumer.Capabilities {
+func (*traceToMetricConnector) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (c *traceToMetricConnectorNative) ConsumeTraces(_ context.Context, traces ptrace.Traces) error {
+func (c *traceToMetricConnector) ConsumeTraces(_ context.Context, traces ptrace.Traces) error {
 	inputs := stats.OTLPTracesToConcentratorInputsWithObfuscation(traces, c.tcfg, c.ctagKeys, c.peerTagKeys, c.obfuscator)
 	for _, input := range inputs {
 		c.concentrator.Add(input)
@@ -177,7 +199,7 @@ func (c *traceToMetricConnectorNative) ConsumeTraces(_ context.Context, traces p
 
 // run awaits incoming stats resulting from the agent's ingestion, converts them
 // to metrics and flushes them using the configured metrics exporter.
-func (c *traceToMetricConnectorNative) run() {
+func (c *traceToMetricConnector) run() {
 	defer c.wg.Done()
 	for {
 		select {
@@ -201,7 +223,7 @@ func (c *traceToMetricConnectorNative) run() {
 			// send metrics to the consumer or next component in pipeline
 			if err := c.metricsConsumer.ConsumeMetrics(ctx, mx); err != nil {
 				c.logger.Error("Failed ConsumeMetrics", zap.Error(err))
-				return
+				continue
 			}
 		case <-c.exit:
 			return

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -9,14 +9,16 @@ import (
 	"sync"
 	"time"
 
-	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/featuregates"
-
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor"
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
+	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/stats"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-go/v5/statsd"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -24,13 +26,8 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap"
 
-	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics"
-
-	"github.com/DataDog/datadog-agent/pkg/obfuscate"
-	"github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes"
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/stats"
+	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/featuregates"
 )
 
 // traceToMetricConnector is the schema for connector

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -39,7 +39,7 @@ import (
 var _ component.Component = (*traceToMetricConnector)(nil) // testing that the connectorImp properly implements the type Component interface
 
 // create test to create a connector, check that basic code compiles
-func TestNewConnectorNative(t *testing.T) {
+func TestNewConnector(t *testing.T) {
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings(metadata.Type)
@@ -52,7 +52,7 @@ func TestNewConnectorNative(t *testing.T) {
 	assert.True(t, ok) // checks if the created connector implements the connectorImp struct
 }
 
-func TestTraceToTraceConnectorNative(t *testing.T) {
+func TestTraceToTraceConnector(t *testing.T) {
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings(metadata.Type)
@@ -167,7 +167,7 @@ func newTranslatorWithStatsChannel(t *testing.T, logger *zap.Logger, ch chan []b
 	return tr
 }
 
-func TestContainerTagsAndHostnameNative(t *testing.T) {
+func TestContainerTagsAndHostname(t *testing.T) {
 	connector, metricsSink := createConnector(t)
 	err := connector.Start(t.Context(), componenttest.NewNopHost())
 	if err != nil {
@@ -269,16 +269,16 @@ var (
 	testSpanID4 = [8]byte{4, 2, 3, 4, 5, 6, 7, 8}
 )
 
-func TestMeasuredAndClientKindNative(t *testing.T) {
+func TestMeasuredAndClientKind(t *testing.T) {
 	t.Run("OperationAndResourceNameV1", func(t *testing.T) {
-		testMeasuredAndClientKindNative(t, false)
+		testMeasuredAndClientKind(t, false)
 	})
 	t.Run("OperationAndResourceNameV2", func(t *testing.T) {
-		testMeasuredAndClientKindNative(t, true)
+		testMeasuredAndClientKind(t, true)
 	})
 }
 
-func testMeasuredAndClientKindNative(t *testing.T, enableOperationAndResourceNameV2 bool) {
+func testMeasuredAndClientKind(t *testing.T, enableOperationAndResourceNameV2 bool) {
 	if err := featuregate.GlobalRegistry().Set("datadog.EnableOperationAndResourceNameV2", enableOperationAndResourceNameV2); err != nil {
 		t.Fatal(err)
 	}

--- a/connector/datadogconnector/factory.go
+++ b/connector/datadogconnector/factory.go
@@ -10,10 +10,9 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
-
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient"
 	"github.com/DataDog/datadog-agent/pkg/trace/stats"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -3,13 +3,16 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/connector/datad
 go 1.24.0
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.72.0-rc.8
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/metrics v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/proto v0.72.0-rc.8
 	github.com/DataDog/datadog-agent/pkg/trace v0.72.0-rc.8
+	github.com/DataDog/datadog-agent/pkg/util/option v0.72.0-rc.8
 	github.com/DataDog/datadog-go/v5 v5.8.1
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.138.0
@@ -52,7 +55,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/status v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/def v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.72.0-rc.8 // indirect
-	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.72.0-rc.8 // indirect
@@ -117,7 +119,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/http v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/json v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.72.0-rc.8 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/option v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.72.0-rc.8 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/quantile v0.72.0-rc.8 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add "NewFactoryForAgent" to support additional tagging and hostname functionality in DDOT, as well as injecting shared components into the connector. Will be imported into datadog-agent in a followup PR.

