### PR TITLE
[chore] [receiver/splunkenterprise] Add missing stability level

### DIFF
--- a/receiver/splunkenterprisereceiver/documentation.md
+++ b/receiver/splunkenterprisereceiver/documentation.md
@@ -434,9 +434,9 @@ This is the overall status of the kvstore for the given deployment.
 
 Gauge tracking the seconds remaining on any given Splunk License found via Splunk API. **Note:** This will only work on a Cluster Manager.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {seconds} | Gauge | Int |
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {seconds} | Gauge | Int | development |
 
 #### Attributes
 

--- a/receiver/splunkenterprisereceiver/metadata.yaml
+++ b/receiver/splunkenterprisereceiver/metadata.yaml
@@ -306,6 +306,8 @@ metrics:
     attributes: [splunk.kvstore.storage.engine, splunk.kvstore.external, splunk.kvstore.status.value, splunk.splunkd.build, splunk.splunkd.version]
   splunk.license.expiration.seconds_remaining:
     enabled: false
+    stability:
+      level: development
     description: Gauge tracking the seconds remaining on any given Splunk License found via Splunk API. **Note:** This will only work on a Cluster Manager.
     unit: "{seconds}"
     gauge:


### PR DESCRIPTION
Add missing stability level to splunk.license.expiration.seconds_remaining metric to unblock core upgrade
