### PR TITLE
Remove unnecessary full copy of maps/slices when setting value on sub-map

### DIFF
--- a/.chloggen/rm-unnecessary-copy.yaml
+++ b/.chloggen/rm-unnecessary-copy.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unnecessary full copy of maps/slices when setting value on sub-map
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43949]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/contexts/internal/ctxutil/value.go
+++ b/pkg/ottl/contexts/internal/ctxutil/value.go
@@ -59,9 +59,21 @@ func SetValue(value pcommon.Value, val any) error {
 			err = SetValue(pval, a)
 		}
 	case pcommon.Slice:
-		v.CopyTo(value.SetEmptySlice())
+		var dest pcommon.Slice
+		if value.Type() == pcommon.ValueTypeSlice {
+			dest = value.Slice()
+		} else {
+			dest = value.SetEmptySlice()
+		}
+		v.CopyTo(dest)
 	case pcommon.Map:
-		v.CopyTo(value.SetEmptyMap())
+		var dest pcommon.Map
+		if value.Type() == pcommon.ValueTypeMap {
+			dest = value.Map()
+		} else {
+			dest = value.SetEmptyMap()
+		}
+		v.CopyTo(dest)
 	case map[string]any:
 		err = value.FromRaw(v)
 	}


### PR DESCRIPTION
The problems happens when assume inside "attributes" there is a key called "tags" that is a pcommon.Map. Here is an example:

```
delete_key(attributes[tags], "test_key") where metric.name = "foo"
```

Because of the changes to always call set value on the target (see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42350) we will get to do a SetValue where the src and destination are the same, but because we always set the destination to emptyMap will do a full copy of the sub-map tags.