### PR TITLE
[chore] run free disk script in scoped-test

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -69,6 +69,7 @@ jobs:
           echo "go_sources: ${{ needs.changedfiles.outputs.go_sources }}"
           echo "go_tests: ${{ needs.changedfiles.outputs.go_tests }}"
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - run: ./.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         id: go-setup
         with:


### PR DESCRIPTION
#### Description
Still saw failures occasionally in scoped-test due to not enough device space so apply the script too. Similar to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44351