### PR TITLE
[chore][receiver/awsxrayreceiver] run make modernize

### DIFF
--- a/receiver/awsxrayreceiver/internal/tracesegment/util.go
+++ b/receiver/awsxrayreceiver/internal/tracesegment/util.go
@@ -28,14 +28,14 @@ func SplitHeaderBody(buf []byte) (*Header, []byte, error) {
 	}
 
 	var headerBytes, bodyBytes []byte
-	loc := bytes.IndexByte(buf, byte(ProtocolSeparator))
-	if loc == -1 {
+	before, after, ok := bytes.Cut(buf, []byte{byte(ProtocolSeparator)})
+	if !ok {
 		return nil, nil, &recvErr.ErrRecoverable{
 			Err: fmt.Errorf("unable to split incoming data as header and segment, incoming bytes: %v", buf),
 		}
 	}
-	headerBytes = buf[0:loc]
-	bodyBytes = buf[loc+1:]
+	headerBytes = before
+	bodyBytes = after
 
 	header := Header{}
 	err := json.Unmarshal(headerBytes, &header)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
receiver/awsxrayreceiver/internal/tracesegment/util.go:31:9: stringscut: bytes.IndexByte can be simplified using bytes.Cut (modernize)
	loc := bytes.IndexByte(buf, byte(ProtocolSeparator))
	       ^
make[2]: *** [lint] Error 1
make[1]: *** [receiver/awsxrayreceiver] Error 2
make: *** [golint] Error 2
```
