### PR TITLE
[receiver/googlecloudpubsub] Support for Google Trusted Partner Cloud project naming convention

### DIFF
--- a/.chloggen/tpc_regex.yaml
+++ b/.chloggen/tpc_regex.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adjusts the subscription regex to accommodate new project naming used for Google Trusted Partner Clouds.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43988]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudpubsubreceiver/config.go
+++ b/receiver/googlecloudpubsubreceiver/config.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-var subscriptionMatcher = regexp.MustCompile(`projects/[a-z][a-z0-9\-]*/subscriptions/`)
+var subscriptionMatcher = regexp.MustCompile(`projects/[a-z][a-z0-9\-]*(:[a-z0-9\-]+)?/subscriptions/`)
 
 type Config struct {
 	// Google Cloud Project ID where the Pubsub client will connect to

--- a/receiver/googlecloudpubsubreceiver/config_test.go
+++ b/receiver/googlecloudpubsubreceiver/config_test.go
@@ -70,4 +70,16 @@ func TestConfigValidation(t *testing.T) {
 	assert.Error(t, c.validate())
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
 	assert.NoError(t, c.validate())
+	// Test for project IDs with a single colon (not at start, not at end)
+	c.Subscription = "projects/s3ns:my-project/subscriptions/my-subscription"
+	assert.NoError(t, c.validate())
+	// Invalid: colon at the start
+	c.Subscription = "projects/:invalid/subscriptions/my-subscription"
+	assert.Error(t, c.validate())
+	// Invalid: colon at the end
+	c.Subscription = "projects/invalid:/subscriptions/my-subscription"
+	assert.Error(t, c.validate())
+	// Invalid: multiple colons
+	c.Subscription = "projects/s3ns:invalid:invalid/subscriptions/my-subscription"
+	assert.Error(t, c.validate())
 }


### PR DESCRIPTION
#### Description

Adds support for Google's Trusted Partner Cloud (TPC) project naming convention which now includes a `:` character.

#### Link to tracking issue

n/a

#### Testing

This has been tested within the sandbox environment of Google's German TPC partner. New unit tests have also been introduced.

#### Documentation

Please see https://documentation.s3ns.fr/docs/overview/tpc-key-differences#key_differences_for_developers for information about this new project naming convention within a TPC.
