### PR TITLE
[receiver/statsdreceiver] Change counter values from int64 to float64

### DIFF
--- a/.chloggen/statsdreceiver-fix-counter-to-float.yaml
+++ b/.chloggen/statsdreceiver-fix-counter-to-float.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed counter metric values from int64 to float64 to preserve precision when sample rates are applied
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44286]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/parser/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser.go
@@ -376,7 +376,7 @@ func (p *StatsDParser) Aggregate(line string, addr net.Addr) error {
 			instrument.counters[parsedMetric.description] = buildCounterMetric(parsedMetric, p.isMonotonicCounter)
 		} else {
 			point := instrument.counters[parsedMetric.description].Metrics().At(0).Sum().DataPoints().At(0)
-			point.SetIntValue(point.IntValue() + parsedMetric.counterValue())
+			point.SetDoubleValue(point.DoubleValue() + parsedMetric.counterValue())
 		}
 
 	case TimingType, HistogramType, DistributionType:

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -2135,7 +2135,7 @@ func TestStatsDParser_IPOnlyAggregation(t *testing.T) {
 	value := metrics[0].Metrics.
 		ResourceMetrics().At(0).
 		ScopeMetrics().At(0).
-		Metrics().At(0).Sum().DataPoints().At(0).IntValue()
+		Metrics().At(0).Sum().DataPoints().At(0).DoubleValue()
 
-	assert.Equal(t, int64(4), value)
+	assert.Equal(t, 4.0, value)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Changed StatsD counter values from int64 to float64 to preserve fractional values. Previously, fractional counter values (e.g., 0.01) were truncated to 0, causing data loss. This change maintains the full  precision of counter metrics.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
n/a

<!--Describe what testing was performed and which tests were added.-->
#### Testing
  - Updated existing test `TestStatsDParser_IPOnlyAggregation` to use DoubleValue()
  - Added new test `TestBuildCounterMetricWithFractionalValue` to verify fractional values are preserved
  - All tests pass: `go test ./...`
<!--Describe the documentation added.-->
#### Documentation
n/a
<!--Please delete paragraphs that you did not use before submitting.-->
