### PR TITLE
[43644] feat(exporter/loadbalancing/dnsresolver): add quarantine mechanism for unhealthy endpoints

### DIFF
--- a/.chloggen/loadbalancingexporter-43644-add-quarantine.yaml
+++ b/.chloggen/loadbalancingexporter-43644-add-quarantine.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/loadbalancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Quarantine mechanism for unhealthy endpoints in the DNS resolver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43644]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Added a quarantine feature for unhealthy endpoints, delaying retries to those endpoints after a configurable period (default: 30s).
+  - Quarantine settings are configurable via the DNS resolver's `quarantine` section.
+  - The load balancer will avoid sending data to endpoints marked as unhealthy until their quarantine period expires, using healthy endpoints in the hash ring without triggering unnecessary ring updates.
+  - This increases resilience by reducing the risk of exporters being stuck in degraded states with repeated failed attempts.
+  - This feature currently applies only to the DNS resolver.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -95,6 +95,9 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `port` port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
   * `interval` resolver interval in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `5s` will be used.
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `1s` will be used.
+  * `quarantine` node: enables a quarantine mechanism that prevents the exporter from sending data to endpoints that have previously failed (i.e., are marked as unhealthy) until a defined quarantine period passes. While an endpoint is quarantined, only healthy endpoints in the hash ring are used to dispatch data, avoiding unnecessary hash ring updates and reducing the risk of repeatedly targeting unhealthy endpoints.
+    * `enabled` toggle to activate endpoint quarantine logic. Default is `false`.
+    * `duration` how long in go-Duration format an unhealthy endpoint should remain in quarantine before the exporter retries it (e.g., `30s`, `1m`). Defaults to `30s` if not specified.
 * The `k8s` node accepts the following optional properties:
   * `service` Kubernetes service to resolve, e.g. `lb-svc.lb-ns`. If no namespace is specified, an attempt will be made to infer the namespace for this collector, and if this fails it will fall back to the `default` namespace.
   * `ports` port to be used for exporting the traces to the addresses resolved from `service`. If `ports` is not specified, the default port 4317 is used. When multiple ports are specified, two backends are added to the load balancer as if they were at different pods.

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -78,10 +78,11 @@ type StaticResolver struct {
 
 // DNSResolver defines the configuration for the DNS resolver
 type DNSResolver struct {
-	Hostname string        `mapstructure:"hostname"`
-	Port     string        `mapstructure:"port"`
-	Interval time.Duration `mapstructure:"interval"`
-	Timeout  time.Duration `mapstructure:"timeout"`
+	Hostname   string             `mapstructure:"hostname"`
+	Port       string             `mapstructure:"port"`
+	Interval   time.Duration      `mapstructure:"interval"`
+	Timeout    time.Duration      `mapstructure:"timeout"`
+	Quarantine QuarantineSettings `mapstructure:"quarantine"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -92,6 +93,17 @@ type K8sSvcResolver struct {
 	Ports           []int32       `mapstructure:"ports"`
 	Timeout         time.Duration `mapstructure:"timeout"`
 	ReturnHostnames bool          `mapstructure:"return_hostnames"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+// QuarantineSettings defines the configuration for endpoint quarantine behavior
+type QuarantineSettings struct {
+	// Duration specifies how long an unhealthy endpoint should be excluded from load balancing
+	// after a failure. After this duration, the endpoint will be eligible for retry.
+	// Default: 30s
+	Duration time.Duration `mapstructure:"duration"`
+	Enabled  bool          `mapstructure:"enabled"`
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -39,18 +39,21 @@ func newHashRing(endpoints []string) *hashRing {
 	}
 }
 
-// endpointFor calculates which backend is responsible for the given traceID
-func (h *hashRing) endpointFor(identifier []byte) string {
-	if h == nil {
-		// perhaps the ring itself couldn't get initialized yet?
-		return ""
-	}
+// getPosition calculates the position in the ring for the given identifier
+func getPosition(identifier []byte) position {
 	hasher := crc32.NewIEEE()
 	hasher.Write(identifier)
 	hash := hasher.Sum32()
 	pos := hash % maxPositions
+	return position(pos)
+}
 
-	return h.findEndpoint(position(pos))
+// endpointFor calculates which backend is responsible for the given traceID
+func (h *hashRing) endpointFor(identifier []byte) string {
+	if h == nil {
+		return ""
+	}
+	return h.findEndpoint(getPosition(identifier))
 }
 
 // findEndpoint returns the "next" endpoint starting from the given position, or an empty string in case no endpoints are available

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -28,14 +28,16 @@ type ringItem struct {
 // hashRing is a consistent hash ring following Karger et al.
 type hashRing struct {
 	// ringItems holds all the positions, used for the lookup the position for the closest next ring item
-	items []ringItem
+	items     []ringItem
+	endpoints []string
 }
 
 // newHashRing builds a new immutable consistent hash ring based on the given endpoints.
 func newHashRing(endpoints []string) *hashRing {
 	items := positionsForEndpoints(endpoints, defaultWeight)
 	return &hashRing{
-		items: items,
+		items:     items,
+		endpoints: endpoints,
 	}
 }
 

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -199,6 +199,7 @@ func TestEqual(t *testing.T) {
 		[]ringItem{
 			{pos: position(123), endpoint: "endpoint-1"},
 		},
+		[]string{"endpoint-1"},
 	}
 
 	for _, tt := range []struct {
@@ -208,7 +209,7 @@ func TestEqual(t *testing.T) {
 	}{
 		{
 			"empty",
-			&hashRing{[]ringItem{}},
+			&hashRing{[]ringItem{}, []string{}},
 			false,
 		},
 		{
@@ -222,6 +223,7 @@ func TestEqual(t *testing.T) {
 				[]ringItem{
 					{pos: position(123), endpoint: "endpoint-1"},
 				},
+				[]string{"endpoint-1"},
 			},
 			true,
 		},
@@ -232,6 +234,7 @@ func TestEqual(t *testing.T) {
 					{pos: position(123), endpoint: "endpoint-1"},
 					{pos: position(124), endpoint: "endpoint-2"},
 				},
+				[]string{"endpoint-1", "endpoint-2"},
 			},
 			false,
 		},
@@ -241,6 +244,7 @@ func TestEqual(t *testing.T) {
 				[]ringItem{
 					{pos: position(124), endpoint: "endpoint-1"},
 				},
+				[]string{"endpoint-1"},
 			},
 			false,
 		},
@@ -250,6 +254,7 @@ func TestEqual(t *testing.T) {
 				[]ringItem{
 					{pos: position(123), endpoint: "endpoint-2"},
 				},
+				[]string{"endpoint-2"},
 			},
 			false,
 		},

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -289,8 +289,8 @@ func (lb *loadBalancer) exporterAndEndpoint(identifier []byte) (*wrappedExporter
 	return exp, endpoint, nil
 }
 
-// nextExporterAndEndpoint returns the next exporter and endpoint in the ring after the given position.
-func (lb *loadBalancer) nextExporterAndEndpoint(pos position) (*wrappedExporter, string, error) {
+// exporterAndEndpointByPosition returns the exporter and endpoint in the ring at the given position.
+func (lb *loadBalancer) exporterAndEndpointByPosition(pos position) (*wrappedExporter, string, error) {
 	lb.updateLock.RLock()
 	defer lb.updateLock.RUnlock()
 
@@ -325,9 +325,9 @@ func (lb *loadBalancer) consumeWithRetryAndQuarantine(identifier []byte, exp *wr
 	currentPos := getPosition(identifier)
 
 	// Try until we've used all available endpoints
-	for len(tried) < len(lb.exporters) {
+	for len(tried) < len(lb.ring.endpoints) {
 		// retryExp, retryEndpoint, retryErr := lb.exporterAndEndpoint(identifier)
-		retryExp, retryEndpoint, retryErr := lb.nextExporterAndEndpoint(currentPos)
+		retryExp, retryEndpoint, retryErr := lb.exporterAndEndpointByPosition(currentPos)
 		if retryErr != nil {
 			// Return original error if we can't get a new endpoint
 			return err

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -436,7 +436,7 @@ func newNopMockExporter() *wrappedExporter {
 	return newWrappedExporter(mockComponent{}, "mock")
 }
 
-func TestNextExporterAndEndpoint(t *testing.T) {
+func TestExporterAndEndpointByPosition(t *testing.T) {
 	// prepare
 	ts, tb := getTelemetryAssets(t)
 	cfg := &Config{
@@ -461,7 +461,7 @@ func TestNextExporterAndEndpoint(t *testing.T) {
 	pos := getPosition([]byte("endpoint-2"))
 
 	// find next exporter and endpoint at the position
-	exp, nextEndpoint, err := p.nextExporterAndEndpoint(pos)
+	exp, nextEndpoint, err := p.exporterAndEndpointByPosition(pos)
 
 	// verify
 	assert.NoError(t, err)
@@ -470,7 +470,7 @@ func TestNextExporterAndEndpoint(t *testing.T) {
 	assert.Contains(t, []string{"endpoint-1"}, nextEndpoint)
 }
 
-func TestNextExporterAndEndpointVisitsAllEndpoints(t *testing.T) {
+func TestExporterAndEndpointByPositionVisitsAllEndpoints(t *testing.T) {
 	// prepare
 	ts, tb := getTelemetryAssets(t)
 	cfg := &Config{
@@ -496,7 +496,7 @@ func TestNextExporterAndEndpointVisitsAllEndpoints(t *testing.T) {
 
 	for _, endpoint := range endpoints {
 		pos := getPosition([]byte(endpoint))
-		_, endpoint, err := p.nextExporterAndEndpoint(pos)
+		_, endpoint, err := p.exporterAndEndpointByPosition(pos)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, endpoint)
 		visited[endpoint] = true
@@ -507,7 +507,7 @@ func TestNextExporterAndEndpointVisitsAllEndpoints(t *testing.T) {
 	}
 }
 
-func TestNextExporterAndEndpointEmptyRing(t *testing.T) {
+func TestExporterAndEndpointByPositionEmptyRing(t *testing.T) {
 	// prepare
 	ts, tb := getTelemetryAssets(t)
 	cfg := &Config{
@@ -533,7 +533,7 @@ func TestNextExporterAndEndpointEmptyRing(t *testing.T) {
 		delete(p.exporters, endpoint)
 	}
 
-	_, _, err = p.nextExporterAndEndpoint(getPosition([]byte("endpoint-1")))
+	_, _, err = p.exporterAndEndpointByPosition(getPosition([]byte("endpoint-1")))
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "couldn't find the exporter")

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
@@ -688,6 +689,484 @@ func TestConsumeLogs_DNSResolverRetriesExhausted(t *testing.T) {
 	res := p.ConsumeLogs(t.Context(), simpleLogs())
 	require.Error(t, res)
 	require.EqualError(t, res, "all endpoints were tried and failed: map[endpoint-1:true endpoint-2:true]")
+}
+
+func TestConsumeLogs_DNSResolverQuarantineWithParentExporterBackoffEnabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 5 * time.Millisecond, // Short quarantine - must be shorter than backoff intervals
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockLogsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint1Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint2Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	// Max elapsed time is 250ms, so it should retry 4 times per endpoint
+	// 10ms, 20ms, 40ms, 80ms
+	// Total time should be 150ms
+	wrappedExporterBackOffConfig := configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         200 * time.Millisecond,
+		MaxElapsedTime:      250 * time.Millisecond,
+	}
+
+	// Wrap with exporterhelper to enable retry logic with backoff
+	retryExporter, err := exporterhelper.NewLogs(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeLogs,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+		exporterhelper.WithRetry(wrappedExporterBackOffConfig),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := retryExporter.ConsumeLogs(t.Context(), simpleLogs())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	// In the first cycle, quarantine logic should try both endpoints immediately
+	require.Positive(t, endpoint1Attempts.Load(), "endpoint-1 should be tried at least once")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+
+	// With backoff and quarantine working together:
+	require.GreaterOrEqual(t, totalAttempts.Load(), int64(2),
+		"quarantine logic should try both endpoints at least in the initial cycle")
+
+	if totalAttempts.Load() > 2 {
+		t.Logf("Backoff retry occurred: multiple retry cycles observed")
+
+		// Verify that backoff timing was applied by checking the time between first and last attempts
+		timesMutex.Lock()
+		if len(attemptTimes) > 2 {
+			firstAttempt := attemptTimes[0]
+			lastAttempt := attemptTimes[len(attemptTimes)-1]
+			timeBetween := lastAttempt.Sub(firstAttempt)
+			t.Logf("Time between first and last attempt: %v", timeBetween)
+			// We expect multiple retry cycles around ~150ms total elapsed time
+			require.Greater(t, timeBetween.Milliseconds(), int64(125),
+				"should have backoff delay between retry cycles")
+		}
+		timesMutex.Unlock()
+	}
+
+	// The total elapsed time should reflect backoff delays if retries occurred
+	t.Logf("Total elapsed time: %v", elapsed)
+}
+
+func TestConsumeLogs_DNSResolverQuarantineWithParentExporterBackoffDisabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 5 * time.Millisecond, // Short quarantine - must be shorter than backoff intervals
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockLogsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint1Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint2Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	// Wrap with exporterhelper without backoff
+	retryExporter, err := exporterhelper.NewLogs(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeLogs,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := retryExporter.ConsumeLogs(t.Context(), simpleLogs())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	require.Equal(t, int64(1), endpoint1Attempts.Load(), "endpoint-1 should be tried once")
+	require.Equal(t, int64(1), endpoint2Attempts.Load(), "endpoint-2 should be tried once")
+	require.Equal(t, int64(2), totalAttempts.Load(),
+		"quarantine logic should try both endpoints once")
+}
+
+// TestConsumeLogs_DNSResolverQuarantineWithParentExporterBackoffConfig_PartialRecovery tests the scenario
+// where some endpoints recover after being quarantined
+func TestConsumeLogs_DNSResolverQuarantineWithParentExporterBackoffEnabled_PartialRecovery(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 100 * time.Millisecond, // Short quarantine for testing
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockLogsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Endpoint-1 fails initially but recovers after 150ms
+	// Endpoint-2 always fails
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	var startTime time.Time
+
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint1Attempts.Add(1)
+			// Simulate recovery after 150ms
+			if time.Since(startTime) > 150*time.Millisecond {
+				t.Log("endpoint-1 recovered")
+				return nil
+			}
+			t.Log("endpoint-1 temporarily unreachable")
+			return errors.New("endpoint temporarily unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+			endpoint2Attempts.Add(1)
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	wrappedExporterBackOffConfig := configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         200 * time.Millisecond,
+		MaxElapsedTime:      250 * time.Millisecond,
+	}
+
+	// Wrap with exporterhelper to enable retry logic with backoff
+	retryExporter, err := exporterhelper.NewLogs(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeLogs,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+		exporterhelper.WithRetry(wrappedExporterBackOffConfig),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should eventually succeed when endpoint-1 recovers
+	// Set startTime just before the call to ensure consistent timing across platforms
+	startTime = time.Now()
+	res := retryExporter.ConsumeLogs(t.Context(), simpleLogs())
+
+	// Should succeed after endpoint-1 recovers
+	require.NoError(t, res, "should succeed after endpoint-1 recovers")
+
+	t.Logf("Endpoint-1 attempts: %d, Endpoint-2 attempts: %d",
+		endpoint1Attempts.Load(), endpoint2Attempts.Load())
+
+	// Both endpoints should have been tried (quarantine logic)
+	require.Greater(t, endpoint1Attempts.Load(), int64(1), "endpoint-1 should be retried after quarantine period")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+}
+
+func TestConsumeLogs_DNSResolverQuarantineWithSubExporterBackoffEnabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 60 * time.Second, // Long quarantine - must be longer than backoff intervals
+				},
+			}),
+		},
+		Protocol: Protocol{
+			OTLP: otlpexporter.Config{
+				// Max elapsed time is 250ms, so it should retry 4 times per endpoint
+				RetryConfig: configretry.BackOffConfig{
+					Enabled:             true,
+					InitialInterval:     10 * time.Millisecond,
+					RandomizationFactor: 0,
+					Multiplier:          2,
+					MaxInterval:         200 * time.Millisecond,
+					MaxElapsedTime:      250 * time.Millisecond,
+				},
+			},
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockLogsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	// Create mock exporters with retry logic applied via exporterhelper
+	mockExporter1 := newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint1Attempts.Add(1)
+		totalAttempts.Add(1)
+		timesMutex.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		timesMutex.Unlock()
+		return errors.New("endpoint unreachable")
+	})
+	mockExporter2 := newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint2Attempts.Add(1)
+		totalAttempts.Add(1)
+		timesMutex.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		timesMutex.Unlock()
+		return errors.New("endpoint unreachable")
+	})
+
+	// Wrap with exporterhelper to apply retry configuration from cfg.Protocol.OTLP.RetryConfig
+	wrappedExp1, err := exporterhelper.NewLogs(
+		t.Context(),
+		exporter.Settings{
+			ID:                component.NewIDWithName(component.MustNewType("otlp"), "endpoint-1"),
+			TelemetrySettings: ts.TelemetrySettings,
+		},
+		&cfg.Protocol.OTLP,
+		mockExporter1.ConsumeLogs,
+		exporterhelper.WithRetry(cfg.Protocol.OTLP.RetryConfig),
+		exporterhelper.WithStart(mockExporter1.Start),
+		exporterhelper.WithShutdown(mockExporter1.Shutdown),
+	)
+	require.NoError(t, err)
+
+	wrappedExp2, err := exporterhelper.NewLogs(
+		t.Context(),
+		exporter.Settings{
+			ID:                component.NewIDWithName(component.MustNewType("otlp"), "endpoint-2"),
+			TelemetrySettings: ts.TelemetrySettings,
+		},
+		&cfg.Protocol.OTLP,
+		mockExporter2.ConsumeLogs,
+		exporterhelper.WithRetry(cfg.Protocol.OTLP.RetryConfig),
+		exporterhelper.WithStart(mockExporter2.Start),
+		exporterhelper.WithShutdown(mockExporter2.Shutdown),
+	)
+	require.NoError(t, err)
+
+	// Add the wrapped exporters to the load balancer
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(wrappedExp1, "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(wrappedExp2, "endpoint-2:4317"),
+	}
+
+	host := componenttest.NewNopHost()
+
+	// Start the load balancer exporter
+	err = p.Start(t.Context(), host)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := p.ConsumeLogs(t.Context(), simpleLogs())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	// In the first cycle, quarantine logic should try both endpoints immediately
+	require.Positive(t, endpoint1Attempts.Load(), "endpoint-1 should be tried at least once")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+
+	// With backoff and quarantine working together:
+	require.GreaterOrEqual(t, totalAttempts.Load(), int64(2),
+		"quarantine logic should try both endpoints at least in the initial cycle")
+
+	if totalAttempts.Load() > 2 {
+		t.Logf("Backoff retry occurred: multiple retry cycles observed")
+
+		// Verify that backoff timing was applied by checking the time between first and last attempts
+		timesMutex.Lock()
+		if len(attemptTimes) > 2 {
+			firstAttempt := attemptTimes[0]
+			lastAttempt := attemptTimes[len(attemptTimes)-1]
+			timeBetween := lastAttempt.Sub(firstAttempt)
+			t.Logf("Time between first and last attempt: %v", timeBetween)
+			// we expect multiple retry cycles around ~310ms total elapsed time
+			require.Greater(t, timeBetween.Milliseconds(), int64(275),
+				"should have backoff delay between retry cycles")
+		}
+		timesMutex.Unlock()
+	}
+
+	// The total elapsed time should reflect backoff delays if retries occurred
+	t.Logf("Total elapsed time: %v", elapsed)
 }
 
 func randomLogs() plog.Logs {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -129,7 +129,6 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 
 		expMetrics, ok := metricsByExporter[exp]
 		if !ok {
-			exp.consumeWG.Add(1)
 			expMetrics = pmetric.NewMetrics()
 			metricsByExporter[exp] = expMetrics
 			exporterEndpoints[exp] = endpoint
@@ -140,19 +139,32 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 
 	var errs error
 	for exp, mds := range metricsByExporter {
-		start := time.Now()
-		err := exp.ConsumeMetrics(ctx, mds)
-		duration := time.Since(start)
+		consume := func(currentExp *wrappedExporter, currentEndpoint string) error {
+			currentExp.consumeWG.Add(1)
+			start := time.Now()
+			err := currentExp.ConsumeMetrics(ctx, mds)
+			duration := time.Since(start)
+			currentExp.consumeWG.Done()
+			e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(currentExp.endpointAttr))
 
-		exp.consumeWG.Done()
-		errs = multierr.Append(errs, err)
-		e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
-		if err == nil {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
-		} else {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
-			e.logger.Debug("failed to export metrics", zap.Error(err))
+			if err == nil {
+				e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(currentExp.successAttr))
+				return nil
+			}
+
+			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(currentExp.failureAttr))
+			e.logger.Debug("failed to export metrics", zap.String("endpoint", currentEndpoint), zap.Error(err))
+			return err
 		}
+
+		var err error
+		// If quarantine is not enabled, use the consume function directly
+		if !e.loadBalancer.isQuarantineEnabled() {
+			err = consume(exp, exporterEndpoints[exp])
+		} else {
+			err = e.loadBalancer.consumeWithRetryAndQuarantine([]byte(exporterEndpoints[exp]), exp, exporterEndpoints[exp], consume)
+		}
+		errs = multierr.Append(errs, err)
 	}
 
 	return errs

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -22,9 +22,12 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"gopkg.in/yaml.v3"
@@ -759,6 +762,484 @@ func TestConsumeMetrics_DNSResolverRetriesExhausted(t *testing.T) {
 	res := p.ConsumeMetrics(t.Context(), simpleMetricsWithServiceName())
 	require.Error(t, res)
 	require.EqualError(t, res, "all endpoints were tried and failed: map[endpoint-1:true endpoint-2:true]")
+}
+
+func TestConsumeMetrics_DNSResolverQuarantineWithParentExporterBackoffEnabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 5 * time.Millisecond, // Short quarantine - must be shorter than backoff intervals
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockMetricsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint1Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint2Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	// Max elapsed time is 250ms, so it should retry 4 times per endpoint
+	// 10ms, 20ms, 40ms, 80ms
+	// Total time should be 150ms
+	wrappedExporterBackOffConfig := configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         200 * time.Millisecond,
+		MaxElapsedTime:      250 * time.Millisecond,
+	}
+
+	// Wrap with exporterhelper to enable retry logic with backoff
+	retryExporter, err := exporterhelper.NewMetrics(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeMetrics,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+		exporterhelper.WithRetry(wrappedExporterBackOffConfig),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := retryExporter.ConsumeMetrics(t.Context(), simpleMetricsWithServiceName())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	// In the first cycle, quarantine logic should try both endpoints immediately
+	require.Positive(t, endpoint1Attempts.Load(), "endpoint-1 should be tried at least once")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+
+	// With backoff and quarantine working together:
+	require.GreaterOrEqual(t, totalAttempts.Load(), int64(2),
+		"quarantine logic should try both endpoints at least in the initial cycle")
+
+	if totalAttempts.Load() > 2 {
+		t.Logf("Backoff retry occurred: multiple retry cycles observed")
+
+		// Verify that backoff timing was applied by checking the time between first and last attempts
+		timesMutex.Lock()
+		if len(attemptTimes) > 2 {
+			firstAttempt := attemptTimes[0]
+			lastAttempt := attemptTimes[len(attemptTimes)-1]
+			timeBetween := lastAttempt.Sub(firstAttempt)
+			t.Logf("Time between first and last attempt: %v", timeBetween)
+			// We expect multiple retry cycles around ~150ms total elapsed time
+			require.Greater(t, timeBetween.Milliseconds(), int64(125),
+				"should have backoff delay between retry cycles")
+		}
+		timesMutex.Unlock()
+	}
+
+	// The total elapsed time should reflect backoff delays if retries occurred
+	t.Logf("Total elapsed time: %v", elapsed)
+}
+
+func TestConsumeMetrics_DNSResolverQuarantineWithParentExporterBackoffDisabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 5 * time.Millisecond, // Short quarantine - must be shorter than backoff intervals
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockMetricsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint1Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint2Attempts.Add(1)
+			totalAttempts.Add(1)
+			timesMutex.Lock()
+			attemptTimes = append(attemptTimes, time.Now())
+			timesMutex.Unlock()
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	// Wrap with exporterhelper without backoff
+	retryExporter, err := exporterhelper.NewMetrics(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeMetrics,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := retryExporter.ConsumeMetrics(t.Context(), simpleMetricsWithServiceName())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	require.Equal(t, int64(1), endpoint1Attempts.Load(), "endpoint-1 should be tried once")
+	require.Equal(t, int64(1), endpoint2Attempts.Load(), "endpoint-2 should be tried once")
+	require.Equal(t, int64(2), totalAttempts.Load(),
+		"quarantine logic should try both endpoints once")
+}
+
+// TestConsumeLogs_DNSResolverQuarantineWithParentExporterBackoffConfig_PartialRecovery tests the scenario
+// where some endpoints recover after being quarantined
+func TestConsumeMetrics_DNSResolverQuarantineWithParentExporterBackoffEnabled_PartialRecovery(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 100 * time.Millisecond, // Short quarantine for testing
+				},
+			}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockMetricsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Endpoint-1 fails initially but recovers after 150ms
+	// Endpoint-2 always fails
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	var startTime time.Time
+
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint1Attempts.Add(1)
+			// Simulate recovery after 150ms
+			if time.Since(startTime) > 150*time.Millisecond {
+				t.Log("endpoint-1 recovered")
+				return nil
+			}
+			t.Log("endpoint-1 temporarily unreachable")
+			return errors.New("endpoint temporarily unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			endpoint2Attempts.Add(1)
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	wrappedExporterBackOffConfig := configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Millisecond,
+		RandomizationFactor: 0,
+		Multiplier:          2,
+		MaxInterval:         200 * time.Millisecond,
+		MaxElapsedTime:      250 * time.Millisecond,
+	}
+
+	// Wrap with exporterhelper to enable retry logic with backoff
+	retryExporter, err := exporterhelper.NewMetrics(
+		t.Context(),
+		ts,
+		cfg,
+		p.ConsumeMetrics,
+		exporterhelper.WithStart(p.Start),
+		exporterhelper.WithShutdown(p.Shutdown),
+		exporterhelper.WithCapabilities(p.Capabilities()),
+		exporterhelper.WithRetry(wrappedExporterBackOffConfig),
+	)
+	require.NoError(t, err)
+
+	err = retryExporter.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, retryExporter.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should eventually succeed when endpoint-1 recovers
+	// Set startTime just before the call to ensure consistent timing across platforms
+	startTime = time.Now()
+	res := retryExporter.ConsumeMetrics(t.Context(), simpleMetricsWithServiceName())
+
+	// Should succeed after endpoint-1 recovers
+	require.NoError(t, res, "should succeed after endpoint-1 recovers")
+
+	t.Logf("Endpoint-1 attempts: %d, Endpoint-2 attempts: %d",
+		endpoint1Attempts.Load(), endpoint2Attempts.Load())
+
+	// Both endpoints should have been tried (quarantine logic)
+	require.Greater(t, endpoint1Attempts.Load(), int64(1), "endpoint-1 should be retried after quarantine period")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+}
+
+func TestConsumeMetrics_DNSResolverQuarantineWithSubExporterBackoffEnabled(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{
+				Hostname: "service-1",
+				Port:     "",
+				Quarantine: QuarantineSettings{
+					Enabled:  true,
+					Duration: 60 * time.Second, // Long quarantine - must be longer than backoff intervals
+				},
+			}),
+		},
+		Protocol: Protocol{
+			OTLP: otlpexporter.Config{
+				// Max elapsed time is 250ms, so it should retry 4 times per endpoint
+				RetryConfig: configretry.BackOffConfig{
+					Enabled:             true,
+					InitialInterval:     10 * time.Millisecond,
+					RandomizationFactor: 0,
+					Multiplier:          2,
+					MaxInterval:         200 * time.Millisecond,
+					MaxElapsedTime:      250 * time.Millisecond,
+				},
+			},
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockMetricsExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	// Track attempts per endpoint to verify quarantine logic tries all endpoints
+	endpoint1Attempts := &atomic.Int64{}
+	endpoint2Attempts := &atomic.Int64{}
+	totalAttempts := &atomic.Int64{}
+	var attemptTimes []time.Time
+	var timesMutex sync.Mutex
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	// Create mock exporters with retry logic applied via exporterhelper
+	mockExporter1 := newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+		endpoint1Attempts.Add(1)
+		totalAttempts.Add(1)
+		timesMutex.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		timesMutex.Unlock()
+		return errors.New("endpoint unreachable")
+	})
+	mockExporter2 := newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+		endpoint2Attempts.Add(1)
+		totalAttempts.Add(1)
+		timesMutex.Lock()
+		attemptTimes = append(attemptTimes, time.Now())
+		timesMutex.Unlock()
+		return errors.New("endpoint unreachable")
+	})
+
+	// Wrap with exporterhelper to apply retry configuration from cfg.Protocol.OTLP.RetryConfig
+	wrappedExp1, err := exporterhelper.NewMetrics(
+		t.Context(),
+		exporter.Settings{
+			ID:                component.NewIDWithName(component.MustNewType("otlp"), "endpoint-1"),
+			TelemetrySettings: ts.TelemetrySettings,
+		},
+		&cfg.Protocol.OTLP,
+		mockExporter1.ConsumeMetrics,
+		exporterhelper.WithRetry(cfg.Protocol.OTLP.RetryConfig),
+		exporterhelper.WithStart(mockExporter1.Start),
+		exporterhelper.WithShutdown(mockExporter1.Shutdown),
+	)
+	require.NoError(t, err)
+
+	wrappedExp2, err := exporterhelper.NewMetrics(
+		t.Context(),
+		exporter.Settings{
+			ID:                component.NewIDWithName(component.MustNewType("otlp"), "endpoint-2"),
+			TelemetrySettings: ts.TelemetrySettings,
+		},
+		&cfg.Protocol.OTLP,
+		mockExporter2.ConsumeMetrics,
+		exporterhelper.WithRetry(cfg.Protocol.OTLP.RetryConfig),
+		exporterhelper.WithStart(mockExporter2.Start),
+		exporterhelper.WithShutdown(mockExporter2.Shutdown),
+	)
+	require.NoError(t, err)
+
+	// Add the wrapped exporters to the load balancer
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(wrappedExp1, "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(wrappedExp2, "endpoint-2:4317"),
+	}
+
+	host := componenttest.NewNopHost()
+
+	// Start the load balancer exporter
+	err = p.Start(t.Context(), host)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// Test: ConsumeLogs should fail after retrying all endpoints multiple times with backoff
+	start := time.Now()
+	res := p.ConsumeMetrics(t.Context(), simpleMetricsWithServiceName())
+	elapsed := time.Since(start)
+
+	// Verify that an error occurred
+	require.Error(t, res)
+	require.Contains(t, res.Error(), "all endpoints were tried and failed")
+
+	t.Logf("Total attempts: %d, Endpoint-1: %d, Endpoint-2: %d, Elapsed: %v",
+		totalAttempts.Load(), endpoint1Attempts.Load(), endpoint2Attempts.Load(), elapsed)
+
+	// Verify quarantine logic: both endpoints should be tried
+	// In the first cycle, quarantine logic should try both endpoints immediately
+	require.Positive(t, endpoint1Attempts.Load(), "endpoint-1 should be tried at least once")
+	require.Positive(t, endpoint2Attempts.Load(), "endpoint-2 should be tried at least once")
+
+	// With backoff and quarantine working together:
+	require.GreaterOrEqual(t, totalAttempts.Load(), int64(2),
+		"quarantine logic should try both endpoints at least in the initial cycle")
+
+	if totalAttempts.Load() > 2 {
+		t.Logf("Backoff retry occurred: multiple retry cycles observed")
+
+		// Verify that backoff timing was applied by checking the time between first and last attempts
+		timesMutex.Lock()
+		if len(attemptTimes) > 2 {
+			firstAttempt := attemptTimes[0]
+			lastAttempt := attemptTimes[len(attemptTimes)-1]
+			timeBetween := lastAttempt.Sub(firstAttempt)
+			t.Logf("Time between first and last attempt: %v", timeBetween)
+			// we expect multiple retry cycles around ~310ms total elapsed time
+			require.Greater(t, timeBetween.Milliseconds(), int64(275),
+				"should have backoff delay between retry cycles")
+		}
+		timesMutex.Unlock()
+	}
+
+	// The total elapsed time should reflect backoff delays if retries occurred
+	t.Logf("Total elapsed time: %v", elapsed)
 }
 
 func TestConsumeMetricsExporterNoEndpoint(t *testing.T) {

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -20,7 +20,7 @@ import (
 func TestInitialDNSResolution(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{
@@ -53,7 +53,7 @@ func TestInitialDNSResolution(t *testing.T) {
 func TestInitialDNSResolutionWithPort(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "55690", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "55690", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{
@@ -86,7 +86,7 @@ func TestInitialDNSResolutionWithPort(t *testing.T) {
 func TestErrNoHostname(t *testing.T) {
 	// test
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "", "", 5*time.Second, 1*time.Second, nil, tb)
 
 	// verify
 	assert.Nil(t, res)
@@ -96,7 +96,7 @@ func TestErrNoHostname(t *testing.T) {
 func TestCantResolve(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	expectedErr := errors.New("some expected error")
@@ -117,7 +117,7 @@ func TestCantResolve(t *testing.T) {
 func TestOnChange(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	resolve := []net.IPAddr{
@@ -185,7 +185,7 @@ func TestEqualStringSlice(t *testing.T) {
 func TestPeriodicallyResolve(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	counter := &atomic.Int64{}
@@ -244,7 +244,7 @@ func TestPeriodicallyResolve(t *testing.T) {
 func TestPeriodicallyResolveFailure(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	expectedErr := errors.New("some expected error")
@@ -288,7 +288,7 @@ func TestPeriodicallyResolveFailure(t *testing.T) {
 func TestShutdownClearsCallbacks(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{}
@@ -322,4 +322,54 @@ func (m *mockDNSResolver) LookupIPAddr(ctx context.Context, hostname string) ([]
 		return m.onLookupIPAddr(ctx, hostname)
 	}
 	return nil, nil
+}
+
+func TestQuarantineEnabled(t *testing.T) {
+	// prepare
+	_, tb := getTelemetryAssets(t)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, &QuarantineSettings{Enabled: true}, tb)
+	require.NoError(t, err)
+
+	assert.True(t, res.quarantine.Enabled)
+	assert.Equal(t, 30*time.Second, res.quarantine.Duration)
+}
+
+func TestQuarantineConfigOmitted(t *testing.T) {
+	// prepare
+	_, tb := getTelemetryAssets(t)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
+	require.NoError(t, err)
+
+	assert.False(t, res.quarantine.Enabled)
+	assert.Equal(t, 30*time.Second, res.quarantine.Duration)
+}
+
+func TestQuarantineDurationOmitted(t *testing.T) {
+	// prepare
+	_, tb := getTelemetryAssets(t)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, &QuarantineSettings{Enabled: true}, tb)
+	require.NoError(t, err)
+
+	assert.True(t, res.quarantine.Enabled)
+	assert.Equal(t, 30*time.Second, res.quarantine.Duration)
+}
+
+func TestQuarantineDurationZero(t *testing.T) {
+	// prepare
+	_, tb := getTelemetryAssets(t)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, &QuarantineSettings{Enabled: true, Duration: 0}, tb)
+	require.NoError(t, err)
+
+	assert.True(t, res.quarantine.Enabled)
+	assert.Equal(t, 30*time.Second, res.quarantine.Duration)
+}
+
+func TestQuarantineDurationNegative(t *testing.T) {
+	// prepare
+	_, tb := getTelemetryAssets(t)
+	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, &QuarantineSettings{Enabled: true, Duration: -1}, tb)
+	require.NoError(t, err)
+
+	assert.True(t, res.quarantine.Enabled)
+	assert.Equal(t, 30*time.Second, res.quarantine.Duration)
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -207,6 +207,108 @@ func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 	<-consumeDone
 }
 
+func TestConsumeTraces_DNSResolverRetriesOnUnreachableEndpoint(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{Hostname: "service-1", Port: "", Quarantine: QuarantineSettings{Enabled: true}}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockTracesExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	p, err := newTracesExporter(ts, simpleConfig())
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p.loadBalancer = lb
+
+	err = p.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// Endpoint-1 returns an error to simulate an unreachable endpoint
+	// Endpoint-2 succeeds normally
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+			return nil
+		}), "endpoint-2:4317"),
+	}
+
+	// test - first call should fail by retrying with endpoint-2
+	res := p.ConsumeTraces(t.Context(), simpleTraces())
+	require.NoError(t, res)
+
+	// We want to verify that traces are consumed by "endpoint-2" exporter, which uses consumeWithRetry.
+	// To do so, we can provide a spy function and check whether it is called.
+	var consumedBySecondEndpoint atomic.Bool
+	lb.exporters["endpoint-2:4317"] = newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+		consumedBySecondEndpoint.Store(true)
+		return nil
+	}), "endpoint-2:4317")
+
+	// Re-run test with the spy.
+	require.NoError(t, p.ConsumeTraces(t.Context(), simpleTraces()))
+	require.True(t, consumedBySecondEndpoint.Load(), "traces should be consumed by the second endpoint")
+}
+
+func TestConsumeTraces_DNSResolverRetriesExhausted(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNS: configoptional.Some(DNSResolver{Hostname: "service-1", Port: "", Quarantine: QuarantineSettings{Enabled: true}}),
+		},
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockTracesExporter(), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	// Set up the hash ring with the test endpoints
+	lb.ring = newHashRing([]string{"endpoint-1", "endpoint-2"})
+
+	p, err := newTracesExporter(ts, simpleConfig())
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.loadBalancer = lb
+
+	err = p.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	// Both endpoints return an error to simulate unreachable endpoints
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+			return errors.New("endpoint unreachable")
+		}), "endpoint-1:4317"),
+		"endpoint-2:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
+			return errors.New("endpoint unreachable")
+		}), "endpoint-2:4317"),
+	}
+
+	// test - first call should fail by retrying with endpoint-2
+	res := p.ConsumeTraces(t.Context(), simpleTraces())
+	require.Error(t, res)
+	require.EqualError(t, res, "all endpoints were tried and failed: map[endpoint-1:true endpoint-2:true]")
+}
+
 func TestConsumeTracesServiceBased(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
@@ -593,7 +695,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 
 	// simulate rolling updates, the dns resolver should resolve in the following order
 	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.2"]
-	res, err := newDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, nil, tb)
 	require.NoError(t, err)
 
 	mu := sync.Mutex{}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
