### PR TITLE
[receiver/awsxrayreceiver] fix span kind when translating segment with parent ID

### DIFF
--- a/.chloggen/awsxrayreceiver-fix.yaml
+++ b/.chloggen/awsxrayreceiver-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awsxray
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix incorrect span kind when translating X-Ray segment to trace span with parent ID
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44404]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/aws/xray/testdata/segmentWithParentId.txt
+++ b/internal/aws/xray/testdata/segmentWithParentId.txt
@@ -1,0 +1,7 @@
+{
+    "trace_id": "1-5f187253-6a106696d56b1f4ef9eba2ed",
+    "id": "5cc4a447f5d4d696",
+    "name": "segment",
+    "start_time": 1595437651.680097,
+    "parent_id": "bda182a644eee9b3"
+}

--- a/receiver/awsxrayreceiver/internal/translator/translator.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -65,7 +66,10 @@ func ToTraces(rawSeg []byte, recorder telemetry.Recorder) (ptrace.Traces, int, e
 	// TraceID of the root segment in because embedded subsegments
 	// do not have that information, but it's needed after we flatten
 	// the embedded subsegment to generate independent child spans.
-	_, err = segToSpans(seg, seg.TraceID, nil, spans)
+	// Sometimes, subsegments are sent separately in an async workflow,
+	// check segment type to determine the proper span kind.
+	isSubsegment := seg.ParentID != nil && seg.Type != nil && strings.EqualFold(*seg.Type, "subsegment")
+	_, err = segToSpans(seg, seg.TraceID, nil, isSubsegment, spans)
 	if err != nil {
 		recorder.RecordSegmentsRejected(count)
 		return ptrace.Traces{}, count, err
@@ -74,10 +78,10 @@ func ToTraces(rawSeg []byte, recorder telemetry.Recorder) (ptrace.Traces, int, e
 	return traceData, count, nil
 }
 
-func segToSpans(seg *awsxray.Segment, traceID, parentID *string, spans ptrace.SpanSlice) (ptrace.Span, error) {
+func segToSpans(seg *awsxray.Segment, traceID, parentID *string, isSubsegment bool, spans ptrace.SpanSlice) (ptrace.Span, error) {
 	span := spans.AppendEmpty()
 
-	err := populateSpan(seg, traceID, parentID, span)
+	err := populateSpan(seg, traceID, parentID, isSubsegment, span)
 	if err != nil {
 		return ptrace.Span{}, err
 	}
@@ -86,7 +90,7 @@ func segToSpans(seg *awsxray.Segment, traceID, parentID *string, spans ptrace.Sp
 	for i := range seg.Subsegments {
 		s := &seg.Subsegments[i]
 		populatedChildSpan, err = segToSpans(s,
-			traceID, seg.ID,
+			traceID, seg.ID, true,
 			spans)
 		if err != nil {
 			return ptrace.Span{}, err
@@ -110,7 +114,7 @@ func segToSpans(seg *awsxray.Segment, traceID, parentID *string, spans ptrace.Sp
 	return span, nil
 }
 
-func populateSpan(seg *awsxray.Segment, traceID, parentID *string, span ptrace.Span) error {
+func populateSpan(seg *awsxray.Segment, traceID, parentID *string, isSubsegment bool, span ptrace.Span) error {
 	attrs := span.Attributes()
 	attrs.Clear()
 	attrs.EnsureCapacity(initAttrCapacity)
@@ -157,11 +161,11 @@ func populateSpan(seg *awsxray.Segment, traceID, parentID *string, span ptrace.S
 
 	span.SetTraceID(traceIDBytes)
 	span.SetSpanID(spanIDBytes)
-
+	if !isSubsegment {
+		span.SetKind(ptrace.SpanKindServer)
+	}
 	if parentIDBytes != [8]byte{} {
 		span.SetParentSpanID(parentIDBytes)
-	} else {
-		span.SetKind(ptrace.SpanKindServer)
 	}
 
 	addStartTime(seg.StartTime, span)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes a translation bug in awsxrayreceiver that when segment is received with parent ID present, it is incorrectly translated to span with `INTERNAL` span kind.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit test

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
