### PR TITLE
[chore][extension/basicauthextension] run make modernize

### DIFF
--- a/extension/basicauthextension/extension.go
+++ b/extension/basicauthextension/extension.go
@@ -143,14 +143,14 @@ func parseBasicAuth(auth string) (*authData, error) {
 	}
 	decoded := string(decodedBytes)
 
-	si := strings.IndexByte(decoded, ':')
-	if si < 0 {
+	before, after, ok := strings.Cut(decoded, ":")
+	if !ok {
 		return nil, errInvalidFormat
 	}
 
 	return &authData{
-		username: decoded[:si],
-		password: decoded[si+1:],
+		username: before,
+		password: after,
 		raw:      encoded,
 	}, nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
extension/basicauthextension/extension.go:146:8: stringscut: strings.IndexByte can be simplified using strings.Cut (modernize)
	si := strings.IndexByte(decoded, ':')
	      ^
make[2]: *** [lint] Error 1
make[1]: *** [extension/basicauthextension] Error 2
make[1]: *** Waiting for unfinished jobs....
```
