### PR TITLE
[chore][receiver/cloudfoundryreceiver] run make modernize

### DIFF
--- a/receiver/cloudfoundryreceiver/config_test.go
+++ b/receiver/cloudfoundryreceiver/config_test.go
@@ -130,9 +130,9 @@ func TestInvalidConfigValidation(t *testing.T) {
 func TestHTTPConfigurationStructConsistency(t *testing.T) {
 	// LimitedClientConfig must have the same structure as ClientConfig, but without the fields that the UAA
 	// library does not support.
-	checkTypeFieldMatch(t, "Endpoint", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
-	checkTypeFieldMatch(t, "TLS", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
-	checkTypeFieldMatch(t, "InsecureSkipVerify", reflect.TypeOf(LimitedTLSClientSetting{}), reflect.TypeOf(configtls.ClientConfig{}))
+	checkTypeFieldMatch(t, "Endpoint", reflect.TypeFor[LimitedClientConfig](), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
+	checkTypeFieldMatch(t, "TLS", reflect.TypeFor[LimitedClientConfig](), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
+	checkTypeFieldMatch(t, "InsecureSkipVerify", reflect.TypeFor[LimitedTLSClientSetting](), reflect.TypeFor[configtls.ClientConfig]())
 }
 
 func loadSuccessfulConfig(t *testing.T) *Config {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
