### PR TITLE
[chore] cmd/opampsupervisor: fix flaky test

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -2118,7 +2118,9 @@ func TestSupervisorRemoteConfigApplyStatus(t *testing.T) {
 
 			// Check that the status is set to APPLYING
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				status := remoteConfigStatus.Load().(*protobufs.RemoteConfigStatus)
+				statusVal := remoteConfigStatus.Load()
+				require.NotNil(c, statusVal) // not set yet
+				status := statusVal.(*protobufs.RemoteConfigStatus)
 				t.Log("status", status.Status)
 				assert.Equal(c, protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLYING, status.Status)
 			}, 5*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
#### Description

The status may not be set by the time the test first checks it, so check that rather than panicking.

#### Link to tracking issue

Fixes #43849

#### Testing

Adding a sleep before https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/2dd76008043a199cb539d398ae12156d5db0032d/cmd/opampsupervisor/e2e_test.go#L2074 triggers the bug reliably. The test passes with a sleep there with change in this PR.

#### Documentation

N/A