### PR TITLE
[chore][prometheusreceiver]: allow native histograms without metadata

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -50,6 +50,8 @@ type Config struct {
 
 	// From feature gate.
 	enableNativeHistograms bool
+	// For testing only.
+	ignoreMetadata bool
 }
 
 // Validate checks the receiver configuration is valid.

--- a/receiver/prometheusreceiver/internal/appendable.go
+++ b/receiver/prometheusreceiver/internal/appendable.go
@@ -21,6 +21,7 @@ type appendable struct {
 	metricAdjuster         MetricsAdjuster
 	useStartTimeMetric     bool
 	enableNativeHistograms bool
+	useMetadata            bool
 	trimSuffixes           bool
 	startTimeMetricRegex   *regexp.Regexp
 	externalLabels         labels.Labels
@@ -38,6 +39,7 @@ func NewAppendable(
 	startTimeMetricRegex *regexp.Regexp,
 	useCreatedMetric bool,
 	enableNativeHistograms bool,
+	useMetadata bool,
 	externalLabels labels.Labels,
 	trimSuffixes bool,
 ) (storage.Appendable, error) {
@@ -59,6 +61,7 @@ func NewAppendable(
 		metricAdjuster:         metricAdjuster,
 		useStartTimeMetric:     useStartTimeMetric,
 		enableNativeHistograms: enableNativeHistograms,
+		useMetadata:            useMetadata,
 		startTimeMetricRegex:   startTimeMetricRegex,
 		externalLabels:         externalLabels,
 		obsrecv:                obsrecv,
@@ -67,5 +70,5 @@ func NewAppendable(
 }
 
 func (o *appendable) Appender(ctx context.Context) storage.Appender {
-	return newTransaction(ctx, o.metricAdjuster, o.sink, o.externalLabels, o.settings, o.obsrecv, o.trimSuffixes, o.enableNativeHistograms)
+	return newTransaction(ctx, o.metricAdjuster, o.sink, o.externalLabels, o.settings, o.obsrecv, o.trimSuffixes, o.enableNativeHistograms, o.useMetadata)
 }

--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -65,3 +65,21 @@ func metadataForMetric(metricName string, mc scrape.MetricMetadataStore) (*scrap
 		Type:         model.MetricTypeUnknown,
 	}, metricName
 }
+
+type emptyMetadataStore struct{}
+
+func (emptyMetadataStore) ListMetadata() []scrape.MetricMetadata {
+	return nil
+}
+
+func (emptyMetadataStore) GetMetadata(string) (scrape.MetricMetadata, bool) {
+	return scrape.MetricMetadata{}, false
+}
+
+func (emptyMetadataStore) SizeMetadata() int {
+	return 0
+}
+
+func (emptyMetadataStore) LengthMetadata() int {
+	return 0
+}

--- a/receiver/prometheusreceiver/internal/metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/metricfamily_test.go
@@ -252,7 +252,7 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamily(tt.metricName, mc, zap.NewNop())
+			mp := newMetricFamily(tt.metricName, mc, zap.NewNop(), false, false)
 			for i, tv := range tt.scrapes {
 				var lbls labels.Labels
 				if tv.extraLabel.Name != "" {
@@ -411,7 +411,7 @@ func TestMetricGroupData_toNHCBDistributionUnitTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamily(tt.metricName, mc, zap.NewNop())
+			mp := newMetricFamily(tt.metricName, mc, zap.NewNop(), false, false)
 			sRef, _ := getSeriesRef(nil, tt.labels, mp.mtype)
 
 			err := mp.addNHCBSeries(sRef, tt.metricName, tt.labels, tt.intervalStartTimeMs, tt.integerHistogram, tt.floatHistogram)
@@ -571,7 +571,7 @@ func TestMetricGroupData_toExponentialDistributionUnitTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamily(tt.metricName, mc, zap.NewNop())
+			mp := newMetricFamily(tt.metricName, mc, zap.NewNop(), true, false)
 			for i, tv := range tt.scrapes {
 				var lbls labels.Labels
 				if tv.extraLabel.Name != "" {
@@ -873,7 +873,7 @@ func TestMetricGroupData_toSummaryUnitTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamily(tt.name, mc, zap.NewNop())
+			mp := newMetricFamily(tt.name, mc, zap.NewNop(), false, false)
 			for _, lbs := range tt.labelsScrapes {
 				for i, scrape := range lbs.scrapes {
 					lb := lbs.labels.Copy()
@@ -1015,7 +1015,7 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamily(tt.metricKind, mc, zap.NewNop())
+			mp := newMetricFamily(tt.metricKind, mc, zap.NewNop(), false, false)
 			for _, tv := range tt.scrapes {
 				lb := tt.labels.Copy()
 				sRef, _ := getSeriesRef(nil, lb, mp.mtype)

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -55,6 +55,7 @@ type transaction struct {
 	isNew                  bool
 	trimSuffixes           bool
 	enableNativeHistograms bool
+	useMetadata            bool
 	addingNativeHistogram  bool // true if the last sample was a native histogram.
 	addingNHCB             bool // true if the last sample was a NHCB.
 	ctx                    context.Context
@@ -89,6 +90,7 @@ func newTransaction(
 	obsrecv *receiverhelper.ObsReport,
 	trimSuffixes bool,
 	enableNativeHistograms bool,
+	useMetadata bool,
 ) *transaction {
 	return &transaction{
 		ctx:                    ctx,
@@ -96,6 +98,7 @@ func newTransaction(
 		isNew:                  true,
 		trimSuffixes:           trimSuffixes,
 		enableNativeHistograms: enableNativeHistograms,
+		useMetadata:            useMetadata,
 		sink:                   sink,
 		metricAdjuster:         metricAdjuster,
 		externalLabels:         externalLabels,
@@ -251,11 +254,7 @@ func (t *transaction) getOrCreateMetricFamily(key resourceKey, scope scopeID, mn
 		fnKey := metricFamilyKey{isExponentialHistogram: mfKey.isExponentialHistogram, name: fn}
 		mf, ok := t.families[key][scope][fnKey]
 		if !ok || !mf.includesMetric(mn) {
-			curMf = newMetricFamily(mn, t.mc, t.logger)
-			// Don't convert NHCB to ExponentialHistogram.
-			if curMf.mtype == pmetric.MetricTypeHistogram && mfKey.isExponentialHistogram && !t.addingNHCB {
-				curMf.mtype = pmetric.MetricTypeExponentialHistogram
-			}
+			curMf = newMetricFamily(mn, t.mc, t.logger, t.addingNativeHistogram, t.addingNHCB)
 			t.families[key][scope][metricFamilyKey{isExponentialHistogram: mfKey.isExponentialHistogram, name: curMf.name}] = curMf
 			return curMf
 		}
@@ -521,9 +520,13 @@ func (t *transaction) initTransaction(lbs labels.Labels) (*resourceKey, error) {
 	if !ok {
 		return nil, errors.New("unable to find target in context")
 	}
-	t.mc, ok = scrape.MetricMetadataStoreFromContext(t.ctx)
-	if !ok {
-		return nil, errors.New("unable to find MetricMetadataStore in context")
+	if t.useMetadata {
+		t.mc, ok = scrape.MetricMetadataStoreFromContext(t.ctx)
+		if !ok {
+			return nil, errors.New("unable to find MetricMetadataStore in context")
+		}
+	} else {
+		t.mc = &emptyMetadataStore{}
 	}
 
 	rKey, err := t.getJobAndInstance(lbs)

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -68,7 +68,7 @@ func TestTransactionCommitWithoutAdding(t *testing.T) {
 }
 
 func testTransactionCommitWithoutAdding(t *testing.T, enableNativeHistograms bool) {
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	assert.NoError(t, tr.Commit())
 }
 
@@ -81,7 +81,7 @@ func TestTransactionRollbackDoesNothing(t *testing.T) {
 }
 
 func testTransactionRollbackDoesNothing(t *testing.T, enableNativeHistograms bool) {
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	assert.NoError(t, tr.Rollback())
 }
 
@@ -94,7 +94,7 @@ func TestTransactionUpdateMetadataDoesNothing(t *testing.T) {
 }
 
 func testTransactionUpdateMetadataDoesNothing(t *testing.T, enableNativeHistograms bool) {
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.UpdateMetadata(0, labels.New(), metadata.Metadata{})
 	assert.NoError(t, err)
 }
@@ -109,7 +109,7 @@ func TestTransactionAppendNoTarget(t *testing.T) {
 
 func testTransactionAppendNoTarget(t *testing.T, enableNativeHistograms bool) {
 	badLabels := labels.FromStrings(model.MetricNameLabel, "counter_test")
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, badLabels, time.Now().Unix()*1000, 1.0)
 	assert.Error(t, err)
 }
@@ -127,7 +127,7 @@ func testTransactionAppendNoMetricName(t *testing.T, enableNativeHistograms bool
 		model.InstanceLabel: "localhost:8080",
 		model.JobLabel:      "test2",
 	})
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, jobNotFoundLb, time.Now().Unix()*1000, 1.0)
 	assert.ErrorIs(t, err, errMetricNameNotFound)
 	assert.ErrorIs(t, tr.Commit(), errNoDataToBuild)
@@ -142,7 +142,7 @@ func TestTransactionAppendEmptyMetricName(t *testing.T) {
 }
 
 func testTransactionAppendEmptyMetricName(t *testing.T, enableNativeHistograms bool) {
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test2",
@@ -161,7 +161,7 @@ func TestTransactionAppendResource(t *testing.T) {
 
 func testTransactionAppendResource(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test",
@@ -192,7 +192,7 @@ func TestTransactionAppendMultipleResources(t *testing.T) {
 
 func testTransactionAppendMultipleResources(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test-1",
@@ -243,7 +243,7 @@ func TestReceiverVersionAndNameAreAttached(t *testing.T) {
 
 func testReceiverVersionAndNameAreAttached(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test",
@@ -279,7 +279,7 @@ func testTransactionCommitErrorWhenAdjusterError(t *testing.T, enableNativeHisto
 	})
 	sink := new(consumertest.MetricsSink)
 	adjusterErr := errors.New("adjuster error")
-	tr := newTransaction(scrapeCtx, &errorAdjuster{err: adjusterErr}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &errorAdjuster{err: adjusterErr}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 	_, err := tr.Append(0, goodLabels, time.Now().Unix()*1000, 1.0)
 	assert.NoError(t, err)
 	assert.ErrorIs(t, tr.Commit(), adjusterErr)
@@ -296,7 +296,7 @@ func TestTransactionAppendDuplicateLabels(t *testing.T) {
 
 func testTransactionAppendDuplicateLabels(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	dupLabels := labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -333,6 +333,7 @@ func testTransactionAppendHistogramNoLe(t *testing.T, enableNativeHistograms boo
 		nopObsRecv(t),
 		false,
 		enableNativeHistograms,
+		true,
 	)
 
 	goodLabels := labels.FromStrings(
@@ -372,6 +373,7 @@ func testTransactionAppendSummaryNoQuantile(t *testing.T, enableNativeHistograms
 		nopObsRecv(t),
 		false,
 		enableNativeHistograms,
+		true,
 	)
 
 	goodLabels := labels.FromStrings(
@@ -411,6 +413,7 @@ func testTransactionAppendValidAndInvalid(t *testing.T, enableNativeHistograms b
 		nopObsRecv(t),
 		false,
 		enableNativeHistograms,
+		true,
 	)
 
 	// a valid counter
@@ -471,7 +474,7 @@ func testTransactionAppendWithEmptyLabelArrayFallbackToTargetLabels(t *testing.T
 		scrape.ContextWithTarget(t.Context(), scrapeTarget),
 		testMetadataStore(testMetadata))
 
-	tr := newTransaction(ctx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(ctx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	_, err := tr.Append(0, labels.FromMap(map[string]string{
 		model.MetricNameLabel: "counter_test",
@@ -489,7 +492,7 @@ func TestAppendExemplarWithNoMetricName(t *testing.T) {
 
 func testAppendExemplarWithNoMetricName(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	labels := labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -510,7 +513,7 @@ func TestAppendExemplarWithEmptyMetricName(t *testing.T) {
 
 func testAppendExemplarWithEmptyMetricName(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	labels := labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -531,7 +534,7 @@ func TestAppendExemplarWithDuplicateLabels(t *testing.T) {
 
 func testAppendExemplarWithDuplicateLabels(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	labels := labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -554,7 +557,7 @@ func TestAppendExemplarWithoutAddingMetric(t *testing.T) {
 
 func testAppendExemplarWithoutAddingMetric(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	labels := labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -576,7 +579,7 @@ func TestAppendExemplarWithNoLabels(t *testing.T) {
 
 func testAppendExemplarWithNoLabels(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	_, err := tr.AppendExemplar(0, labels.EmptyLabels(), exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errNoJobInstance, err)
@@ -592,7 +595,7 @@ func TestAppendExemplarWithEmptyLabelArray(t *testing.T) {
 
 func testAppendExemplarWithEmptyLabelArray(t *testing.T, enableNativeHistograms bool) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 
 	_, err := tr.AppendExemplar(0, labels.FromStrings(), exemplar.Exemplar{Value: 0})
 	assert.Equal(t, errNoJobInstance, err)
@@ -600,7 +603,7 @@ func testAppendExemplarWithEmptyLabelArray(t *testing.T, enableNativeHistograms 
 
 func TestAppendCTZeroSampleNoLabels(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendCTZeroSample(0, labels.FromStrings(), 0, 100)
 	assert.ErrorContains(t, err, "job or instance cannot be found from labels")
@@ -608,7 +611,7 @@ func TestAppendCTZeroSampleNoLabels(t *testing.T) {
 
 func TestAppendHistogramCTZeroSampleNoLabels(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendHistogramCTZeroSample(0, labels.FromStrings(), 0, 100, nil, nil)
 	assert.ErrorContains(t, err, "job or instance cannot be found from labels")
@@ -616,7 +619,7 @@ func TestAppendHistogramCTZeroSampleNoLabels(t *testing.T) {
 
 func TestAppendCTZeroSampleDuplicateLabels(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -630,7 +633,7 @@ func TestAppendCTZeroSampleDuplicateLabels(t *testing.T) {
 
 func TestAppendHistogramCTZeroSampleDuplicateLabels(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendHistogramCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -644,7 +647,7 @@ func TestAppendHistogramCTZeroSampleDuplicateLabels(t *testing.T) {
 
 func TestAppendCTZeroSampleEmptyMetricName(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -656,7 +659,7 @@ func TestAppendCTZeroSampleEmptyMetricName(t *testing.T) {
 
 func TestAppendHistogramCTZeroSampleEmptyMetricName(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	_, err := tr.AppendHistogramCTZeroSample(0, labels.FromStrings(
 		model.InstanceLabel, "0.0.0.0:8855",
@@ -668,7 +671,7 @@ func TestAppendHistogramCTZeroSampleEmptyMetricName(t *testing.T) {
 
 func TestAppendCTZeroSample(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false)
+	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, false, true)
 
 	var atMs, ctMs int64
 	atMs, ctMs = 200, 100
@@ -702,7 +705,7 @@ func TestAppendCTZeroSample(t *testing.T) {
 
 func TestAppendHistogramCTZeroSample(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true)
+	tr := newTransaction(scrapeCtx, &nopAdjuster{}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, true, true)
 
 	var atMs, ctMs int64
 	atMs, ctMs = 200, 100
@@ -2014,7 +2017,7 @@ func (tt buildTestData) run(t *testing.T, enableNativeHistograms bool) {
 	st := ts
 	for i, page := range tt.inputs {
 		sink := new(consumertest.MetricsSink)
-		tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms)
+		tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(receivertest.NopType), nopObsRecv(t), false, enableNativeHistograms, true)
 		for _, pt := range page.pts {
 			// set ts for testing
 			pt.t = st

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -96,7 +96,7 @@ func getBoundary(metricType pmetric.MetricType, labels labels.Labels) (float64, 
 }
 
 // convToMetricType returns the data type and if it is monotonic
-func convToMetricType(metricType model.MetricType) (pmetric.MetricType, bool) {
+func convToMetricType(metricType model.MetricType, exponentialHistogram bool) (pmetric.MetricType, bool) {
 	switch metricType {
 	case model.MetricTypeCounter:
 		// always use float64, as it's the internal data type used in prometheus
@@ -105,6 +105,9 @@ func convToMetricType(metricType model.MetricType) (pmetric.MetricType, bool) {
 	case model.MetricTypeGauge, model.MetricTypeUnknown:
 		return pmetric.MetricTypeGauge, false
 	case model.MetricTypeHistogram:
+		if exponentialHistogram {
+			return pmetric.MetricTypeExponentialHistogram, true
+		}
 		return pmetric.MetricTypeHistogram, true
 	// dropping support for gaugehistogram for now until we have an official spec of its implementation
 	// a draft can be found in: https://docs.google.com/document/d/1KwV0mAXwwbvvifBvDKH_LU1YjyXE_wxCkHNoCGq1GX0/edit#heading=h.1cvzqd4ksd23

--- a/receiver/prometheusreceiver/internal/util_test.go
+++ b/receiver/prometheusreceiver/internal/util_test.go
@@ -59,6 +59,7 @@ func TestConvToMetricType(t *testing.T) {
 	tests := []struct {
 		name          string
 		mtype         model.MetricType
+		isExponential bool
 		want          pmetric.MetricType
 		wantMonotonic bool
 	}{
@@ -84,6 +85,13 @@ func TestConvToMetricType(t *testing.T) {
 			name:          "model.histogram",
 			mtype:         model.MetricTypeHistogram,
 			want:          pmetric.MetricTypeHistogram,
+			wantMonotonic: true,
+		},
+		{
+			name:          "model.histogram",
+			mtype:         model.MetricTypeHistogram,
+			isExponential: true,
+			want:          pmetric.MetricTypeExponentialHistogram,
 			wantMonotonic: true,
 		},
 		{
@@ -114,7 +122,7 @@ func TestConvToMetricType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, monotonic := convToMetricType(tt.mtype)
+			got, monotonic := convToMetricType(tt.mtype, tt.isExponential)
 			require.Equal(t, got.String(), tt.want.String())
 			require.Equal(t, tt.wantMonotonic, monotonic)
 		})

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -177,6 +177,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, logger *slog.L
 		startTimeMetricRegex,
 		useCreatedMetricGate.IsEnabled(),
 		r.cfg.enableNativeHistograms,
+		!r.cfg.ignoreMetadata,
 		r.cfg.PrometheusConfig.GlobalConfig.ExternalLabels,
 		r.cfg.TrimMetricSuffixes,
 	)

--- a/receiver/prometheusreceiver/metrics_receiver_protobuf_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_protobuf_test.go
@@ -4,6 +4,7 @@
 package prometheusreceiver
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -164,6 +165,9 @@ func TestScrapeViaProtobuf(t *testing.T) {
 	})
 }
 
+// TestNativeVsClassicHistogramScrapeViaProtobuf checks the classic and native histograms
+// can co-exists, regardless whether metadata is available or not.
+// When there is no metadata, float series are all mapped 1:1 to Gauge metrics.
 func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 	classicHistogram := &dto.MetricFamily{
 		Name: "test_classic_histogram",
@@ -328,6 +332,7 @@ func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 		mutCfg                 func(*PromConfig)
 		enableNativeHistograms bool
 		expected               []metricExpectation
+		expectedIgnoreMetadata []metricExpectation
 	}{
 		"feature enabled scrape classic off": {
 			enableNativeHistograms: true,
@@ -369,6 +374,53 @@ func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 					nil,
 				},
 			},
+			expectedIgnoreMetadata: []metricExpectation{
+				{
+					"test_classic_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram",
+					pmetric.MetricTypeExponentialHistogram,
+					"",
+					[]dataPointExpectation{{
+						exponentialHistogramComparator: []exponentialHistogramComparator{
+							compareExponentialHistogram(3, 1213, 456, 2, -1, []uint64{1, 0, 2}, -3, []uint64{1, 0, 1}),
+							checkMixedHistogramNativeExemplars,
+						},
+					}},
+					nil,
+				},
+				{
+					"test_native_histogram",
+					pmetric.MetricTypeExponentialHistogram,
+					"",
+					[]dataPointExpectation{{
+						exponentialHistogramComparator: []exponentialHistogramComparator{
+							compareExponentialHistogram(3, 1214, 3456, 5, -3, []uint64{1, 0, 2}, 2, []uint64{1, 0, 0, 1}),
+							checkNativeHistogramExemplars,
+						},
+					}},
+					nil,
+				},
+			},
 		},
 		"feature disabled scrape classic off": {
 			enableNativeHistograms: false,
@@ -395,6 +447,50 @@ func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 							checkMixedHistogramClassicExemplars,
 						},
 					}},
+					nil,
+				},
+			},
+			expectedIgnoreMetadata: []metricExpectation{
+				{
+					"test_classic_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
 					nil,
 				},
 			},
@@ -457,6 +553,74 @@ func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 					nil,
 				},
 			},
+			expectedIgnoreMetadata: []metricExpectation{
+				{
+					"test_classic_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{ // Scrape both classic and native buckets from mixed histograms.
+					"test_mixed_histogram",
+					pmetric.MetricTypeExponentialHistogram,
+					"",
+					[]dataPointExpectation{{
+						exponentialHistogramComparator: []exponentialHistogramComparator{
+							compareExponentialHistogram(3, 1213, 456, 2, -1, []uint64{1, 0, 2}, -3, []uint64{1, 0, 1}),
+							checkMixedHistogramNativeExemplars,
+						},
+					}},
+					nil,
+				},
+				{ // Scrape native only histograms as is.
+					"test_native_histogram",
+					pmetric.MetricTypeExponentialHistogram,
+					"",
+					[]dataPointExpectation{{
+						exponentialHistogramComparator: []exponentialHistogramComparator{
+							compareExponentialHistogram(3, 1214, 3456, 5, -3, []uint64{1, 0, 2}, 2, []uint64{1, 0, 0, 1}),
+							checkNativeHistogramExemplars,
+						},
+					}},
+					nil,
+				},
+			},
 		},
 		"feature disabled scrape classic on": {
 			mutCfg: func(cfg *PromConfig) {
@@ -492,33 +656,86 @@ func TestNativeVsClassicHistogramScrapeViaProtobuf(t *testing.T) {
 					nil,
 				},
 			},
+			expectedIgnoreMetadata: []metricExpectation{
+				{
+					"test_classic_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_classic_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_bucket",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_count",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+				{
+					"test_mixed_histogram_sum",
+					pmetric.MetricTypeGauge,
+					"",
+					nil,
+					nil,
+				},
+			},
 		},
 	}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+	for _, ignoreMetadata := range []bool{false, true} {
+		t.Run(fmt.Sprintf("skip metadata=%v", ignoreMetadata), func(t *testing.T) {
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 
-			targets := []*testData{
-				{
-					name: "target1",
-					pages: []mockPrometheusResponse{
-						{code: 200, useProtoBuf: true, buf: buffer.Bytes()},
-					},
-					validateFunc: func(t *testing.T, td *testData, result []pmetric.ResourceMetrics) {
-						verifyNumValidScrapeResults(t, td, result)
-						doCompare(t, "target1", td.attributes, result[0], tc.expected)
-					},
-				},
+					targets := []*testData{
+						{
+							name: "target1",
+							pages: []mockPrometheusResponse{
+								{code: 200, useProtoBuf: true, buf: buffer.Bytes()},
+							},
+							validateFunc: func(t *testing.T, td *testData, result []pmetric.ResourceMetrics) {
+								verifyNumValidScrapeResults(t, td, result)
+								if ignoreMetadata {
+									doCompare(t, "target1", td.attributes, result[0], tc.expectedIgnoreMetadata)
+								} else {
+									doCompare(t, "target1", td.attributes, result[0], tc.expected)
+								}
+							},
+						},
+					}
+					mutCfg := tc.mutCfg
+					if mutCfg == nil {
+						mutCfg = func(*PromConfig) {}
+					}
+					testComponent(t, targets, func(c *Config) {
+						c.enableNativeHistograms = tc.enableNativeHistograms
+						c.ignoreMetadata = ignoreMetadata
+						c.PrometheusConfig.GlobalConfig.ScrapeProtocols = []config.ScrapeProtocol{config.PrometheusProto}
+					}, mutCfg)
+				})
 			}
-			mutCfg := tc.mutCfg
-			if mutCfg == nil {
-				mutCfg = func(*PromConfig) {}
-			}
-			testComponent(t, targets, func(c *Config) {
-				c.enableNativeHistograms = tc.enableNativeHistograms
-				c.PrometheusConfig.GlobalConfig.ScrapeProtocols = []config.ScrapeProtocol{config.PrometheusProto}
-			}, mutCfg)
 		})
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Some downstream applications (grafana/alloy) have use cases when metadata is not available.
For appending samples, it is not required for native histograms, since native histograms samples know their own type explicitly. This used to work before #39451 where I started to rely too heavily on metadata.

Tested locally and in Grafana Alloy via https://github.com/grafana/alloy/pull/4309.

No visible changes for OTEL collector.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing

ongoing

<!--Describe the documentation added.-->
#### Documentation

N/A

<!--Please delete paragraphs that you did not use before submitting.-->
