### PR TITLE
[receiver/azuremonitor] unexport functions

### DIFF
--- a/.chloggen/unexport_functions.yaml
+++ b/.chloggen/unexport_functions.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: unexport NewMutexMapImpl and NewSyncMapImpl
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43925]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/azuremonitorreceiver/concurrency.go
+++ b/receiver/azuremonitorreceiver/concurrency.go
@@ -47,7 +47,7 @@ type syncMapImpl[V any] struct {
 	m sync.Map
 }
 
-func NewSyncMapImpl[V any]() concurrentMetricsBuilderMap[V] {
+func newSyncMapImpl[V any]() concurrentMetricsBuilderMap[V] {
 	return &syncMapImpl[V]{}
 }
 
@@ -85,7 +85,7 @@ type mutexMapImpl[V any] struct {
 	mutex sync.RWMutex
 }
 
-func NewMutexMapImpl[V any]() concurrentMetricsBuilderMap[V] {
+func newMutexMapImpl[V any]() concurrentMetricsBuilderMap[V] {
 	return &mutexMapImpl[V]{m: make(map[string]V)}
 }
 

--- a/receiver/azuremonitorreceiver/concurrency_test.go
+++ b/receiver/azuremonitorreceiver/concurrency_test.go
@@ -25,12 +25,12 @@ func BenchmarkConcurrentMapImpl(b *testing.B) {
 }
 
 func BenchmarkSyncMapImpl(b *testing.B) {
-	m := NewSyncMapImpl[int]()
+	m := newSyncMapImpl[int]()
 	benchmarkMapImpl(b, m)
 }
 
 func BenchmarkMutexMapImpl(b *testing.B) {
-	m := NewMutexMapImpl[int]()
+	m := newMutexMapImpl[int]()
 	benchmarkMapImpl(b, m)
 }
 
@@ -63,11 +63,11 @@ func BenchmarkConcurrentMapImplLarge(b *testing.B) {
 }
 
 func BenchmarkSyncMapImplLarge(b *testing.B) {
-	m := NewSyncMapImpl[int]()
+	m := newSyncMapImpl[int]()
 	benchmarkMapImplLarge(b, m)
 }
 
 func BenchmarkMutexMapImplLarge(b *testing.B) {
-	m := NewMutexMapImpl[int]()
+	m := newMutexMapImpl[int]()
 	benchmarkMapImplLarge(b, m)
 }


### PR DESCRIPTION
Both functions are used for benchmarks in the module. They do not need to be exposed as API.