### PR TITLE
[chore][processor/k8sattributes] migrate from using deprecated k8s API

### DIFF
--- a/processor/k8sattributesprocessor/internal/kube/informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/informer.go
@@ -57,8 +57,8 @@ func newSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  informerListFuncWithSelectors(client, namespace, ls, fs),
-			WatchFunc: informerWatchFuncWithSelectors(client, namespace, ls, fs),
+			ListWithContextFunc:  informerListFuncWithSelectors(client, namespace, ls, fs),
+			WatchFuncWithContext: informerWatchFuncWithSelectors(client, namespace, ls, fs),
 		},
 		&api_v1.Pod{},
 		watchSyncPeriod,
@@ -66,21 +66,19 @@ func newSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func informerListFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
+func informerListFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
 		opts.LabelSelector = ls.String()
 		opts.FieldSelector = fs.String()
-		return client.CoreV1().Pods(namespace).List(context.Background(), opts)
+		return client.CoreV1().Pods(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func informerWatchFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
+func informerWatchFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 		opts.LabelSelector = ls.String()
 		opts.FieldSelector = fs.String()
-		return client.CoreV1().Pods(namespace).Watch(context.Background(), opts)
+		return client.CoreV1().Pods(namespace).Watch(ctx, opts)
 	}
 }
 
@@ -110,8 +108,8 @@ func newNamespaceSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  namespaceInformerListFunc(client),
-			WatchFunc: namespaceInformerWatchFunc(client),
+			ListWithContextFunc:  namespaceInformerListFunc(client),
+			WatchFuncWithContext: namespaceInformerWatchFunc(client),
 		},
 		&api_v1.Namespace{},
 		watchSyncPeriod,
@@ -119,17 +117,15 @@ func newNamespaceSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func namespaceInformerListFunc(client kubernetes.Interface) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.CoreV1().Namespaces().List(context.Background(), opts)
+func namespaceInformerListFunc(client kubernetes.Interface) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.CoreV1().Namespaces().List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func namespaceInformerWatchFunc(client kubernetes.Interface) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.CoreV1().Namespaces().Watch(context.Background(), opts)
+func namespaceInformerWatchFunc(client kubernetes.Interface) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.CoreV1().Namespaces().Watch(ctx, opts)
 	}
 }
 
@@ -139,8 +135,8 @@ func newReplicaSetSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  replicasetListFuncWithSelectors(client, namespace),
-			WatchFunc: replicasetWatchFuncWithSelectors(client, namespace),
+			ListWithContextFunc:  replicasetListFuncWithSelectors(client, namespace),
+			WatchFuncWithContext: replicasetWatchFuncWithSelectors(client, namespace),
 		},
 		&apps_v1.ReplicaSet{},
 		watchSyncPeriod,
@@ -148,17 +144,15 @@ func newReplicaSetSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func replicasetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.AppsV1().ReplicaSets(namespace).List(context.Background(), opts)
+func replicasetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.AppsV1().ReplicaSets(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func replicasetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.AppsV1().ReplicaSets(namespace).Watch(context.Background(), opts)
+func replicasetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.AppsV1().ReplicaSets(namespace).Watch(ctx, opts)
 	}
 }
 
@@ -168,8 +162,8 @@ func newDeploymentSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  deploymentListFuncWithSelectors(client, namespace),
-			WatchFunc: deploymentWatchFuncWithSelectors(client, namespace),
+			ListWithContextFunc:  deploymentListFuncWithSelectors(client, namespace),
+			WatchFuncWithContext: deploymentWatchFuncWithSelectors(client, namespace),
 		},
 		&apps_v1.Deployment{},
 		watchSyncPeriod,
@@ -177,17 +171,15 @@ func newDeploymentSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func deploymentListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.AppsV1().Deployments(namespace).List(context.Background(), opts)
+func deploymentListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.AppsV1().Deployments(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func deploymentWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.AppsV1().Deployments(namespace).Watch(context.Background(), opts)
+func deploymentWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.AppsV1().Deployments(namespace).Watch(ctx, opts)
 	}
 }
 
@@ -197,8 +189,8 @@ func newStatefulSetSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  statefulsetListFuncWithSelectors(client, namespace),
-			WatchFunc: statefulsetWatchFuncWithSelectors(client, namespace),
+			ListWithContextFunc:  statefulsetListFuncWithSelectors(client, namespace),
+			WatchFuncWithContext: statefulsetWatchFuncWithSelectors(client, namespace),
 		},
 		&apps_v1.StatefulSet{},
 		watchSyncPeriod,
@@ -206,17 +198,15 @@ func newStatefulSetSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func statefulsetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.AppsV1().StatefulSets(namespace).List(context.Background(), opts)
+func statefulsetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.AppsV1().StatefulSets(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func statefulsetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.AppsV1().StatefulSets(namespace).Watch(context.Background(), opts)
+func statefulsetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.AppsV1().StatefulSets(namespace).Watch(ctx, opts)
 	}
 }
 
