### PR TITLE
[chore][receiver/googlecloudmonitoringreceiver] run make modernize

### DIFF
--- a/receiver/googlecloudmonitoringreceiver/receiver.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -327,19 +328,20 @@ func (mr *monitoringReceiver) convertGCPTimeSeriesToMetrics(metrics pmetric.Metr
 
 // Helper function to generate a unique key for a resource based on its attributes
 func generateResourceKey(resourceType string, labels map[string]string, timeSeries *monitoringpb.TimeSeries) string {
-	key := resourceType
+	var key strings.Builder
+	key.WriteString(resourceType)
 	for k, v := range labels {
-		key += k + v
+		key.WriteString(k + v)
 	}
 	if timeSeries != nil {
 		for k, v := range timeSeries.Metric.Labels {
-			key += k + v
+			key.WriteString(k + v)
 		}
 		if timeSeries.Resource.Labels != nil {
 			for k, v := range timeSeries.Resource.Labels {
-				key += k + v
+				key.WriteString(k + v)
 			}
 		}
 	}
-	return key
+	return key.String()
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
