### PR TITLE
[extension/sumologic] move api and credentials packages to internal

### DIFF
--- a/.chloggen/sumologic_internal.yaml
+++ b/.chloggen/sumologic_internal.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/sumologic
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move api and credentials packages to internal
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43789]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -33,8 +33,8 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 )
 
 type SumologicExtension struct {

--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -23,8 +23,8 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/metadata"
 )
 

--- a/extension/sumologicextension/factory.go
+++ b/extension/sumologicextension/factory.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/metadata"
 )
 

--- a/extension/sumologicextension/factory_test.go
+++ b/extension/sumologicextension/factory_test.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/extension"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/extension/sumologicextension/internal/api/error.go
+++ b/extension/sumologicextension/internal/api/error.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
+package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
 
 type ErrorResponsePayload struct {
 	ID     string  `json:"id"`

--- a/extension/sumologicextension/internal/api/metadata.go
+++ b/extension/sumologicextension/internal/api/metadata.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
+package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
 
 type OpenMetadataHostDetails struct {
 	Name        string `json:"name"`

--- a/extension/sumologicextension/internal/api/register.go
+++ b/extension/sumologicextension/internal/api/register.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
+package api // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
 
 type OpenRegisterRequestPayload struct {
 	CollectorName string         `json:"collectorName"`

--- a/extension/sumologicextension/internal/credentials/credentialsstore_localfs.go
+++ b/extension/sumologicextension/internal/credentials/credentialsstore_localfs.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 
 import (
 	"encoding/json"

--- a/extension/sumologicextension/internal/credentials/credentialsstore_localfs_test.go
+++ b/extension/sumologicextension/internal/credentials/credentialsstore_localfs_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
 )
 
 func TestCredentialsStoreLocalFs(t *testing.T) {

--- a/extension/sumologicextension/internal/credentials/encrypt.go
+++ b/extension/sumologicextension/internal/credentials/encrypt.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 
 import (
 	"crypto/aes"

--- a/extension/sumologicextension/internal/credentials/store.go
+++ b/extension/sumologicextension/internal/credentials/store.go
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/credentials"
+package credentials // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/credentials"
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/api"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension/internal/api"
 )
 
 // CollectorCredentials are used for storing the credentials received during


### PR DESCRIPTION
Reduce the API of the component, hiding most of the structs. This is required for checkapi upgrade v0.28.1 as it picks up on the structs.