### PR TITLE
[chore][internal/otelarrow] improve linting

### DIFF
--- a/internal/otelarrow/netstats/netstats_test.go
+++ b/internal/otelarrow/netstats/netstats_test.go
@@ -67,10 +67,6 @@ func viewsFromLevel(level configtelemetry.Level) []metric.View {
 				Name:  "otelcol_*_compressed_size",
 				Scope: scope,
 			}),
-			dropView(metric.Instrument{
-				Name:  "otelcol_*_compressed_size",
-				Scope: scope,
-			}),
 			// makeRecvMetrics for exporters.
 			dropView(metric.Instrument{
 				Name:  "otelcol_exporter_recv",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
internal/otelarrow/netstats/netstats_test.go:70:4: dupOption: function argument `dropView(metric.Instrument{
	Name:	"otelcol_*_compressed_size",
	Scope:	scope,
})` is duplicated (gocritic)
			dropView(metric.Instrument{
			^
make[2]: *** [lint] Error 1
make[1]: *** [internal/otelarrow] Error 2
make[1]: *** Waiting for unfinished jobs....
```
