### PR TITLE
Fix race condition in bearertokenauth extension, the dobule removal of watcher

### DIFF
--- a/.chloggen/bearertoken-fix-race-condition.yaml
+++ b/.chloggen/bearertoken-fix-race-condition.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/bearertokenauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove error messages `fsnotify: can't remove non-existent watch` when watching kubernetes SA tokens.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44104]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/bearertoken-fix-race-condition.yaml
+++ b/.chloggen/bearertoken-fix-race-condition.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: extension/bearertokenauth
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove error messages `fsnotify: can't remove non-existent watch` when watching kubernetes SA tokens.
+note: "Remove error messages `fsnotify: can't remove non-existent watch` when watching kubernetes SA tokens."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [44104]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description


```bash
2025-10-02T02:30:59.851Z	error	bearertokenauthextension@v0.135.0/bearertokenauth.go:131	fsnotify: can't remove non-existent watch: /var/run/secrets/kubernetes.io/serviceaccount/token	{"resource": {"service.instance.id": "db1e09f0-e9b5-421e-b9f2-539af8965363", "service.name": "otelcol", "service.version": "0.135.0"}, "otelcol.component.id": "bearertokenauth", "otelcol.component.kind": "extension"}
github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension.(*bearerTokenAuth).startWatcher
	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension@v0.135.0/bearertokenauth.go:131
```

The error means the code called watcher.Remove(path) on a file that the fsnotify watcher was already no longer watching.
In the specific case of the Kubernetes service account token, this happens because Kubernetes rotates the token by deleting and replacing the file (it's an atomic update).


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing


```
make otelcontribcol
make docker-otelcontribcol
docker tag localhost/otelcontribcol:latest pavolloffay/otelcolcontrib-bearertokenfix:1 
docker push pavolloffay/otelcolcontrib-bearertokenfix:1

docker run pavolloffay/otelcolcontrib-bearertokenfix:1
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
