### PR TITLE
[chore][receiver/apachereceiver] run make modernize

### DIFF
--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -166,11 +166,11 @@ func parseStats(resp string) map[string]string {
 	metrics := make(map[string]string)
 
 	for field := range strings.SplitSeq(resp, "\n") {
-		index := strings.Index(field, ": ")
-		if index == -1 {
+		key, value, found := strings.Cut(field, ": ")
+		if !found {
 			continue
 		}
-		metrics[field[:index]] = field[index+2:]
+		metrics[key] = value
 	}
 	return metrics
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
receiver/apachereceiver/scraper.go:169:12: stringscut: strings.Index can be simplified using strings.Cut (modernize)
		index := strings.Index(field, ": ")
		         ^
make[2]: *** [lint] Error 1
make[1]: *** [receiver/apachereceiver] Error 2
make[1]: *** Waiting for unfinished jobs....
```
