### PR TITLE
[exporter/stef] Fix connection creation bug causing test failures

### DIFF
--- a/.chloggen/tigran_fix-stef-conn-bug.yaml
+++ b/.chloggen/tigran_fix-stef-conn-bug.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/stef
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix STEF connection creation bug
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44048]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: On some rare occasions due to a bug STEF exporter was incorrectly disconnecting just |
+  created STEF connection causing connection error messages in the log. This fixes the bug.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/stefexporter/internal/stefconn.go
+++ b/exporter/stefexporter/internal/stefconn.go
@@ -97,6 +97,15 @@ func (s *StefConnCreator) Create(ctx context.Context) (Conn, error) {
 			// for connection to be established. We have to cancel the
 			// connection attempt (and the whole connection if it raced us and
 			// managed to connect - we will reconnect later again in that case).
+			select {
+			case <-connectionAttemptDone:
+				// Connection attempt already finished, nothing to do. This can happen
+				// if <-ctx.Done() above selects sooner than <-connectionAttemptDone.
+				// That is ok, we are done.
+				return
+			default:
+			}
+
 			s.logger.Debug("Canceling connection context because Create() caller cancelled.")
 			connCancel()
 		case <-connectionAttemptDone:


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42947

TestHarness_MetricsGoldenData/stef-stef was sporadically failing because of a bug in the implementation of Create() function. Just created connection could have been closed because of the bug, depending on the order of "select" operations and the timing of other operations.

This now fixes the bug, ensuring the code does not try to cancel a successfully created connection.

I managed to create a simple repro by adding a time delay in the inner goroutine, but I won't be commiting the change since it is detrimental to production code. There is no trivial way to add a reliable test that verifies specifically this bug, but TestHarness_MetricsGoldenData/stef-stef was already hitting it once in a while, so we will rely on that as the test that verifies the bug fix.
