### PR TITLE
[chore][exporter/clickhouseexporter] run make modernize

### DIFF
--- a/exporter/clickhouseexporter/exporter_logs_integration_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_integration_test.go
@@ -105,7 +105,7 @@ func simpleLogs(count int, mapBody bool) plog.Logs {
 	sl.Scope().SetVersion("1.0.0")
 	sl.Scope().Attributes().PutStr("lib", "clickhouse")
 	timestamp := telemetryTimestamp
-	for i := 0; i < count; i++ {
+	for i := range count {
 		r := sl.LogRecords().AppendEmpty()
 		r.SetTimestamp(pcommon.NewTimestampFromTime(timestamp))
 		r.SetObservedTimestamp(pcommon.NewTimestampFromTime(timestamp))

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -14,18 +14,6 @@ import (
 func TestLogsExporter_New(t *testing.T) {
 	type validate func(*testing.T, *logsExporter, error)
 
-	_ = func(t *testing.T, exporter *logsExporter, err error) {
-		require.NoError(t, err)
-		require.NotNil(t, exporter)
-	}
-
-	_ = func(want error) validate {
-		return func(t *testing.T, exporter *logsExporter, err error) {
-			require.Nil(t, exporter)
-			require.ErrorIs(t, err, want, "Expected error '%v', but got '%v'", want, err)
-		}
-	}
-
 	failWithMsg := func(msg string) validate {
 		return func(t *testing.T, _ *logsExporter, err error) {
 			require.ErrorContains(t, err, msg)

--- a/exporter/clickhouseexporter/exporter_metrics_integration_test.go
+++ b/exporter/clickhouseexporter/exporter_metrics_integration_test.go
@@ -60,7 +60,7 @@ func simpleMetrics(count int) pmetric.Metrics {
 	sm.Scope().SetName("Scope name 1")
 	sm.Scope().SetVersion("Scope version 1")
 	timestamp := time.Unix(1703498029, 0)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// gauge
 		m := sm.Metrics().AppendEmpty()
 		m.SetName("gauge metrics")
@@ -179,7 +179,7 @@ func simpleMetrics(count int) pmetric.Metrics {
 	sm.Scope().SetDroppedAttributesCount(20)
 	sm.Scope().SetName("Scope name 2")
 	sm.Scope().SetVersion("Scope version 2")
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// gauge
 		m := sm.Metrics().AppendEmpty()
 		m.SetName("gauge metrics")
@@ -286,7 +286,7 @@ func simpleMetrics(count int) pmetric.Metrics {
 	sm.Scope().SetDroppedAttributesCount(20)
 	sm.Scope().SetName("Scope name 3")
 	sm.Scope().SetVersion("Scope version 3")
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// gauge
 		m := sm.Metrics().AppendEmpty()
 		m.SetName("gauge metrics")

--- a/exporter/clickhouseexporter/exporter_traces_integration_test.go
+++ b/exporter/clickhouseexporter/exporter_traces_integration_test.go
@@ -129,7 +129,7 @@ func simpleTraces(count int) ptrace.Traces {
 	ss.Scope().Attributes().PutStr("lib", "clickhouse")
 	timestamp := telemetryTimestamp
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		s := ss.Spans().AppendEmpty()
 		s.SetTraceID([16]byte{1, 2, 3, byte(i)})
 		s.SetSpanID([8]byte{1, 2, 3, byte(i)})

--- a/exporter/clickhouseexporter/integration_test.go
+++ b/exporter/clickhouseexporter/integration_test.go
@@ -144,7 +144,7 @@ func pushConcurrentlyNoError(t *testing.T, fn func() error) {
 	)
 
 	wg.Add(count)
-	for i := 0; i < count; i++ {
+	for range count {
 		go func() {
 			defer wg.Done()
 			err := fn()
@@ -165,12 +165,12 @@ var telemetryTimestamp = time.Unix(1703498029, 0).UTC()
 func testIntegrationWithImage(t *testing.T, clickhouseImage string) {
 	c, chEnv, err := createClickhouseContainer(clickhouseImage)
 	if err != nil {
-		t.Fatal(fmt.Errorf("failed to create ClickHouse container \"%s\": %w", clickhouseImage, err))
+		t.Fatalf("failed to create ClickHouse container %q: %v", clickhouseImage, err)
 	}
 	defer func(c testcontainers.Container) {
 		err := c.Terminate(t.Context())
 		if err != nil {
-			fmt.Println(fmt.Errorf("failed to terminate ClickHouse container \"%s\": %w", clickhouseImage, err))
+			t.Logf("failed to terminate ClickHouse container %q: %v", clickhouseImage, err)
 		}
 	}(c)
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

The two funcs inside `TestLogsExporter_New` was removed due to the panic below.

```sh
ERRO [runner] Panic: printf: package "clickhouseexporter" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: types.Object is nil, not *types.Var: goroutine 15745 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x64
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*action).analyzeSafe.func1()
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/goanalysis/runner_action.go:55 +0x1d8
panic({0x104263340?, 0x140195b78f0?})
	runtime/panic.go:783 +0x120
golang.org/x/tools/go/analysis/passes/printf.findPrintLike-range1({0x1401677ef48?, 0x368d858?})
	golang.org/x/tools@v0.39.0/go/analysis/passes/printf/printf.go:228 +0x5f8
golang.org/x/tools/go/ast/inspector.Cursor.Preorder.func1(0x140195b78c0)
	golang.org/x/tools@v0.39.0/go/ast/inspector/cursor.go:132 +0xbc
golang.org/x/tools/go/analysis/passes/printf.findPrintLike(0x140066d02a0, 0x14008a64628)
	golang.org/x/tools@v0.39.0/go/analysis/passes/printf/printf.go:186 +0x138
golang.org/x/tools/go/analysis/passes/printf.run(0x140066d02a0)
	golang.org/x/tools@v0.39.0/go/analysis/passes/printf/printf.go:117 +0x64
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*action).analyze.func3(...)
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/goanalysis/runner_checker.go:183
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*action).analyze(0x14003b5e5e0)
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/goanalysis/runner_checker.go:209 +0x980
github.com/golangci/golangci-lint/v2/pkg/timeutils.(*Stopwatch).TrackStage(0x1400443d770, {0x103b1c716, 0x6}, 0x1401fee9f00)
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*action).analyzeSafe(0x14003b5e5e0?)
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/goanalysis/runner_action.go:59 +0x64
github.com/golangci/golangci-lint/v2/pkg/goanalysis.(*loadingPackage).analyze.func2()
	github.com/golangci/golangci-lint/v2@v2.6.2/pkg/goanalysis/runner_loadingpackage.go:111 +0x6c
golang.org/x/sync/errgroup.(*Group).Go.func1()
	golang.org/x/sync@v0.18.0/errgroup/errgroup.go:93 +0x4c
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 712
	golang.org/x/sync@v0.18.0/errgroup/errgroup.go:78 +0x90
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: printf: package "clickhouseexporter" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: types.Object is nil, not *types.Var
WARN [runner/exclusion_paths] The pattern "third_party" match no issues
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Path: "internal/healthcheck/internal/common/", Linters: "revive"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Path: "cmd/telemetrygen/internal/common/", Linters: "revive"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Path: "cmd/telemetrygen/pkg/", Linters: "revive"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party", Linters: "gci, gofumpt"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "cachedBytes", Path: "pagefile.go", Linters: "unused"]
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Text: "var-naming: avoid meaningless package names", Path: "processor/transformprocessor/internal/common/", Linters: "revive"]
ERRO Running error: can't run linter goanalysis_metalinter
goanalysis_metalinter: printf: package "clickhouseexporter" (isInitialPkg: true, needAnalyzeSource: true): interface conversion: types.Object is nil, not *types.Var
make: *** [lint] Error 3
```