### PR TITLE
[exporter/elasticsearchexporter] Improve error msg for invalid number datapoints

### DIFF
--- a/.chloggen/dp-number-error-messages.yaml
+++ b/.chloggen/dp-number-error-messages.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve error message when an invalid Number data point is received.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39063]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/internal/datapoints/number.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/number.go
@@ -32,13 +32,13 @@ func (dp Number) Value() (pcommon.Value, error) {
 	case pmetric.NumberDataPointValueTypeDouble:
 		value := dp.DoubleValue()
 		if math.IsNaN(value) || math.IsInf(value, 0) {
-			return pcommon.Value{}, fmt.Errorf("invalid number data point %q", dp.metric.Name())
+			return pcommon.Value{}, fmt.Errorf("invalid double value in number data point %q, either NaN or Inf", dp.metric.Name())
 		}
 		return pcommon.NewValueDouble(value), nil
 	case pmetric.NumberDataPointValueTypeInt:
 		return pcommon.NewValueInt(dp.IntValue()), nil
 	}
-	return pcommon.Value{}, fmt.Errorf("invalid number data point %q", dp.metric.Name())
+	return pcommon.Value{}, fmt.Errorf("invalid number data point %q, wrong ValueType %s", dp.metric.Name(), dp.ValueType())
 }
 
 func (dp Number) DynamicTemplate(metric pmetric.Metric) string {


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Improve error messages when a Number data point value is invalid.

The previous error messages conflate the 2 failure cases, making it hard to troubleshoot the exact error.

The new messages identify uniquely the error via a unique message and provide additional troubleshooting information when the data point value type is not recognized.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/39063
