### PR TITLE
[chore] test with more recent Kubernetes versions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,8 +105,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - "v1.30.0"
-          - "v1.23.17"
+          - "v1.32.8"
+          - "v1.34.0"
         component:
           - receiver/k8sclusterreceiver
           - processor/k8sattributesprocessor


### PR DESCRIPTION
Move from testing 1.23 and 1.30 to 1.32 and 1.34.