### PR TITLE
[chore][testbed] run make modernize

### DIFF
--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,32 +55,32 @@ func createConfigYaml(
 
 	// Prepare extra processor config section and comma-separated list of extra processor
 	// names to use in corresponding "processors" settings.
-	processorsSections := ""
-	processorsList := ""
+	var processorsSections strings.Builder
+	var processorsList strings.Builder
 	if len(processors) > 0 {
 		first := true
 		for i := range processors {
-			processorsSections += processors[i].Body + "\n"
+			processorsSections.WriteString(processors[i].Body + "\n")
 			if !first {
-				processorsList += ","
+				processorsList.WriteString(",")
 			}
-			processorsList += processors[i].Name
+			processorsList.WriteString(processors[i].Name)
 			first = false
 		}
 	}
 
 	// Prepare extra extension config section and comma-separated list of extra extension
 	// names to use in corresponding "extensions" settings.
-	extensionsSections := ""
-	extensionsList := ""
+	var extensionsSections strings.Builder
+	var extensionsList strings.Builder
 	if len(extensions) > 0 {
 		first := true
 		for name, cfg := range extensions {
-			extensionsSections += cfg + "\n"
+			extensionsSections.WriteString(cfg + "\n")
 			if !first {
-				extensionsList += ","
+				extensionsList.WriteString(",")
 			}
-			extensionsList += name
+			extensionsList.WriteString(name)
 			first = false
 		}
 	}
@@ -122,13 +123,13 @@ service:
 		format,
 		sender.GenConfigYAMLStr(),
 		receiver.GenConfigYAMLStr(),
-		processorsSections,
+		processorsSections.String(),
 		resultDir,
-		extensionsSections,
-		extensionsList,
+		extensionsSections.String(),
+		extensionsList.String(),
 		pipeline,
 		sender.ProtocolName(),
-		processorsList,
+		processorsList.String(),
 		receiver.ProtocolName(),
 	)
 }

--- a/testbed/tests/syslog_integration_test.go
+++ b/testbed/tests/syslog_integration_test.go
@@ -6,6 +6,7 @@ package tests // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ service:
 
 	// prepare data
 
-	message := ""
+	var message strings.Builder
 	expectedAttributes := []map[string]any{}
 	expectedLogs := plog.NewLogs()
 	rl := expectedLogs.ResourceLogs().AppendEmpty()
@@ -168,7 +169,7 @@ service:
 		lr.SetSeverityText(e.severityText)
 		lr.SetTimestamp(e.timestamp)
 		expectedAttributes = append(expectedAttributes, e.attributes)
-		message += e.message + "\n"
+		message.WriteString(e.message + "\n")
 	}
 
 	// Prepare client
@@ -176,7 +177,7 @@ service:
 	require.NoError(t, err)
 
 	// Write requests
-	fmt.Fprint(conn, message)
+	fmt.Fprint(conn, message.String())
 
 	// Wait for all messages
 	for len(backend.ReceivedLogs) < 1 {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
testbed/tests/scenarios.go:62:4: stringsbuilder: using string += string in a loop is inefficient (modernize)
			processorsSections += processors[i].Body + "\n"
			^
testbed/tests/scenarios.go:64:5: stringsbuilder: using string += string in a loop is inefficient (modernize)
				processorsList += ","
				^
testbed/tests/scenarios.go:78:4: stringsbuilder: using string += string in a loop is inefficient (modernize)
			extensionsSections += cfg + "\n"
			^
testbed/tests/scenarios.go:80:5: stringsbuilder: using string += string in a loop is inefficient (modernize)
				extensionsList += ","
				^
testbed/tests/syslog_integration_test.go:171:3: stringsbuilder: using string += string in a loop is inefficient (modernize)
		message += e.message + "\n"
		^
```