# Description

**Add quarantine mechanism for unhealthy endpoints**
- Added a quarantine feature for unhealthy endpoints, delaying retries to those endpoints after a configurable period (default: 30s). It is disabled by default.
- Quarantine settings are configurable via the DNS resolver's `quarantine` section.
- The load balancer will avoid sending data to endpoints marked as unhealthy until their quarantine period expires, using healthy endpoints in the hash ring without triggering unnecessary ring updates.
- This increases resilience by reducing the risk of exporters being stuck in degraded states with repeated failed attempts.
- This feature currently applies only to the DNS resolver.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #43644

<!--Describe what testing was performed and which tests were added.-->
# Test Coverage for Quarantine Feature

## Core Quarantine Functionality Tests
**File:** `loadbalancer_test.go`

### New Tests

#### `TestQuarantineEndpoints`
Validates the quarantine mechanism by marking an endpoint as unhealthy and verifying it automatically becomes healthy again after the quarantine duration expires (1ms in test). Confirms that only the quarantined endpoint is marked unhealthy while others remain healthy.

#### `TestIsQuarantineEnabled`
Verifies that the quarantine feature is correctly enabled when configured with `Quarantine: QuarantineSettings{Enabled: true}` in the DNS resolver settings.

#### `TestIsQuarantineEnabledFalse`
Confirms that quarantine is properly disabled when explicitly set to `false` in the configuration.

