### PR TITLE
[receiver/prometheus] associate _created metric from OM Counters to same metricfamily and metricgroup as _total metric

### DIFF
--- a/.chloggen/erw_ct_family.yaml
+++ b/.chloggen/erw_ct_family.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change how scrape counter metric's metricFamily and metricGroup are cached within a transaction. 
+  This enables _created line of counter in openmetrics-text format to be attributed to the same metricGroup as the counter itself.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43888]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -49,6 +49,7 @@ type metricGroup struct {
 	// - https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1
 	createdSeconds float64
 	value          float64
+	hasValue       bool
 	hValue         *histogram.Histogram
 	fhValue        *histogram.FloatHistogram
 	complexValue   []*dataPoint
@@ -405,6 +406,9 @@ func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 }
 
 func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
+	if !mg.hasValue {
+		return
+	}
 	tsNanos := timestampFromMs(mg.ts)
 	point := dest.AppendEmpty()
 	// gauge/undefined types have no start time.
@@ -495,9 +499,11 @@ func (mf *metricFamily) addSeries(seriesRef uint64, metricName string, ls labels
 			mg.createdSeconds = v
 		} else {
 			mg.value = v
+			mg.hasValue = true
 		}
 	default:
 		mg.value = v
+		mg.hasValue = true
 	}
 
 	return nil

--- a/receiver/prometheusreceiver/metrics_receiver_created_timestamp_zero_ingestion_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_created_timestamp_zero_ingestion_test.go
@@ -141,24 +141,9 @@ func verifyOpenMetricsCreatedTimestampZeroIngestionDisabled(t *testing.T, td *te
 			[]dataPointExpectation{
 				{
 					numberPointComparator: []numberPointComparator{
-						compareStartTimestamp(tsZero),
-						compareTimestamp(ts1),
-						compareDoubleValue(1.0),
-					},
-				},
-			},
-			nil,
-		},
-		{
-			"a_seconds_created",
-			pmetric.MetricTypeSum,
-			"s",
-			[]dataPointExpectation{
-				{
-					numberPointComparator: []numberPointComparator{
 						compareStartTimestamp(timestampFromFloat64(123.456)),
 						compareTimestamp(ts1),
-						compareDoubleValue(0),
+						compareDoubleValue(1.0),
 					},
 				},
 			},

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -4,6 +4,7 @@
 package prometheusreceiver
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -11,9 +12,11 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -326,4 +329,214 @@ func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pme
 		},
 	}
 	doCompare(t, "scrape-infostatesetmetrics-1", wantAttributes, m1, e1)
