### PR TITLE
k8sclusterreceiver: add init/ephemeral container metrics

### DIFF
--- a/.chloggen/collect-sidecar-metrics.yaml
+++ b/.chloggen/collect-sidecar-metrics.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_cluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Collect k8s.container metrics for sidecar and ephemeral containers.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42571]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Sidecar containers and ephemeral containers are now included in k8s.container metrics collection.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/internal/container/containers.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers.go
@@ -79,51 +79,51 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 		}
 	}
 
-    rb := mb.NewResourceBuilder()
-    var containerID string
-    var imageStr string
-    if cs, ok := findContainerStatusForName(pod, c.Name); ok {
-        containerID = cs.ContainerID
-        imageStr = cs.Image
-        mb.RecordK8sContainerRestartsDataPoint(ts, int64(cs.RestartCount))
-        mb.RecordK8sContainerReadyDataPoint(ts, boolToInt64(cs.Ready))
-        if cs.LastTerminationState.Terminated != nil {
-            rb.SetK8sContainerStatusLastTerminatedReason(cs.LastTerminationState.Terminated.Reason)
-        }
-        switch {
-        case cs.State.Running != nil:
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateRunning)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
-        case cs.State.Terminated != nil:
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateTerminated)
-        case cs.State.Waiting != nil:
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateWaiting)
-            mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
-        }
+	rb := mb.NewResourceBuilder()
+	var containerID string
+	var imageStr string
+	if cs, ok := findContainerStatusForName(pod, c.Name); ok {
+		containerID = cs.ContainerID
+		imageStr = cs.Image
+		mb.RecordK8sContainerRestartsDataPoint(ts, int64(cs.RestartCount))
+		mb.RecordK8sContainerReadyDataPoint(ts, boolToInt64(cs.Ready))
+		if cs.LastTerminationState.Terminated != nil {
+			rb.SetK8sContainerStatusLastTerminatedReason(cs.LastTerminationState.Terminated.Reason)
+		}
+		switch {
+		case cs.State.Running != nil:
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateRunning)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
+		case cs.State.Terminated != nil:
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateWaiting)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateTerminated)
+		case cs.State.Waiting != nil:
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateRunning)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 1, metadata.AttributeK8sContainerStatusStateWaiting)
+			mb.RecordK8sContainerStatusStateDataPoint(ts, 0, metadata.AttributeK8sContainerStatusStateTerminated)
+		}
 
-        // Record k8s.container.status.reason metric: for each known reason emit 1 for the current one, 0 otherwise.
-        var reason string
-        switch {
-        case cs.State.Terminated != nil:
-            reason = cs.State.Terminated.Reason
-        case cs.State.Waiting != nil:
-            reason = cs.State.Waiting.Reason
-        default:
-            reason = ""
-        }
-        // Emit in deterministic order for test stability.
-        for _, attrVal := range allContainerStatusReasons {
-            val := int64(0)
-            if reason != "" && reason == attrVal.String() {
-                val = 1
-            }
-            mb.RecordK8sContainerStatusReasonDataPoint(ts, val, attrVal)
-        }
-    }
+		// Record k8s.container.status.reason metric: for each known reason emit 1 for the current one, 0 otherwise.
+		var reason string
+		switch {
+		case cs.State.Terminated != nil:
+			reason = cs.State.Terminated.Reason
+		case cs.State.Waiting != nil:
+			reason = cs.State.Waiting.Reason
+		default:
+			reason = ""
+		}
+		// Emit in deterministic order for test stability.
+		for _, attrVal := range allContainerStatusReasons {
+			val := int64(0)
+			if reason != "" && reason == attrVal.String() {
+				val = 1
+			}
+			mb.RecordK8sContainerStatusReasonDataPoint(ts, val, attrVal)
+		}
+	}
 
 	rb.SetK8sPodUID(string(pod.UID))
 	rb.SetK8sPodName(pod.Name)
