### PR TITLE
Feat enable module

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -86,6 +86,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.139.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter v0.139.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter v0.139.0

--- a/exporter/googlecloudstorageexporter/README.md
+++ b/exporter/googlecloudstorageexporter/README.md
@@ -33,7 +33,7 @@ Here is an example configuration for this exporter:
 exporters:
   googlecloudstorage:
     encoding: text_encoding
-    storage:
+    bucket:
       name: bucket-test
       project_id: project-test
       reuse_if_exists: true


### PR DESCRIPTION
This pull request adds support for the `googlecloudstorageexporter` to the collector build and updates its configuration documentation to use the correct field name. The key changes are:

**Exporter additions:**

* Added the `googlecloudstorageexporter` to the list of enabled exporters in `builder-config.yaml`, allowing the collector to export telemetry data to Google Cloud Storage.

**Documentation updates:**

* Updated the configuration example in `README.md` for `googlecloudstorageexporter` to use the correct field name `bucket` instead of `storage`, ensuring users can configure the exporter correctly.