### PR TITLE
[chore] Fix First Time Contributor flow

### DIFF
--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - labeled
 
 permissions: read-all
 
@@ -31,5 +30,5 @@ jobs:
             **Important reminders:**
             - Please review our [Contributing Guidelines](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md).
             - Don't forget to sign the [Contributor License Agreement (CLA)](https://identity.linuxfoundation.org/projects/cncf) if you haven't already.
-            
+
             A maintainer will review your pull request soon. Thank you for helping make OpenTelemetry better!


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
It's very nice of the bot to welcome first time contributors, but it's a bit too overzealous about it. :)

The current state of the action causes it to run every time any labels on the target PR are changed. This PR updates the action it so it only runs on PR open.


<!--Describe what testing was performed and which tests were added.-->
#### Testing
I'm actually unsure how to test this, but I am reasonably sure this will be fine (famous last words I guess). It appears to always work with the PR opening, so I don't think the labelling is necessary. It looks like the `label` trigger was added to support manually adding the label, but it doesn't appear that will be necessary since the PR open trigger handles it.


<!--Please delete paragraphs that you did not use before submitting.-->