@@ -144,25 +144,25 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 // findContainerStatusForName returns the ContainerStatus matching the given name from
 // any of container, init container, or ephemeral container statuses.
 func findContainerStatusForName(pod *corev1.Pod, name string) (*corev1.ContainerStatus, bool) {
-    for i := range pod.Status.ContainerStatuses {
-        cs := &pod.Status.ContainerStatuses[i]
-        if cs.Name == name {
-            return cs, true
-        }
-    }
-    for i := range pod.Status.InitContainerStatuses {
-        cs := &pod.Status.InitContainerStatuses[i]
-        if cs.Name == name {
-            return cs, true
-        }
-    }
-    for i := range pod.Status.EphemeralContainerStatuses {
-        cs := &pod.Status.EphemeralContainerStatuses[i]
-        if cs.Name == name {
-            return cs, true
-        }
-    }
-    return nil, false
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		if cs.Name == name {
+			return cs, true
+		}
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		cs := &pod.Status.InitContainerStatuses[i]
+		if cs.Name == name {
+			return cs, true
+		}
+	}
+	for i := range pod.Status.EphemeralContainerStatuses {
+		cs := &pod.Status.EphemeralContainerStatuses[i]
+		if cs.Name == name {
+			return cs, true
+		}
+	}
+	return nil, false
 }
 
 func GetMetadata(pod *corev1.Pod, cs corev1.ContainerStatus, logger *zap.Logger) *metadata.KubernetesMetadata {

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -60,6 +60,30 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			LastTerminationState: cs.LastTerminationState,
 		})
 	}
+    for i := range pod.Status.InitContainerStatuses {
+        cs := &pod.Status.InitContainerStatuses[i]
+        newPod.Status.InitContainerStatuses = append(newPod.Status.InitContainerStatuses, corev1.ContainerStatus{
+            Name:                 cs.Name,
+            Image:                cs.Image,
+            ContainerID:          cs.ContainerID,
+            RestartCount:         cs.RestartCount,
+            Ready:                cs.Ready,
+            State:                cs.State,
+            LastTerminationState: cs.LastTerminationState,
+        })
+    }
+    for i := range pod.Status.EphemeralContainerStatuses {
+        cs := &pod.Status.EphemeralContainerStatuses[i]
+        newPod.Status.EphemeralContainerStatuses = append(newPod.Status.EphemeralContainerStatuses, corev1.ContainerStatus{
+            Name:                 cs.Name,
+            Image:                cs.Image,
+            ContainerID:          cs.ContainerID,
+            RestartCount:         cs.RestartCount,
+            Ready:                cs.Ready,
+            State:                cs.State,
+            LastTerminationState: cs.LastTerminationState,
+        })
+    }
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
 		newPod.Spec.Containers = append(newPod.Spec.Containers, corev1.Container{
@@ -70,6 +94,29 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			},
 		})
 	}
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
+		newPod.Spec.InitContainers = append(newPod.Spec.InitContainers, corev1.Container{
+			Name:          c.Name,
+			RestartPolicy: c.RestartPolicy,
+			Resources: corev1.ResourceRequirements{
+				Requests: c.Resources.Requests,
+				Limits:   c.Resources.Limits,
+			},
+		})
+	}
+    for i := range pod.Spec.EphemeralContainers {
+        c := &pod.Spec.EphemeralContainers[i]
+        newPod.Spec.EphemeralContainers = append(newPod.Spec.EphemeralContainers, corev1.EphemeralContainer{
+            EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+                Name: c.Name,
+                Resources: corev1.ResourceRequirements{
+                    Requests: c.Resources.Requests,
+                    Limits:   c.Resources.Limits,
+                },
+            },
+        })
+    }
 	return newPod
 }
 
@@ -88,6 +135,33 @@ func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.
 		c := pod.Spec.Containers[i]
 		container.RecordSpecMetrics(logger, mb, c, pod, ts)
 	}
