### PR TITLE
Fix transfromprocessor tests to use require.NoError and pass string to ParseJSON

### DIFF
--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
@@ -338,14 +339,14 @@ func TestLoadConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.id.Name(), func(t *testing.T) {
 			cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 
 			sub, err := cm.Sub(tt.id.String())
-			assert.NoError(t, err)
-			assert.NoError(t, sub.Unmarshal(cfg))
+			require.NoError(t, err)
+			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.expected == nil {
 				err = xconfmap.Validate(cfg)
@@ -357,7 +358,7 @@ func TestLoadConfig(t *testing.T) {
 					}
 				}
 			} else {
-				assert.NoError(t, xconfmap.Validate(cfg))
+				require.NoError(t, xconfmap.Validate(cfg))
 				assert.EqualExportedValues(t, tt.expected, cfg)
 				assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
 			}
@@ -369,13 +370,13 @@ func Test_UnknownContextID(t *testing.T) {
 	id := component.NewIDWithName(metadata.Type, "unknown_context")
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
 	sub, err := cm.Sub(id.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Error(t, sub.Unmarshal(cfg))
 }
 
@@ -383,24 +384,24 @@ func Test_UnknownErrorMode(t *testing.T) {
 	id := component.NewIDWithName(metadata.Type, "unknown_error_mode")
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
 	sub, err := cm.Sub(id.String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Error(t, sub.Unmarshal(cfg))
 }
 
 func Test_MixedConfigurationStyles(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
 	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "mixed_configuration_styles").String())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ErrorContains(t, sub.Unmarshal(cfg), "configuring multiple configuration styles is not supported")
 }

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -70,14 +70,14 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 		ProfileStatements: []common.ContextStatements{},
 	}, cfg)
 	assertConfigContainsDefaultFunctions(t, *cfg.(*Config))
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 
 func TestFactoryCreateProcessor_Empty(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	err := xconfmap.Validate(cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestFactoryCreateTraces_InvalidActions(t *testing.T) {
@@ -91,7 +91,7 @@ func TestFactoryCreateTraces_InvalidActions(t *testing.T) {
 		},
 	}
 	ap, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, ap)
 }
 
@@ -105,13 +105,12 @@ func TestFactoryCreateTraces(t *testing.T) {
 			Context: "span",
 			Statements: []string{
 				`set(attributes["test"], "pass") where name == "operationA"`,
-				`set(attributes["test error mode"], ParseJSON(1)) where name == "operationA"`,
+				`set(attributes["test error mode"], ParseJSON("1")) where name == "operationA"`,
 			},
 		},
 	}
 	tp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
