### PR TITLE
[exporter/prometheusexporter] add independent metric cleanup

### DIFF
--- a/.chloggen/independent-metric-cleanup.yaml
+++ b/.chloggen/independent-metric-cleanup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix metric cleanup by adding independent metric cleanup
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41123]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -28,7 +28,7 @@ type prometheusExporter struct {
 	registry     *prometheus.Registry
 	settings     component.TelemetrySettings
 
-	// background metric cleanup 
+	// background metric cleanup
 	cleanupCancel context.CancelFunc
 	cleanupWG     sync.WaitGroup
 }
@@ -89,7 +89,7 @@ func (pe *prometheusExporter) Start(ctx context.Context, host component.Host) er
 		_ = srv.Serve(ln)
 	}()
 
-	interval := pe.config.MetricExpiration / 2
+	interval := max(pe.config.MetricExpiration/2, time.Second*10)
 	cleanupCtx, cancel := context.WithCancel(context.Background())
 	pe.cleanupCancel = cancel
 	pe.cleanupWG.Add(1)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
fixes memory leak in prometheus exporter by adding independent metric cleanup.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41123 