### PR TITLE
[chore] [processor/k8sattributes] Fix passthrough mode regression

### DIFF
--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -144,7 +144,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 
 	for i := range podIdentifierValue {
 		if podIdentifierValue[i].Source.From == kube.ConnectionSource && podIdentifierValue[i].Value != "" {
-			if kp.rules.PodIP {
+			if kp.passthroughMode || kp.rules.PodIP {
 				setResourceAttribute(resource.Attributes(), kube.K8sIPLabelName, podIdentifierValue[i].Value)
 			}
 			break

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -370,7 +370,7 @@ func (strAddr) Network() string {
 	return "tcp"
 }
 
-func TestIPDetectionFromContext(t *testing.T) {
+func TestPassthroughIPDetectionFromContext(t *testing.T) {
 	addresses := []net.Addr{
 		&net.IPAddr{
 			IP: net.IPv4(1, 1, 1, 1),
@@ -386,7 +386,7 @@ func TestIPDetectionFromContext(t *testing.T) {
 		strAddr("1.1.1.1:3200"),
 	}
 	for _, addr := range addresses {
-		m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil, withExtractMetadata("k8s.pod.ip"))
+		m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil, withPassthrough())
 		ctx := client.NewContext(t.Context(), client.Info{
 			Addr: addr,
 		})
@@ -430,7 +430,6 @@ func TestProcessorNoAttrs(t *testing.T) {
 		NewFactory().CreateDefaultConfig(),
 		nil,
 		withExtractMetadata(string(conventions.K8SPodNameKey)),
-		withExtractMetadata("k8s.pod.ip"),
 	)
 
 	ctx := client.NewContext(t.Context(), client.Info{
@@ -459,7 +458,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
-	m.assertResourceAttributesLen(0, 1)
+	m.assertResourceAttributesLen(0, 0)
 
 	// attrs should be added now
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
@@ -489,7 +488,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 
 	m.assertBatchesLen(2)
 	m.assertResourceObjectLen(1)
-	m.assertResourceAttributesLen(1, 4)
+	m.assertResourceAttributesLen(1, 3)
 
 	// passthrough doesn't add attrs
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
@@ -735,7 +734,6 @@ func TestAddPodLabels(t *testing.T) {
 		t,
 		NewFactory().CreateDefaultConfig(),
 		nil,
-		withExtractMetadata("k8s.pod.ip"),
 	)
 
 	tests := map[string]map[string]string{
@@ -790,7 +788,6 @@ func TestAddPodLabels(t *testing.T) {
 		m.assertResourceObjectLen(i)
 		m.assertResource(i, func(res pcommon.Resource) {
 			require.Positive(t, res.Attributes().Len())
-			assertResourceHasStringAttribute(t, res, "k8s.pod.ip", ip)
 			for k, v := range attrs {
 				assertResourceHasStringAttribute(t, res, k, v)
 			}
@@ -815,7 +812,6 @@ func TestAddNamespaceLabels(t *testing.T) {
 			return cfg
 		}(),
 		nil,
-		withExtractMetadata("k8s.pod.ip"),
 	)
 
 	podIP := "1.1.1.1"
@@ -868,8 +864,7 @@ func TestAddNamespaceLabels(t *testing.T) {
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
 	m.assertResource(0, func(res pcommon.Resource) {
-		assert.Equal(t, 3, res.Attributes().Len())
-		assertResourceHasStringAttribute(t, res, "k8s.pod.ip", podIP)
+		assert.Equal(t, 2, res.Attributes().Len())
 		assertResourceHasStringAttribute(t, res, "nslabel", "1")
 		assertResourceHasStringAttribute(t, res, "service.namespace", "namespace-1")
 	})
@@ -890,7 +885,6 @@ func TestAddNodeLabels(t *testing.T) {
 			return cfg
 		}(),
 		nil,
-		withExtractMetadata("k8s.pod.ip"),
 	)
 
 	podIP := "1.1.1.1"
@@ -943,8 +937,7 @@ func TestAddNodeLabels(t *testing.T) {
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
 	m.assertResource(0, func(res pcommon.Resource) {
-		assert.Equal(t, 2, res.Attributes().Len())
-		assertResourceHasStringAttribute(t, res, "k8s.pod.ip", podIP)
+		assert.Equal(t, 1, res.Attributes().Len())
 		assertResourceHasStringAttribute(t, res, "nodelabel", "1")
 	})
 }
@@ -960,7 +953,6 @@ func TestAddNodeUID(t *testing.T) {
 			return cfg
 		}(),
 		nil,
-		withExtractMetadata("k8s.pod.ip"),
 	)
 
 	podIP := "1.1.1.1"
@@ -1010,8 +1002,7 @@ func TestAddNodeUID(t *testing.T) {
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
 	m.assertResource(0, func(res pcommon.Resource) {
-		assert.Equal(t, 3, res.Attributes().Len())
-		assertResourceHasStringAttribute(t, res, "k8s.pod.ip", podIP)
+		assert.Equal(t, 2, res.Attributes().Len())
 		assertResourceHasStringAttribute(t, res, "k8s.node.uid", nodeUID)
 		assertResourceHasStringAttribute(t, res, "nodelabel", "1")
 	})


### PR DESCRIPTION
PR #43910 fixed the issue where k8s.pod.ip was always set regardless of configuration, but it broke passthrough mode which relies on this attribute being set automatically.

In passthrough mode, the processor should always set k8s.pod.ip from the connection source, regardless of the extract.metadata configuration. This is the intended behavior as passthrough mode is designed to detect and tag pod IPs without invoking k8s APIs.

No changelog entry needed since #43910 isn't released yet
