### PR TITLE
[chore][extension/cgroupruntimeextension] run make modernize

### DIFF
--- a/extension/cgroupruntimeextension/integration_test.go
+++ b/extension/cgroupruntimeextension/integration_test.go
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 //go:build integration && linux
-// +build integration,linux
 
 // Privileged access is required to set cgroup's memory and cpu max values
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
extension/cgroupruntimeextension/integration_test.go:4:1: plusbuild: +build line is no longer needed (modernize)
// +build integration,linux
^
make: *** [lint] Error 1
```