+}
+
+var counterPayload = `# TYPE test_counter counter
+test_counter_total 12
+test_counter_created 1.55555e+09
+`
+
+var counterMultiPayload = `# TYPE test_counter counter
+test_counter_total{foo="bar1"} 12
+test_counter_created{foo="bar1"} 1.55555e+09
+test_counter_total{foo="bar2"} 100
+test_counter_created{foo="bar2"} 1
+`
+
+var counterReversePayload = `# TYPE test_counter counter
+test_counter_created 1.55555e+09
+test_counter_total 12
+`
+
+var counterNoValue = `# TYPE test_counter counter
+test_counter_created 1.55555e+09
+`
+
+var summaryPayload = `# TYPE test_summary summary
+test_summary_count 1
+test_summary_sum 2
+test_summary_created 1.55555e+09
+test_summary{quantile="0.5"} 0.7
+test_summary{quantile="1"} 0.8
+`
+
+var histogramPayload = `# TYPE test_histogram histogram
+test_histogram_bucket{le="0.0"} 0.0
+test_histogram_bucket{le="10.0"} 15.0
+test_histogram_bucket{le="+Inf"} 50.0
+test_histogram_count 50.0
+test_histogram_sum 123.3
+test_histogram_created 1.55555e+09
+`
+
+func formPage(payloads ...string) string {
+	sb := strings.Builder{}
+	for _, payload := range payloads {
+		sb.Write([]byte(payload))
+	}
+	sb.Write([]byte("# EOF\n"))
+	return sb.String()
+}
+
+func TestCreatedMetric(t *testing.T) {
+	tests := []*testData{
+		{
+			name: "counter",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: formPage(counterPayload), useOpenMetrics: true},
+			},
+			validateFunc: verifyCreatedTimeMetric(verifyOpts{true, false, false, nil}),
+		},
+		{
+			name: "counter reversed",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: formPage(counterReversePayload), useOpenMetrics: true},
+			},
+			validateFunc: verifyCreatedTimeMetric(verifyOpts{true, false, false, nil}),
+		},
+		{
+			name: "counter multiple series",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: formPage(counterMultiPayload), useOpenMetrics: true},
+			},
+			validateFunc: verifyCreatedTimeMetric(verifyOpts{true, false, false, func(t *testing.T, metrics []pmetric.Metric) {
+				for _, metric := range metrics {
+					if metric.Name() != "test_counter_total" {
+						continue
+					}
+					require.Equal(t, 2, metric.Sum().DataPoints().Len())
+					var first, second pmetric.NumberDataPoint
+					if v, k := metric.Sum().DataPoints().At(0).Attributes().Get("foo"); k && v.AsString() == "bar1" {
+						first = metric.Sum().DataPoints().At(0)
+						second = metric.Sum().DataPoints().At(1)
+					} else {
+						first = metric.Sum().DataPoints().At(1)
+						second = metric.Sum().DataPoints().At(0)
+					}
+					fooValue, _ := first.Attributes().Get("foo")
+					require.Equal(t, "bar1", fooValue.AsString())
+					require.Equal(t, expectedST, first.StartTimestamp())
+					require.Equal(t, 12.0, first.DoubleValue())
+					fooValue, _ = second.Attributes().Get("foo")
+					require.Equal(t, "bar2", fooValue.AsString())
+					require.Equal(t, pcommon.Timestamp(time.Unix(1, 0).UnixNano()), second.StartTimestamp())
+					require.Equal(t, 100.0, second.DoubleValue())
+					return
+				}
+				t.Fatalf("did not find expected metric")
+			}}),
+		},
+		{
+			name: "counter no value",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: formPage(counterNoValue), useOpenMetrics: true},
+			},
+			validateFunc: verifyCreatedTimeMetric(verifyOpts{false, false, false, nil}),
+		},
+		{
+			name: "all",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: formPage(counterPayload, summaryPayload, histogramPayload), useOpenMetrics: true},
+			},
+			validateFunc: verifyCreatedTimeMetric(verifyOpts{true, true, true, nil}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testComponent(t, []*testData{test}, nil)
+		})
+	}
+}
+
+type verifyOpts struct {
+	wantCounter   bool
+	wantSummary   bool
+	wantHisto     bool
+	checkOverride func(t *testing.T, metrics []pmetric.Metric)
+}
+
+const ctMetricValueAsSecFloat = 1.55555e+09
+
+var (
+	expectedSTSecsPart  = int64(ctMetricValueAsSecFloat)
+	expectedSTNanosPart = int64((ctMetricValueAsSecFloat - float64(expectedSTSecsPart)) * float64(time.Second))
+	expectedST          = pcommon.Timestamp(expectedSTSecsPart*int64(time.Second) + expectedSTNanosPart)
+)
+
+func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+	return func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+		wantCounter, wantSummary, wantHisto := o.wantCounter, o.wantSummary, o.wantHisto
+		require.NotEmpty(t, mds, "At least one resource metric should be present")
+		metrics := getMetrics(mds[0])
+		assertUp(t, 1, metrics)
+
+		if !wantCounter && !wantSummary && !wantHisto {
+			require.Equal(t, len(metrics), countScrapeMetrics(metrics, false))
+			return
+		}
+		require.Greater(t, len(metrics), countScrapeMetrics(metrics, false))
+
+		if len(mds) > 1 {
+			// We expect a single scrape and the rest (if exists) to be stale (up==0).
+			for _, m := range mds[1:] {
+				metrics = getMetrics(m)
+				assertUp(t, 0, metrics)
+			}
+		}
+
+		if o.checkOverride != nil {
+			o.checkOverride(t, metrics)
+			return
+		}
+
+		var (
+			seenHisto   bool
+			seenSummary bool
+			seenCounter bool
+		)
+		// inspect the scraped metric
+		for _, m := range metrics {
+			name := m.Name()
+			if !strings.HasPrefix(name, "test_") {
+				continue
+			}
+			switch name {
+			case "test_histogram":
+				h := m.Histogram()
+				require.NotNil(t, h)
+				require.Equal(t, expectedST, h.DataPoints().At(0).StartTimestamp())
+				seenHisto = true
+			case "test_summary":
+				s := m.Summary()
+				require.NotNil(t, s)
+				require.Equal(t, expectedST, s.DataPoints().At(0).StartTimestamp())
+				seenSummary = true
+			case "test_counter_total":
+				s := m.Sum()
+				require.NotNil(t, s)
+				require.Equal(t, expectedST, s.DataPoints().At(0).StartTimestamp())
+				seenCounter = true
+			default:
+				require.Fail(t, "unexpected metric name", name)
+			}
+		}
+
+		msgFn := func(seen bool) string {
+			if seen {
+				return "scraped metric contains %s which is not expected"
+			}
+			return "scraped metric does not contain expected %s"
+		}
+		if wantHisto != seenHisto {
+			require.Fail(t, fmt.Sprintf(msgFn(seenHisto), "histogram test_histogram"))
+		}
+
+		if wantSummary != seenSummary {
+			require.Fail(t, fmt.Sprintf(msgFn(seenSummary), "summary test_summary"))
+		}
+		if wantCounter != seenCounter {
+			require.Fail(t, fmt.Sprintf(msgFn(seenCounter), "counter test_counter_total"))
+		}
+	}
 }

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -464,7 +464,7 @@ var (
 	expectedST          = pcommon.Timestamp(expectedSTSecsPart*int64(time.Second) + expectedSTNanosPart)
 )
 
