### PR TITLE
[chore][receiver/prometheusremotewritereceiver] run make modernize

### DIFF
--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -1829,7 +1829,7 @@ func TestConcurrentRequestsforSameResourceAttributes(t *testing.T) {
 	}
 
 	requests := []*writev2.Request{}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		requests = append(requests, createRequest("metric_"+strconv.Itoa(i+1), float64(i+1)*10, int64(i+1)*1000))
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
