### PR TITLE
[receiver/sqlserver] Fix incorrect usage of topQueryCount instead of MaxQuerySampleCount

### DIFF
--- a/.chloggen/sqlserver-fix-to-fetch-proper-amount-of-queries.yaml
+++ b/.chloggen/sqlserver-fix-to-fetch-proper-amount-of-queries.yaml
@@ -10,7 +10,7 @@ component: receiver/sqlserver
 note: Resolved inaccurate data sampling in query metrics collection.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [44162]
+issues: [44303]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/sqlserver-fix-to-fetch-proper-amount-of-queries.yaml
+++ b/.chloggen/sqlserver-fix-to-fetch-proper-amount-of-queries.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sqlserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Resolved inaccurate data sampling in query metrics collection.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44162]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -645,7 +645,7 @@ func (s *sqlServerScraperHelper) recordDatabaseQueryTextAndPlan(ctx context.Cont
 	rows, err := s.client.QueryRows(
 		ctx,
 		sql.Named("lookbackTime", -int(s.config.EffectiveLookbackTime().Seconds())),
-		sql.Named("topNValue", s.config.TopQueryCount),
+		sql.Named("maxSampleCount", s.config.MaxQuerySampleCount),
 	)
 	if err != nil {
 		if !errors.Is(err, sqlquery.ErrNullValueWarning) {

--- a/receiver/sqlserverreceiver/templates/dbQueryAndTextQuery.tmpl
+++ b/receiver/sqlserverreceiver/templates/dbQueryAndTextQuery.tmpl
@@ -1,5 +1,5 @@
 with qstats as (
-	SELECT TOP(@topNValue)
+	SELECT TOP(@maxSampleCount)
 		REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
 		HOST_NAME() AS [computer_name],
 		MAX(qs.plan_handle) AS query_plan_handle,

--- a/receiver/sqlserverreceiver/testdata/databaseTopQueryWithoutInstanceName.txt
+++ b/receiver/sqlserverreceiver/testdata/databaseTopQueryWithoutInstanceName.txt
@@ -1,5 +1,5 @@
 with qstats as (
-	SELECT TOP(@topNValue)
+	SELECT TOP(@maxSampleCount)
 		REPLACE(@@SERVERNAME,'\',':') AS [sql_instance],
 		HOST_NAME() AS [computer_name],
 		MAX(qs.plan_handle) AS query_plan_handle,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In the `sqlserverreceiver`, for the query that fetches query metrics and plans, the parameters are passed from the receiver. In this code, `TopQueryCollection.topQueryCount` was used instead of `TopQueryCollection.MaxQuerySampleCount`, causing a significantly smaller number of queries to be sampled for calculating the actual top N results.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44303

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests updated
