### PR TITLE
[receiver/azureeventhubreceiver] Update default checkpoint when storage is enabled and storage compatibility

### DIFF
--- a/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
+++ b/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azureeventhub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make storage of new azeventhub library backworks compatable and fix checkpoint starting at earliest when storage is enabled
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
+++ b/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: receiver/azureeventhub
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Make storage of new azeventhub library backworks compatable and fix checkpoint starting at earliest when storage is enabled
+note: Make storage of new azeventhub library backworks compatible and fix checkpoint starting at earliest when storage is enabled
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: []

--- a/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
+++ b/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: receiver/azureeventhub
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Make storage of new azeventhub library backworks compatible and fix checkpoint starting at earliest when storage is enabled
+note: Make storage of new azeventhub library backward compatible and fix checkpoint starting at earliest when storage is enabled
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [44461]

--- a/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
+++ b/.chloggen/dylan_update-default-checkpoint-with-storage.yaml
@@ -10,7 +10,7 @@ component: receiver/azureeventhub
 note: Make storage of new azeventhub library backworks compatible and fix checkpoint starting at earliest when storage is enabled
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [44461]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -5,6 +5,7 @@ package azureeventhubreceiver // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -20,6 +21,24 @@ type checkpointSeqNumber struct {
 	// Offset only used for backwards compatibility
 	Offset         string `json:"offset"`
 	SequenceNumber int64  `json:"sequenceNumber"`
