### PR TITLE
[receiver/carbon] unexport PathParserHelper

### DIFF
--- a/.chloggen/unexport_pathparserhelper.yaml
+++ b/.chloggen/unexport_pathparserhelper.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/carbon
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unexport PathParserHelper
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43997]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/carbonreceiver/protocol/path_parser_helper.go
+++ b/receiver/carbonreceiver/protocol/path_parser_helper.go
@@ -23,13 +23,13 @@ import (
 // See https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol,
 // for more information.
 //
-// The type PathParserHelper implements the common code for parsers that differ
+// The type pathParserHelper implements the common code for parsers that differ
 // only by the way that they handle the <metric_path>.
 type pathParser interface {
 	// parsePath parses the <metric_path> of a Carbon line (see Parse function
 	// for description of the full line). The results of parsing the path are
 	// stored on the parsedPath struct. Implementers of the interface can assume
-	// that the PathParserHelper will never pass nil when calling this method.
+	// that the pathParserHelper will never pass nil when calling this method.
 	parsePath(path string, parsedPath *parsedPath) error
 }
 
@@ -54,13 +54,13 @@ const (
 	CumulativeMetricType = TargetMetricType("cumulative")
 )
 
-// PathParserHelper implements the common code to parse a Carbon line taking a
+// pathParserHelper implements the common code to parse a Carbon line taking a
 // pathParser to implement a full parser.
-type PathParserHelper struct {
+type pathParserHelper struct {
 	pathParser pathParser
 }
 
-var _ Parser = (*PathParserHelper)(nil)
+var _ Parser = (*pathParserHelper)(nil)
 
 // newParser creates a new Parser instance that receives plaintext
 // Carbon data.
@@ -68,7 +68,7 @@ func newParser(pathParser pathParser) (Parser, error) {
 	if pathParser == nil {
 		return nil, errors.New("nil pathParser")
 	}
-	return &PathParserHelper{
+	return &pathParserHelper{
 		pathParser: pathParser,
 	}, nil
 }
@@ -89,7 +89,7 @@ func newParser(pathParser pathParser) (Parser, error) {
 //
 // The <metric_timestamp> is the Unix time text of when the measurement was
 // made.
-func (pph *PathParserHelper) Parse(line string) (pmetric.Metric, error) {
+func (pph *pathParserHelper) Parse(line string) (pmetric.Metric, error) {
 	parts := strings.SplitN(line, " ", 4)
 	if len(parts) != 3 {
 		return pmetric.Metric{}, fmt.Errorf("invalid carbon metric [%s]", line)

--- a/receiver/carbonreceiver/protocol/regex_parser.go
+++ b/receiver/carbonreceiver/protocol/regex_parser.go
@@ -156,7 +156,7 @@ type regexPathParser struct {
 	plaintextPathParser plaintextPathParser
 }
 
-// parsePath converts the <metric_path> of a Carbon line (see PathParserHelper
+// parsePath converts the <metric_path> of a Carbon line (see pathParserHelper
 // a full description of the line format) according to the RegexParserConfig
 // settings.
 func (rpp *regexPathParser) parsePath(path string, parsedPath *parsedPath) error {


### PR DESCRIPTION
This struct is not used outside carbonreceiver. It should not be part of the public API of the component.