### PR TITLE
[chore] [exporter/googlecloudstorageexporter] docs: fixed wrong example config in README

### DIFF
--- a/exporter/googlecloudstorageexporter/README.md
+++ b/exporter/googlecloudstorageexporter/README.md
@@ -34,7 +34,7 @@ Here is an example configuration for this exporter:
 exporters:
   googlecloudstorage:
     encoding: text_encoding
-    storage:
+    bucket:
       name: bucket-test
       project_id: project-test
       reuse_if_exists: true


### PR DESCRIPTION
Replaced the "storage" with "bucket" in the README.md example of usage.