### PR TITLE
[chore][extension/encoding/awslogsencodingextension] run make modernize

### DIFF
--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/elb-access-log/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/elb-access-log/unmarshaler.go
@@ -285,7 +285,7 @@ func (f *elbAccessLogUnmarshaler) addToALBAccessLogs(resourceAttr *resourceAttri
 	}
 	if albRecord.ActionsExecuted != unknownField {
 		actions := recordLog.Attributes().PutEmptySlice(AttributeELBActionsExecuted)
-		for _, action := range strings.Split(albRecord.ActionsExecuted, ",") {
+		for action := range strings.SplitSeq(albRecord.ActionsExecuted, ",") {
 			actions.AppendEmpty().SetStr(action)
 		}
 	}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/network-firewall-log/benchmark_test.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/network-firewall-log/benchmark_test.go
@@ -36,8 +36,8 @@ func readAndCompressLogFileForBenchmark(b *testing.B, dir, file string) []byte {
 func BenchmarkUnmarshalNetworkFirewallAlertLog(b *testing.B) {
 	u := networkFirewallLogUnmarshaler{buildInfo: component.BuildInfo{}}
 	data := readAndCompressLogFileForBenchmark(b, "testdata", "valid_alert_log.json")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := u.UnmarshalAWSLogs(bytes.NewReader(data))
 		if err != nil {
 			b.Fatal(err)
@@ -48,8 +48,8 @@ func BenchmarkUnmarshalNetworkFirewallAlertLog(b *testing.B) {
 func BenchmarkUnmarshalNetworkFirewallFlowLog(b *testing.B) {
 	u := networkFirewallLogUnmarshaler{buildInfo: component.BuildInfo{}}
 	data := readAndCompressLogFileForBenchmark(b, "testdata", "valid_flow_log.json")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := u.UnmarshalAWSLogs(bytes.NewReader(data))
 		if err != nil {
 			b.Fatal(err)
@@ -60,8 +60,8 @@ func BenchmarkUnmarshalNetworkFirewallFlowLog(b *testing.B) {
 func BenchmarkUnmarshalNetworkFirewallTLSLog(b *testing.B) {
 	u := networkFirewallLogUnmarshaler{buildInfo: component.BuildInfo{}}
 	data := readAndCompressLogFileForBenchmark(b, "testdata", "valid_tls_log.json")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		_, err := u.UnmarshalAWSLogs(bytes.NewReader(data))
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
extension/encoding/awslogsencodingextension/internal/unmarshaler/elb-access-log/unmarshaler.go:288:26: stringsseq: Ranging over SplitSeq is more efficient (modernize)
		for _, action := range strings.Split(albRecord.ActionsExecuted, ",") {
		                       ^
extension/encoding/awslogsencodingextension/internal/unmarshaler/network-firewall-log/benchmark_test.go:40:14: bloop: b.N can be modernized using b.Loop() (modernize)
	for i := 0; i < b.N; i++ {
	            ^
extension/encoding/awslogsencodingextension/internal/unmarshaler/network-firewall-log/benchmark_test.go:52:14: bloop: b.N can be modernized using b.Loop() (modernize)
	for i := 0; i < b.N; i++ {
	            ^
extension/encoding/awslogsencodingextension/internal/unmarshaler/network-firewall-log/benchmark_test.go:64:14: bloop: b.N can be modernized using b.Loop() (modernize)
	for i := 0; i < b.N; i++ {
	            ^
make[2]: *** [lint] Error 1
make[1]: *** [extension/encoding/awslogsencodingextension] Error 2
make[1]: *** Waiting for unfinished jobs....
```
