### PR TITLE
[chore][pkg/translator/faro] run make modernize

### DIFF
--- a/pkg/translator/faro/keyval.go
+++ b/pkg/translator/faro/keyval.go
@@ -116,13 +116,14 @@ func exceptionMessage(e *faroTypes.Exception) string {
 
 // exceptionToString is the string representation of an Exception
 func exceptionToString(e *faroTypes.Exception) string {
-	stacktrace := exceptionMessage(e)
+	var stacktrace strings.Builder
+	stacktrace.WriteString(exceptionMessage(e))
 	if e.Stacktrace != nil {
 		for i := range e.Stacktrace.Frames {
-			stacktrace += frameToString(&e.Stacktrace.Frames[i])
+			stacktrace.WriteString(frameToString(&e.Stacktrace.Frames[i]))
 		}
 	}
-	return stacktrace
+	return stacktrace.String()
 }
 
 // frameToString function converts a Frame into a human readable string


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
pkg/translator/faro/keyval.go:122:4: stringsbuilder: using string += string in a loop is inefficient (modernize)
			stacktrace += frameToString(&e.Stacktrace.Frames[i])
			^
```