### PR TITLE
[chore][pkg/ottl] improve linting

### DIFF
--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -971,7 +971,8 @@ func Test_StandardStringGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1221,7 +1222,8 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 					assert.Equal(t, tt.want, *val)
 				}
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1298,7 +1300,8 @@ func Test_StandardFloatGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1475,7 +1478,8 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 					assert.Equal(t, tt.want, *val)
 				}
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1552,7 +1556,8 @@ func Test_StandardIntGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1729,7 +1734,8 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 					assert.Equal(t, tt.want, *val)
 				}
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -1928,7 +1934,8 @@ func Test_StandardByteSliceLikeGetter(t *testing.T) {
 					assert.Equal(t, tt.want, val)
 				}
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -2005,7 +2012,8 @@ func Test_StandardBoolGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -2161,7 +2169,8 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 					assert.Equal(t, tt.want, *val)
 				}
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -2358,7 +2367,8 @@ func Test_StandardPSliceGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})
@@ -2444,7 +2454,8 @@ func Test_StandardPMapGetter(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, val)
 			} else {
-				assert.IsType(t, TypeError(""), err)
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
 		})

--- a/pkg/ottl/ottlfuncs/func_is_list_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_list_test.go
@@ -186,5 +186,6 @@ func Test_IsList_Error(t *testing.T) {
 	})
 	result, err := exprFunc(t.Context(), nil)
 	assert.Equal(t, false, result)
-	assert.IsType(t, ottl.TypeError(""), err)
+	var typeErr ottl.TypeError
+	assert.ErrorAs(t, err, &typeErr)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
pkg/ottl/expression_test.go:974:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1224:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1301:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1478:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1555:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1732:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:1931:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:2008:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:2164:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:2361:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/expression_test.go:2447:5: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
				assert.IsType(t, TypeError(""), err)
				^
pkg/ottl/ottlfuncs/func_is_list_test.go:189:2: error-is-as: use assert.ErrorIs or assert.ErrorAs depending on the case (testifylint)
	assert.IsType(t, ottl.TypeError(""), err)
	^
make[2]: *** [lint] Error 1
make[1]: *** [pkg/ottl] Error 2
```