+	for i := range pod.Spec.InitContainers {
+		c := pod.Spec.InitContainers[i]
+		if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			container.RecordSpecMetrics(logger, mb, c, pod, ts)
+		}
+	}
+<<<<<<< Updated upstream
+    for i := range pod.Spec.EphemeralContainers {
+        ec := pod.Spec.EphemeralContainers[i]
+        // Convert EphemeralContainer to a minimal Container for metrics (name/resources)
+        c := corev1.Container{
+            Name: ec.Name,
+            Resources: ec.Resources,
+        }
+        container.RecordSpecMetrics(logger, mb, c, pod, ts)
+    }
+    
+=======
+	for i := range pod.Spec.EphemeralContainers {
+		ec := pod.Spec.EphemeralContainers[i]
+		c := corev1.Container{
+			Name:      ec.Name,
+			Resources: ec.Resources,
+		}
+		container.RecordSpecMetrics(logger, mb, c, pod, ts)
+	}
+>>>>>>> Stashed changes
 }
 
 func reasonToInt(reason string) int32 {
@@ -274,6 +348,16 @@ func getPodContainerProperties(pod *corev1.Pod, logger *zap.Logger) map[experime
 	km := map[experimentalmetricmetadata.ResourceID]*metadata.KubernetesMetadata{}
 	for i := range pod.Status.ContainerStatuses {
 		cs := pod.Status.ContainerStatuses[i]
+		md := container.GetMetadata(pod, cs, logger)
+		km[md.ResourceID] = md
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		cs := pod.Status.InitContainerStatuses[i]
+		md := container.GetMetadata(pod, cs, logger)
+		km[md.ResourceID] = md
+	}
+	for i := range pod.Status.EphemeralContainerStatuses {
+		cs := pod.Status.EphemeralContainerStatuses[i]
 		md := container.GetMetadata(pod, cs, logger)
 		km[md.ResourceID] = md
 	}

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -60,30 +60,30 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			LastTerminationState: cs.LastTerminationState,
 		})
 	}
-    for i := range pod.Status.InitContainerStatuses {
-        cs := &pod.Status.InitContainerStatuses[i]
-        newPod.Status.InitContainerStatuses = append(newPod.Status.InitContainerStatuses, corev1.ContainerStatus{
-            Name:                 cs.Name,
-            Image:                cs.Image,
-            ContainerID:          cs.ContainerID,
-            RestartCount:         cs.RestartCount,
-            Ready:                cs.Ready,
-            State:                cs.State,
-            LastTerminationState: cs.LastTerminationState,
-        })
-    }
-    for i := range pod.Status.EphemeralContainerStatuses {
-        cs := &pod.Status.EphemeralContainerStatuses[i]
-        newPod.Status.EphemeralContainerStatuses = append(newPod.Status.EphemeralContainerStatuses, corev1.ContainerStatus{
-            Name:                 cs.Name,
-            Image:                cs.Image,
-            ContainerID:          cs.ContainerID,
-            RestartCount:         cs.RestartCount,
-            Ready:                cs.Ready,
-            State:                cs.State,
-            LastTerminationState: cs.LastTerminationState,
-        })
-    }
+	for i := range pod.Status.InitContainerStatuses {
+		cs := &pod.Status.InitContainerStatuses[i]
+		newPod.Status.InitContainerStatuses = append(newPod.Status.InitContainerStatuses, corev1.ContainerStatus{
+			Name:                 cs.Name,
+			Image:                cs.Image,
+			ContainerID:          cs.ContainerID,
+			RestartCount:         cs.RestartCount,
+			Ready:                cs.Ready,
+			State:                cs.State,
+			LastTerminationState: cs.LastTerminationState,
+		})
+	}
+	for i := range pod.Status.EphemeralContainerStatuses {
+		cs := &pod.Status.EphemeralContainerStatuses[i]
+		newPod.Status.EphemeralContainerStatuses = append(newPod.Status.EphemeralContainerStatuses, corev1.ContainerStatus{
+			Name:                 cs.Name,
+			Image:                cs.Image,
+			ContainerID:          cs.ContainerID,
+			RestartCount:         cs.RestartCount,
+			Ready:                cs.Ready,
+			State:                cs.State,
+			LastTerminationState: cs.LastTerminationState,
+		})
+	}
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
 		newPod.Spec.Containers = append(newPod.Spec.Containers, corev1.Container{
@@ -105,18 +105,18 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			},
 		})
 	}