-func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, _ *testData, mds []pmetric.ResourceMetrics) {
 	return func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
 		wantCounter, wantSummary, wantHisto := o.wantCounter, o.wantSummary, o.wantHisto
 		require.NotEmpty(t, mds, "At least one resource metric should be present")

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -336,11 +336,14 @@ test_counter_total 12
 test_counter_created 1.55555e+09
 `
 
+// shuffle the order of _created and _total lines
+// with an orphaned _created line {foo=bar3} that should not produce a Sum datapoint
 var counterMultiPayload = `# TYPE test_counter counter
+test_counter_created{foo="bar2"} 1
 test_counter_total{foo="bar1"} 12
 test_counter_created{foo="bar1"} 1.55555e+09
+test_counter_created{foo="bar3"} 100
 test_counter_total{foo="bar2"} 100
-test_counter_created{foo="bar2"} 1
 `
 
 var counterReversePayload = `# TYPE test_counter counter
@@ -465,7 +468,7 @@ var (
 )
 
 func verifyCreatedTimeMetric(o verifyOpts) func(t *testing.T, _ *testData, mds []pmetric.ResourceMetrics) {
-	return func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+	return func(t *testing.T, _ *testData, mds []pmetric.ResourceMetrics) {
 		wantCounter, wantSummary, wantHisto := o.wantCounter, o.wantSummary, o.wantHisto
 		require.NotEmpty(t, mds, "At least one resource metric should be present")
 		metrics := getMetrics(mds[0])


### PR DESCRIPTION
#### Description
From #43888:
It seems we have two paths to "parse" the `_created` metric line for Summaries and Histograms into the metricgroup's CT field in promreceiver. 
1) With `EnableCreatedTimestampZeroIngestion` enabled: the _created line is parsed by the om parser and and added to the approriate metric via appender's `AppendCT*` methods. This works for Summaries, Histograms and Counters but with known resource regressions (#40245), from having to copy a new parser to forward-seek the _created line.

2) With `EnableCreatedTimestampZeroIngestion` disabled (by default): the _created line is parsed by the om parser as its own metric. The promReceiver transaction ends up caching/keying the _created metric into the same metric family and group as the summary/histogram bucket/count/quantile lines - using well know suffixes to re-normalize metric names. The code path does not call the parser's `CreatedTimestamp` method. I'm not sure if this is all intentional behaviour or a happy accident.
This doesn't work for counters because of the special naming [convention](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/internal/metadata.go#L46) used to form its cache key. 

If we're okay with the behaviour described in point 2 - I'd like to extend it to counters as well here.



<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
addresses issue #43888

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit Tests
Manual Test (results in issue)

I ran this build for a few hours scraping a bunch of _created metrics - no obvious leaks have occurred yet. 
<!--Describe the documentation added.-->

<img width="1282" height="262" alt="image" src="https://github.com/user-attachments/assets/6c52c5cd-946c-49e7-8ff0-e2b76c451ab1" />


