### PR TITLE
[chore][receiver/windowseventlogreceiver] improve linting

### DIFF
--- a/receiver/windowseventlogreceiver/factory_test.go
+++ b/receiver/windowseventlogreceiver/factory_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver/internal/metadata"
@@ -42,7 +41,7 @@ func TestCreateAndShutdown(t *testing.T) {
 
 	if runtime.GOOS != "windows" {
 		assert.Error(t, err)
-		assert.IsType(t, pipeline.ErrSignalNotSupported, err)
+		assert.ErrorContains(t, err, "windows eventlog receiver is only supported on Windows")
 		assert.Nil(t, receiver)
 	} else {
 		assert.NoError(t, err)

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -20,7 +20,6 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.139.1-0.20251106125304-a6a176660925
 	go.opentelemetry.io/collector/consumer/consumertest v0.139.1-0.20251106125304-a6a176660925
 	go.opentelemetry.io/collector/pdata v1.45.1-0.20251106125304-a6a176660925
-	go.opentelemetry.io/collector/pipeline v1.45.1-0.20251106125304-a6a176660925
 	go.opentelemetry.io/collector/receiver/receivertest v0.139.1-0.20251106125304-a6a176660925
 	go.uber.org/zap v1.27.0
 )
@@ -58,6 +57,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.139.1-0.20251106125304-a6a176660925 // indirect
 	go.opentelemetry.io/collector/featuregate v1.45.1-0.20251106125304-a6a176660925 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.139.1-0.20251106125304-a6a176660925 // indirect
+	go.opentelemetry.io/collector/pipeline v1.45.1-0.20251106125304-a6a176660925 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.139.1-0.20251106125304-a6a176660925 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.139.1-0.20251106125304-a6a176660925 // indirect
 	go.opentelemetry.io/otel v1.38.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
WARN [runner/exclusion_paths] The pattern "third_party" match no issues
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "cachedBytes", Path: "pagefile.go", Linters: "unused"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party", Linters: "gci, gofumpt"]
receiver/windowseventlogreceiver/factory_test.go:45:3: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
		assert.IsType(t, pipeline.ErrSignalNotSupported, err)
		^
make: *** [lint] Error 1
```
