### PR TITLE
[chore] run free disk in 1 more CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -543,6 +543,7 @@ jobs:
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - run: ./.github/workflows/scripts/free-disk-space.sh
       - name: Mkdir bin and dist
         run: |
           mkdir bin/ dist/


### PR DESCRIPTION
#### Description
run free-disk-space.sh in publish-dev to fix failures like http://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/19441084245/job/55625789797