+}
+
+// UnmarshalJSON is a custom unmarshaller to allow for backward compatibility
+// with the sequence number field
+func (c *checkpointSeqNumber) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if val, ok := raw["sequenceNumber"]; ok {
+		c.SequenceNumber = int64(val.(float64))
+	} else if val, ok := raw["seqNumber"]; ok {
+		c.SequenceNumber = int64(val.(float64))
+	}
+	if val, ok := raw["offset"]; ok {
+		c.Offset = val.(string)
+	}
+	return nil
 }
 
 type azPartitionClient interface {

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub.go
@@ -26,17 +26,18 @@ type checkpointSeqNumber struct {
 // UnmarshalJSON is a custom unmarshaller to allow for backward compatibility
 // with the sequence number field
 func (c *checkpointSeqNumber) UnmarshalJSON(data []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
+	// Primary struct shape
+	type Alias checkpointSeqNumber
+	var tmp struct {
+		Alias
+		SeqNumber *int64 `json:"seqNumber"` // fallback
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
-	if val, ok := raw["sequenceNumber"]; ok {
-		c.SequenceNumber = int64(val.(float64))
-	} else if val, ok := raw["seqNumber"]; ok {
-		c.SequenceNumber = int64(val.(float64))
-	}
-	if val, ok := raw["offset"]; ok {
-		c.Offset = val.(string)
+	*c = checkpointSeqNumber(tmp.Alias)
+	if tmp.SeqNumber != nil {
+		c.SequenceNumber = *tmp.SeqNumber
 	}
 	return nil
 }

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,7 +206,7 @@ func TestHubWrapperAzeventhubImpl_Namespace(t *testing.T) {
 
 	namespace, err := mockHubWrapper.namespace()
 	require.NoError(t, err)
-	assert.Equal(t, "test.servicebus.windows.net", namespace)
+	assert.Equal(t, "test", namespace)
 
 	mockHubWrapper = &hubWrapperAzeventhubImpl{
 		hub: &mockAzeventHub{},
@@ -253,5 +254,125 @@ func TestGetConsumerGroup(t *testing.T) {
 			result := getConsumerGroup(config)
 			assert.Equal(t, test.expectedGroup, result)
 		})
+	}
+}
+
+func TestStartPos(t *testing.T) {
+	testCases := []struct {
+		enableStorage bool
+		applyOffset   bool
+		offset        string
+		namespace     string
+		eventHubName  string
+		consumerGroup string
+		partitionID   string
+
+		storageClient *mockStorageClient
+
+		expectedSeqNumber *int64
+		expectedLatest    *bool
+		expectedOffset    *string
+	}{
+		{
+			enableStorage: false,
+			applyOffset:   true,
+			offset:        "10",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+
+			expectedOffset: to.Ptr("10"),
+		},
+		{
+			enableStorage: false,
+			applyOffset:   false,
+			offset:        "10",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+
+			expectedLatest: to.Ptr(true),
+		},
+		{
+			enableStorage: false,
+			applyOffset:   false,
+			offset:        "",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+
+			expectedLatest: to.Ptr(true),
+		},
+		{
+			enableStorage: true,
+			applyOffset:   false,
+			offset:        "",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+
+			expectedLatest: to.Ptr(true),
+		},
+		{
+			enableStorage: true,
+			applyOffset:   true,
+			offset:        "10",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+
+			expectedOffset: to.Ptr("10"),
+		},
+		{
+			enableStorage: true,
+			applyOffset:   false,
+			offset:        "",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+			storageClient: &mockStorageClient{
+				storage: map[string][]byte{
+					"test/name/cg/0": []byte(`{"sequenceNumber": 100}`),
+				},
+			},
+
+			expectedSeqNumber: to.Ptr(int64(100)),
+		},
+	}
+
+	for _, test := range testCases {
+		h := hubWrapperAzeventhubImpl{}
+		h.config = &Config{
+			Offset: test.offset,
+		}
+		if test.enableStorage {
+			s := &mockStorageClient{}
+			if test.storageClient != nil {
+				s = test.storageClient
+			}
+			h.storage = getStorageCheckpointPersister(s)
+		}
+		startPos := h.getStartPos(
+			test.applyOffset,
+			test.namespace,
+			test.eventHubName,
+			test.consumerGroup,
+			test.partitionID,
+		)
+		if test.expectedSeqNumber != nil {
+			require.Equal(t, *test.expectedSeqNumber, *startPos.SequenceNumber)
+		}
+		if test.expectedLatest != nil {
+			require.Equal(t, *test.expectedLatest, *startPos.Latest)
+		}
+		if test.expectedOffset != nil {
+			require.Equal(t, *test.expectedOffset, *startPos.Offset)
+		}
 	}
 }

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
@@ -344,6 +344,22 @@ func TestStartPos(t *testing.T) {
 
 			expectedSeqNumber: to.Ptr(int64(100)),
 		},
+		{
+			enableStorage: true,
+			applyOffset:   false,
+			offset:        "",
+			namespace:     "test",
+			eventHubName:  "name",
+			consumerGroup: "cg",
+			partitionID:   "0",
+			storageClient: &mockStorageClient{
+				storage: map[string][]byte{
+					"test/name/cg/0": []byte(`{"seqNumber": 200}`),
+				},
+			},
+
+			expectedSeqNumber: to.Ptr(int64(200)),
+		},
 	}
 
 	for _, test := range testCases {

--- a/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_legacy.go
@@ -24,7 +24,7 @@ func newLegacyHubWrapper(h *eventhubHandler) (*hubWrapperLegacyImpl, error) {
 			eventhub.HubWithOffsetPersistence(
 				&storageCheckpointPersister[persist.Checkpoint]{
 					storageClient: h.storageClient,
-					defaultValue:  persist.NewCheckpointFromStartOfStream(),
+					defaultValue:  persist.NewCheckpointFromEndOfStream(),
 				},
 			),
 		)

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -166,11 +166,11 @@ func (m *mockStorageClient) Delete(_ context.Context, key string) error {
 	return nil
 }
 
-func (m *mockStorageClient) Batch(_ context.Context, _ ...*storage.Operation) error {
+func (*mockStorageClient) Batch(_ context.Context, _ ...*storage.Operation) error {
 	return nil
 }
 
-func (m *mockStorageClient) Close(_ context.Context) error {
+func (*mockStorageClient) Close(_ context.Context) error {
 	return nil
 }
 

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -145,25 +145,32 @@ func TestShouldInitializeStorageClient(t *testing.T) {
 	}
 }
 
-type mockStorageClient struct{}
+type mockStorageClient struct {
+	storage map[string][]byte
+}
 
-func (*mockStorageClient) Get(_ context.Context, _ string) ([]byte, error) {
+func (m *mockStorageClient) Get(_ context.Context, key string) ([]byte, error) {
+	if len(m.storage[key]) > 0 {
+		return m.storage[key], nil
+	}
 	return nil, nil
 }
 
-func (*mockStorageClient) Set(_ context.Context, _ string, _ []byte) error {
+func (m *mockStorageClient) Set(_ context.Context, key string, val []byte) error {
+	m.storage[key] = val
 	return nil
 }
 
-func (*mockStorageClient) Delete(_ context.Context, _ string) error {
+func (m *mockStorageClient) Delete(_ context.Context, key string) error {
+	m.storage[key] = []byte{}
 	return nil
 }
 
-func (*mockStorageClient) Batch(_ context.Context, _ ...*storage.Operation) error {
+func (m *mockStorageClient) Batch(_ context.Context, _ ...*storage.Operation) error {
 	return nil
 }
 
-func (*mockStorageClient) Close(_ context.Context) error {
+func (m *mockStorageClient) Close(_ context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- When storage was enabled for either the legacy or the new implementation, the receiver would start at the beginning of the stream when it should be starting at the end of the stream.
- Updated the new SDK checkpoint storage to be compatible with the legacy storage format. This makes sure there are no negative side effects from upgrading. The new SDK is still under a feature flag.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Make sure that both with `legacy` and `azeventhub` when storage is enabled and nothing is stored yet, that the default checkpoint is the latest. Tests were added to validate this case.
- Verify that after running the current (legacy) version, you can enable the `ezeventhub` feature flag and the checkpoint is correctly resumed.
