### PR TITLE
[chore][internal/collectd] run make modernize

### DIFF
--- a/internal/collectd/labels.go
+++ b/internal/collectd/labels.go
@@ -33,11 +33,11 @@ func LabelsFromName(val *string) (metricName string, labels map[string]string) {
 					cindex = len(dimensions)
 				}
 				piece := dimensions[prev:cindex]
-				tindex := strings.Index(piece, "=")
-				if tindex == -1 || strings.Contains(piece[tindex+1:], "=") {
+				before, after, ok := strings.Cut(piece, "=")
+				if !ok || strings.Contains(after, "=") {
 					return metricName, labels
 				}
-				working[piece[:tindex]] = piece[tindex+1:]
+				working[before] = after
 				if cindex == len(dimensions) {
 					break
 				}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
internal/collectd/labels.go:36:15: stringscut: strings.Index can be simplified using strings.Cut (modernize)
				tindex := strings.Index(piece, "=")
				          ^
make[2]: *** [lint] Error 1
make[1]: *** [internal/collectd] Error 2
make[1]: *** Waiting for unfinished jobs....
```