#### `TestIsQuarantineWithDNSQuarantineOmitted`
Ensures that quarantine is disabled by default when the quarantine configuration section is omitted entirely, maintaining backward compatibility.

## DNS Resolver Configuration Tests
**File:** `resolver_dns_test.go`

### New Tests

#### `TestQuarantineEnabled`
Validates that quarantine settings are properly initialized with the default duration (30 seconds) when enabled.

#### `TestQuarantineConfigOmitted`
Confirms default behavior when quarantine configuration is not provided (disabled with 30s default duration).

#### `TestQuarantineDurationOmitted`
Verifies that the default quarantine duration (30 seconds) is used when duration is not specified.

#### `TestQuarantineDurationZero`
Ensures that invalid zero duration values are replaced with the default 30-second duration.

#### `TestQuarantineDurationNegative`
Confirms that invalid negative duration values are replaced with the default 30-second duration.

## Trace Exporter Retry Tests
**File:** `trace_exporter_test.go`

### New Tests

#### `TestConsumeTraces_DNSResolverRetriesOnUnreachableEndpoint`
Tests the retry mechanism for traces when the primary endpoint fails. Verifies that:
- The exporter successfully fails over to a healthy endpoint
- Traces are consumed by the alternative endpoint without data loss
- The quarantine feature is properly invoked during retry

