### PR TITLE
[receiver/statsdreceiver] Discard NaN and infinite metric values

### DIFF
--- a/.chloggen/statsdreceiver-drop-nan-inf-values.yaml
+++ b/.chloggen/statsdreceiver-drop-nan-inf-values.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/statsd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Discard StatsD metrics with NaN or infinite values to prevent invalid data from entering the metric pipeline
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/parser/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser.go
@@ -345,6 +345,15 @@ func (p *StatsDParser) Aggregate(line string, addr net.Addr) error {
 		return err
 	}
 
+	// Discard NaN and infinite values for all metric types
+	if math.IsNaN(parsedMetric.asFloat) || math.IsInf(parsedMetric.asFloat, 0) {
+		reason := "NaN"
+		if math.IsInf(parsedMetric.asFloat, 0) {
+			reason = "infinite"
+		}
+		return fmt.Errorf("discarding metric %q: invalid %s value", parsedMetric.description.name, reason)
+	}
+
 	addrKey := newNetAddr(addr)
 	if p.enableIPOnlyAggregation {
 		addrKey = newIPOnlyNetAddr(addr)

--- a/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/parser/statsd_parser_test.go
@@ -2139,3 +2139,40 @@ func TestStatsDParser_IPOnlyAggregation(t *testing.T) {
 
 	assert.Equal(t, int64(4), value)
 }
+
+func TestStatsDParser_DiscardInvalidValues(t *testing.T) {
+	p := &StatsDParser{}
+	assert.NoError(t, p.Initialize(false, false, false, false, nil))
+	addr, _ := net.ResolveUDPAddr("udp", "1.2.3.4:5678")
+	// Test that NaN and infinite values return errors for all metric types
+	invalidTestCases := []struct {
+		packet      string
+		expectedErr string
+	}{
+		{"test.counter:NaN|c", "discarding metric \"test.counter\": invalid NaN value"},
+		{"test.gauge:+Inf|g", "discarding metric \"test.gauge\": invalid infinite value"},
+		{"test.timer:-Inf|ms", "discarding metric \"test.timer\": invalid infinite value"},
+		{"test.histogram:NaN|h", "discarding metric \"test.histogram\": invalid NaN value"},
+	}
+
+	for _, tc := range invalidTestCases {
+		err := p.Aggregate(tc.packet, addr)
+		assert.EqualError(t, err, tc.expectedErr)
+	}
+
+	// Test that valid values are processed normally
+	assert.NoError(t, p.Aggregate("test.valid:42.5|g", addr))
+
+	// Only the valid value should remain, invalid ones should be discarded
+	metrics := p.GetMetrics()
+	assert.Len(t, metrics, 1)
+
+	// Verify the valid metric was processed
+	resourceMetrics := metrics[0].Metrics.ResourceMetrics()
+	assert.Equal(t, 1, resourceMetrics.Len())
+	scopeMetrics := resourceMetrics.At(0).ScopeMetrics()
+	assert.Equal(t, 1, scopeMetrics.Len())
+	gaugeMetrics := scopeMetrics.At(0).Metrics()
+	assert.Equal(t, 1, gaugeMetrics.Len())
+	assert.Equal(t, "test.valid", gaugeMetrics.At(0).Name())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
 Add validation to discard StatsD metrics with NaN (Not-a-Number) or infinite values before aggregation. These values are invalid for metric collection and can cause issues in downstream metric processing and storage systems.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
n/a

<!--Describe what testing was performed and which tests were added.-->
#### Testing
  - Added `TestStatsDParser_DiscardInvalidValues` covering NaN/Inf rejection for all metric types
  - All existing tests pass: `go test ./...`
<!--Describe the documentation added.-->
#### Documentation
n/a
<!--Please delete paragraphs that you did not use before submitting.-->
