### PR TITLE
[bug_fix] Rename component name to ciscoos

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -234,7 +234,7 @@ components:
     - receiver/bigip
     - receiver/carbon
     - receiver/chrony
-    - receiver/ciscoosreceiver
+    - receiver/ciscoos
     - receiver/cloudflare
     - receiver/cloudfoundry
     - receiver/collectd

--- a/.chloggen/receiver-ciscoos-rename.yaml
+++ b/.chloggen/receiver-ciscoos-rename.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/ciscoos
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Rename receiver component name from `ciscoosreceiver` to `ciscoos` to follow naming conventions."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users must update their collector configuration from `ciscoosreceiver/device` to `ciscoos/device`.
+  This is acceptable as the component is in alpha stability.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/ciscoosreceiver/README.md
+++ b/receiver/ciscoosreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: metrics   |
 | Distributions | [] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fciscoos%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fciscoos) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fciscoos%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fciscoos) |
-| Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_ciscoosreceiver)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_ciscoosreceiver&displayType=list) |
+| Code coverage | [![codecov](https://codecov.io/github/open-telemetry/opentelemetry-collector-contrib/graph/main/badge.svg?component=receiver_ciscoos)](https://app.codecov.io/gh/open-telemetry/opentelemetry-collector-contrib/tree/main/?components%5B0%5D=receiver_ciscoos&displayType=list) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dmitryax](https://www.github.com/dmitryax) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#alpha
@@ -25,7 +25,7 @@ The following settings are available:
 | `timeout` | duration | No | SSH connection and command timeout (default: 30s) |
 | `scrapers` | map | Yes | Scrapers to enable |
 
-**Note:** Each receiver instance monitors a single device. To monitor multiple devices, create multiple receiver instances with unique identifiers (e.g., `ciscoosreceiver/device1`, `ciscoosreceiver/device2`).
+**Note:** Each receiver instance monitors a single device. To monitor multiple devices, create multiple receiver instances with unique identifiers (e.g., `ciscoos/device1`, `ciscoos/device2`).
 
 ### Device Configuration
 
@@ -95,7 +95,7 @@ All metrics include the following resource attributes following OpenTelemetry se
 ```yaml
 receivers:
   # Example 1: Password authentication
-  ciscoosreceiver/switch01:
+  ciscoos/switch01:
     collection_interval: 60s
     timeout: 30s
     device:
@@ -130,7 +130,7 @@ receivers:
             enabled: true
 
   # Example 2: SSH key file authentication
-  ciscoosreceiver/router01:
+  ciscoos/router01:
     collection_interval: 60s
     timeout: 30s
     device:
@@ -153,7 +153,7 @@ receivers:
             enabled: true
 
   # Example 3: Fallback authentication (key file with password backup)
-  ciscoosreceiver/firewall01:
+  ciscoos/firewall01:
     collection_interval: 60s
     timeout: 30s
     device:
@@ -182,6 +182,6 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [ciscoosreceiver/switch01, ciscoosreceiver/router01, ciscoosreceiver/firewall01]
+      receivers: [ciscoos/switch01, ciscoos/router01, ciscoos/firewall01]
       exporters: [debug]
 ```

--- a/receiver/ciscoosreceiver/factory_test.go
+++ b/receiver/ciscoosreceiver/factory_test.go
@@ -24,7 +24,7 @@ import (
 func TestNewFactory(t *testing.T) {
 	factory := NewFactory()
 	require.NotNil(t, factory)
-	assert.Equal(t, "ciscoosreceiver", factory.Type().String())
+	assert.Equal(t, "ciscoos", factory.Type().String())
 }
 
 func TestCreateDefaultConfig(t *testing.T) {

--- a/receiver/ciscoosreceiver/generated_component_test.go
+++ b/receiver/ciscoosreceiver/generated_component_test.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-var typ = component.MustNewType("ciscoosreceiver")
+var typ = component.MustNewType("ciscoos")
 
 func TestComponentFactoryType(t *testing.T) {
 	require.Equal(t, typ, NewFactory().Type())

--- a/receiver/ciscoosreceiver/internal/metadata/generated_status.go
+++ b/receiver/ciscoosreceiver/internal/metadata/generated_status.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("ciscoosreceiver")
+	Type      = component.MustNewType("ciscoos")
 	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver"
 )
 

--- a/receiver/ciscoosreceiver/metadata.yaml
+++ b/receiver/ciscoosreceiver/metadata.yaml
@@ -1,4 +1,4 @@
-type: ciscoosreceiver
+type: ciscoos
 
 status:
   class: receiver


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR renames the Cisco OS receiver component name from `ciscoosreceiver` to `ciscoos`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation
Updated README.md with all configuration examples using the new ciscoos 
<!--Please delete paragraphs that you did not use before submitting.-->