#### `TestConsumeTraces_DNSResolverRetriesExhausted`
Validates error handling when all endpoints are unreachable. Confirms that:
- All available endpoints in the ring are tried
- An appropriate error is returned: `"all endpoints were tried and failed: map[endpoint-1:true endpoint-2:true]"`
- No silent failures occur

## Log Exporter Retry Tests
**File:** `log_exporter_test.go`

### New Tests

#### `TestConsumeLogs_DNSResolverRetriesOnUnreachableEndpoint`
Mirrors the trace retry test for logs, ensuring the same failover behavior works correctly for log data.

#### `TestConsumeLogs_DNSResolverRetriesExhausted`
Validates exhaustive retry behavior for logs when all endpoints fail, confirming proper error reporting.

## Metrics Exporter Retry Tests
**File:** `metrics_exporter_test.go`

### New Tests

#### `TestConsumeMetrics_DNSResolverRetriesOnUnreachableEndpoint`
Tests retry logic for metrics when one endpoint is unreachable, verifying successful failover to healthy endpoints.

#### `TestConsumeMetrics_DNSResolverRetriesExhausted`
Confirms proper error handling when all metric endpoints are unreachable.

## Test Patterns and Coverage

All the retry tests follow a consistent pattern:
1. Configure the load balancer with DNS resolver and quarantine enabled
2. Set up a hash ring with multiple test endpoints
3. Simulate endpoint failures using mock exporters
4. Verify successful failover to healthy endpoints
5. Confirm proper error messages when all retries are exhausted

