### PR TITLE
[exporter/elasticsearch]Handle empty histogram buckets

### DIFF
--- a/.chloggen/handle-empty-histbuckets.yaml
+++ b/.chloggen/handle-empty-histbuckets.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle empty histogram buckets to not result in an invalid datapoint error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44022]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram.go
@@ -68,8 +68,10 @@ func histogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pco
 		// It is possible for explicit bounds to be nil. In this case create
 		// a bucket using the count and sum which are required to be present.
 		// See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
-		counts.AppendEmpty().SetInt(safeUint64ToInt64(dp.Count()))
-		values.AppendEmpty().SetDouble(dp.Sum() / float64(dp.Count()))
+		if dp.Count() > 0 {
+			counts.AppendEmpty().SetInt(safeUint64ToInt64(dp.Count()))
+			values.AppendEmpty().SetDouble(dp.Sum() / float64(dp.Count()))
+		}
 
 		return vm, nil
 	}

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram.go
@@ -53,11 +53,9 @@ func (dp Histogram) Metric() pmetric.Metric {
 }
 
 func histogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pcommon.Value, error) {
-	// Histogram conversion function is from
-	// https://github.com/elastic/apm-data/blob/3b28495c3cbdc0902983134276eb114231730249/input/otlp/metrics.go#L277
 	bucketCounts := dp.BucketCounts()
 	explicitBounds := dp.ExplicitBounds()
-	if bucketCounts.Len() != explicitBounds.Len()+1 || explicitBounds.Len() == 0 {
+	if bucketCounts.Len() > 0 && bucketCounts.Len() != explicitBounds.Len()+1 {
 		return pcommon.Value{}, fmt.Errorf("invalid histogram data point %q", metric.Name())
 	}
 
@@ -66,8 +64,18 @@ func histogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pco
 	counts := m.PutEmptySlice("counts")
 	values := m.PutEmptySlice("values")
 
-	values.EnsureCapacity(bucketCounts.Len())
+	if explicitBounds.Len() == 0 {
+		// It is possible for explict bounds to be nil. In this case create
+		// a bucket using the count and sum which are required to be present.
+		// See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
+		counts.AppendEmpty().SetInt(safeUint64ToInt64(dp.Count()))
+		values.AppendEmpty().SetDouble(dp.Sum() / float64(dp.Count()))
+
+		return vm, nil
+	}
+
 	counts.EnsureCapacity(bucketCounts.Len())
+	values.EnsureCapacity(bucketCounts.Len())
 	for i, count := range bucketCounts.All() {
 		if count == 0 {
 			continue

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram.go
@@ -65,7 +65,7 @@ func histogramToValue(dp pmetric.HistogramDataPoint, metric pmetric.Metric) (pco
 	values := m.PutEmptySlice("values")
 
 	if explicitBounds.Len() == 0 {
-		// It is possible for explict bounds to be nil. In this case create
+		// It is possible for explicit bounds to be nil. In this case create
 		// a bucket using the count and sum which are required to be present.
 		// See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram
 		counts.AppendEmpty().SetInt(safeUint64ToInt64(dp.Count()))

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package datapoints // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/datapoints"
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestHistogramValue(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		histogramDP pmetric.HistogramDataPoint
+		expected    func(t *testing.T) pcommon.Value
+	}{
+		{
+			name: "required_fields_only",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				dp.SetCount(100)
+				dp.SetSum(1000)
+				return dp
+			}(),
+			expected: func(t *testing.T) pcommon.Value {
+				t.Helper()
+				v := pcommon.NewValueMap()
+				require.NoError(t, v.FromRaw(map[string]any{
+					"counts": []any{100},
+					"values": []any{10.0},
+				}))
+				return v
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := pmetric.NewMetric()
+			m.SetName("test")
+			tc.histogramDP.MoveTo(m.SetEmptyHistogram().DataPoints().AppendEmpty())
+
+			esHist := NewHistogram(m, m.Histogram().DataPoints().At(0))
+			actual, err := esHist.Value()
+			require.NoError(t, err)
+			assert.True(t, tc.expected(t).Equal(actual))
+		})
+	}
+}

--- a/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
+++ b/exporter/elasticsearchexporter/internal/datapoints/histogram_test.go
@@ -20,6 +20,25 @@ func TestHistogramValue(t *testing.T) {
 		expected    func(t *testing.T) pcommon.Value
 	}{
 		{
+			name: "empty",
+			histogramDP: func() pmetric.HistogramDataPoint {
+				now := time.Now()
+				dp := pmetric.NewHistogramDataPoint()
+				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(now.Add(-1 * time.Hour)))
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+				return dp
+			}(),
+			expected: func(t *testing.T) pcommon.Value {
+				t.Helper()
+				v := pcommon.NewValueMap()
+				require.NoError(t, v.FromRaw(map[string]any{
+					"counts": []any{},
+					"values": []any{},
+				}))
+				return v
+			},
+		},
+		{
 			name: "required_fields_only",
 			histogramDP: func() pmetric.HistogramDataPoint {
 				now := time.Now()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Empty histogram buckets should not error out.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44022

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tests added.

<!--Describe the documentation added.-->
#### Documentation

N/A
<!--Please delete paragraphs that you did not use before submitting.-->
