### PR TITLE
Fix routing to default route when error occurs

### DIFF
--- a/.chloggen/fix-routing-error.yaml
+++ b/.chloggen/fix-routing-error.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/routing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix routing to default route when error occurs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44386]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Before we used to send everything (even records match without error) to the default pipeline, |
+  after this change only entries that return error will be "ignored" and if no other rule in the |
+  table picks them will be sent to the default rule.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -61,9 +61,9 @@ func (*logsConnector) Capabilities() consumer.Capabilities {
 
 func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	groups := make(map[consumer.Logs]plog.Logs)
-	var errs error
 	matched := plog.NewLogs()
 	for i := 0; i < len(c.router.routeSlice) && ld.ResourceLogs().Len() > 0; i++ {
+		var errs error
 		route := c.router.routeSlice[i]
 		switch route.statementContext {
 		case "request":
@@ -76,7 +76,11 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 				func(rl plog.ResourceLogs) bool {
 					rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
 					_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
-					errs = errors.Join(errs, err)
+					// If error during statement evaluation consider it as not a match.
+					if err != nil {
+						errs = errors.Join(errs, err)
+						return false
+					}
 					return isMatch
 				},
 			)
@@ -85,23 +89,28 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 				func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
 					ltx := ottllog.NewTransformContext(lr, sl.Scope(), rl.Resource(), sl, rl)
 					_, isMatch, err := route.logStatement.Execute(ctx, ltx)
-					errs = errors.Join(errs, err)
+					// If error during statement evaluation consider it as not a match.
+					if err != nil {
+						errs = errors.Join(errs, err)
+						return false
+					}
 					return isMatch
 				},
 			)
 		}
-		if errs != nil {
-			if c.config.ErrorMode == ottl.PropagateError {
-				return errs
-			}
-			groupAllLogs(groups, c.router.defaultConsumer, matched)
+		if errs != nil && c.config.ErrorMode == ottl.PropagateError {
+			return errs
 		}
 		groupAllLogs(groups, route.consumer, matched)
 	}
 	// anything left wasn't matched by any route. Send to default consumer
 	groupAllLogs(groups, c.router.defaultConsumer, ld)
+	var errs error
 	for consumer, group := range groups {
-		errs = errors.Join(errs, consumer.ConsumeLogs(ctx, group))
+		err := consumer.ConsumeLogs(ctx, group)
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 	return errs
 }

--- a/connector/routingconnector/router.go
+++ b/connector/routingconnector/router.go
@@ -245,7 +245,7 @@ func (r *router[C]) registerRouteConsumers() (err error) {
 				route.logStatement = statement
 			}
 		} else {
-			pipelineNames := []string{}
+			var pipelineNames []string
 			for _, pipeline := range item.Pipelines {
 				pipelineNames = append(pipelineNames, pipeline.String())
 			}


### PR DESCRIPTION
Before we used to send everything (records match without error) to the default pipeline, after this change only entries that return error will be "ignored" and if no other rule in the table picks them will be sent to the default rule.