### PR TITLE
[exporter/signalfxexporter] Make sending tags from the SignalFx Exporter configurable

### DIFF
--- a/.chloggen/signalfxexporter-drop-tags.yaml
+++ b/.chloggen/signalfxexporter-drop-tags.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Makes sending tags from SignalFx Exporter configurable"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43799]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  New optional configuration flag "drop_tags" has been added to SignalFx Exporter to allow users to disable tag metadata sending.
+  This feature has been introduced due to a common issue among Splunk Observability customers when they're receiving more tags 
+  than allowed limit. 
+  
+  
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/signalfxexporter-drop-tags.yaml
+++ b/.chloggen/signalfxexporter-drop-tags.yaml
@@ -16,7 +16,7 @@ issues: [43799]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  New optional configuration flag "drop_tags" has been added to SignalFx Exporter to allow users to disable tag metadata sending.
+  New optional configuration flag `drop_tags` has been added to SignalFx Exporter to allow users to disable tag metadata sending.
   This feature has been introduced due to a common issue among Splunk Observability customers when they're receiving more tags 
   than allowed limit. 
   

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -26,13 +26,13 @@ The following configuration options are required:
 
 - `access_token` (no default): The access token is the [authentication token
   provided by Splunk Observability
-  Cloud](https://docs.splunk.com/observability/en/admin/authentication/authentication-tokens/manage-usage.html).
+  Cloud](https://help.splunk.com/en/splunk-observability-cloud/administer/authentication-and-security/authentication-tokens/manage-usage-with-access-tokens).
   The access token can be obtained from the web app.
 - Either `realm` or both `api_url` and `ingest_url`. Both `api_url` and
   `ingest_url` take precedence over `realm`.
   - `realm` (no default): SignalFx realm where the data will be received.
   - `api_url` (no default): Destination to which [properties and
-    tags](https://docs.splunk.com/observability/en/metrics-and-metadata/metrics-finder-metadata-catalog.html)
+    tags](https://help.splunk.com/en/splunk-observability-cloud/data-tools/metric-finder-and-metadata-catalogue)
     are sent. If `realm` is set, this option is derived and will be
     `https://api.{realm}.signalfx.com`. If a value is explicitly set, the
     value of `realm` will not be used in determining `api_url`. The explicit
@@ -128,7 +128,7 @@ The following configuration options can also be configured:
   - `max_conns_per_host` (default = 20): The maximum total number of connections the client can keep open per host.
   - `idle_conn_timeout` (default = 30s): The maximum amount of time an idle connection will remain open before closing itself.
   - `timeout` (default = 10s): Amount of time to wait for the dimension HTTP request to complete.
-  - `drop_tags` (default = false): Flag that indicates whether metadata tags should be sent to Splunk Observability be the exporter.
+  - `drop_tags` (default = false): Flag that indicates whether to drop the tags from the metadata sent to Splunk Observability Cloud by the exporter.
 - `nonalphanumeric_dimension_chars`: (default = `"_-."`) A string of characters 
 that are allowed to be used as a dimension key in addition to alphanumeric 
 characters. Each nonalphanumeric dimension key character that isn't in this string 

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -128,6 +128,7 @@ The following configuration options can also be configured:
   - `max_conns_per_host` (default = 20): The maximum total number of connections the client can keep open per host.
   - `idle_conn_timeout` (default = 30s): The maximum amount of time an idle connection will remain open before closing itself.
   - `timeout` (default = 10s): Amount of time to wait for the dimension HTTP request to complete.
+  - `drop_tags` (default = false): Flag that indicates whether metadata tags should be sent to Splunk Observability be the exporter.
 - `nonalphanumeric_dimension_chars`: (default = `"_-."`) A string of characters 
 that are allowed to be used as a dimension key in addition to alphanumeric 
 characters. Each nonalphanumeric dimension key character that isn't in this string 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -156,6 +156,7 @@ type DimensionClientConfig struct {
 	MaxConnsPerHost     int           `mapstructure:"max_conns_per_host"`
 	IdleConnTimeout     time.Duration `mapstructure:"idle_conn_timeout"`
 	Timeout             time.Duration `mapstructure:"timeout"`
+	DropTags            bool          `mapstructure:"drop_tags"`
 }
 
 func (cfg *Config) getMetricTranslator(done chan struct{}) (*translation.MetricTranslator, error) {

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -84,6 +84,7 @@ func TestLoadConfig(t *testing.T) {
 					MaxConnsPerHost:     20,
 					IdleConnTimeout:     30 * time.Second,
 					Timeout:             10 * time.Second,
+					DropTags:            false,
 				},
 				ExcludeMetrics:      nil,
 				IncludeMetrics:      nil,
@@ -163,6 +164,7 @@ func TestLoadConfig(t *testing.T) {
 					MaxConnsPerHost:     10000,
 					IdleConnTimeout:     2 * time.Hour,
 					Timeout:             20 * time.Second,
+					DropTags:            false,
 				},
 				ExcludeMetrics: []dpfilters.MetricFilter{
 					{

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -153,6 +153,7 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 			MaxIdleConnsPerHost: se.config.DimensionClient.MaxIdleConnsPerHost,
 			IdleConnTimeout:     se.config.DimensionClient.IdleConnTimeout,
 			Timeout:             se.config.DimensionClient.Timeout,
+			DropTags:            se.config.DimensionClient.DropTags,
 		})
 	dimClient.Start()
 

--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -82,6 +82,7 @@ type DimensionClientOptions struct {
 	MaxIdleConnsPerHost int
 	IdleConnTimeout     time.Duration
 	Timeout             time.Duration
+	DropTags            bool
 }
 
 // NewDimensionClient returns a new client


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

New optional configuration flag `drop_tags` has been added to SignalFx Exporter to allow users to disable tags metadata sending.

This feature has been introduced due to a common issue among Splunk Observability customers when they're receiving more tags than allowed limit. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- added unit test to check if `drop_tags` flag is working

<!--Describe the documentation added.-->
#### Documentation

- added new config option description in README file

<!--Please delete paragraphs that you did not use before submitting.-->
