### PR TITLE
[chore][CHANGELOG] Remove duplicate ciscoosreceiver entry from v0.139.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,6 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
   Supports Cisco IOS, IOS-XE, and NX-OS devices with SSH-based metric collection.
   Initial implementation includes system scraper for device availability and connection metrics.
   
-- `receiver/ciscoosreceiver`: `ciscoosreceiver`: Add new receiver for collecting metrics from Cisco network devices via SSH (#42647)
-  Supports Cisco IOS, IOS-XE, and NX-OS devices with SSH-based metric collection.
-  Initial implementation includes system scraper for device availability and connection metrics.
-  
 - `receiver/gitlab`: Promote GitLab receiver to Alpha stability (#41592)
 - `receiver/jmx`: Add JMX metrics gatherer version 1.51.0-alpha (#43666)
 - `receiver/jmx`: Add JMX scraper version 1.51.0-alpha (#43667)


### PR DESCRIPTION
#### Description

The same chlog entry was added in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43568 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43815, resulting in duplicate entries in changelog and release notes.

_I'll update release notes once this is merged._