### PR TITLE
[receiver/azuremonitorreceiver] Collect only supported aggregations for each metric (501 not implemented issue)

### DIFF
--- a/.chloggen/fix_43648.yaml
+++ b/.chloggen/fix_43648.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Collect only supported aggregations for each metric (501 not implemented issue)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43648]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Some metrics were not collected because we requested all available aggregation types. This led to 501 errors, as the Azure API returned responses indicating that certain aggregations were not implemented.
+  We now use the supported aggregations field from each metric definition to filter and request only the aggregations that are actually supported.
+  The user can expect less 501 errors in the logs and more metrics in the results.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -59,7 +59,21 @@ Authenticating using managed identities has the following optional settings:
 
 ### Filtering metrics
 
-The `metrics` configuration setting is designed to limit scraping to specific metrics and their particular aggregations. It accepts a nested map where the key of the top-level is the Azure Metric Namespace, the key of the nested map is an Azure Metric Name, and the map values are a list of aggregation methods (e.g., Average, Minimum, Maximum, Total, Count). Additionally, the metric map value can be an empty array or an array with one element `*` (asterisk). In this case, the scraper will fetch all supported aggregations for a metric. The letter case of the Namespaces, Metric names, and Aggregations does not affect the functionality.
+The `metrics` configuration setting is designed to **limit** scraping to specific metrics and their particular aggregations.
+It accepts a nested map where 
+- the key of the top-level is the Azure Metric Namespace,
+- the key of the nested map is an Azure Metric Name,
+- and the map values are a list of aggregation methods (e.g., Average, Minimum, Maximum, Total, Count).
+
+> [!NOTE]  
+> - **"All aggregations" shortcut**: The metric map value can be an empty array ``[]`` or an array with one "wildcard" element `[*]`.
+    In this case, the scraper will fetch **all supported aggregations** for that metric, which is also the case if no
+    `metrics` configuration is provided.
+> - **Case Insensitive**: The letter case of the Namespaces, Metric names, and Aggregations does not affect the functionality.
+
+> [!WARNING]  
+> If you started providing a `metrics` configuration for a namespace, you have to specify all the metrics and their 
+> aggregations for that namespace. Otherwise, these metrics will be ignored.
 
 Scraping limited metrics and aggregations:
 
@@ -75,6 +89,7 @@ receivers:
       "microsoft.eventhub/namespaces": # scraper will fetch only the metrics listed below:
         IncomingMessages: [total]     # metric IncomingMessages with aggregation "Total"
         NamespaceCpuUsage: [*]        # metric NamespaceCpuUsage with all known aggregations
