### PR TITLE
[receiver/windowsservice] 44087 fix accessdenied

### DIFF
--- a/.chloggen/44087-fix-accessdenied.yaml
+++ b/.chloggen/44087-fix-accessdenied.yaml
@@ -4,7 +4,7 @@
 change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/windowsfilereceiver
+component: receiver/windowsservice
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fixed an error where incorrect permissions and bad error handling were causing the receiver to stop reporting metrics"

--- a/.chloggen/44087-fix-accessdenied.yaml
+++ b/.chloggen/44087-fix-accessdenied.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/windowsfilereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed an error where incorrect permissions and bad error handling were causing the receiver to stop reporting metrics"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44087]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/windowsservicereceiver/go.mod
+++ b/receiver/windowsservicereceiver/go.mod
@@ -16,7 +16,6 @@ require (
 	go.opentelemetry.io/collector/scraper v0.139.1-0.20251106125304-a6a176660925
 	go.opentelemetry.io/collector/scraper/scraperhelper v0.139.1-0.20251106125304-a6a176660925
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.36.0
 )
@@ -51,6 +50,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250804133106-a7a43d27e69b // indirect
 	google.golang.org/grpc v1.76.0 // indirect

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -8,13 +8,14 @@ package windowsservicereceiver // import "github.com/open-telemetry/opentelemetr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	"go.uber.org/multierr"
+	"go.opentelemetry.io/collector/scraper/scrapererror"
 	"go.uber.org/zap"
 	"golang.org/x/sys/windows"
 
@@ -114,7 +115,7 @@ func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, err
 		return ws.mb.Emit(), err
 	}
 
-	var scrapeErr error
+	var scrapeErr scrapererror.ScrapeErrors
 
 	for _, name := range names {
 		if !ws.allowed(name) {
@@ -123,18 +124,18 @@ func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, err
 
 		svc, err := updateService(&ws.mgr, name)
 		if err != nil {
-			scrapeErr = multierr.Append(scrapeErr, err)
+			scrapeErr.AddPartial(1, fmt.Errorf("updateService failed for %v: %v", name, err))
 			continue
 		}
 
 		if err := svc.updateStatus(); err != nil {
 			_ = svc.close()
-			scrapeErr = multierr.Append(scrapeErr, err)
+			scrapeErr.AddPartial(1, fmt.Errorf("updateStatus failed for %v: %v", name, err))
 			continue
 		}
 		if err := svc.updateConfig(); err != nil {
 			_ = svc.close()
-			scrapeErr = multierr.Append(scrapeErr, err)
+			scrapeErr.AddPartial(1, fmt.Errorf("updateConfig failed for %v: %v", name, err))
 			continue
 		}
 
@@ -144,9 +145,9 @@ func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, err
 		ws.mb.RecordWindowsServiceStatusDataPoint(ts, val, name, startAttr)
 
 		if err := svc.close(); err != nil {
-			scrapeErr = multierr.Append(scrapeErr, err)
+			scrapeErr.AddPartial(1, fmt.Errorf("failed to close service %v: %v", name, err))
 		}
 	}
 
-	return ws.mb.Emit(), scrapeErr
+	return ws.mb.Emit(), scrapeErr.Combine()
 }

--- a/receiver/windowsservicereceiver/scraper.go
+++ b/receiver/windowsservicereceiver/scraper.go
@@ -124,18 +124,18 @@ func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, err
 
 		svc, err := updateService(&ws.mgr, name)
 		if err != nil {
-			scrapeErr.AddPartial(1, fmt.Errorf("updateService failed for %v: %v", name, err))
+			scrapeErr.AddPartial(1, fmt.Errorf("updateService failed for %v: %w", name, err))
 			continue
 		}
 
 		if err := svc.updateStatus(); err != nil {
 			_ = svc.close()
-			scrapeErr.AddPartial(1, fmt.Errorf("updateStatus failed for %v: %v", name, err))
+			scrapeErr.AddPartial(1, fmt.Errorf("updateStatus failed for %v: %w", name, err))
 			continue
 		}
 		if err := svc.updateConfig(); err != nil {
 			_ = svc.close()
-			scrapeErr.AddPartial(1, fmt.Errorf("updateConfig failed for %v: %v", name, err))
+			scrapeErr.AddPartial(1, fmt.Errorf("updateConfig failed for %v: %w", name, err))
 			continue
 		}
 
@@ -145,7 +145,7 @@ func (ws *windowsServiceScraper) scrape(_ context.Context) (pmetric.Metrics, err
 		ws.mb.RecordWindowsServiceStatusDataPoint(ts, val, name, startAttr)
 
 		if err := svc.close(); err != nil {
-			scrapeErr.AddPartial(1, fmt.Errorf("failed to close service %v: %v", name, err))
+			scrapeErr.AddPartial(1, fmt.Errorf("failed to close service %v: %w", name, err))
 		}
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes a bug where a combination of error handling and misconfigured permissions (specifically the default permissions in [sys/windows](https://pkg.go.dev/golang.org/x/sys/windows)) caused an number of `access_denied` errors and the metrics to not be correctly exported.

In addition some more context was added to erros during the scrape function.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [44087](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44087)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested on local windows machine using the following config:
```yaml
receivers:
  windowsservice:
    collection_interval: 20s
```