-	assert.NotNil(t, tp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	td := ptrace.NewTraces()
 	span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
@@ -121,7 +120,7 @@ func TestFactoryCreateTraces(t *testing.T) {
 	assert.False(t, ok)
 
 	err = tp.ConsumeTraces(t.Context(), td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, ok := span.Attributes().Get("test")
 	assert.True(t, ok)
@@ -154,13 +153,12 @@ func TestFactoryCreateMetrics(t *testing.T) {
 			Context: "datapoint",
 			Statements: []string{
 				`set(attributes["test"], "pass") where metric.name == "operationA"`,
-				`set(attributes["test error mode"], ParseJSON(1)) where metric.name == "operationA"`,
+				`set(attributes["test error mode"], ParseJSON("1")) where metric.name == "operationA"`,
 			},
 		},
 	}
 	metricsProcessor, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
-	assert.NotNil(t, metricsProcessor)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	metrics := pmetric.NewMetrics()
 	metric := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
@@ -170,7 +168,7 @@ func TestFactoryCreateMetrics(t *testing.T) {
 	assert.False(t, ok)
 
 	err = metricsProcessor.ConsumeMetrics(t.Context(), metrics)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, ok := metric.Sum().DataPoints().At(0).Attributes().Get("test")
 	assert.True(t, ok)
@@ -187,13 +185,12 @@ func TestFactoryCreateLogs(t *testing.T) {
 			Context: "log",
 			Statements: []string{
 				`set(attributes["test"], "pass") where body == "operationA"`,
-				`set(attributes["test error mode"], ParseJSON(1)) where body == "operationA"`,
+				`set(attributes["test error mode"], ParseJSON("1")) where body == "operationA"`,
 			},
 		},
 	}
 	lp, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
-	assert.NotNil(t, lp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ld := plog.NewLogs()
 	log := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
@@ -203,7 +200,7 @@ func TestFactoryCreateLogs(t *testing.T) {
 	assert.False(t, ok)
 
 	err = lp.ConsumeLogs(t.Context(), ld)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	val, ok := log.Attributes().Get("test")
 	assert.True(t, ok)
@@ -307,12 +304,12 @@ func TestFactoryCreateLogProcessor(t *testing.T) {
 			}
 			lp, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, lp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			ld := tt.createLogs()
 
 			err = lp.ConsumeLogs(t.Context(), ld)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exLd := tt.createLogs()
 			tt.want(exLd)
@@ -400,12 +397,12 @@ func TestFactoryCreateProfileProcessor(t *testing.T) {
 			}
 			lp, err := factory.CreateProfiles(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, lp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			pd := tt.createProfiles()
 
 			err = lp.ConsumeProfiles(t.Context(), pd)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.want(), pd)
 		})
@@ -474,12 +471,12 @@ func TestFactoryCreateResourceProcessor(t *testing.T) {
 			}
 			lp, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, lp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			ld := tt.createLogs()
 
 			err = lp.ConsumeLogs(t.Context(), ld)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exLd := tt.createLogs()
 			tt.want(exLd)
@@ -551,12 +548,12 @@ func TestFactoryCreateScopeProcessor(t *testing.T) {
 			}
 			lp, err := factory.CreateLogs(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, lp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			ld := tt.createLogs()
 
 			err = lp.ConsumeLogs(t.Context(), ld)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exLd := tt.createLogs()
 			tt.want(exLd)
@@ -633,12 +630,12 @@ func TestFactoryCreateMetricProcessor(t *testing.T) {
 			}
 			mp, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, mp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			td := tt.createMetrics()
 
 			err = mp.ConsumeMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := tt.createMetrics()
 			tt.want(exTd)
@@ -718,12 +715,12 @@ func TestFactoryCreateDataPointProcessor(t *testing.T) {
 			}
 			mp, err := factory.CreateMetrics(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, mp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			td := tt.createMetrics()
 
 			err = mp.ConsumeMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := tt.createMetrics()
 			tt.want(exTd)
@@ -799,12 +796,12 @@ func TestFactoryCreateSpanProcessor(t *testing.T) {
 			}
 			mp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, mp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			td := tt.createTraces()
 
 			err = mp.ConsumeTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := tt.createTraces()
 			tt.want(exTd)
@@ -879,12 +876,12 @@ func TestFactoryCreateSpanEventProcessor(t *testing.T) {
 			}
 			mp, err := factory.CreateTraces(t.Context(), processortest.NewNopSettings(metadata.Type), cfg, consumertest.NewNop())
 			assert.NotNil(t, mp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			td := tt.createTraces()
 
 			err = mp.ConsumeTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := tt.createTraces()
 			tt.want(exTd)

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -61,10 +61,10 @@ func Test_ProcessLogs_ResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -102,10 +102,10 @@ func Test_ProcessLogs_InferredResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -143,10 +143,10 @@ func Test_ProcessLogs_ScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -184,10 +184,10 @@ func Test_ProcessLogs_InferredScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -438,10 +438,10 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "log", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -692,10 +692,10 @@ func Test_ProcessLogs_InferredLogContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -809,10 +809,10 @@ func Test_ProcessLogs_MixContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -899,10 +899,10 @@ func Test_ProcessLogs_InferredMixContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -931,8 +931,8 @@ func Test_ProcessLogs_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructLogs()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON("1"))`}}}, ottl.PropagateError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
 			assert.Error(t, err)
@@ -952,7 +952,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 			name:      "log: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(log.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(log.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(log.attributes["test"], "pass") where log.body == "operationA"`}},
 			},
 			want: func(td plog.Logs) {
@@ -963,16 +963,16 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 			name:      "log: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(log.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(log.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(log.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(log.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["test"], "pass")`}},
 			},
 			want: func(td plog.Logs) {
@@ -983,16 +983,16 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 			name:      "resource: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["test"], "pass")`}},
 			},
 			want: func(td plog.Logs) {
@@ -1003,10 +1003,10 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 			name:      "scope: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 	}
 
@@ -1014,7 +1014,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor(tt.statements, tt.errorMode, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = processor.ProcessLogs(t.Context(), td)
 			if tt.wantErrorWith != "" {
 				if err == nil {
@@ -1023,7 +1023,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErrorWith)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			exTd := constructLogs()
 			tt.want(exTd)
 			assert.Equal(t, exTd, td)
@@ -1141,10 +1141,10 @@ func Test_ProcessLogs_CacheAccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)
@@ -1191,10 +1191,10 @@ func Test_ProcessLogs_InferredContextFromConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructLogs()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, false, componenttest.NewNopTelemetrySettings(), DefaultLogFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessLogs(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructLogs()
 			tt.want(exTd)

--- a/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
@@ -6,7 +6,6 @@ package metrics
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -486,7 +485,7 @@ func Test_aggregateOnAttributeValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluate, err := AggregateOnAttributeValue(tt.t, tt.attribute, tt.values, tt.newValue)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -254,9 +255,9 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)
@@ -436,9 +437,9 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)
@@ -565,9 +566,9 @@ func TestUniform_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)
@@ -694,9 +695,9 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -120,7 +121,7 @@ func Test_convertGaugeToSum(t *testing.T) {
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)
 
 			_, err := exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -88,7 +89,7 @@ func Test_convertSumToGauge(t *testing.T) {
 			exprFunc, _ := convertSumToGauge()
 
 			_, err := exprFunc(nil, ctx)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -118,10 +119,10 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
 			evaluate, err := convertSummaryCountValToSum(tt.temporality, tt.monotonicity, tt.suffix)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
@@ -6,7 +6,7 @@ package metrics
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -128,10 +128,10 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 			tt.input.CopyTo(actualMetric.AppendEmpty())
 
 			evaluate, err := convertSummaryQuantileValToGauge(tt.key, tt.suffix)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetric, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)
@@ -144,7 +144,7 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 			sl2 := actualMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
 			actualMetric.CopyTo(sl2)
 
-			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -128,10 +129,10 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
 			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity, tt.suffix)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -126,9 +126,9 @@ func Test_copyMetric(t *testing.T) {
 			tt.want(expected)
 
 			exprFunc, err := copyMetric(tt.name, tt.desc, tt.unit)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = exprFunc(nil, ottlmetric.NewTransformContext(input, ms, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			x := pmetric.NewScopeMetrics()
 			y := pmetric.NewScopeMetrics()
@@ -136,7 +136,7 @@ func Test_copyMetric(t *testing.T) {
 			expected.CopyTo(x.Metrics())
 			ms.CopyTo(y.Metrics())
 
-			assert.NoError(t, pmetrictest.CompareScopeMetrics(x, y))
+			require.NoError(t, pmetrictest.CompareScopeMetrics(x, y))
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -178,7 +179,7 @@ func Test_extractCountMetric(t *testing.T) {
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
 			evaluate, err := extractCountMetric(tt.monotonicity, tt.suffix)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -305,7 +306,7 @@ func Test_extractSumMetric(t *testing.T) {
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
 			evaluate, err := extractSumMetric(tt.monotonicity, tt.suffix)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -136,7 +137,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, exprFunc)
 
 			metric := pmetric.NewMetric()
@@ -161,7 +162,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 
 			result, err := exprFunc(t.Context(), ctx)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Nil(t, result)
 
 			actualBounds := dp.ExplicitBounds().AsRaw()
@@ -204,13 +205,13 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	dp.SetDoubleValue(10.0)
 
 	exprFunc, err := mergeHistogramBuckets(0.5)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, exprFunc)
 
 	ctx := ottldatapoint.NewTransformContext(dp, metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
 	result, err := exprFunc(t.Context(), ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, result)
 
 	assert.Equal(t, 10.0, dp.DoubleValue())

--- a/processor/transformprocessor/internal/metrics/func_scale_test.go
+++ b/processor/transformprocessor/internal/metrics/func_scale_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -175,7 +176,7 @@ func TestScale(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.wantFunc(), target.GetMetric())
 		})

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -59,10 +59,10 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -100,10 +100,10 @@ func Test_ProcessMetrics_InferredResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -141,10 +141,10 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -182,10 +182,10 @@ func Test_ProcessMetrics_InferredScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -386,10 +386,10 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "metric", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -566,10 +566,10 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 
 			td := constructMetrics()
 			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -1009,10 +1009,10 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		t.Run(tt.statements[0], func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "datapoint", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -1457,10 +1457,10 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 			}
 
 			processor, err := NewProcessor(contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -1595,10 +1595,10 @@ func Test_ProcessMetrics_MixContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -1614,19 +1614,19 @@ func Test_ProcessMetrics_ErrorMode(t *testing.T) {
 		context   common.ContextID
 	}{
 		{
-			statement: `set(attributes["test"], ParseJSON(1))`,
+			statement: `set(attributes["test"], ParseJSON("1"))`,
 			context:   "resource",
 		},
 		{
-			statement: `set(attributes["test"], ParseJSON(1))`,
+			statement: `set(attributes["test"], ParseJSON("1"))`,
 			context:   "scope",
 		},
 		{
-			statement: `set(name, ParseJSON(1))`,
+			statement: `set(name, ParseJSON("1"))`,
 			context:   "metric",
 		},
 		{
-			statement: `set(attributes["test"], ParseJSON(1))`,
+			statement: `set(attributes["test"], ParseJSON("1"))`,
 			context:   "datapoint",
 		},
 	}
@@ -1635,7 +1635,7 @@ func Test_ProcessMetrics_ErrorMode(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{tt.statement}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
 			assert.Error(t, err)
@@ -1655,7 +1655,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 			name:      "metric: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(metric.name, ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(metric.name, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(metric.name, "pass") where metric.name == "operationA" `}},
 			},
 			want: func(td pmetric.Metrics) {
@@ -1666,16 +1666,16 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 			name:      "metric: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(metric.name, ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(metric.name, ParseJSON(true))`}},
+				{Statements: []string{`set(metric.name, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(metric.name, ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "datapoint: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(datapoint.attributes["test"], "pass") where metric.name == "operationA" `}},
 			},
 			want: func(td pmetric.Metrics) {
@@ -1687,16 +1687,16 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 			name:      "datapoint: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON(true))`}},
+				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["test"], "pass")`}},
 			},
 			want: func(td pmetric.Metrics) {
@@ -1707,16 +1707,16 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 			name:      "resource: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["test"], "pass")`}},
 			},
 			want: func(td pmetric.Metrics) {
@@ -1727,10 +1727,10 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 			name:      "scope: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 	}
 
@@ -1738,7 +1738,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = processor.ProcessMetrics(t.Context(), td)
 			if tt.wantErrorWith != "" {
 				if err == nil {
@@ -1747,7 +1747,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErrorWith)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			exTd := constructMetrics()
 			tt.want(exTd)
 			assert.Equal(t, exTd, td)
@@ -1901,10 +1901,10 @@ func Test_ProcessMetrics_CacheAccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)
@@ -1958,10 +1958,10 @@ func Test_ProcessMetrics_InferredContextFromConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructMetrics()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultMetricFunctions, DefaultDataPointFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessMetrics(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructMetrics()
 			tt.want(exTd)

--- a/processor/transformprocessor/internal/profiles/processor_test.go
+++ b/processor/transformprocessor/internal/profiles/processor_test.go
@@ -64,7 +64,7 @@ func Test_ProcessProfiles_ResourceContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -105,7 +105,7 @@ func Test_ProcessProfiles_InferredResourceContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -146,7 +146,7 @@ func Test_ProcessProfiles_ScopeContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -187,7 +187,7 @@ func Test_ProcessProfiles_InferredScopeContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -402,7 +402,7 @@ func Test_ProcessProfiles_ProfileContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -610,7 +610,7 @@ func Test_ProcessProfiles_InferredProfileContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -727,7 +727,7 @@ func Test_ProcessProfiles_MixContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -817,7 +817,7 @@ func Test_ProcessProfiles_InferredMixContext(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -834,15 +834,15 @@ func Test_ProcessProfiles_ErrorMode(t *testing.T) {
 	}{
 		{
 			context:   "resource",
-			statement: `set(attributes["test"], ParseJSON(1))`,
+			statement: `set(attributes["test"], ParseJSON("1"))`,
 		},
 		{
 			context:   "scope",
-			statement: `set(attributes["test"], ParseJSON(1))`,
+			statement: `set(attributes["test"], ParseJSON("1"))`,
 		},
 		{
 			context:   "profile",
-			statement: `set(original_payload_format, ParseJSON(1))`,
+			statement: `set(original_payload_format, ParseJSON("1"))`,
 		},
 	}
 
@@ -853,7 +853,7 @@ func Test_ProcessProfiles_ErrorMode(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 }
@@ -870,7 +870,7 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 			name:      "profile: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(profile.original_payload_format, ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(profile.original_payload_format, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(profile.original_payload_format, "pass") where profile.dropped_attributes_count == 1`}},
 			},
 			want: func(td pprofile.Profiles) {
@@ -882,16 +882,16 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 			name:      "profile: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(profile.original_payload_format, ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(profile.original_payload_format, ParseJSON(true))`}},
+				{Statements: []string{`set(profile.original_payload_format, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(profile.original_payload_format, ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["test"], "pass")`}},
 			},
 			want: func(td pprofile.Profiles) {
@@ -902,16 +902,16 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 			name:      "resource: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["test"], "pass")`}},
 			},
 			want: func(td pprofile.Profiles) {
@@ -922,10 +922,10 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 			name:      "scope: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 	}
 
@@ -943,7 +943,7 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErrorWith)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -1077,7 +1077,7 @@ func Test_ProcessProfiles_CacheAccess(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)
@@ -1215,10 +1215,10 @@ func Test_ProcessProfiles_InferredContextFromConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructProfiles()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultProfileFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessProfiles(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructProfiles()
 			tt.want(exTd)

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -64,10 +64,10 @@ func Test_ProcessTraces_ResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "resource", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -105,10 +105,10 @@ func Test_ProcessTraces_InferredResourceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -146,10 +146,10 @@ func Test_ProcessTraces_ScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "scope", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -187,10 +187,10 @@ func Test_ProcessTraces_InferredScopeContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -487,10 +487,10 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -787,10 +787,10 @@ func Test_ProcessTraces_InferredTraceContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -817,10 +817,10 @@ func Test_ProcessTraces_SpanEventContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "spanevent", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -847,10 +847,10 @@ func Test_ProcessTraces_InferredSpanEventContext(t *testing.T) {
 		t.Run(tt.statement, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "", Statements: []string{tt.statement}}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -964,10 +964,10 @@ func Test_ProcessTraces_MixContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -999,11 +999,11 @@ func Test_ProcessTraces_ErrorMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(string(tt.context), func(t *testing.T) {
 			td := constructTraces()
-			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON(1))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			processor, err := NewProcessor([]common.ContextStatements{{Context: tt.context, Statements: []string{`set(attributes["test"], ParseJSON("1"))`}}}, ottl.PropagateError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 }
@@ -1020,7 +1020,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 			name:      "span: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(span.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(span.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(span.attributes["test"], "pass") where span.name == "operationA" `}},
 			},
 			want: func(td ptrace.Traces) {
@@ -1031,16 +1031,16 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 			name:      "span: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(span.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(span.attributes["test"], ParseJSON(true))`}},
+				{Statements: []string{`set(span.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(span.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "spanevent: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(spanevent.attributes["test"], "pass") where spanevent.name == "eventA" `}},
 			},
 			want: func(td ptrace.Traces) {
@@ -1051,16 +1051,16 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 			name:      "spanevent: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON(true))`}},
+				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["test"], "pass")`}},
 			},
 			want: func(td ptrace.Traces) {
@@ -1071,16 +1071,16 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 			name:      "resource: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(resource.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "expected string but got bool",
+			wantErrorWith: "could not convert parsed value of type bool to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["test"], "pass")`}},
 			},
 			want: func(td ptrace.Traces) {
@@ -1091,10 +1091,10 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 			name:      "scope: statements group error mode does not affect default",
 			errorMode: ottl.PropagateError,
 			statements: []common.ContextStatements{
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(1))`}, ErrorMode: ottl.IgnoreError},
-				{Statements: []string{`set(scope.attributes["pass"], ParseJSON(true))`}},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
+				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: `expected string but got bool`,
+			wantErrorWith: `could not convert parsed value of type bool to JSON object`,
 		},
 	}
 
@@ -1102,7 +1102,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor(tt.statements, tt.errorMode, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = processor.ProcessTraces(t.Context(), td)
 			if tt.wantErrorWith != "" {
 				if err == nil {
@@ -1111,7 +1111,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErrorWith)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			exTd := constructTraces()
 			tt.want(exTd)
 			assert.Equal(t, exTd, td)
@@ -1259,10 +1259,10 @@ func Test_ProcessTraces_CacheAccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor(tt.statements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -1316,10 +1316,10 @@ func Test_ProcessTraces_InferredContextFromConditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			td := constructTraces()
 			processor, err := NewProcessor(tt.contextStatements, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			_, err = processor.ProcessTraces(t.Context(), td)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			exTd := constructTraces()
 			tt.want(exTd)
@@ -1532,12 +1532,12 @@ func BenchmarkTwoSpans(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(b, err)
+			require.NoError(b, err)
 			b.ResetTimer()
 			for b.Loop() {
 				td := constructTraces()
 				_, err = processor.ProcessTraces(b.Context(), td)
-				assert.NoError(b, err)
+				require.NoError(b, err)
 			}
 		})
 	}
@@ -1574,12 +1574,12 @@ func BenchmarkHundredSpans(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
-			assert.NoError(b, err)
+			require.NoError(b, err)
 			b.ResetTimer()
 			for b.Loop() {
 				td := constructTracesNum(100)
 				_, err = processor.ProcessTraces(b.Context(), td)
-				assert.NoError(b, err)
+				require.NoError(b, err)
 			}
 		})
 	}

--- a/processor/transformprocessor/processor_test.go
+++ b/processor/transformprocessor/processor_test.go
@@ -23,7 +23,7 @@ func TestFlattenDataDisabledByDefault(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	assert.False(t, oCfg.FlattenData)
-	assert.NoError(t, oCfg.Validate())
+	require.NoError(t, oCfg.Validate())
 }
 
 func TestFlattenDataRequiresGate(t *testing.T) {
@@ -56,12 +56,12 @@ func TestProcessLogsWithoutFlatten(t *testing.T) {
 	expected, err := golden.ReadLogs(filepath.Join("testdata", "logs", "expected-without-flatten.yaml"))
 	require.NoError(t, err)
 
-	assert.NoError(t, p.ConsumeLogs(t.Context(), input))
+	require.NoError(t, p.ConsumeLogs(t.Context(), input))
 
 	actual := sink.AllLogs()
 	require.Len(t, actual, 1)
 
-	assert.NoError(t, plogtest.CompareLogs(expected, actual[0]))
+	require.NoError(t, plogtest.CompareLogs(expected, actual[0]))
 }
 
 func TestProcessLogsWithFlatten(t *testing.T) {
@@ -87,12 +87,12 @@ func TestProcessLogsWithFlatten(t *testing.T) {
 	expected, err := golden.ReadLogs(filepath.Join("testdata", "logs", "expected-with-flatten.yaml"))
 	require.NoError(t, err)
 
-	assert.NoError(t, p.ConsumeLogs(t.Context(), input))
+	require.NoError(t, p.ConsumeLogs(t.Context(), input))
 
 	actual := sink.AllLogs()
 	require.Len(t, actual, 1)
 
-	assert.NoError(t, plogtest.CompareLogs(expected, actual[0]))
+	require.NoError(t, plogtest.CompareLogs(expected, actual[0]))
 }
 
 func BenchmarkLogsWithoutFlatten(b *testing.B) {
@@ -116,7 +116,7 @@ func BenchmarkLogsWithoutFlatten(b *testing.B) {
 	require.NoError(b, err)
 
 	for b.Loop() {
-		assert.NoError(b, p.ConsumeLogs(b.Context(), input))
+		require.NoError(b, p.ConsumeLogs(b.Context(), input))
 	}
 }
 
@@ -142,6 +142,6 @@ func BenchmarkLogsWithFlatten(b *testing.B) {
 	require.NoError(b, err)
 
 	for b.Loop() {
-		assert.NoError(b, p.ConsumeLogs(b.Context(), input))
+		require.NoError(b, p.ConsumeLogs(b.Context(), input))
 	}
 }


### PR DESCRIPTION
The motivation for this PR is to prepare for a change to expend optimization of literal values and remove runtime overhead for converting literals into typed getters. See second commit in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44201

Test only change, no need for changelog.