### PR TITLE
[chore][pkg/datadog] improve linting

### DIFF
--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -186,6 +186,7 @@ func (c *Config) Validate() error {
 
 // StaticAPIKey Check checks if api::key is either empty or contains invalid (non-hex) characters
 // It does not validate online; this is handled on startup.
+//
 // Deprecated: [v0.136.0] Do not use, will be removed on the next minor version
 func StaticAPIKeyCheck(key string) error {
 	if key == "" {

--- a/pkg/datadog/config/metrics.go
+++ b/pkg/datadog/config/metrics.go
@@ -71,6 +71,7 @@ type HistogramConfig struct {
 
 	// SendCountSum states if the export should send .sum and .count metrics for histograms.
 	// The default is false.
+	//
 	// Deprecated: [v0.75.0] Use `send_aggregation_metrics` (HistogramConfig.SendAggregations) instead.
 	SendCountSum bool `mapstructure:"send_count_sum_metrics"`
 

--- a/pkg/datadog/config/traces.go
+++ b/pkg/datadog/config/traces.go
@@ -51,6 +51,7 @@ type TracesConfig struct {
 	// For the best experience with `peer.service`, it is recommended to also enable `compute_stats_by_span_kind`.
 	// If enabling both causes the datadog exporter to consume too many resources, try disabling `compute_stats_by_span_kind` first.
 	// If the overhead remains high, it will be due to a high cardinality of `peer.service` values from the traces. You may need to check your instrumentation.
+	//
 	// Deprecated: Please use PeerTagsAggregation instead
 	PeerServiceAggregation bool `mapstructure:"peer_service_aggregation"`
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
pkg/datadog/config/config.go:189:1: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
// Deprecated: [v0.136.0] Do not use, will be removed on the next minor version
^
pkg/datadog/config/metrics.go:74:2: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
	// Deprecated: [v0.75.0] Use `send_aggregation_metrics` (HistogramConfig.SendAggregations) instead.
	^
pkg/datadog/config/traces.go:54:2: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
	// Deprecated: Please use PeerTagsAggregation instead
	^
```
