### PR TITLE
[chore][processor/resourcedetectionprocessor] improve linting

### DIFF
--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	confighttp.ClientConfig `mapstructure:",squash"`
 	// Attributes is an allowlist of attributes to add.
 	// If a supplied attribute is not a valid attribute of a supplied detector it will be ignored.
+	//
 	// Deprecated: Please use detector's resource_attributes config instead
 	Attributes []string `mapstructure:"attributes"`
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
WARN [runner/exclusion_paths] The pattern "third_party" match no issues
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "cachedBytes", Path: "pagefile.go", Linters: "unused"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party", Linters: "gci, gofumpt"]
processor/resourcedetectionprocessor/config.go:50:2: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
	// Deprecated: Please use detector's resource_attributes config instead
	^
make: *** [lint] Error 1
```
