### PR TITLE
[chore][exporter/prometheusexporter] run make modernize

### DIFF
--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	EnableOpenMetrics bool `mapstructure:"enable_open_metrics"`
 
 	// AddMetricSuffixes controls whether suffixes are added to metric names. Defaults to true.
+	//
 	// Deprecated: Use TranslationStrategy instead. This setting is ignored when TranslationStrategy is explicitly set.
 	AddMetricSuffixes bool `mapstructure:"add_metric_suffixes"`
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
exporter/prometheusexporter/config.go:45:2: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
	// Deprecated: Use TranslationStrategy instead. This setting is ignored when TranslationStrategy is explicitly set.
	^
make[2]: *** [lint] Error 1
make[1]: *** [exporter/prometheusexporter] Error 2
make[1]: *** Waiting for unfinished jobs....
```
