### PR TITLE
[chore] Make Makefile.Common more portable

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -2,7 +2,7 @@
 # the value `-o pipefail` (or `set -o pipefail`) is added to each shell command that make runs
 # otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause
 # test to pass in CI when they should not.
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 .SHELLFLAGS = -o pipefail -c
 
 # SRC_ROOT is the top of the source tree.


### PR DESCRIPTION
#### Description

This PR makes the shebang in `Makefile.Common` more portable so it can work across a wider range of distributions, e.g. on NixOS, where bash has a different location.

