### PR TITLE
[chore][exporter/splunkhecexporter] run make modernize

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1696,7 +1696,6 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 
 	err := c.pushLogData(t.Context(), logs)
 	require.Error(t, err)
-	assert.IsType(t, consumererror.Logs{}, err)
 
 	// Only the record that was not successfully sent should be returned
 	var logsErr consumererror.Logs


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
exporter/splunkhecexporter/client_test.go:1699:2: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
	assert.IsType(t, consumererror.Logs{}, err)
	^
make[2]: *** [lint] Error 1
make[1]: *** [exporter/splunkhecexporter] Error 2
make[1]: *** Waiting for unfinished jobs....
```

I removed the line since it seems redundant with the lines below

```go
        // Only the record that was not successfully sent should be returned
	var logsErr consumererror.Logs
	require.ErrorAs(t, err, &logsErr)
```
