### PR TITLE
[chore][receiver/k8sobjects] migrate from using deprecated k8s API

### DIFF
--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -362,7 +362,7 @@ func (kr *k8sobjectsreceiver) sendInitialState(ctx context.Context, config *K8sO
 
 // doWatch returns true when watching is done, false when watching should be restarted.
 func (kr *k8sobjectsreceiver) doWatch(ctx context.Context, config *K8sObjectsConfig, resourceVersion string, watchFunc cache.WatchFuncWithContext, stopperChan chan struct{}) bool {
-	watcher, err := watch.NewRetryWatcher(resourceVersion, &cache.ListWatch{WatchFuncWithContext: watchFunc})
+	watcher, err := watch.NewRetryWatcherWithContext(ctx, resourceVersion, &cache.ListWatch{WatchFuncWithContext: watchFunc})
 	if err != nil {
 		kr.setting.Logger.Error("error in watching object",
 			zap.String("resource", config.gvr.String()),

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -279,11 +279,11 @@ func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjects
 		kr.sendInitialState(ctx, config, resource)
 	}
 
-	watchFunc := func(options metav1.ListOptions) (apiWatch.Interface, error) {
+	watchFunc := cache.WatchFuncWithContext(func(ctx context.Context, options metav1.ListOptions) (apiWatch.Interface, error) {
 		options.FieldSelector = config.FieldSelector
 		options.LabelSelector = config.LabelSelector
 		return resource.Watch(ctx, options)
-	}
+	})
 
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -361,9 +361,8 @@ func (kr *k8sobjectsreceiver) sendInitialState(ctx context.Context, config *K8sO
 }
 
 // doWatch returns true when watching is done, false when watching should be restarted.
-func (kr *k8sobjectsreceiver) doWatch(ctx context.Context, config *K8sObjectsConfig, resourceVersion string, watchFunc func(options metav1.ListOptions) (apiWatch.Interface, error), stopperChan chan struct{}) bool {
-	//nolint:staticcheck // SA1019 TODO: resolve as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
-	watcher, err := watch.NewRetryWatcher(resourceVersion, &cache.ListWatch{WatchFunc: watchFunc})
+func (kr *k8sobjectsreceiver) doWatch(ctx context.Context, config *K8sObjectsConfig, resourceVersion string, watchFunc cache.WatchFuncWithContext, stopperChan chan struct{}) bool {
+	watcher, err := watch.NewRetryWatcher(resourceVersion, &cache.ListWatch{WatchFuncWithContext: watchFunc})
 	if err != nil {
 		kr.setting.Logger.Error("error in watching object",
 			zap.String("resource", config.gvr.String()),


### PR DESCRIPTION
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43891
