### PR TITLE
[receiver/journald] add a watchdog goroutine to restart journalctl when it hangs

### DIFF
--- a/pkg/stanza/operator/input/journald/config_all.go
+++ b/pkg/stanza/operator/input/journald/config_all.go
@@ -4,6 +4,8 @@
 package journald // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald"
 
 import (
+	"time"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
@@ -40,6 +42,7 @@ type Config struct {
 	Namespace           string        `mapstructure:"namespace,omitempty"`
 	ConvertMessageBytes bool          `mapstructure:"convert_message_bytes,omitempty"`
 	Merge               bool          `mapstructure:"merge,omitempty"`
+	ReadTimeout         time.Duration `mapstructure:"read_timeout,omitempty"`
 }
 
 type MatchConfig map[string]string

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -36,6 +36,10 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		return nil, err
 	}
 
+	if c.ReadTimeout < 0 {
+		return nil, fmt.Errorf("invalid value '%s' for parameter 'read_timeout'", c.ReadTimeout)
+	}
+
 	return &Input{
 		InputOperator: inputOperator,
 		newCmd: func(ctx context.Context, cursor []byte) cmd {
@@ -48,6 +52,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 			// journalctl is an executable that is required for this operator to function
 		},
 		convertMessageBytes: c.ConvertMessageBytes,
+		readTimeout:         c.ReadTimeout,
 	}, nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The systemd-journald could crash or have journal file corruptions when rotating the journal files, which could leave the `ReadBytes()` method stuck forever.

This PR introduces a "watchdog" goroutine to take a `read_timeout` config and cancel the current running journalctl process. The input will restart the journalctl. Based on our observation, a restart of journalctl after the crash or file corruptions resumes the log consumption.

The overhead on the consumption is mainly updating the `lastRead`, which should be negligible most of the time. The watchdog goroutine runs in an interval of `read_timeout / 2`.

The `read_timeout` is 0 by default, which means no watchdog check and remains backward compatible.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #44007.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Add a simple bash script that print a line every second, and load it to systemd.

`log_every_second.sh`:
```bash
while true; do
    echo "Log message: $(date)"
    sleep 1
done
```

`log.service`:
```
[Unit]
Description=Print logs to journald every second
After=network.target

[Service]
ExecStart=/usr/local/bin/log_every_second.sh
Restart=always
StandardOutput=journal
StandardError=journal

[Install]
WantedBy=multi-user.target
```

Start the otelcol with the following config. Take note that the `read_timeout` is set to 5s.
```yaml
service:
  extensions: [file_storage/state]
  telemetry:
    logs:
      level: info
  pipelines:
    logs:
      receivers: [journald]
      processors: []
      exporters: [debug]

receivers:
  journald:
    storage: file_storage/state
    read_timeout: 5s

exporters:
  debug:
    verbosity: basic
    sampling_initial: 1
    sampling_thereafter: 0

extensions:
  file_storage/state:
    directory: /tmp
```

`systemctl stop log.service` and observe the otelcol's behaviour. The journactl process will be cancelled after the read_timeout (5s in this case). Once we resume the `log.service`, it will start to consume from it:
```bash
2025-11-04T02:01:04.248Z	warn	journald/input.go:184	journalctl read exceeded timeout, canceling command	{"otelcol.component.id": "journald", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "journald_input", "operator_type": "journald_input", "last_read": "2025-11-04T02:00:59.247Z", "read_timeout": 5}
2025-11-04T02:01:04.249Z	error	journald/input.go:104	journalctl command exited	{"otelcol.component.id": "journald", "otelcol.component.kind": "receiver", "otelcol.signal": "logs", "operator_id": "journald_input", "operator_type": "journald_input", "error": "signal: killed"}
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald.(*Input).run
	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.125.0/operator/input/journald/input.go:104
2025-11-04T02:01:07.904Z	info	Logs	{"otelcol.component.id": "debug", "otelcol.component.kind": "exporter", "otelcol.signal": "logs", "resource logs": 1, "log records": 9}
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
