### PR TITLE
[chore] [receiver/expvar] fix test when updating core

### DIFF
--- a/receiver/expvarreceiver/config_test.go
+++ b/receiver/expvarreceiver/config_test.go
@@ -85,7 +85,11 @@ func TestLoadConfig(t *testing.T) {
 				return
 			}
 			assert.NoError(t, xconfmap.Validate(cfg))
-			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{}), cmpopts.IgnoreUnexported(configoptional.Optional[configauth.Config]{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, cfg,
+				cmpopts.IgnoreUnexported(metadata.MetricConfig{}),
+				cmpopts.IgnoreUnexported(configoptional.Optional[configauth.Config]{}),
+				cmpopts.IgnoreUnexported(configoptional.Optional[confighttp.CookiesConfig]{}),
+			); diff != "" {
 				t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### Description

Update test to ignore CookiesConfig since it's going to be wrapped in an uncomparable Optional.

https://github.com/open-telemetry/opentelemetry-collector/actions/runs/19494893940/job/55795086093?pr=14058

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A