### PR TITLE
[exporter/elasticsearch] Update ecs mode encoder semconv attributes

### DIFF
--- a/.chloggen/es-exporter-update-semconv-maps.yaml
+++ b/.chloggen/es-exporter-update-semconv-maps.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/elasticsearchexporter
+component: exporter/elasticsearch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Update Elasticsearch exporter ECS mapping mode encoder semantic convention mappings

--- a/.chloggen/es-exporter-update-semconv-maps.yaml
+++ b/.chloggen/es-exporter-update-semconv-maps.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update Elasticsearch exporter ECS mapping mode encoder semantic convention mappings
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43805]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -206,11 +206,12 @@ func (ecsModeEncoder) encodeLog(
 
 	// Finally, try to map record-level attributes to ECS fields.
 	recordAttrsConversionMap := map[string]string{
-		"event.name":                           "event.action",
-		string(semconv.ExceptionMessageKey):    "error.message",
-		string(semconv.ExceptionStacktraceKey): "error.stacktrace",
-		string(semconv.ExceptionTypeKey):       "error.type",
-		string(semconv.ExceptionEscapedKey):    "event.error.exception.handled",
+		"event.name":                            "event.action",
+		string(semconv.ExceptionMessageKey):     "error.message",
+		string(semconv.ExceptionStacktraceKey):  "error.stacktrace",
+		string(semconv.ExceptionTypeKey):        "error.type",
+		string(semconv.ExceptionEscapedKey):     "event.error.exception.handled",
+		string(semconv.HTTPResponseBodySizeKey): "http.response.encoded_body_size",
 	}
 	encodeAttributesECSMode(&document, record.Attributes(), recordAttrsConversionMap, resourceAttrsToPreserve)
 	addDataStreamAttributes(&document, "", idx)
@@ -254,7 +255,12 @@ func (ecsModeEncoder) encodeSpan(
 
 	// Finally, try to map record-level attributes to ECS fields.
 	spanAttrsConversionMap := map[string]string{
-		// None at the moment
+		string(semconv.MessagingDestinationNameKey): "span.message.queue.name",
+		"messaging.operation.name":                  "span.action",
+		string(semconv.DBSystemKey):                 "span.db.type",
+		"db.namespace":                              "span.db.instance",
+		"db.query.text":                             "span.db.statement",
+		string(semconv.HTTPResponseBodySizeKey):     "http.response.encoded_body_size",
 	}
 
 	// Handle special cases.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -42,13 +42,18 @@ var resourceAttrsConversionMap = map[string]string{
 	string(semconv.ContainerImageTagsKey):     "container.image.tag",
 	string(semconv.HostNameKey):               "host.hostname",
 	string(semconv.HostArchKey):               "host.architecture",
+	string(semconv.ProcessParentPIDKey):       "process.parent.pid",
+	string(semconv.ProcessExecutableNameKey):  "process.title",
 	string(semconv.ProcessExecutablePathKey):  "process.executable",
+	string(semconv.ProcessCommandLineKey):     "process.args",
 	string(semconv.ProcessRuntimeNameKey):     "service.runtime.name",
 	string(semconv.ProcessRuntimeVersionKey):  "service.runtime.version",
 	string(semconv.OSNameKey):                 "host.os.name",
 	string(semconv.OSTypeKey):                 "host.os.platform",
 	string(semconv.OSDescriptionKey):          "host.os.full",
 	string(semconv.OSVersionKey):              "host.os.version",
+	string(semconv.ClientAddressKey):          "client.ip",
+	string(semconv.SourceAddressKey):          "source.ip",
 	string(semconv.K8SDeploymentNameKey):      "kubernetes.deployment.name",
 	string(semconv.K8SNamespaceNameKey):       "kubernetes.namespace",
 	string(semconv.K8SNodeNameKey):            "kubernetes.node.name",
@@ -61,6 +66,8 @@ var resourceAttrsConversionMap = map[string]string{
 	string(semconv.K8SDaemonSetNameKey):       "kubernetes.daemonset.name",
 	string(semconv.K8SContainerNameKey):       "kubernetes.container.name",
 	string(semconv.K8SClusterNameKey):         "orchestrator.cluster.name",
+	string(semconv.FaaSInstanceKey):           "faas.id",
+	string(semconv.FaaSTriggerKey):            "faas.trigger.type",
 }
 
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -458,7 +458,18 @@ func TestEncodeSpanECSMode(t *testing.T) {
 		string(semconv.ServiceInstanceIDKey):     "23",
 		string(semconv.ServiceNameKey):           "some-service",
 		string(semconv.ServiceVersionKey):        "env-version-1234",
+		string(semconv.ProcessParentPIDKey):      "42",
+		string(semconv.ProcessExecutableNameKey): "node",
+		string(semconv.ClientAddressKey):         "12.53.12.1",
+		string(semconv.SourceAddressKey):         "12.53.12.1",
+		string(semconv.FaaSInstanceKey):          "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+		string(semconv.FaaSTriggerKey):           "api-gateway",
 	})
+	require.NoError(t, err)
+
+	// add slice attributes
+	processCommandLineSlice := resource.Attributes().PutEmptySlice(string(semconv.ProcessCommandLineKey))
+	err = processCommandLineSlice.FromRaw([]any{"node", "app.js"})
 	require.NoError(t, err)
 
 	scope := pcommon.NewInstrumentationScope()
@@ -539,6 +550,21 @@ func TestEncodeSpanECSMode(t *testing.T) {
 		  "name": "23"
 		},
 		"version": "env-version-1234"
+	  },
+	  "process": {
+		"parent": { "pid": "42" },
+		"title": "node",
+		"args" : ["node", "app.js"]
+	  },
+	  "client": {
+		"ip": "12.53.12.1"
+      },
+	  "source": {
+		"ip": "12.53.12.1"
+      },
+	  "faas": {
+		"id" : "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+		"trigger": { "type": "api-gateway" }
 	  }
 	}`, buf.String())
 }
@@ -591,6 +617,12 @@ func TestEncodeLogECSMode(t *testing.T) {
 		string(semconv.K8SDaemonSetNameKey):      "daemonset.name",
 		string(semconv.K8SContainerNameKey):      "container.name",
 		string(semconv.K8SClusterNameKey):        "cluster.name",
+		string(semconv.ProcessParentPIDKey):      "42",
+		string(semconv.ProcessExecutableNameKey): "node",
+		string(semconv.ClientAddressKey):         "12.53.12.1",
+		string(semconv.SourceAddressKey):         "12.53.12.1",
+		string(semconv.FaaSInstanceKey):          "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+		string(semconv.FaaSTriggerKey):           "api-gateway",
 	})
 	require.NoError(t, err)
 
@@ -655,8 +687,10 @@ func TestEncodeLogECSMode(t *testing.T) {
 		},
 		"process": {
 		  "pid": 9833,
-		  "command_line": "/usr/bin/ssh -l user 10.0.0.16",
-		  "executable": "/usr/bin/ssh"
+		  "args": "/usr/bin/ssh -l user 10.0.0.16",
+		  "executable": "/usr/bin/ssh",
+          "parent": { "pid": "42" },
+		   "title": "node"
 		},
 		"service": {
 		  "name": "foo.bar",
@@ -691,7 +725,17 @@ func TestEncodeLogECSMode(t *testing.T) {
 		  "daemonset": {"name": "daemonset.name"},
 		  "container": {"name": "container.name"}
 		},
-		"orchestrator": {"cluster": {"name": "cluster.name"}}
+		"orchestrator": {"cluster": {"name": "cluster.name"}},
+        "client": {
+			"ip": "12.53.12.1"
+		},
+        "source": {
+			"ip": "12.53.12.1"
+		},
+        "faas": {
+		    "id" : "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+		     "trigger": { "type": "api-gateway" }
+	  }
 	}`, buf.String())
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- Add new sem conv resource attributes to the ecs mode encoder
- Add new sem conv record attributes to the ecs mode log and span encoders
   * I created a separate [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43806) to update the otel version since some attributes added in this PR are not present in v1.22.0

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43805

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Updated unit test 
- Setup a local collector with the elasticsearch exporter to validate indexed documents
