### PR TITLE
[chore][pkg/stanza] run make modernize

### DIFF
--- a/pkg/stanza/fileconsumer/internal/tracker/tracker_windows.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package tracker // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/tracker"
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
pkg/stanza/fileconsumer/internal/tracker/tracker_windows.go:5:1: plusbuild: +build line is no longer needed (modernize)
// +build windows
^
make: *** [lint] Error 1
```
