### PR TITLE
[chore][exporter/datasetexporter] run make modernize

### DIFF
--- a/exporter/datasetexporter/logs_exporter_integration_test.go
+++ b/exporter/datasetexporter/logs_exporter_integration_test.go
@@ -102,11 +102,11 @@ func TestConsumeLogsManyLogsShouldSucceed(t *testing.T) {
 		err = logs.Start(t.Context(), componenttest.NewNopHost())
 		assert.NoError(t, err)
 
-		for bI := 0; bI < maxBatchCount; bI++ {
+		for bI := range maxBatchCount {
 			batch := plog.NewLogs()
 			rL := batch.ResourceLogs().AppendEmpty()
 			sL := rL.ScopeLogs().AppendEmpty()
-			for lI := 0; lI < logsPerBatch; lI++ {
+			for lI := range logsPerBatch {
 				key := fmt.Sprintf("%04d-%06d", bI, lI)
 				log := sL.LogRecords().AppendEmpty()
 				log.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
