### PR TITLE
[chore] internal/kafka: remove redundant warning

### DIFF
--- a/internal/kafka/franz_client.go
+++ b/internal/kafka/franz_client.go
@@ -5,11 +5,8 @@ package kafka // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/fnv"
-	"io"
-	"net"
 	"strings"
 	"time"
 
@@ -244,11 +241,6 @@ func commonOpts(ctx context.Context, clientCfg configkafka.ClientConfig,
 		if tlsCfg != nil {
 			opts = append(opts, kgo.DialTLSConfig(tlsCfg))
 		}
-	} else {
-		// Add a hook that gives a hint that TLS is not configured
-		// in case we try to connect to a TLS-only broker.
-		var hook kgo.HookBrokerConnect = hookBrokerConnectPlaintext{logger: logger}
-		opts = append(opts, kgo.WithHooks(hook))
 	}
 	// Configure authentication
 	if clientCfg.Authentication.PlainText != nil {
@@ -376,25 +368,4 @@ func saramaHashFn(b []byte) uint32 {
 	h.Reset()
 	h.Write(b)
 	return h.Sum32()
-}
-
-type hookBrokerConnectPlaintext struct {
-	logger *zap.Logger
-}
-
-func (h hookBrokerConnectPlaintext) OnBrokerConnect(
-	meta kgo.BrokerMetadata, _ time.Duration, conn net.Conn, err error,
-) {
-	if conn == nil {
-		// Could not make a network connection, this is not related to TLS.
-		return
-	}
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		h.logger.Warn(
-			"failed to connect to broker, it may require TLS but TLS is not configured",
-			zap.String("host", meta.Host),
-			zap.Error(err),
-		)
-		return
-	}
 }

--- a/internal/kafka/franz_client_test.go
+++ b/internal/kafka/franz_client_test.go
@@ -164,7 +164,8 @@ func TestNewFranzSyncProducer_TLS(t *testing.T) {
 		// Should fail because the server expects TLS.
 		require.Error(t, tryConnect(nil))
 		filtered := observedLogs.FilterMessage(
-			"failed to connect to broker, it may require TLS but TLS is not configured",
+			// franz-go logs this warning message:
+			"read from broker received EOF during api versions discovery, which often happens when the broker requires TLS and the client is not using it (is TLS misconfigured?)",
 		)
 		assert.NotEmpty(t, filtered.All())
 	})


### PR DESCRIPTION
#### Description

Remove the hook that guesses that TLS is misconfigured, since franz-go now warns on the same scenario. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40145#issuecomment-3413371399

#### Link to tracking issue

N/A

#### Testing

Updated tests

#### Documentation

N/A