### PR TITLE
[chore][exporter/googlecloudpubsub] update to cloud.google.com/go/pubsub/v2

### DIFF
--- a/exporter/googlecloudpubsubexporter/exporter.go
+++ b/exporter/googlecloudpubsubexporter/exporter.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"

--- a/exporter/googlecloudpubsubexporter/exporter_test.go
+++ b/exporter/googlecloudpubsubexporter/exporter_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	pb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/google/uuid"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/google
 go 1.24.0
 
 require (
-	cloud.google.com/go/pubsub v1.49.0
+	cloud.google.com/go/pubsub/v2 v2.3.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.15.0
 	github.com/stretchr/testify v1.11.1

--- a/exporter/googlecloudpubsubexporter/go.sum
+++ b/exporter/googlecloudpubsubexporter/go.sum
@@ -1,5 +1,3 @@
-cloud.google.com/go v0.120.0 h1:wc6bgG9DHyKqF5/vQvX1CiZrtHnxJjBlKUyF9nP6meA=
-cloud.google.com/go v0.120.0/go.mod h1:/beW32s8/pGRuj4IILWQNd4uuebeT4dkOhKmkfit64Q=
 cloud.google.com/go/auth v0.17.0 h1:74yCm7hCj2rUyyAocqnFzsAYXgJhrG26XCFimrc/Kz4=
 cloud.google.com/go/auth v0.17.0/go.mod h1:6wv/t5/6rOPAX4fJiRjKkJCvswLwdet7G8+UGXt7nCQ=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
@@ -8,8 +6,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.2 h1:qgFRAGEmd8z6dJ/qyEchAuL9jpswyODjA2lS+w234g8=
 cloud.google.com/go/iam v1.5.2/go.mod h1:SE1vg0N81zQqLzQEwxL2WI6yhetBdbNQuTvIKCSkUHE=
-cloud.google.com/go/pubsub v1.49.0 h1:5054IkbslnrMCgA2MAEPcsN3Ky+AyMpEZcii/DoySPo=
-cloud.google.com/go/pubsub v1.49.0/go.mod h1:K1FswTWP+C1tI/nfi3HQecoVeFvL4HUOB1tdaNXKhUY=
+cloud.google.com/go/pubsub/v2 v2.3.0 h1:DgAN907x+sP0nScYfBzneRiIhWoXcpCD8ZAut8WX9vs=
+cloud.google.com/go/pubsub/v2 v2.3.0/go.mod h1:O5f0KHG9zDheZAd3z5rlCRhxt2JQtB+t/IYLKK3Bpvw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=

--- a/exporter/googlecloudpubsubexporter/publisher_client.go
+++ b/exporter/googlecloudpubsubexporter/publisher_client.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	pubsub "cloud.google.com/go/pubsub/apiv1"
-	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	pubsub "cloud.google.com/go/pubsub/v2/apiv1"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -18,7 +18,7 @@ import (
 // publisherClient subset of `pubsub.PublisherClient`
 type publisherClient interface {
 	Close() error
-	Publish(ctx context.Context, req *pubsubpb.PublishRequest, opts ...gax.CallOption) (*pubsubpb.PublishResponse, error)
+	Publish(ctx context.Context, in *pubsubpb.PublishRequest, opts ...gax.CallOption) (*pubsubpb.PublishResponse, error)
 }
 
 // wrappedPublisherClient allows to override the close function
@@ -40,7 +40,8 @@ func newPublisherClient(ctx context.Context, config *Config, userAgent string) (
 		return nil, fmt.Errorf("failed preparing the gRPC client options to PubSub: %w", err)
 	}
 
-	client, err := pubsub.NewPublisherClient(ctx, clientOptions...)
+	// In new v2 client the Publish is moved to the TopicAdmin client
+	client, err := pubsub.NewTopicAdminClient(ctx, clientOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating the gRPC client to PubSub: %w", err)
 	}

--- a/exporter/googlecloudpubsubexporter/publisher_client_test.go
+++ b/exporter/googlecloudpubsubexporter/publisher_client_test.go
@@ -6,7 +6,7 @@ package googlecloudpubsubexporter
 import (
 	"testing"
 
-	pubsub "cloud.google.com/go/pubsub/apiv1"
+	pubsub "cloud.google.com/go/pubsub/v2/apiv1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
@@ -88,7 +88,7 @@ func TestNewPublisherClient(t *testing.T) {
 		client, err := newPublisherClient(ctx, cfg, "test-user-agent 6789")
 		assert.NoError(t, err)
 		require.NotEmpty(t, client)
-		assert.IsType(t, &pubsub.PublisherClient{}, client)
+		assert.IsType(t, &pubsub.TopicAdminClient{}, client)
 		assert.NoError(t, client.Close())
 	})
 
@@ -103,7 +103,7 @@ func TestNewPublisherClient(t *testing.T) {
 		client, err := newPublisherClient(ctx, cfg, "test-user-agent 6789")
 		assert.NoError(t, err)
 		require.NotEmpty(t, client)
-		assert.IsType(t, &pubsub.PublisherClient{}, client)
+		assert.IsType(t, &pubsub.TopicAdminClient{}, client)
 		assert.NoError(t, client.Close())
 	})
 


### PR DESCRIPTION
#### Description
Update to cloud.google.com/go/pubsub/v2 package to keep Renovate bot happy.

This PR is scoped to the `exporter/googlepubsubexporter`

#### Link to tracking issue
This PR fixes renovate trying to upgrade but can't because it requires code changes:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42871

And remove the Pubsub part in the combined deprecation fix PR:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41646

#### Testing

Changed existing test to match the new API.

#### Documentation

No documentation change required.