### PR TITLE
[chore] re-enable gosec G115

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,7 +83,7 @@ linters:
           deny:
             - pkg: github.com/azure/go-autorest
               desc: "This package is deprecated (EOL). Please use an alternative Azure SDK."
-              
+
             - pkg: go.uber.org/atomic
               desc: Use 'sync/atomic' instead of go.uber.org/atomic
 
@@ -139,7 +139,6 @@ linters:
 
     gosec:
       excludes:
-        - G115
         - G402
         - G404
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Re-enable gosec G115, originally disabled in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36913

Context: https://cloud-native.slack.com/archives/C01N6P7KR6W/p1763419833114989