### PR TITLE
[chore] [receiver/collectd] Fix README copy-paste

### DIFF
--- a/receiver/collectdreceiver/README.md
+++ b/receiver/collectdreceiver/README.md
@@ -37,7 +37,7 @@ The following settings are required:
 The following settings are optional:
 
 - `attributes_prefix` (no default): Used to add query parameters in key=value format to all metrics.
-- `timeout` (default = `30s`): The request timeout for any docker daemon query.
+- `timeout` (default = `30s`): Used as the `read_timeout` and `write_timeout` for the listening server.
 
 Example:
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The description for the `timeout` config field was inacurrate, and appears to have been copied from [the dockerstats receiver docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9b02d0acb7a4657a7f136c1334471ea25c2043ae/receiver/dockerstatsreceiver/README.md?plain=1#L44) :)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
I didn't make one. I can, this just seems pretty trivial.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
