### PR TITLE
Add TrimPrefix and TrimSuffix to OTTL

### DIFF
--- a/.chloggen/trim-suffix-prefix.yaml
+++ b/.chloggen/trim-suffix-prefix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add TrimPrefix and TrimSuffix to OTTL
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43883]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a much optimal way to remove prefix/suffix compare with `replace_pattern(name, "^prefixed", "")`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -2147,6 +2147,44 @@ Examples:
 - `Trim(" this is a test ", " ")`
 - `Trim("!!this is a test!!", "!!")`
 
+### TrimPrefix
+
+`TrimPrefix(value, prefix)`
+
+The `TrimPrefix` function returns the `value` without the provided leading `prefix` string. If `value` doesn't start with `prefix`, `value` is returned unchanged.
+
+The returned type is `string`.
+
+If the `value` is not a string or does not exist, the `TrimPrefix` converter will return an error.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `set(resource.attributes["service.name"], TrimPrefix(resource.attributes["service.name"], "ingest_"))`
+
+
+- `TrimPrefix("ingest_service", "ingest_")`
+
+### TrimSuffix
+
+`TrimSuffix(value, suffix)`
+
+The `TrimSuffix` function returns the `value` without the provided trailing `suffix` string. If `value` doesn't start with `suffix`, `value` is returned unchanged.
+
+The returned type is `string`.
+
+If the `value` is not a string or does not exist, the `TrimSuffix` converter will return an error.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `set(resource.attributes["service.name"], TrimSuffix(resource.attributes["service.name"], "_service"))`
+
+
+- `TrimSuffix("ingest_service", "_service")`
+
 ### String
 
 `String(value)`

--- a/pkg/ottl/ottlfuncs/func_trim_prefix.go
+++ b/pkg/ottl/ottlfuncs/func_trim_prefix.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type TrimPrefixArguments[K any] struct {
+	Target ottl.StringGetter[K]
+	Prefix ottl.StringGetter[K]
+}
+
+func NewTrimPrefixFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Trim", &TrimPrefixArguments[K]{}, createTrimPrefixFunction[K])
+}
+
+func createTrimPrefixFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*TrimPrefixArguments[K])
+
+	if !ok {
+		return nil, errors.New("TrimFactory args must be of type *TrimPrefixArguments[K]")
+	}
+
+	return trimPrefix(args.Target, args.Prefix), nil
+}
+
+func trimPrefix[K any](target, prefix ottl.StringGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		prefixVal, err := prefix.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return strings.TrimPrefix(val, prefixVal), nil
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_trim_prefix_test.go
+++ b/pkg/ottl/ottlfuncs/func_trim_prefix_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_TrimPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   any
+		prefix   ottl.StringGetter[any]
+		expected string
+	}{
+		{
+			name:     "has prefix true",
+			target:   "hello world",
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "hello ", nil }},
+			expected: "world",
+		},
+		{
+			name:     "has prefix false",
+			target:   "hello world",
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return " world", nil }},
+			expected: "hello world",
+		},
+		{
+			name:     "target pcommon.Value",
+			target:   pcommon.NewValueStr("hello world"),
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "hello", nil }},
+			expected: " world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := NewTrimPrefixFactory[any]()
+			exprFunc, err := factory.CreateFunction(
+				ottl.FunctionContext{},
+				&TrimPrefixArguments[any]{
+					Target: ottl.StandardStringGetter[any]{
+						Getter: func(context.Context, any) (any, error) {
+							return tt.target, nil
+						},
+					},
+					Prefix: tt.prefix,
+				})
+			assert.NoError(t, err)
+			result, err := exprFunc(t.Context(), nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_TrimPrefix_Error(t *testing.T) {
+	target := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	prefix := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return "test", nil
+		},
+	}
+	exprFunc := trimPrefix[any](target, prefix)
+	_, err := exprFunc(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func Test_TrimPrefix_Error_prefix(t *testing.T) {
+	target := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	prefix := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	exprFunc := trimPrefix[any](target, prefix)
+	_, err := exprFunc(t.Context(), nil)
+	require.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/func_trim_suffix.go
+++ b/pkg/ottl/ottlfuncs/func_trim_suffix.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type TrimSuffixArguments[K any] struct {
+	Target ottl.StringGetter[K]
+	Suffix ottl.StringGetter[K]
+}
+
+func NewTrimSuffixFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Trim", &TrimSuffixArguments[K]{}, createTrimSuffixFunction[K])
+}
+
+func createTrimSuffixFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*TrimSuffixArguments[K])
+
+	if !ok {
+		return nil, errors.New("TrimFactory args must be of type *TrimSuffixArguments[K]")
+	}
+
+	return trimSuffix(args.Target, args.Suffix), nil
+}
+
+func trimSuffix[K any](target, prefix ottl.StringGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		prefixVal, err := prefix.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return strings.TrimSuffix(val, prefixVal), nil
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_trim_suffix_test.go
+++ b/pkg/ottl/ottlfuncs/func_trim_suffix_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_TrimSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   any
+		prefix   ottl.StringGetter[any]
+		expected string
+	}{
+		{
+			name:     "has prefix true",
+			target:   "hello world",
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "hello ", nil }},
+			expected: "hello world",
+		},
+		{
+			name:     "has prefix false",
+			target:   "hello world",
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return " world", nil }},
+			expected: "hello",
+		},
+		{
+			name:     "target pcommon.Value",
+			target:   pcommon.NewValueStr("hello world"),
+			prefix:   &ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "world", nil }},
+			expected: "hello ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := NewTrimSuffixFactory[any]()
+			exprFunc, err := factory.CreateFunction(
+				ottl.FunctionContext{},
+				&TrimSuffixArguments[any]{
+					Target: ottl.StandardStringGetter[any]{
+						Getter: func(context.Context, any) (any, error) {
+							return tt.target, nil
+						},
+					},
+					Suffix: tt.prefix,
+				})
+			assert.NoError(t, err)
+			result, err := exprFunc(t.Context(), nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_TrimSuffix_Error(t *testing.T) {
+	target := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	prefix := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return "test", nil
+		},
+	}
+	exprFunc := trimSuffix[any](target, prefix)
+	_, err := exprFunc(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func Test_TrimSuffix_Error_prefix(t *testing.T) {
+	target := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	prefix := &ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return true, nil
+		},
+	}
+	exprFunc := trimSuffix[any](target, prefix)
+	_, err := exprFunc(t.Context(), nil)
+	require.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -100,6 +100,8 @@ func converters[K any]() []ottl.Factory[K] {
 		NewTimeFactory[K](),
 		NewFormatTimeFactory[K](),
 		NewTrimFactory[K](),
+		NewTrimPrefixFactory[K](),
+		NewTrimSuffixFactory[K](),
 		NewToKeyValueStringFactory[K](),
 		NewToCamelCaseFactory[K](),
 		NewToLowerCaseFactory[K](),


### PR DESCRIPTION
This is a much optimal way to remove prefix/suffix compare with `replace_pattern(name, "^prefixed", "")`