@@ -226,8 +216,8 @@ func newDaemonSetSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  daemonsetListFuncWithSelectors(client, namespace),
-			WatchFunc: daemonsetWatchFuncWithSelectors(client, namespace),
+			ListWithContextFunc:  daemonsetListFuncWithSelectors(client, namespace),
+			WatchFuncWithContext: daemonsetWatchFuncWithSelectors(client, namespace),
 		},
 		&apps_v1.DaemonSet{},
 		watchSyncPeriod,
@@ -241,8 +231,8 @@ func newJobSharedInformer(
 ) cache.SharedInformer {
 	informer := cache.NewSharedInformer(
 		&cache.ListWatch{
-			ListFunc:  jobListFuncWithSelectors(client, namespace),
-			WatchFunc: jobWatchFuncWithSelectors(client, namespace),
+			ListWithContextFunc:  jobListFuncWithSelectors(client, namespace),
+			WatchFuncWithContext: jobWatchFuncWithSelectors(client, namespace),
 		},
 		&batch_v1.Job{},
 		watchSyncPeriod,
@@ -250,30 +240,26 @@ func newJobSharedInformer(
 	return informer
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func jobListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.BatchV1().Jobs(namespace).List(context.Background(), opts)
+func jobListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.BatchV1().Jobs(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func jobWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.BatchV1().Jobs(namespace).Watch(context.Background(), opts)
+func jobWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.BatchV1().Jobs(namespace).Watch(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func daemonsetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListFunc {
-	return func(opts metav1.ListOptions) (runtime.Object, error) {
-		return client.AppsV1().DaemonSets(namespace).List(context.Background(), opts)
+func daemonsetListFuncWithSelectors(client kubernetes.Interface, namespace string) cache.ListWithContextFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return client.AppsV1().DaemonSets(namespace).List(ctx, opts)
 	}
 }
 
-//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-func daemonsetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFunc {
-	return func(opts metav1.ListOptions) (watch.Interface, error) {
-		return client.AppsV1().DaemonSets(namespace).Watch(context.Background(), opts)
+func daemonsetWatchFuncWithSelectors(client kubernetes.Interface, namespace string) cache.WatchFuncWithContext {
+	return func(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+		return client.AppsV1().DaemonSets(namespace).Watch(ctx, opts)
 	}
 }

--- a/processor/k8sattributesprocessor/internal/kube/informer_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/informer_test.go
@@ -4,6 +4,7 @@
 package kube
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -90,7 +91,7 @@ func Test_informerListFuncWithSelectors(t *testing.T) {
 	assert.NoError(t, err)
 	listFunc := informerListFuncWithSelectors(c, "test-ns", ls, fs)
 	opts := metav1.ListOptions{}
-	obj, err := listFunc(opts)
+	obj, err := listFunc(context.Background(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -100,7 +101,7 @@ func Test_namespaceInformerListFunc(t *testing.T) {
 	assert.NoError(t, err)
 	listFunc := namespaceInformerListFunc(c)
 	opts := metav1.ListOptions{}
-	obj, err := listFunc(opts)
+	obj, err := listFunc(context.Background(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -127,7 +128,7 @@ func Test_informerWatchFuncWithSelectors(t *testing.T) {
 	assert.NoError(t, err)
 	watchFunc := informerWatchFuncWithSelectors(c, "test-ns", ls, fs)
 	opts := metav1.ListOptions{}
-	obj, err := watchFunc(opts)
+	obj, err := watchFunc(context.Background(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -137,7 +138,7 @@ func Test_namespaceInformerWatchFunc(t *testing.T) {
 	assert.NoError(t, err)
 	watchFunc := namespaceInformerWatchFunc(c)
 	opts := metav1.ListOptions{}
-	obj, err := watchFunc(opts)
+	obj, err := watchFunc(context.Background(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }

--- a/processor/k8sattributesprocessor/internal/kube/informer_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/informer_test.go
@@ -4,7 +4,6 @@
 package kube
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -91,7 +90,7 @@ func Test_informerListFuncWithSelectors(t *testing.T) {
 	assert.NoError(t, err)
 	listFunc := informerListFuncWithSelectors(c, "test-ns", ls, fs)
 	opts := metav1.ListOptions{}
-	obj, err := listFunc(context.Background(), opts)
+	obj, err := listFunc(t.Context(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -101,7 +100,7 @@ func Test_namespaceInformerListFunc(t *testing.T) {
 	assert.NoError(t, err)
 	listFunc := namespaceInformerListFunc(c)
 	opts := metav1.ListOptions{}
-	obj, err := listFunc(context.Background(), opts)
+	obj, err := listFunc(t.Context(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -128,7 +127,7 @@ func Test_informerWatchFuncWithSelectors(t *testing.T) {
 	assert.NoError(t, err)
 	watchFunc := informerWatchFuncWithSelectors(c, "test-ns", ls, fs)
 	opts := metav1.ListOptions{}
-	obj, err := watchFunc(context.Background(), opts)
+	obj, err := watchFunc(t.Context(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }
@@ -138,7 +137,7 @@ func Test_namespaceInformerWatchFunc(t *testing.T) {
 	assert.NoError(t, err)
 	watchFunc := namespaceInformerWatchFunc(c)
 	opts := metav1.ListOptions{}
-	obj, err := watchFunc(context.Background(), opts)
+	obj, err := watchFunc(t.Context(), opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, obj)
 }


### PR DESCRIPTION
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