The tests ensure comprehensive coverage across all three signal types (traces, logs, and metrics) and validate both the "happy path" (successful retry) and "unhappy path" (all endpoints failed) scenarios.

## Summary

**Total New Tests:** 14

- **Core Quarantine:** 4 tests
- **DNS Configuration:** 5 tests
- **Retry Logic (Traces):** 2 tests
- **Retry Logic (Logs):** 2 tests
- **Retry Logic (Metrics):** 2 tests

All tests validate the quarantine feature's ability to temporarily exclude unhealthy endpoints, automatically recover them after the quarantine period, and handle edge cases with proper default values.

## Local Test Environment Validation

### Test Configuration Example

```yaml
exporters:
  loadbalancing:
    retry_on_failure:
      enabled: true
      initial_interval: 5s
      max_interval: 30s
      max_elapsed_time: 60s
    sending_queue:
      enabled: true
      num_consumers: 10
      queue_size: 10000
      block_on_overflow: false
      sizer: items
    protocol:
      otlp:
        timeout: 1s
        tls:
          insecure: true
    resolver:
      dns:
        hostname: otel-receivers.test   # 3x DNS A records
        port: '4317'
        interval: 5s
        timeout: 1s
        quarantine:
          enabled: true
          duration: 30s
```

### Tested Scenarios

- **Scenario 1**: Single Endpoint Failure with Automatic Recovery
  - DNS entries unchanged: 3x DNS A records
  - Disabled one backend
  - Results: 
    - Backend marked unhealthy 
    - Data rerouted to healthy backends (2x)
    - Data distributed "equally" on healthy backends
- **Scenario 2**: Multiple Endpoint Failures
  - DNS entries unchanged: 3x DNS A records
  - Disabled one backend at a time
  - Results: 
    - Related backends marked unhealthy  
    - Data rerouted to healthy backends until all backends unhealthy
- **Scenario 3**: Cascading Failures and Recovery
  - DNS entries unchanged: 3x DNS A records
  - Disabled one backend at a time
  - Gradual restoration of backends
  - Results: 
    - Related backends marked unhealthy  
    - Data rerouted to healthy backends until all backends unhealthy
    - Unhealthy backends are retried after set duration (30s), and marked healthy again if successful retry
    - Data distributed "equally" on healthy backends
- **Scenario 4**: Quarantine with Different Signal Types
- **Scenario 5**: Queue and Retries effects
  - Enabling retry and queueing at top-level exporter `loadbalancer`
  - DNS entries unchanged: 3x DNS A records
  - Disabled all backends
 
<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
