### PR TITLE
Avoid unnecessary allocations in ParseJSON

### DIFF
--- a/.chloggen/avoid-map-alloc.yaml
+++ b/.chloggen/avoid-map-alloc.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid unnecessary allocations in ParseJSON
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44284]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
+	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.140.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.140.0
 	github.com/stretchr/testify v1.11.1
@@ -38,7 +39,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -247,14 +247,16 @@ const benchData = `{
 
 func BenchmarkParseJSON(b *testing.B) {
 	ctx := b.Context()
-	b.ReportAllocs()
+	getter := ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) {
+			return benchData, nil
+		},
+	}
 
+	b.ReportAllocs()
+	b.ResetTimer()
 	for b.Loop() {
-		_, err := parseJSON(ottl.StandardStringGetter[any]{
-			Getter: func(context.Context, any) (any, error) {
-				return benchData, nil
-			},
-		})(ctx, nil)
+		_, err := parseJSON(getter)(ctx, nil)
 		require.NoError(b, err)
 	}
 }

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -966,7 +966,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(log.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(log.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
@@ -986,7 +986,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
@@ -1006,7 +1006,7 @@ func Test_ProcessLogs_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 	}
 

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -1669,7 +1669,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(metric.name, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(metric.name, ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "datapoint: statements group with error mode",
@@ -1690,7 +1690,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(datapoint.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
@@ -1710,7 +1710,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
@@ -1730,7 +1730,7 @@ func Test_ProcessMetrics_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 	}
 

--- a/processor/transformprocessor/internal/profiles/processor_test.go
+++ b/processor/transformprocessor/internal/profiles/processor_test.go
@@ -885,7 +885,7 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(profile.original_payload_format, ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(profile.original_payload_format, ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
@@ -905,7 +905,7 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
@@ -925,7 +925,7 @@ func Test_ProcessProfiles_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 	}
 

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -1034,7 +1034,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(span.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(span.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "spanevent: statements group with error mode",
@@ -1054,7 +1054,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(spanevent.attributes["test"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "resource: statements group with error mode",
@@ -1074,7 +1074,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(resource.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: "could not convert parsed value of type bool to JSON object",
+			wantErrorWith: "could not convert parsed value of type \"Bool\" to JSON object",
 		},
 		{
 			name:      "scope: statements group with error mode",
@@ -1094,7 +1094,7 @@ func Test_ProcessTraces_StatementsErrorMode(t *testing.T) {
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("1"))`}, ErrorMode: ottl.IgnoreError},
 				{Statements: []string{`set(scope.attributes["pass"], ParseJSON("true"))`}},
 			},
-			wantErrorWith: `could not convert parsed value of type bool to JSON object`,
+			wantErrorWith: `could not convert parsed value of type "Bool" to JSON object`,
 		},
 	}
 


### PR DESCRIPTION
**Before:**
```
BenchmarkParseJSON-12    	   95502	     12567 ns/op	   10873 B/op	     171 allocs/op
```

**After with string copy:**
```
BenchmarkParseJSON-12    	   72692	     16066 ns/op	   23954 B/op	     132 allocs/op
```

**After without string copy:**
```
BenchmarkParseJSON-12    	  207938	      5571 ns/op	    7845 B/op	      98 allocs/op
```

**After with string copy, but with optimize reading:**
```
BenchmarkParseJSON-12    	  181356	      6696 ns/op	   11464 B/op	     123 allocs/op
```

Based on a review, I did some investigations and benchmarks and discover that the main reason `github.com/goccy/go-json` is fast is because it does not safely copy the strings (but reference the initial bytes). With that optimization this change is more than 2x faster.