### PR TITLE
starttimemetrics processor does not set start timestamp if already set

### DIFF
--- a/.chloggen/metricstarttime_alreadyset.yaml
+++ b/.chloggen/metricstarttime_alreadyset.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/metricstarttime
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not set start timestamp if it is already set.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43739]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster.go
@@ -82,6 +82,10 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 					dataPoints := metric.Sum().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
+						if st := dp.StartTimestamp(); st != 0 && st != dp.Timestamp() {
+							// Report point as is if the start timestamp is already set.
+							continue
+						}
 						refTsi, found := tsm.Get(metric, dp.Attributes())
 						if !found {
 							refTsi.Number = datapointstorage.NumberInfo{StartTime: startTimeTs}
@@ -97,6 +101,10 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 					dataPoints := metric.Summary().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
+						if st := dp.StartTimestamp(); st != 0 && st != dp.Timestamp() {
+							// Report point as is if the start timestamp is already set.
+							continue
+						}
 						refTsi, found := tsm.Get(metric, dp.Attributes())
 						if !found {
 							refTsi.Summary = datapointstorage.SummaryInfo{StartTime: startTimeTs}
@@ -111,6 +119,10 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 					dataPoints := metric.Histogram().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
+						if st := dp.StartTimestamp(); st != 0 && st != dp.Timestamp() {
+							// Report point as is if the start timestamp is already set.
+							continue
+						}
 						refTsi, found := tsm.Get(metric, dp.Attributes())
 						if !found {
 							refTsi.Histogram = datapointstorage.HistogramInfo{StartTime: startTimeTs, ExplicitBounds: dp.ExplicitBounds().AsRaw()}
@@ -126,6 +138,10 @@ func (a *Adjuster) AdjustMetrics(_ context.Context, metrics pmetric.Metrics) (pm
 					dataPoints := metric.ExponentialHistogram().DataPoints()
 					for l := 0; l < dataPoints.Len(); l++ {
 						dp := dataPoints.At(l)
+						if st := dp.StartTimestamp(); st != 0 && st != dp.Timestamp() {
+							// Report point as is if the start timestamp is already set.
+							continue
+						}
 						refTsi, found := tsm.Get(metric, dp.Attributes())
 						if !found {
 							refTsi.ExponentialHistogram = datapointstorage.ExponentialHistogramInfo{StartTime: startTimeTs, Scale: dp.Scale()}

--- a/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/starttimemetric/adjuster_test.go
@@ -18,11 +18,12 @@ import (
 )
 
 var (
-	t1 = testhelper.TimestampFromMs(1)
-	t2 = testhelper.TimestampFromMs(2)
-	t3 = testhelper.TimestampFromMs(3)
-	t4 = testhelper.TimestampFromMs(4)
-	t5 = testhelper.TimestampFromMs(5)
+	tUnknown = testhelper.TimestampFromMs(0)
+	t1       = testhelper.TimestampFromMs(1)
+	t2       = testhelper.TimestampFromMs(2)
+	t3       = testhelper.TimestampFromMs(3)
+	t4       = testhelper.TimestampFromMs(4)
+	t5       = testhelper.TimestampFromMs(5)
 
 	bounds0  = []float64{1, 2, 4}
 	percent0 = []float64{10, 50, 90}
@@ -41,7 +42,7 @@ var (
 )
 
 func TestStartTimeMetricMatch(t *testing.T) {
-	const startTime = pcommon.Timestamp(123 * 1e9)
+	startTime := tUnknown
 	const currentTime = pcommon.Timestamp(126 * 1e9)
 	const collectorStartTime = pcommon.Timestamp(129 * 1e9)
 	const matchBuilderStartTime = 124
@@ -99,6 +100,17 @@ func TestStartTimeMetricMatch(t *testing.T) {
 				testhelper.GaugeMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
 			),
 			expectedStartTime: timestampFromFloat64(matchBuilderStartTime + 1),
+		},
+		{
+			name: "start time already set",
+			inputs: testhelper.Metrics(
+				testhelper.SumMetric("test_sum_metric", testhelper.DoublePoint(nil, t1, currentTime, 16)),
+				testhelper.HistogramMetric("test_histogram_metric", testhelper.HistogramPoint(nil, t1, currentTime, []float64{1, 2}, []uint64{2, 3, 4})),
+				testhelper.SummaryMetric("test_summary_metric", testhelper.SummaryPoint(nil, t1, currentTime, 10, 100, []float64{10, 50, 90}, []float64{9, 15, 48})),
+				testhelper.GaugeMetric("example_process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime)),
+				testhelper.GaugeMetric("process_start_time_seconds", testhelper.DoublePoint(nil, startTime, currentTime, matchBuilderStartTime+1)),
+			),
+			expectedStartTime: t1,
 		},
 		{
 			name: "empty gauge start time metrics",
@@ -189,7 +201,7 @@ func TestStartTimeMetricMatch(t *testing.T) {
 }
 
 func TestStartTimeMetricFallback(t *testing.T) {
-	const startTime = pcommon.Timestamp(123 * 1e9)
+	startTime := tUnknown
 	const currentTime = pcommon.Timestamp(126 * 1e9)
 	mockStartTime := time.Now().Add(-10 * time.Hour)
 	mockStartTimeSeconds := float64(mockStartTime.Unix())
@@ -281,7 +293,7 @@ func TestStartTimeMetricFallback(t *testing.T) {
 }
 
 func TestMultiMetrics(t *testing.T) {
-	const startTime = pcommon.Timestamp(123 * 1e9)
+	startTime := tUnknown
 	const currentTime = pcommon.Timestamp(126 * 1e9)
 	const matchBuilderStartTime = 124
 	matchedStartTimeStamp := timestampFromFloat64(matchBuilderStartTime)

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster.go
@@ -95,6 +95,10 @@ func (*Adjuster) adjustMetricHistogram(tsm *datapointstorage.TimeseriesMap, curr
 	currentPoints := histogram.DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentDist := currentPoints.At(i)
+		if st := currentDist.StartTimestamp(); st != 0 && st != currentDist.Timestamp() {
+			// Report point as is if the start timestamp is already set.
+			continue
+		}
 
 		refTsi, found := tsm.Get(current, currentDist.Attributes())
 		if !found {
@@ -140,6 +144,10 @@ func (*Adjuster) adjustMetricExponentialHistogram(tsm *datapointstorage.Timeseri
 	currentPoints := histogram.DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentDist := currentPoints.At(i)
+		if st := currentDist.StartTimestamp(); st != 0 && st != currentDist.Timestamp() {
+			// Report point as is if the start timestamp is already set.
+			continue
+		}
 
 		refTsi, found := tsm.Get(current, currentDist.Attributes())
 		if !found {
@@ -182,6 +190,10 @@ func (*Adjuster) adjustMetricSum(tsm *datapointstorage.TimeseriesMap, current pm
 	currentPoints := current.Sum().DataPoints()
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSum := currentPoints.At(i)
+		if st := currentSum.StartTimestamp(); st != 0 && st != currentSum.Timestamp() {
+			// Report point as is if the start timestamp is already set.
+			continue
+		}
 
 		refTsi, found := tsm.Get(current, currentSum.Attributes())
 		if !found {
@@ -221,6 +233,10 @@ func (*Adjuster) adjustMetricSummary(tsm *datapointstorage.TimeseriesMap, curren
 
 	for i := 0; i < currentPoints.Len(); i++ {
 		currentSummary := currentPoints.At(i)
+		if st := currentSummary.StartTimestamp(); st != 0 && st != currentSummary.Timestamp() {
+			// Report point as is if the start timestamp is already set.
+			continue
+		}
 
 		refTsi, found := tsm.Get(current, currentSummary.Attributes())
 		if !found {

--- a/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
+++ b/processor/metricstarttimeprocessor/internal/truereset/adjuster_test.go
@@ -483,6 +483,27 @@ func TestMultiMetrics(t *testing.T) {
 	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
 }
 
+func TestStartTimeAlreadySet(t *testing.T) {
+	script := []*testhelper.MetricsAdjusterTest{
+		{
+			Description: "TestStartTimeAlreadySet",
+			Metrics: testhelper.Metrics(
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t1, t2, 44)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t1, t2, 44)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t1, t2, bounds0, []uint64{4, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t1, t2, 10, 40, percent0, []float64{1, 5, 8})),
+			),
+			Adjusted: testhelper.Metrics(
+				testhelper.GaugeMetric(gauge1, testhelper.DoublePoint(k1v1k2v2, t1, t2, 44)),
+				testhelper.SumMetric(sum1, testhelper.DoublePoint(k1v1k2v2, t1, t2, 44)),
+				testhelper.HistogramMetric(histogram1, testhelper.HistogramPoint(k1v1k2v2, t1, t2, bounds0, []uint64{4, 2, 3, 7})),
+				testhelper.SummaryMetric(summary1, testhelper.SummaryPoint(k1v1k2v2, t1, t2, 10, 40, percent0, []float64{1, 5, 8})),
+			),
+		},
+	}
+	testhelper.RunScript(t, NewAdjuster(componenttest.NewNopTelemetrySettings(), time.Minute), script)
+}
+
 func TestNewDataPointsAdded(t *testing.T) {
 	script := []*testhelper.MetricsAdjusterTest{
 		{


### PR DESCRIPTION
#### Description

Makes the behavior of strategies consistent: they do not adjust metrics which already have a valid start time set (and aren't a true-reset point).

#### Link to tracking issue
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43739

#### Testing

Added and updated unit tests.

cc @eriksywu @ridwanmsharif @braydonk 
