### PR TITLE
[chore][receiver/prometheusreceiver] Increase coverage of metadata.go and transaction.go

### DIFF
--- a/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
+++ b/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
@@ -1,27 +1,27 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package metadata
+package metadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 
 import "github.com/prometheus/prometheus/scrape"
 
 // FakeMetadataStore implements scrape.MetricMetadataStore for tests.
 // It is safe to use from other packages' tests
-type fakeMetadataStore struct {
+type FakeMetadataStore struct {
 	data map[string]scrape.MetricMetadata
 }
 
 // NewFakeMetadataStore creates a FakeMetadataStore initialized with the given metadata.
-func NewFakeMetadataStore(init map[string]scrape.MetricMetadata) *fakeMetadataStore {
+func NewFakeMetadataStore(init map[string]scrape.MetricMetadata) *FakeMetadataStore {
 	// copy defensively to avoid external mutation
 	cp := make(map[string]scrape.MetricMetadata, len(init))
 	for k, v := range init {
 		cp[k] = v
 	}
-	return &fakeMetadataStore{data: cp}
+	return &FakeMetadataStore{data: cp}
 }
 
-func (f fakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
+func (f FakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
 	out := make([]scrape.MetricMetadata, 0, len(f.data))
 	for _, m := range f.data {
 		out = append(out, m)
@@ -29,15 +29,15 @@ func (f fakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
 	return out
 }
 
-func (f fakeMetadataStore) GetMetadata(name string) (scrape.MetricMetadata, bool) {
+func (f FakeMetadataStore) GetMetadata(name string) (scrape.MetricMetadata, bool) {
 	m, ok := f.data[name]
 	return m, ok
 }
 
-func (f fakeMetadataStore) SizeMetadata() int {
+func (f FakeMetadataStore) SizeMetadata() int {
 	return len(f.data)
 }
 
-func (f fakeMetadataStore) LengthMetadata() int {
+func (f FakeMetadataStore) LengthMetadata() int {
 	return len(f.data)
 }

--- a/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
+++ b/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
@@ -1,0 +1,40 @@
+package metadata
+
+import "github.com/prometheus/prometheus/scrape"
+
+// FakeMetadataStore implements scrape.MetricMetadataStore for tests.
+// It is safe to use from other packages' tests
+type fakeMetadataStore struct {
+	data map[string]scrape.MetricMetadata
+}
+
+// NewFakeMetadataStore creates a FakeMetadataStore initialized with the given metadata.
+func NewFakeMetadataStore(init map[string]scrape.MetricMetadata) *fakeMetadataStore {
+	// copy defensively to avoid external mutation
+	cp := make(map[string]scrape.MetricMetadata, len(init))
+	for k, v := range init {
+		cp[k] = v
+	}
+	return &fakeMetadataStore{data: cp}
+}
+
+func (f fakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
+	out := make([]scrape.MetricMetadata, 0, len(f.data))
+	for _, m := range f.data {
+		out = append(out, m)
+	}
+	return out
+}
+
+func (f fakeMetadataStore) GetMetadata(name string) (scrape.MetricMetadata, bool) {
+	m, ok := f.data[name]
+	return m, ok
+}
+
+func (f fakeMetadataStore) SizeMetadata() int {
+	return len(f.data)
+}
+
+func (f fakeMetadataStore) LengthMetadata() int {
+	return len(f.data)
+}

--- a/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
+++ b/receiver/prometheusreceiver/internal/metadata/fakemetadata.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package metadata
 
 import "github.com/prometheus/prometheus/scrape"

--- a/receiver/prometheusreceiver/internal/metadata_test.go
+++ b/receiver/prometheusreceiver/internal/metadata_test.go
@@ -6,9 +6,10 @@ package internal
 import (
 	"testing"
 
-	fakemetadata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/scrape"
+
+	fakemetadata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 )
 
 func TestMetadataForMetric_Internal(t *testing.T) {
@@ -124,8 +125,4 @@ func TestMetadataForMetric_PrefersInternalOverExternal(t *testing.T) {
 	if m.MetricFamily != scrapeUpMetricName {
 		t.Fatalf("expected family %q from internal map, got %q", scrapeUpMetricName, m.MetricFamily)
 	}
-}
-
-func TestEmptyMetadataStore_ImplementsInterface(t *testing.T) {
-	var _ scrape.MetricMetadataStore = emptyMetadataStore{}
 }

--- a/receiver/prometheusreceiver/internal/metadata_test.go
+++ b/receiver/prometheusreceiver/internal/metadata_test.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/scrape"
+)
+
+type fakeMetadataStore struct {
+	data map[string]scrape.MetricMetadata
+}
+
+func (f fakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
+	out := make([]scrape.MetricMetadata, 0, len(f.data))
+	for _, m := range f.data {
+		out = append(out, m)
+	}
+	return out
+}
+
+func (f fakeMetadataStore) GetMetadata(name string) (scrape.MetricMetadata, bool) {
+	m, ok := f.data[name]
+	return m, ok
+}
+
+func (f fakeMetadataStore) SizeMetadata() int {
+	return len(f.data)
+}
+
+func (f fakeMetadataStore) LengthMetadata() int {
+	return len(f.data)
+}
+
+func TestMetadataForMetric_Internal(t *testing.T) {
+	// Internal metric should return from internalMetricMetadata, ignoring external store.
+	metadata, resolved := metadataForMetric(scrapeUpMetricName, emptyMetadataStore{})
+	if resolved != scrapeUpMetricName {
+		t.Fatalf("expected resolved name %q, got %q", scrapeUpMetricName, resolved)
+	}
+	if metadata.Type != model.MetricTypeGauge {
+		t.Fatalf("expected type Gauge, got %v", metadata.Type)
+	}
+	if metadata.MetricFamily != scrapeUpMetricName {
+		t.Fatalf("expected family %q, got %q", scrapeUpMetricName, metadata.MetricFamily)
+	}
+}
+
+func TestMetadataForMetric_ExternalExactHit(t *testing.T) {
+	store := fakeMetadataStore{
+		data: map[string]scrape.MetricMetadata{
+			"http_requests_total": {
+				MetricFamily: "http_requests_total",
+				Type:         model.MetricTypeCounter,
+				Help:         "Total HTTP requests",
+			},
+		},
+	}
+	metadata, resolved := metadataForMetric("http_requests_total", store)
+	if resolved != "http_requests_total" {
+		t.Fatalf("expected resolved name http_requests_total, got %q", resolved)
+	}
+	if metadata.Type != model.MetricTypeCounter {
+		t.Fatalf("expected Counter, got %v", metadata.Type)
+	}
+}
+
+func TestMetadataForMetric_NormalizedFallback_Gauge(t *testing.T) {
+	// Simulate a merged metric like "histogram_count" where store only knows the base name.
+	store := fakeMetadataStore{
+		data: map[string]scrape.MetricMetadata{
+			"histogram": {
+				MetricFamily: "histogram",
+				Type:         model.MetricTypeGauge,
+				Help:         "Histogram base metric",
+			},
+		},
+	}
+	metadata, resolved := metadataForMetric("histogram_count", store)
+	// For non-counter types, resolved should be the normalized base name.
+	if resolved != "histogram" {
+		t.Fatalf("expected resolved name histogram, got %q", resolved)
+	}
+	if metadata.Type != model.MetricTypeGauge {
+		t.Fatalf("expected Gauge, got %v", metadata.Type)
+	}
+	if metadata.MetricFamily != "histogram" {
+		t.Fatalf("expected family histogram, got %q", metadata.MetricFamily)
+	}
+}
+
+func TestMetadataForMetric_NormalizedFallback_CounterKeepsOriginal(t *testing.T) {
+	// If normalized metadata type is Counter, resolved should stay the original name.
+	store := fakeMetadataStore{
+		data: map[string]scrape.MetricMetadata{
+			"requests": {
+				MetricFamily: "requests",
+				Type:         model.MetricTypeCounter,
+				Help:         "Requests counter",
+			},
+		},
+	}
+	metadata, resolved := metadataForMetric("requests_total", store)
+	if resolved != "requests_total" {
+		t.Fatalf("expected resolved name requests_total, got %q", resolved)
+	}
+	if metadata.Type != model.MetricTypeCounter {
+		t.Fatalf("expected Counter, got %v", metadata.Type)
+	}
+	if metadata.MetricFamily != "requests" {
+		t.Fatalf("expected family requests, got %q", metadata.MetricFamily)
+	}
+}
+
+func TestMetadataForMetric_Unknown(t *testing.T) {
+	// Neither internal nor external store has the metric.
+	store := emptyMetadataStore{}
+	const name = "custom_metric_unknown"
+	metadata, resolved := metadataForMetric(name, store)
+	if resolved != name {
+		t.Fatalf("expected resolved name %q, got %q", name, resolved)
+	}
+	if metadata.Type != model.MetricTypeUnknown {
+		t.Fatalf("expected Unknown, got %v", metadata.Type)
+	}
+	if metadata.MetricFamily != name {
+		t.Fatalf("expected family %q, got %q", name, metadata.MetricFamily)
+	}
+}
+
+func TestMetadataForMetric_PrefersInternalOverExternal(t *testing.T) {
+	// Ensure internal metric metadata is used even if external store provides a conflicting entry.
+	store := fakeMetadataStore{
+		data: map[string]scrape.MetricMetadata{
+			scrapeUpMetricName: {
+				MetricFamily: "up_external",
+				Type:         model.MetricTypeCounter,
+				Help:         "External override attempt",
+			},
+		},
+	}
+	m, resolved := metadataForMetric(scrapeUpMetricName, store)
+	if resolved != scrapeUpMetricName {
+		t.Fatalf("expected resolved name %q, got %q", scrapeUpMetricName, resolved)
+	}
+	// Internal definition should win: Gauge with original family.
+	if m.Type != model.MetricTypeGauge {
+		t.Fatalf("expected type Gauge from internal map, got %v", m.Type)
+	}
+	if m.MetricFamily != scrapeUpMetricName {
+		t.Fatalf("expected family %q from internal map, got %q", scrapeUpMetricName, m.MetricFamily)
+	}
+}
+
+func TestEmptyMetadataStore_ImplementsInterface(t *testing.T) {
+	var _ scrape.MetricMetadataStore = emptyMetadataStore{}
+}

--- a/receiver/prometheusreceiver/internal/metadata_test.go
+++ b/receiver/prometheusreceiver/internal/metadata_test.go
@@ -6,34 +6,10 @@ package internal
 import (
 	"testing"
 
+	fakemetadata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/scrape"
 )
-
-type fakeMetadataStore struct {
-	data map[string]scrape.MetricMetadata
-}
-
-func (f fakeMetadataStore) ListMetadata() []scrape.MetricMetadata {
-	out := make([]scrape.MetricMetadata, 0, len(f.data))
-	for _, m := range f.data {
-		out = append(out, m)
-	}
-	return out
-}
-
-func (f fakeMetadataStore) GetMetadata(name string) (scrape.MetricMetadata, bool) {
-	m, ok := f.data[name]
-	return m, ok
-}
-
-func (f fakeMetadataStore) SizeMetadata() int {
-	return len(f.data)
-}
-
-func (f fakeMetadataStore) LengthMetadata() int {
-	return len(f.data)
-}
 
 func TestMetadataForMetric_Internal(t *testing.T) {
 	// Internal metric should return from internalMetricMetadata, ignoring external store.
@@ -50,15 +26,14 @@ func TestMetadataForMetric_Internal(t *testing.T) {
 }
 
 func TestMetadataForMetric_ExternalExactHit(t *testing.T) {
-	store := fakeMetadataStore{
-		data: map[string]scrape.MetricMetadata{
-			"http_requests_total": {
-				MetricFamily: "http_requests_total",
-				Type:         model.MetricTypeCounter,
-				Help:         "Total HTTP requests",
-			},
+	store := fakemetadata.NewFakeMetadataStore(map[string]scrape.MetricMetadata{
+		"http_requests_total": {
+			MetricFamily: "http_requests_total",
+			Type:         model.MetricTypeCounter,
+			Help:         "Total HTTP requests",
 		},
-	}
+	},
+	)
 	metadata, resolved := metadataForMetric("http_requests_total", store)
 	if resolved != "http_requests_total" {
 		t.Fatalf("expected resolved name http_requests_total, got %q", resolved)
@@ -70,15 +45,13 @@ func TestMetadataForMetric_ExternalExactHit(t *testing.T) {
 
 func TestMetadataForMetric_NormalizedFallback_Gauge(t *testing.T) {
 	// Simulate a merged metric like "histogram_count" where store only knows the base name.
-	store := fakeMetadataStore{
-		data: map[string]scrape.MetricMetadata{
-			"histogram": {
-				MetricFamily: "histogram",
-				Type:         model.MetricTypeGauge,
-				Help:         "Histogram base metric",
-			},
+	store := fakemetadata.NewFakeMetadataStore(map[string]scrape.MetricMetadata{
+		"histogram": {
+			MetricFamily: "histogram",
+			Type:         model.MetricTypeGauge,
+			Help:         "Histogram base metric",
 		},
-	}
+	})
 	metadata, resolved := metadataForMetric("histogram_count", store)
 	// For non-counter types, resolved should be the normalized base name.
 	if resolved != "histogram" {
@@ -94,15 +67,14 @@ func TestMetadataForMetric_NormalizedFallback_Gauge(t *testing.T) {
 
 func TestMetadataForMetric_NormalizedFallback_CounterKeepsOriginal(t *testing.T) {
 	// If normalized metadata type is Counter, resolved should stay the original name.
-	store := fakeMetadataStore{
-		data: map[string]scrape.MetricMetadata{
-			"requests": {
-				MetricFamily: "requests",
-				Type:         model.MetricTypeCounter,
-				Help:         "Requests counter",
-			},
+	store := fakemetadata.NewFakeMetadataStore(map[string]scrape.MetricMetadata{
+		"requests": {
+			MetricFamily: "requests",
+			Type:         model.MetricTypeCounter,
+			Help:         "Requests counter",
 		},
-	}
+	},
+	)
 	metadata, resolved := metadataForMetric("requests_total", store)
 	if resolved != "requests_total" {
 		t.Fatalf("expected resolved name requests_total, got %q", resolved)
@@ -133,15 +105,14 @@ func TestMetadataForMetric_Unknown(t *testing.T) {
 
 func TestMetadataForMetric_PrefersInternalOverExternal(t *testing.T) {
 	// Ensure internal metric metadata is used even if external store provides a conflicting entry.
-	store := fakeMetadataStore{
-		data: map[string]scrape.MetricMetadata{
-			scrapeUpMetricName: {
-				MetricFamily: "up_external",
-				Type:         model.MetricTypeCounter,
-				Help:         "External override attempt",
-			},
+	store := fakemetadata.NewFakeMetadataStore(map[string]scrape.MetricMetadata{
+		scrapeUpMetricName: {
+			MetricFamily: "up_external",
+			Type:         model.MetricTypeCounter,
+			Help:         "External override attempt",
 		},
-	}
+	},
+	)
 	m, resolved := metadataForMetric(scrapeUpMetricName, store)
 	if resolved != scrapeUpMetricName {
 		t.Fatalf("expected resolved name %q, got %q", scrapeUpMetricName, resolved)

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -2213,3 +2213,126 @@ func assertEquivalentMetrics(t *testing.T, want, got pmetric.Metrics) {
 		}
 	}
 }
+
+func newObs(t *testing.T) *receiverhelper.ObsReport {
+	obs, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		Transport:              "http",
+		ReceiverCreateSettings: receivertest.NewNopSettings(receivertest.NopType),
+	})
+	require.NoError(t, err)
+	return obs
+}
+
+func TestDetectAndStoreNativeHistogramStaleness_NonHistogramReturnsFalse(t *testing.T) {
+	tr := newTxn(t, true, true)
+	// metadata says "gauge" → should not be considered native histogram staleness
+	tr.mc = fakeMetadataStore{data: map[string]scrape.MetricMetadata{
+		"foo": {MetricFamily: "foo", Type: model.MetricTypeGauge},
+	}}
+
+	rk := resourceKey{job: "job-a", instance: "localhost:1234"}
+	ok := tr.detectAndStoreNativeHistogramStaleness(time.Now().UnixMilli(), &rk, emptyScopeID, "foo", labels.FromMap(map[string]string{
+		string(model.MetricNameLabel): "foo",
+	}))
+	require.False(t, ok, "expected false when metadata type != histogram")
+}
+
+func TestGetOrCreateMetricFamily_DistinctFamiliesForNativeVsClassic(t *testing.T) {
+	tr := newTxn(t, true, true)
+	// Provide metadata so normalization doesn't kick in; name is the same family
+	tr.mc = fakeMetadataStore{data: map[string]scrape.MetricMetadata{
+		"same_family": {MetricFamily: "same_family", Type: model.MetricTypeHistogram},
+	}}
+
+	rk := resourceKey{job: "job-a", instance: "localhost:1234"}
+
+	// First: classic path (addingNativeHistogram=false)
+	tr.addingNativeHistogram = false
+	mfClassic := tr.getOrCreateMetricFamily(rk, emptyScopeID, "same_family")
+
+	// Second: native path (addingNativeHistogram=true)
+	tr.addingNativeHistogram = true
+	mfNative := tr.getOrCreateMetricFamily(rk, emptyScopeID, "same_family")
+
+	require.NotNil(t, mfClassic)
+	require.NotNil(t, mfNative)
+	// Even with the same name, keys include native flag → distinct entries
+	require.NotEqual(t, mfClassic, mfNative, "expected distinct metric family instances for native vs classic")
+}
+
+func TestGetSeriesRef_IgnoresNotUsefulLabels(t *testing.T) {
+	// Build two label sets that differ only in labels likely excluded by getSortedNotUsefulLabels (e.g., _otel_* scope labels)
+	lsA := labels.FromStrings(
+		string(model.MetricNameLabel), "metric_x",
+		"env", "prod",
+		"__name__", "metric_x", // already the metric name label
+		"otel_scope_name", "scope_a",
+	)
+	lsB := labels.FromStrings(
+		string(model.MetricNameLabel), "metric_x",
+		"env", "prod",
+		"otel_scope_name", "scope_b", // differs only in an excluded label
+	)
+
+	var buf []byte
+	hashA, buf := getSeriesRef(buf, lsA, pmetric.MetricTypeSum)
+	hashB, _ := getSeriesRef(buf, lsB, pmetric.MetricTypeSum)
+
+	require.Equal(t, hashA, hashB, "series ref should be equal when differing only by excluded labels")
+}
+
+func TestAddTargetInfo_DoesNotCopyJobInstanceOrMetricName(t *testing.T) {
+	tr := newTxn(t, false, false)
+	rk := resourceKey{job: "job-a", instance: "localhost:1234"}
+	// Prime nodeResources
+	tr.nodeResources[rk] = CreateResource(rk.job, rk.instance, labels.FromStrings(model.SchemeLabel, "http"))
+
+	ls := labels.FromStrings(
+		string(model.MetricNameLabel), "target_info",
+		string(model.JobLabel), rk.job,
+		string(model.InstanceLabel), rk.instance,
+		"extra", "v",
+		"another", "x",
+	)
+	tr.AddTargetInfo(rk, ls)
+
+	res := tr.nodeResources[rk]
+	attrs := res.Attributes()
+	_, hasJob := attrs.Get(string(model.JobLabel))
+	_, hasInstance := attrs.Get(string(model.InstanceLabel))
+	_, hasName := attrs.Get(string(model.MetricNameLabel))
+	_, hasExtra := attrs.Get("extra")
+	_, hasAnother := attrs.Get("another")
+
+	require.False(t, hasJob, "job label must not be copied to resource attributes")
+	require.False(t, hasInstance, "instance label must not be copied to resource attributes")
+	require.False(t, hasName, "metric name label must not be copied to resource attributes")
+	require.True(t, hasExtra, "custom label should be copied")
+	require.True(t, hasAnother, "custom label should be copied")
+}
+
+func newTxn(t *testing.T, useMetadata bool, enableNative bool) *transaction {
+	ctx := context.Background()
+	lbls := labels.FromMap(map[string]string{
+		string(model.InstanceLabel): "localhost:1234",
+		string(model.JobLabel):      "job-a",
+	})
+	target := scrape.NewTarget(
+		lbls,
+		&config.ScrapeConfig{},
+		map[model.LabelName]model.LabelValue{
+			model.AddressLabel: "localhost:1234",
+			model.SchemeLabel:  "http",
+		},
+		nil,
+	)
+	ctx = scrape.ContextWithTarget(ctx, target)
+	if useMetadata {
+		ctx = scrape.ContextWithMetricMetadataStore(ctx, fakeMetadataStore{data: map[string]scrape.MetricMetadata{}})
+	}
+	sink := &consumertest.MetricsSink{}
+	settings := receivertest.NewNopSettings(receivertest.NopType)
+	// quiet logger
+	settings.Logger = zap.NewNop()
+	return newTransaction(ctx, &nopAdjuster{}, sink, labels.EmptyLabels(), settings, newObs(t), false, enableNative, useMetadata)
+}

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	fakemetadata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -27,11 +26,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+
 	conventions "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	fakemetadata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 )
 
 const (
@@ -2312,8 +2313,8 @@ func TestAddTargetInfo_DoesNotCopyJobInstanceOrMetricName(t *testing.T) {
 	require.True(t, hasAnother, "custom label should be copied")
 }
 
-func newTxn(t *testing.T, useMetadata bool, enableNative bool) *transaction {
-	ctx := context.Background()
+func newTxn(t *testing.T, useMetadata, enableNative bool) *transaction {
+	ctx := t.Context()
 	lbls := labels.FromMap(map[string]string{
 		string(model.InstanceLabel): "localhost:1234",
 		string(model.JobLabel):      "job-a",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds unit tests for metadataForMetric in receiver/prometheusreceiver/internal, covering:

- Internal metric lookup
- External store exact hits
- Normalization fallback (merged names)
- Counter normalization (retain original name)
- Unknown metric default
- Preference of internal over external overrides

Increases transaction.go test coverage by adding focused unit tests for:

- Native histogram staleness detection negative path (non-histogram metadata)
- Distinct metric family keys for native vs classic histograms
- Series reference hashing ignoring non-useful labels
- Target info attribute propagation excluding job/instance/metric name

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44183

