### PR TITLE
[cmd/telemetrygen] move validate func out of common

### DIFF
--- a/cmd/telemetrygen/internal/validate/validate.go
+++ b/cmd/telemetrygen/internal/validate/validate.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package common
+package validate
 
 import (
 	"encoding/hex"
@@ -15,7 +15,7 @@ var (
 	errInvalidSpanID        = errors.New("failed to create SpanID byte array from the given SpanID, make sure the SpanID is a hex representation of a [8]byte, like: '5828fa4960140870'")
 )
 
-func ValidateTraceID(traceID string) error {
+func TraceID(traceID string) error {
 	if len(traceID) != 32 {
 		return errInvalidTraceIDLength
 	}
@@ -28,7 +28,7 @@ func ValidateTraceID(traceID string) error {
 	return nil
 }
 
-func ValidateSpanID(spanID string) error {
+func SpanID(spanID string) error {
 	if len(spanID) != 16 {
 		return errInvalidSpanIDLength
 	}

--- a/cmd/telemetrygen/internal/validate/validate_test.go
+++ b/cmd/telemetrygen/internal/validate/validate_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package common
+package validate
 
 import (
 	"testing"
@@ -33,7 +33,7 @@ func TestValidateTraceID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateTraceID(tt.traceID)
+			err := TraceID(tt.traceID)
 			assert.ErrorIs(t, err, tt.expected)
 		})
 	}
@@ -63,7 +63,7 @@ func TestValidateSpanID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSpanID(tt.spanID)
+			err := SpanID(tt.spanID)
 			assert.ErrorIs(t, err, tt.expected)
 		})
 	}

--- a/cmd/telemetrygen/pkg/logs/config.go
+++ b/cmd/telemetrygen/pkg/logs/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/validate"
 	types "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/pkg"
 )
 
@@ -70,13 +71,13 @@ func (c *Config) Validate() error {
 	}
 
 	if c.TraceID != "" {
-		if err := common.ValidateTraceID(c.TraceID); err != nil {
+		if err := validate.TraceID(c.TraceID); err != nil {
 			return err
 		}
 	}
 
 	if c.SpanID != "" {
-		if err := common.ValidateSpanID(c.SpanID); err != nil {
+		if err := validate.SpanID(c.SpanID); err != nil {
 			return err
 		}
 	}

--- a/cmd/telemetrygen/pkg/metrics/config.go
+++ b/cmd/telemetrygen/pkg/metrics/config.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/validate"
 	types "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/pkg"
 )
 
@@ -86,13 +87,13 @@ func (c *Config) Validate() error {
 	}
 
 	if c.TraceID != "" {
-		if err := common.ValidateTraceID(c.TraceID); err != nil {
+		if err := validate.TraceID(c.TraceID); err != nil {
 			return err
 		}
 	}
 
 	if c.SpanID != "" {
-		if err := common.ValidateSpanID(c.SpanID); err != nil {
+		if err := validate.SpanID(c.SpanID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Removing common package. Moving the code to validate package instead.
