### PR TITLE
[pkg/translator/zipkin] Unexport ToTranslator

### DIFF
--- a/.chloggen/zipkin_pkg_api.yaml
+++ b/.chloggen/zipkin_pkg_api.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/zipkin
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport ToTranslator
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43852]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/translator/zipkin/zipkinv2/from_translator_test.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator_test.go
@@ -135,7 +135,7 @@ func TestInternalTracesToZipkinSpansAndBack(t *testing.T) {
 		zipkinSpans, err := FromTranslator{}.FromTraces(td)
 		assert.NoError(t, err)
 		assert.Len(t, zipkinSpans, td.SpanCount())
-		tdFromZS, zErr := ToTranslator{}.ToTraces(zipkinSpans)
+		tdFromZS, zErr := toTranslator{}.ToTraces(zipkinSpans)
 		assert.NoError(t, zErr, "%+v", zipkinSpans)
 		assert.NotNil(t, tdFromZS)
 		assert.Equal(t, td.SpanCount(), tdFromZS.SpanCount())

--- a/pkg/translator/zipkin/zipkinv2/json.go
+++ b/pkg/translator/zipkin/zipkinv2/json.go
@@ -12,7 +12,7 @@ import (
 )
 
 type jsonUnmarshaler struct {
-	toTranslator ToTranslator
+	toTranslator toTranslator
 }
 
 // UnmarshalTraces from JSON bytes.
@@ -26,7 +26,7 @@ func (j jsonUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 
 // NewJSONTracesUnmarshaler returns an unmarshaler for JSON bytes.
 func NewJSONTracesUnmarshaler(parseStringTags bool) ptrace.Unmarshaler {
-	return jsonUnmarshaler{toTranslator: ToTranslator{ParseStringTags: parseStringTags}}
+	return jsonUnmarshaler{toTranslator: toTranslator{ParseStringTags: parseStringTags}}
 }
 
 // NewJSONTracesMarshaler returns a marshaler to JSON bytes.

--- a/pkg/translator/zipkin/zipkinv2/protobuf.go
+++ b/pkg/translator/zipkin/zipkinv2/protobuf.go
@@ -13,7 +13,7 @@ type protobufUnmarshaler struct {
 	// the "X-B3-Flags" header is set to 1 on the request.
 	debugWasSet bool
 
-	toTranslator ToTranslator
+	toTranslator toTranslator
 }
 
 // UnmarshalTraces from protobuf bytes.
@@ -29,7 +29,7 @@ func (p protobufUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) 
 func NewProtobufTracesUnmarshaler(debugWasSet, parseStringTags bool) ptrace.Unmarshaler {
 	return protobufUnmarshaler{
 		debugWasSet:  debugWasSet,
-		toTranslator: ToTranslator{ParseStringTags: parseStringTags},
+		toTranslator: toTranslator{ParseStringTags: parseStringTags},
 	}
 }
 

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -27,14 +27,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/internal/zipkin"
 )
 
-// ToTranslator converts from Zipkin data model to pdata.
-type ToTranslator struct {
+// toTranslator converts from Zipkin data model to pdata.
+type toTranslator struct {
 	// ParseStringTags should be set to true if tags should be converted to numbers when possible.
 	ParseStringTags bool
 }
 
 // ToTraces translates Zipkin v2 spans into ptrace.Traces.
-func (t ToTranslator) ToTraces(zipkinSpans []*zipkinmodel.SpanModel) (ptrace.Traces, error) {
+func (t toTranslator) ToTraces(zipkinSpans []*zipkinmodel.SpanModel) (ptrace.Traces, error) {
 	traceData := ptrace.NewTraces()
 	if len(zipkinSpans) == 0 {
 		return traceData, nil

--- a/pkg/translator/zipkin/zipkinv2/to_translator_test.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator_test.go
@@ -141,7 +141,7 @@ func TestZipkinSpansToInternalTraces(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			td, err := ToTranslator{}.ToTraces(test.zs)
+			td, err := toTranslator{}.ToTraces(test.zs)
 			assert.Equal(t, test.err, err)
 			if test.name != "nilSpan" {
 				assert.Equal(t, len(test.zs), td.SpanCount())
@@ -241,7 +241,7 @@ func TestV2SpanWithoutTimestampGetsTag(t *testing.T) {
 		Tags:           nil,
 	}
 
-	gb, err := ToTranslator{}.ToTraces(spans)
+	gb, err := toTranslator{}.ToTraces(spans)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 		return


### PR DESCRIPTION
This is a breaking change of this package: this struct is not used directly anywhere in contrib, and therefore it would make sense to no longer expose it. I would like to hear back if anyone is using this directly as API.