### PR TITLE
[chore][receiver/awscontainerinsightreceiver] run make modernize

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go
@@ -213,8 +213,8 @@ func getCGroupMountPoint(mountConfigPath string) (string, error) {
 			fields = strings.Split(text, " ")
 			// safe as mountinfo encodes mountpoints with spaces as \040.
 			// an example: 26 22 0:23 / /cgroup/cpu rw,relatime - cgroup cgroup rw,cpu
-			index               = strings.Index(text, " - ")
-			postSeparatorFields = strings.Fields(text[index+3:])
+			_, after, _         = strings.Cut(text, " - ")
+			postSeparatorFields = strings.Fields(after)
 			numPostFields       = len(postSeparatorFields)
 		)
 		// this is an error as we can't detect if the mount is for "cgroup"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup.go:216:26: stringscut: strings.Index can be simplified using strings.Cut (modernize)
			index               = strings.Index(text, " - ")
			                      ^
make[2]: *** [lint] Error 1
make[1]: *** [receiver/awscontainerinsightreceiver] Error 2
```
