### PR TITLE
[testbed] Enable debug logs for STEF correctness tests

### DIFF
--- a/testbed/correctnesstests/metrics/metrics_correctness_test.go
+++ b/testbed/correctnesstests/metrics/metrics_correctness_test.go
@@ -24,6 +24,8 @@ func TestHarness_MetricsGoldenData(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
 	res := results{}
 	res.Init("results")
 	for _, test := range tests {


### PR DESCRIPTION
I was trying to understand why we get failures in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42947 and it is unclear so far.

I am enabling debug logs to see if it can help when the failure happens next time.
