### PR TITLE
[receiver/prometheusremotewritereceiver] accept unspecified histogram

### DIFF
--- a/.chloggen/accept-unspecified-histogram.yaml
+++ b/.chloggen/accept-unspecified-histogram.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: prometheusremotewrite receiver now accepts metric type unspcified histograms.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/concurrency-bug.yaml
+++ b/.chloggen/concurrency-bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/prometheusremotewrite 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed a concurrency bug in the Prometheus remote write receiver where concurrent requests with identical job/instance labels would return empty responses after the first successful request.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42159]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -341,7 +341,8 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 		description := req.Symbols[ts.Metadata.HelpRef]
 
 		// Handle histograms separately due to their complex mixed-schema processing
-		if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM {
+		if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM ||
+			ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_UNSPECIFIED && len(ts.Histograms) > 0 {
 			prw.processHistogramTimeSeries(otelMetrics, ls, ts, scopeName, scopeVersion, metricName, unit, description, metricCache, &stats, modifiedResourceMetric)
 			continue
 		}
@@ -513,6 +514,11 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			}
 			metricCache[metricIDHash] = histMetric
+			if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM {
+				histMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+			} else {
+				histMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "unknown")
+			}
 		} else if len(histMetric.Description()) < len(description) {
 			// When the new description is longer than the existing one, we should update the metric description.
 			// Reference to this behavior: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -514,9 +514,10 @@ func (prw *prometheusRemoteWriteReceiver) processHistogramTimeSeries(
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			}
 			metricCache[metricIDHash] = histMetric
-			if ts.Metadata.Type == writev2.Metadata_METRIC_TYPE_HISTOGRAM {
+			switch ts.Metadata.Type {
+			case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
 				histMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
-			} else {
+			default:
 				histMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "unknown")
 			}
 		} else if len(histMetric.Description()) < len(description) {

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -466,7 +466,7 @@ func TestTranslateV2(t *testing.T) {
 				cbneMetric.SetName("test_metric")
 				cbneMetric.SetUnit("")
 				cbneMetric.SetDescription("")
-				// cbneMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				cbneMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist := cbneMetric.SetEmptyHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -497,7 +497,7 @@ func TestTranslateV2(t *testing.T) {
 				expMetric.SetName("test_metric")
 				expMetric.SetUnit("")
 				expMetric.SetDescription("")
-				// expMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				expMetric.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				expHist := expMetric.SetEmptyExponentialHistogram()
 				expHist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -744,7 +744,7 @@ func TestTranslateV2(t *testing.T) {
 				m.SetName("test_metric")
 				m.SetUnit("")
 				m.SetDescription("")
-				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -828,7 +828,7 @@ func TestTranslateV2(t *testing.T) {
 				m.SetName("test_metric")
 				m.SetUnit("")
 				m.SetDescription("")
-				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -891,7 +891,7 @@ func TestTranslateV2(t *testing.T) {
 				m := sm.Metrics().AppendEmpty()
 				m.SetName("test_metric")
 				m.SetUnit("")
-				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -981,7 +981,7 @@ func TestTranslateV2(t *testing.T) {
 				m := sm.Metrics().AppendEmpty()
 				m.SetName("test_metric")
 				m.SetUnit("")
-				// m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 
 				hist := m.SetEmptyExponentialHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -1177,6 +1177,7 @@ func TestTranslateV2(t *testing.T) {
 				m1.SetName("test_hncb_histogram")
 				m1.SetUnit("")
 				m1.SetDescription("")
+				m1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist := m1.SetEmptyHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -1243,6 +1244,7 @@ func TestTranslateV2(t *testing.T) {
 				m1.SetName("test_hncb_histogram_stale")
 				m1.SetUnit("")
 				m1.SetDescription("")
+				m1.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist := m1.SetEmptyHistogram()
 				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -1395,7 +1397,7 @@ func TestTranslateV2(t *testing.T) {
 				m2.SetName("test_mixed_histogram")
 				m2.SetUnit("")
 				m2.SetDescription("")
-				// m2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
+				m2.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "histogram")
 				hist2 := m2.SetEmptyExponentialHistogram()
 				hist2.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 
@@ -1410,6 +1412,90 @@ func TestTranslateV2(t *testing.T) {
 				dp2.Positive().SetOffset(0)
 				dp2.Positive().BucketCounts().FromRaw([]uint64{30, 70})
 
+				return metrics
+			}(),
+		},
+		{
+			name: "unspecified histogram",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric", // 1, 2
+					"job", "service-x/test", // 3, 4
+					"instance", "107cn001", // 5, 6
+					"otel_scope_name", "scope1", // 7, 8
+					"otel_scope_version", "v1", // 9, 10
+					"attr1", "attr1", // 11, 12
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						CreatedTimestamp: 1,
+						Metadata: writev2.Metadata{
+							Type: writev2.Metadata_METRIC_TYPE_UNSPECIFIED,
+						},
+						Histograms: []writev2.Histogram{
+							{
+								Count: &writev2.Histogram_CountInt{
+									CountInt: 20,
+								},
+								Sum:           30,
+								Timestamp:     1,
+								ZeroThreshold: 1,
+								ZeroCount: &writev2.Histogram_ZeroCountInt{
+									ZeroCountInt: 2,
+								},
+								Schema:         -4,
+								PositiveSpans:  []writev2.BucketSpan{{Offset: 1, Length: 2}, {Offset: 3, Length: 1}},
+								NegativeSpans:  []writev2.BucketSpan{{Offset: 0, Length: 1}, {Offset: 2, Length: 1}},
+								PositiveDeltas: []int64{100, 244, 221},
+								NegativeDeltas: []int64{1, 2},
+							},
+						},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+					},
+				},
+			},
+			expectedStats: remote.WriteResponseStats{
+				Confirmed:  true,
+				Samples:    0,
+				Histograms: 1,
+				Exemplars:  0,
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				metrics := pmetric.NewMetrics()
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				attrs := rm.Resource().Attributes()
+				attrs.PutStr("service.namespace", "service-x")
+				attrs.PutStr("service.name", "test")
+				attrs.PutStr("service.instance.id", "107cn001")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName("scope1")
+				sm.Scope().SetVersion("v1")
+
+				m := sm.Metrics().AppendEmpty()
+				m.SetName("test_metric")
+				m.SetUnit("")
+				m.SetDescription("")
+				m.Metadata().PutStr(prometheus.MetricMetadataTypeKey, "unknown")
+
+				hist := m.SetEmptyExponentialHistogram()
+				hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+				dp := hist.DataPoints().AppendEmpty()
+				dp.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetStartTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp.SetScale(-4)
+				dp.SetSum(30)
+				dp.SetCount(20)
+				dp.SetZeroCount(2)
+				dp.SetZeroThreshold(1)
+				dp.Positive().SetOffset(0)
+				dp.Positive().BucketCounts().FromRaw([]uint64{100, 344, 0, 0, 0, 565})
+				dp.Negative().BucketCounts().FromRaw([]uint64{1})
+				dp.Negative().SetOffset(-1)
+				dp.Negative().BucketCounts().FromRaw([]uint64{1, 0, 0, 3})
+				dp.Attributes().PutStr("attr1", "attr1")
 				return metrics
 			}(),
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
prometheusremote write receiver now accepts histogram with unspecified metric type.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41840 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a testcase in ` TestTranslateV2` test function to test unspecified histogram.
