### PR TITLE
[chore] [receiver/webhookevent] Fix `Good request with gzip` test in webhookeventreceiver

### DIFF
--- a/receiver/webhookeventreceiver/receiver_test.go
+++ b/receiver/webhookeventreceiver/receiver_test.go
@@ -180,8 +180,11 @@ func TestHandleReq(t *testing.T) {
 				gzipWriter := gzip.NewWriter(&msg)
 				_, err = gzipWriter.Write(msgJSON)
 				require.NoError(t, err, "Gzip writer failed")
+				err = gzipWriter.Close()
+				require.NoError(t, err, "Gzip writer failed to close")
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/events", &msg)
+				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This test ostensibly tests that a request sent with gzip is accepted by the receiver, however because there's no mechanism to return back from the receiver what log was actually parsed, it was missed that this doesn't actually excercise the gzip flow.

In particular the test:

- Doesn't close the writer, which can result in invalid gzip streams
- Doesn't set the Content-Encoding on the request, so the receiver never realises it's meant to use gzip anyway

As a result, this test was passing, but the "log" produced was a meaningless truncated gzip stream. This fixes the test to actually exercise the flow (which, thankfully, is working).