-    for i := range pod.Spec.EphemeralContainers {
-        c := &pod.Spec.EphemeralContainers[i]
-        newPod.Spec.EphemeralContainers = append(newPod.Spec.EphemeralContainers, corev1.EphemeralContainer{
-            EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-                Name: c.Name,
-                Resources: corev1.ResourceRequirements{
-                    Requests: c.Resources.Requests,
-                    Limits:   c.Resources.Limits,
-                },
-            },
-        })
-    }
+	for i := range pod.Spec.EphemeralContainers {
+		c := &pod.Spec.EphemeralContainers[i]
+		newPod.Spec.EphemeralContainers = append(newPod.Spec.EphemeralContainers, corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name: c.Name,
+				Resources: corev1.ResourceRequirements{
+					Requests: c.Resources.Requests,
+					Limits:   c.Resources.Limits,
+				},
+			},
+		})
+	}
 	return newPod
 }
 
@@ -141,27 +141,15 @@ func RecordMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, pod *corev1.
 			container.RecordSpecMetrics(logger, mb, c, pod, ts)
 		}
 	}
-<<<<<<< Updated upstream
-    for i := range pod.Spec.EphemeralContainers {
-        ec := pod.Spec.EphemeralContainers[i]
-        // Convert EphemeralContainer to a minimal Container for metrics (name/resources)
-        c := corev1.Container{
-            Name: ec.Name,
-            Resources: ec.Resources,
-        }
-        container.RecordSpecMetrics(logger, mb, c, pod, ts)
-    }
-    
-=======
 	for i := range pod.Spec.EphemeralContainers {
 		ec := pod.Spec.EphemeralContainers[i]
+		// Convert EphemeralContainer to a minimal Container for metrics (name/resources)
 		c := corev1.Container{
 			Name:      ec.Name,
 			Resources: ec.Resources,
 		}
 		container.RecordSpecMetrics(logger, mb, c, pod, ts)
 	}
->>>>>>> Stashed changes
 }
 
 func reasonToInt(reason string) int32 {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Collect k8s.container metrics for sidecar containers and ephemeral containers.

**Sidecar containers** (Kubernetes 1.29+): Init containers with `restartPolicy: Always` are now recognized as sidecars and their metrics are collected alongside regular containers.

**Ephemeral containers**: Debug containers added via `kubectl debug` are now included in metrics collection.

**Regular init containers** (without `restartPolicy: Always`) are intentionally NOT collected, as they are short-lived and complete before the main containers start.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42571

<!--Describe what testing was performed and which tests were added.-->
#### Testing
**Unit Tests Added:**
- `TestSidecarMetrics`: Verifies sidecar container metrics are collected while regular init containers are not
- `TestEphemeralContainerMetrics`: Verifies ephemeral container metrics are collected

**Manual Testing with Kind cluster:**

Test Pod:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sidecar-test-pod
spec:
  containers:
    - name: main-app
      image: busybox:latest
      resources:
        limits:
          cpu: "100m"
          memory: "64Mi"
  initContainers:
    - name: my-sidecar
      image: busybox:latest
      restartPolicy: Always  # This makes it a sidecar
      resources:
        limits:
          cpu: "50m"
          memory: "32Mi"
    - name: regular-init  # No restartPolicy - regular init container
      image: busybox:latest
```

Sidecar Container Metrics Output:
```
Resource attributes:
     -> k8s.pod.name: Str(sidecar-test-pod)
     -> k8s.container.name: Str(my-sidecar)
     -> container.image.name: Str(docker.io/library/busybox)
Metrics:
     -> k8s.container.cpu_limit: 0.050000
     -> k8s.container.cpu_request: 0.050000
     -> k8s.container.memory_limit: 33554432
     -> k8s.container.memory_request: 33554432
     -> k8s.container.ready: 1
     -> k8s.container.restarts: 0
```

Ephemeral Container (added via `kubectl debug`):
```bash
kubectl debug sidecar-test-pod -it --image=busybox:latest --target=main-app
```
```
Resource attributes:
     -> k8s.pod.name: Str(sidecar-test-pod)
     -> k8s.container.name: Str(debugger-4sw76)
     -> container.image.name: Str(docker.io/library/busybox)
Metrics:
     -> k8s.container.ready: 0
     -> k8s.container.restarts: 0
```

<!--Describe the documentation added.-->
#### Documentation
Changelog entry added in `.chloggen/collect-sidecar-metrics.yaml`

<!--Please delete paragraphs that you did not use before submitting.-->