### PR TITLE
[exporter/kafka] franz-go: Fix underreported kafka_exporter_write_latency metric

### DIFF
--- a/.chloggen/kafkaexporter_franzgo-write-metric.yaml
+++ b/.chloggen/kafkaexporter_franzgo-write-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "franz-go: Fix underreported kafka_exporter_write_latency metric"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43803]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
@@ -77,7 +77,7 @@ func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, thrott
 
 var _ kgo.HookBrokerE2E = FranzProducerMetrics{}
 
-func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, e2e kgo.BrokerE2E) {
+func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2E) {
 	outcome := "success"
 	if e2e.Err() != nil {
 		outcome = "failure"

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
@@ -26,6 +26,8 @@ func NewFranzProducerMetrics(tb *metadata.TelemetryBuilder) FranzProducerMetrics
 	return FranzProducerMetrics{tb: tb}
 }
 
+var _ kgo.HookBrokerConnect = FranzProducerMetrics{}
+
 func (fpm FranzProducerMetrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
 	outcome := "success"
 	if err != nil {
@@ -41,6 +43,8 @@ func (fpm FranzProducerMetrics) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.
 	)
 }
 
+var _ kgo.HookBrokerDisconnect = FranzProducerMetrics{}
+
 func (fpm FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ net.Conn) {
 	fpm.tb.KafkaBrokerClosed.Add(
 		context.Background(),
@@ -50,6 +54,8 @@ func (fpm FranzProducerMetrics) OnBrokerDisconnect(meta kgo.BrokerMetadata, _ ne
 		),
 	)
 }
+
+var _ kgo.HookBrokerThrottle = FranzProducerMetrics{}
 
 func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
 	// KafkaBrokerThrottlingDuration is deprecated in favor of KafkaBrokerThrottlingLatency.
@@ -69,15 +75,17 @@ func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, thrott
 	)
 }
 
-func (fpm FranzProducerMetrics) OnBrokerWrite(meta kgo.BrokerMetadata, _ int16, _ int, writeWait, timeToWrite time.Duration, err error) {
+var _ kgo.HookBrokerE2E = FranzProducerMetrics{}
+
+func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, e2e kgo.BrokerE2E) {
 	outcome := "success"
-	if err != nil {
+	if e2e.Err() != nil {
 		outcome = "failure"
 	}
 	// KafkaExporterLatency is deprecated in favor of KafkaExporterWriteLatency.
 	fpm.tb.KafkaExporterLatency.Record(
 		context.Background(),
-		writeWait.Milliseconds()+timeToWrite.Milliseconds(),
+		e2e.DurationE2E().Milliseconds()+e2e.WriteWait.Milliseconds(),
 		metric.WithAttributes(
 			attribute.String("node_id", kgo.NodeName(meta.NodeID)),
 			attribute.String("outcome", outcome),
@@ -85,13 +93,15 @@ func (fpm FranzProducerMetrics) OnBrokerWrite(meta kgo.BrokerMetadata, _ int16, 
 	)
 	fpm.tb.KafkaExporterWriteLatency.Record(
 		context.Background(),
-		writeWait.Seconds()+timeToWrite.Seconds(),
+		e2e.DurationE2E().Seconds()+e2e.WriteWait.Seconds(),
 		metric.WithAttributes(
 			attribute.String("node_id", kgo.NodeName(meta.NodeID)),
 			attribute.String("outcome", outcome),
 		),
 	)
 }
+
+var _ kgo.HookProduceBatchWritten = FranzProducerMetrics{}
 
 // OnProduceBatchWritten is called when a batch has been produced.
 // https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookProduceBatchWritten
@@ -125,6 +135,8 @@ func (fpm FranzProducerMetrics) OnProduceBatchWritten(meta kgo.BrokerMetadata, t
 		metric.WithAttributes(attrs...),
 	)
 }
+
+var _ kgo.HookProduceRecordUnbuffered = FranzProducerMetrics{}
 
 // OnProduceRecordUnbuffered records the number of produced messages that were
 // not produced due to errors. The successfully produced records is recorded by


### PR DESCRIPTION
#### Description
franz-go: Fix underreported kafka_exporter_write_latency metric by using OnBrokerE2E franz-go hook that takes response read time into account

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43803

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
