### PR TITLE
[exporter/stef] Fix flaky TestConnManagerFlush

### DIFF
--- a/exporter/stefexporter/internal/connmanager_test.go
+++ b/exporter/stefexporter/internal/connmanager_test.go
@@ -290,16 +290,11 @@ func TestConnManagerFlush(t *testing.T) {
 				// Release the connection first.
 				cm.Release(t.Context(), conn)
 
-				// Advance the clock so that the connection is flush in the background.
-				// We advance the clock twice the reconnect period to guarantee that
-				// all connections are flushed (all connections are expected to be flushed
-				// in one reconnect period, but that's on the edge, we want a guarantee,
-				// that's why double).
-				cm.clock.(*clockwork.FakeClock).Advance(reconnectPeriod * 2)
-
 				// Make sure the flush is done.
 				assert.Eventually(
 					t, func() bool {
+						// Advance the clock so that the connection is flush in the background.
+						cm.clock.(*clockwork.FakeClock).Advance(flushPeriod)
 						return conn.conn.(*mockConn).Flushed()
 					},
 					5*time.Second,


### PR DESCRIPTION
#### Description

TestConnManagerFlush was previously advancing the fake clock without waiting for the flusher to even start. This meant that if the flusher goroutine was late to start it would never receive the tick from the fake clock.

Changed the test to continuously advance the fake clock while waiting for flush to happen. We use similar approach in other tests with fake clock.

This is a fake clock problem. It is never an issue with real clock since real clock already advances in continuous manner. There is no bug in the ConnManager flusher implementation, no fixes are needed there. I considered making ConnManager.Start() wait until flusher is ready, but that's unnecessary with real clock and I don't want to change it just to make fake clock implementation happy.

#### Link to tracking issue

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42947#issuecomment-3388258007

#### Testing

Run `go test -run TestConnManagerFlush -count 1000` in a loop for a while successfully.
Previously this was reliably failing.