+        ActiveConnections: []         # metric ActiveConnections with all known aggregations (same effect than [*])
 ```
 
 ### Use Batch API (experimental)

--- a/receiver/azuremonitorreceiver/mocks_test.go
+++ b/receiver/azuremonitorreceiver/mocks_test.go
@@ -299,12 +299,13 @@ func newResourcesMockData(inputMap map[string][][]*armresources.GenericResourceE
 }
 
 // metricsDefinitionMockInput is used to mock the response of the metrics definition API.
-// Everything is required except dimensions.
+// Everything is required except dimensions and supportedAggregationTypes.
 type metricsDefinitionMockInput struct {
-	namespace  string
-	name       string
-	timeGrain  string
-	dimensions []string
+	namespace                 string                       // required
+	name                      string                       // required
+	timeGrain                 string                       // required
+	dimensions                []string                     // optional
+	supportedAggregationTypes []armmonitor.AggregationType // optional
 }
 
 // newMetricsDefinitionMockData is a helper function to create metrics definition list response.
@@ -325,6 +326,15 @@ func newMetricsDefinitionMockData(inputMap map[string][]metricsDefinitionMockInp
 			for _, dimension := range input.dimensions {
 				toAppend.Dimensions = append(toAppend.Dimensions, &armmonitor.LocalizableString{Value: &dimension})
 			}
+
+			if len(input.supportedAggregationTypes) == 0 {
+				input.supportedAggregationTypes = armmonitor.PossibleAggregationTypeValues()
+			}
+
+			for _, aggregationType := range input.supportedAggregationTypes {
+				toAppend.SupportedAggregationTypes = append(toAppend.SupportedAggregationTypes, &aggregationType)
+			}
+
 			values[i] = &toAppend
 		}
 

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -366,7 +366,7 @@ func (s *azureScraper) getResourceMetricsDefinitions(ctx context.Context, subscr
 
 		for _, v := range nextResult.Value {
 			metricName := *v.Name.Value
-			metricAggregations := getMetricAggregations(*v.Namespace, metricName, s.cfg.Metrics)
+			metricAggregations := getMetricAggregations(*v.Namespace, metricName, s.cfg.Metrics, convertAggregationsToStr(v.SupportedAggregationTypes))
 			if len(metricAggregations) == 0 {
 				continue
 			}
@@ -515,30 +515,39 @@ func (s *azureScraper) processTimeseriesData(
 	}
 }
 
-func getMetricAggregations(metricNamespace, metricName string, filters NestedListAlias) []string {
+// getMetricAggregations returns a list of aggregations for a given namespace/metric.
+// Two parameters are considered to know the aggregation to choose
+// - a filter (given in configuration)
+// - a list of supported aggregations (given by the API)
+// If one namespace/metrics combination matches a provided filter,
+// > Then it returns the aggregations in the filter
+// > Otherwise it returns all supported aggregations.
+// Note that a special filter * is supported to return all supported aggregations explicitly.
+// /!\ It does not control the aggregations in the filters. If it's not in the supported list, it still lets it pass.
+func getMetricAggregations(metricNamespace, metricName string, filters NestedListAlias, supportedAggregations []string) []string {
 	// default behavior when no metric filters specified: pass all metrics with all aggregations
 	if len(filters) == 0 {
-		return aggregations
+		return supportedAggregations
 	}
 
 	metricsFilters, ok := mapFindInsensitive(filters, metricNamespace)
-	// metric namespace not found or it's empty: pass all metrics from the namespace
+	// metric namespace isn't found, or it's empty: pass all metrics from the namespace
 	if !ok || len(metricsFilters) == 0 {
-		return aggregations
+		return supportedAggregations
 	}
 
 	aggregationsFilters, ok := mapFindInsensitive(metricsFilters, metricName)
-	// if target metric is absent in metrics map: filter out metric
+	// if the target metric is absent in the metrics map: filter out metric
 	if !ok {
 		return []string{}
 	}
 	// allow all aggregations if others are not specified
 	if len(aggregationsFilters) == 0 || slices.Contains(aggregationsFilters, filterAllAggregations) {
-		return aggregations
+		return supportedAggregations
 	}
 
-	// collect known supported aggregations
-	out := []string{}
+	// collect known aggregations without filtering on supported
+	var out []string
 	for _, filter := range aggregationsFilters {
 		for _, aggregation := range aggregations {
 			if strings.EqualFold(aggregation, filter) {
@@ -548,6 +557,14 @@ func getMetricAggregations(metricNamespace, metricName string, filters NestedLis
 	}
 
 	return out
+}
+
+func convertAggregationsToStr(aggregations []*armmonitor.AggregationType) []string {
+	var result []string
+	for _, aggr := range aggregations {
+		result = append(result, string(*aggr))
+	}
+	return result
 }
 
 func mapFindInsensitive[T any](m map[string]T, key string) (T, bool) {

--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -351,7 +351,7 @@ func (s *azureBatchScraper) getResourceMetricsDefinitionsByType(ctx context.Cont
 
 		for _, v := range nextResult.Value {
 			metricName := *v.Name.Value
-			metricAggregations := getMetricAggregations(*v.Namespace, metricName, s.cfg.Metrics)
+			metricAggregations := getMetricAggregations(*v.Namespace, metricName, s.cfg.Metrics, convertAggregationsToStr(v.SupportedAggregationTypes))
 			if len(metricAggregations) == 0 {
 				continue
 			}

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -583,21 +583,24 @@ func TestGetMetricAggregations(t *testing.T) {
 	testNamespaceName := "Microsoft.AAD/DomainServices"
 	testMetricName := "MetricName"
 	tests := []struct {
-		name    string
-		filters NestedListAlias
-		want    []string
+		name                  string
+		filters               NestedListAlias
+		supportedAggregations []string
+		want                  []string
 	}{
 		{
-			name:    "should return all aggregations when metrics filter empty",
-			filters: NestedListAlias{},
-			want:    aggregations,
+			name:                  "should return supported aggregations when metrics filter empty",
+			filters:               NestedListAlias{},
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return all aggregations when namespace not in filters",
 			filters: NestedListAlias{
 				"another.namespace": nil,
 			},
-			want: aggregations,
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return all aggregations when metric in filters",
@@ -606,7 +609,8 @@ func TestGetMetricAggregations(t *testing.T) {
 					testMetricName: {},
 				},
 			},
-			want: aggregations,
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return all aggregations ignoring metric name case",
@@ -615,7 +619,8 @@ func TestGetMetricAggregations(t *testing.T) {
 					strings.ToLower(testMetricName): {},
 				},
 			},
-			want: aggregations,
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return all aggregations when asterisk in filters",
@@ -624,7 +629,8 @@ func TestGetMetricAggregations(t *testing.T) {
 					testMetricName: {filterAllAggregations},
 				},
 			},
-			want: aggregations,
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should be empty when metric not in filters",
@@ -633,7 +639,8 @@ func TestGetMetricAggregations(t *testing.T) {
 					"not_this_metric": {},
 				},
 			},
-			want: []string{},
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{},
 		},
 		{
 			name: "should return one aggregations",
@@ -642,7 +649,8 @@ func TestGetMetricAggregations(t *testing.T) {
 					testMetricName: {aggregations[0]},
 				},
 			},
-			want: []string{aggregations[0]},
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return one aggregations ignoring aggregation case",
@@ -651,7 +659,18 @@ func TestGetMetricAggregations(t *testing.T) {
 					testMetricName: {strings.ToLower(aggregations[0])},
 				},
 			},
-			want: []string{aggregations[0]},
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0]},
+		},
+		{
+			name: "should return one aggregations even if not supported",
+			filters: NestedListAlias{
+				testNamespaceName: {
+					testMetricName: {aggregations[0]},
+				},
+			},
+			supportedAggregations: []string{aggregations[2]},
+			want:                  []string{aggregations[0]},
 		},
 		{
 			name: "should return many aggregations",
@@ -660,13 +679,14 @@ func TestGetMetricAggregations(t *testing.T) {
 					testMetricName: {aggregations[0], aggregations[2]},
 				},
 			},
-			want: []string{aggregations[0], aggregations[2]},
+			supportedAggregations: []string{aggregations[0]},
+			want:                  []string{aggregations[0], aggregations[2]},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getMetricAggregations(testNamespaceName, testMetricName, tt.filters)
+			got := getMetricAggregations(testNamespaceName, testMetricName, tt.filters, tt.supportedAggregations)
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When we collect metrics, we ask for all available aggregations (Average, Sum, Min, Max, ...) but when we do so with some metrics, Azure API is giving a 501 Not Implemented error. So we need to really respect the definition of each metric.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates #43648 (not fully fixing)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
For the full e2e tests, the impact on tests has only been to setup supported aggregation in the ``metrics definition`` mocks. We simulate supporting all aggregation in the definition to make sure the tests results are unchanged. 

We rely on unit test of the ``getMetricAggregations`` function to test a more variety of cases.

<!--Describe the documentation added.-->
#### Documentation

Updated to provide more details.
<img width="1089" height="829" alt="image" src="https://github.com/user-attachments/assets/28b8559b-0b7a-4e23-9072-f4023ea61747" />

<!--Please delete paragraphs that you did not use before submitting.-->
