### PR TITLE
[extension/opamp] Use SetCapabilities() instead of Capabilities

### DIFF
--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -148,7 +148,6 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 			},
 			OnMessage: o.onMessage,
 		},
-		Capabilities: o.capabilities.toAgentCapabilities(),
 	}
 
 	if err := o.createAgentDescription(); err != nil {
@@ -170,6 +169,11 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 		if err := o.opampClient.SetAvailableComponents(o.availableComponents); err != nil {
 			return err
 		}
+	}
+
+	capabilities := o.capabilities.toAgentCapabilities()
+	if err := o.opampClient.SetCapabilities(&capabilities); err != nil {
+		return err
 	}
 
 	o.logger.Debug("Starting OpAMP client...")


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Sets the agent capabilities on the OpAMP client with `client.SetCapabilities()` instead of the deprecated `settings.Capabilities`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43763

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
