### PR TITLE
[chore][internal/coreinternal] run make modernize

### DIFF
--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -6,6 +6,7 @@ package metricstestutil // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -343,9 +344,13 @@ func diffValues(
 }
 
 func attrMapToString(m pcommon.Map) string {
-	out := ""
+	var out strings.Builder
 	for k, v := range m.All() {
-		out += "[" + k + "=" + v.AsString() + "]"
+		out.WriteString("[")
+		out.WriteString(k)
+		out.WriteString("=")
+		out.WriteString(v.AsString())
+		out.WriteString("]")
 	}
-	return out
+	return out.String()
 }

--- a/internal/coreinternal/metricstestutil/metric_diff.go
+++ b/internal/coreinternal/metricstestutil/metric_diff.go
@@ -6,6 +6,7 @@ package metricstestutil // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -343,9 +344,9 @@ func diffValues(
 }
 
 func attrMapToString(m pcommon.Map) string {
-	out := ""
+	var out strings.Builder
 	for k, v := range m.All() {
-		out += "[" + k + "=" + v.AsString() + "]"
+		out.WriteString("[" + k + "=" + v.AsString() + "]")
 	}
-	return out
+	return out.String()
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
internal/coreinternal/metricstestutil/metric_diff.go:348:3: stringsbuilder: using string += string in a loop is inefficient (modernize)
		out += "[" + k + "=" + v.AsString() + "]"
		^
make[2]: *** [lint] Error 1
make[1]: *** [internal/coreinternal] Error 2
make[1]: *** Waiting for unfinished jobs....
```
