### PR TITLE
feat/re-allow append w/ compression

### DIFF
--- a/.chloggen/44382-filexporter-allow append with zstd compression.yaml
+++ b/.chloggen/44382-filexporter-allow append with zstd compression.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/file
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow usage of append mode with zstd compression
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44382]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -64,7 +64,7 @@ The following settings are optional:
 
 - `format`[default: json]: define the data format of encoded telemetry data. The setting can be overridden with `proto`.
 - `encoding`[default: none]: if specified, uses an encoding extension to encode telemetry data. Overrides `format`.
-- `append`[default: `false`] defines whether append to the file (`true`) or truncate (`false`). If `append: true` is set then setting `rotation` or `compression` is currently not supported.
+- `append`[default: `false`] defines whether append to the file (`true`) or truncate (`false`). If `append: true` is set then setting `rotation` is currently not supported.
 - `compression`[no default]: the compression algorithm used when exporting telemetry data to file. Supported compression algorithms:`zstd`
 - `flush_interval`[default: 1s]: `time.Duration` interval between flushes. See [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for valid formats. 
 NOTE: a value without unit is in nanoseconds and `flush_interval` is ignored and writes are not buffered if `rotation` is set.

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -5,8 +5,6 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"errors"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -17,12 +15,6 @@ import (
 const (
 	rotationFieldName = "rotation"
 	backupsFieldName  = "max_backups"
-)
-
-var (
-	errInvalidOctal          = errors.New("directory_permissions value must be a valid octal representation")
-	errInvalidPermissionBits = errors.New("directory_permissions contain invalid bits for file access")
-	errDirPermsRequireCreate = errors.New("directory_permissions requires create_directory to be true")
 )
 
 // Config defines configuration for file exporter.
@@ -60,13 +52,6 @@ type Config struct {
 
 	// GroupBy enables writing to separate files based on a resource attribute.
 	GroupBy *GroupBy `mapstructure:"group_by"`
-
-	// CreateDirectory specifies that the parent directory of the output file should be created automatically on start.
-	CreateDirectory bool `mapstructure:"create_directory"`
-	// DirectoryPermissions specifies permissions used when creating directories (minus process umask).
-	// Value must be an octal string like "0755".
-	DirectoryPermissions       string `mapstructure:"directory_permissions"`
-	directoryPermissionsParsed int64  `mapstructure:"-"`
 }
 
 // Rotation an option to rolling log files
@@ -114,9 +99,6 @@ func (cfg *Config) Validate() error {
 	if cfg.Path == "" {
 		return errors.New("path must be non-empty")
 	}
-	if cfg.Append && cfg.Compression != "" {
-		return errors.New("append and compression enabled at the same time is not supported")
-	}
 	if cfg.Append && cfg.Rotation != nil {
 		return errors.New("append and rotation enabled at the same time is not supported")
 	}
@@ -143,27 +125,6 @@ func (cfg *Config) Validate() error {
 		if cfg.GroupBy.ResourceAttribute == "" {
 			return errors.New("resource_attribute must not be empty when group_by is enabled")
 		}
-	}
-
-	// If directory auto-creation is enabled, validate and parse permissions.
-	if cfg.CreateDirectory {
-		permStr := cfg.DirectoryPermissions
-		// Default to 0755 if not provided.
-		if permStr == "" {
-			permStr = "0755"
-			cfg.DirectoryPermissions = permStr
-		}
-		permissions, err := strconv.ParseInt(permStr, 8, 32)
-		if err != nil {
-			return errInvalidOctal
-		}
-		if permissions&int64(os.ModePerm) != permissions {
-			return errInvalidPermissionBits
-		}
-		cfg.directoryPermissionsParsed = permissions
-	} else if cfg.DirectoryPermissions != "" {
-		// If not creating directories, directory_permissions must not be set.
-		return errDirPermsRequireCreate
 	}
 
 	return nil

--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -5,6 +5,8 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"errors"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +17,12 @@ import (
 const (
 	rotationFieldName = "rotation"
 	backupsFieldName  = "max_backups"
+)
+
+var (
+	errInvalidOctal          = errors.New("directory_permissions value must be a valid octal representation")
+	errInvalidPermissionBits = errors.New("directory_permissions contain invalid bits for file access")
+	errDirPermsRequireCreate = errors.New("directory_permissions requires create_directory to be true")
 )
 
 // Config defines configuration for file exporter.
@@ -52,6 +60,13 @@ type Config struct {
 
 	// GroupBy enables writing to separate files based on a resource attribute.
 	GroupBy *GroupBy `mapstructure:"group_by"`
+
+	// CreateDirectory specifies that the parent directory of the output file should be created automatically on start.
+	CreateDirectory bool `mapstructure:"create_directory"`
+	// DirectoryPermissions specifies permissions used when creating directories (minus process umask).
+	// Value must be an octal string like "0755".
+	DirectoryPermissions       string `mapstructure:"directory_permissions"`
+	directoryPermissionsParsed int64  `mapstructure:"-"`
 }
 
 // Rotation an option to rolling log files
@@ -125,6 +140,27 @@ func (cfg *Config) Validate() error {
 		if cfg.GroupBy.ResourceAttribute == "" {
 			return errors.New("resource_attribute must not be empty when group_by is enabled")
 		}
+	}
+
+	// If directory auto-creation is enabled, validate and parse permissions.
+	if cfg.CreateDirectory {
+		permStr := cfg.DirectoryPermissions
+		// Default to 0755 if not provided.
+		if permStr == "" {
+			permStr = "0755"
+			cfg.DirectoryPermissions = permStr
+		}
+		permissions, err := strconv.ParseInt(permStr, 8, 32)
+		if err != nil {
+			return errInvalidOctal
+		}
+		if permissions&int64(os.ModePerm) != permissions {
+			return errInvalidPermissionBits
+		}
+		cfg.directoryPermissionsParsed = permissions
+	} else if cfg.DirectoryPermissions != "" {
+		// If not creating directories, directory_permissions must not be set.
+		return errDirPermsRequireCreate
 	}
 
 	return nil


### PR DESCRIPTION
#### Description
Adding "feature". Re-allowing the append config in w/ zstd compression because its funcional.
Each message is appended to the compressed file in batches.


#### Testing
Added test in which batches are added individually, and validated append and decompression in batches.


