### PR TITLE
[receiver/awscloudwatch] Support filtering log groups by account ID

### DIFF
--- a/.chloggen/cloudwatch_account_id.yaml
+++ b/.chloggen/cloudwatch_account_id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for filtering log groups by account ID.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38391]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -52,6 +52,7 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
   - `pattern`: (optional) A case-sensitive substring (not a regular expression) that must be present in the log group names, used to limit the number of log groups discovered.
     - Only one of `prefix` or `pattern` can be specified. If both are omitted, all log streams up to the limit are collected.
   - `account_identifiers`: (optional) A list of AWS account IDs to filter log groups by. Only log groups from the specified accounts will be discovered.
+  - `include_linked_accounts`: (optional; default = false) When using a monitoring account, set this to `true` to have autodiscovery return log groups in the accounts listed in `account_identifiers`. If this is `true` and `account_identifiers` contains a `null` value, all log groups in the monitoring account and in all linked source accounts are returned (behavior is handled by the AWS CloudWatch Logs API).
   - `streams`: (optional) If `streams` is omitted, then all streams will be attempted to retrieve events from.
     - `names`: A list of full log stream names to filter the discovered log groups to collect from.
     - `prefixes`: A list of prefixes to filter the discovered log groups to collect from.
@@ -87,6 +88,7 @@ awscloudwatch:
       autodiscover:
         limit: 100
         account_identifiers: ["123456789012", "987654321098"]
+        include_linked_accounts: true
         prefix: /aws/lambda/
 ```
 

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -51,6 +51,7 @@ This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/devel
     - Only one of `prefix` or `pattern` can be specified. If both are omitted, all log streams up to the limit are collected.
   - `pattern`: (optional) A case-sensitive substring (not a regular expression) that must be present in the log group names, used to limit the number of log groups discovered.
     - Only one of `prefix` or `pattern` can be specified. If both are omitted, all log streams up to the limit are collected.
+  - `account_identifiers`: (optional) A list of AWS account IDs to filter log groups by. Only log groups from the specified accounts will be discovered.
   - `streams`: (optional) If `streams` is omitted, then all streams will be attempted to retrieve events from.
     - `names`: A list of full log stream names to filter the discovered log groups to collect from.
     - `prefixes`: A list of prefixes to filter the discovered log groups to collect from.
@@ -73,6 +74,20 @@ awscloudwatch:
         prefix: /aws/eks/
         streams:
           prefixes: [kube-api-controller]
+```
+
+#### Autodiscovery with Account ID Filtering Example
+
+```yaml
+awscloudwatch:
+  region: us-west-1
+  logs:
+    poll_interval: 1m
+    groups:
+      autodiscover:
+        limit: 100
+        account_identifiers: ["123456789012", "987654321098"]
+        prefix: /aws/lambda/
 ```
 
 #### Named Example

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -44,10 +44,11 @@ type GroupConfig struct {
 
 // AutodiscoverConfig is the configuration for the autodiscovery functionality of log groups
 type AutodiscoverConfig struct {
-	Prefix  string       `mapstructure:"prefix"`
-	Pattern string       `mapstructure:"pattern"`
-	Limit   int          `mapstructure:"limit"`
-	Streams StreamConfig `mapstructure:"streams"`
+	Prefix             string       `mapstructure:"prefix"`
+	Pattern            string       `mapstructure:"pattern"`
+	Limit              int          `mapstructure:"limit"`
+	AccountIdentifiers []string     `mapstructure:"account_identifiers"`
+	Streams            StreamConfig `mapstructure:"streams"`
 }
 
 // StreamConfig represents the configuration for the log stream filtering

--- a/receiver/awscloudwatchreceiver/config.go
+++ b/receiver/awscloudwatchreceiver/config.go
@@ -44,11 +44,12 @@ type GroupConfig struct {
 
 // AutodiscoverConfig is the configuration for the autodiscovery functionality of log groups
 type AutodiscoverConfig struct {
-	Prefix             string       `mapstructure:"prefix"`
-	Pattern            string       `mapstructure:"pattern"`
-	Limit              int          `mapstructure:"limit"`
-	AccountIdentifiers []string     `mapstructure:"account_identifiers"`
-	Streams            StreamConfig `mapstructure:"streams"`
+	Prefix                string       `mapstructure:"prefix"`
+	Pattern               string       `mapstructure:"pattern"`
+	Limit                 int          `mapstructure:"limit"`
+	Streams               StreamConfig `mapstructure:"streams"`
+	AccountIdentifiers    []string     `mapstructure:"account_identifiers"`
+	IncludeLinkedAccounts *bool        `mapstructure:"include_linked_accounts"`
 }
 
 // StreamConfig represents the configuration for the log stream filtering

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -402,6 +402,10 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 			req.LogGroupNamePrefix = &auto.Prefix
 		}
 
+		if len(auto.AccountIdentifiers) > 0 {
+			req.AccountIdentifiers = auto.AccountIdentifiers
+		}
+
 		dlgResults, err := l.client.DescribeLogGroups(ctx, req)
 		if err != nil {
 			return groups, fmt.Errorf("unable to list log groups: %w", err)

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -402,6 +402,8 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 			req.LogGroupNamePrefix = &auto.Prefix
 		}
 
+		req.IncludeLinkedAccounts = auto.IncludeLinkedAccounts
+
 		if len(auto.AccountIdentifiers) > 0 {
 			req.AccountIdentifiers = auto.AccountIdentifiers
 		}

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -402,7 +402,9 @@ func (l *logsReceiver) discoverGroups(ctx context.Context, auto *AutodiscoverCon
 			req.LogGroupNamePrefix = &auto.Prefix
 		}
 
-		req.IncludeLinkedAccounts = auto.IncludeLinkedAccounts
+		if auto.IncludeLinkedAccounts != nil {
+			req.IncludeLinkedAccounts = auto.IncludeLinkedAccounts
+		}
 
 		if len(auto.AccountIdentifiers) > 0 {
 			req.AccountIdentifiers = auto.AccountIdentifiers

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -359,6 +359,10 @@ func TestAutodiscoverAccountIdentifiers(t *testing.T) {
 		"DescribeLogGroups",
 		mock.Anything,
 		mock.MatchedBy(func(input *cloudwatchlogs.DescribeLogGroupsInput) bool {
+			// Ensure the request includes the expected account ID and that IncludeLinkedAccounts is enabled.
+			if input.IncludeLinkedAccounts == nil || !*input.IncludeLinkedAccounts {
+				return false
+			}
 			for _, accountID := range input.AccountIdentifiers {
 				if accountID == testAccountID {
 					return true
@@ -388,8 +392,9 @@ func TestAutodiscoverAccountIdentifiers(t *testing.T) {
 	cfg.Region = "us-west-1"
 	cfg.Logs.Groups = GroupConfig{
 		AutodiscoverConfig: &AutodiscoverConfig{
-			Limit:              1,
-			AccountIdentifiers: []string{testAccountID},
+			Limit:                 1,
+			AccountIdentifiers:    []string{testAccountID},
+			IncludeLinkedAccounts: aws.Bool(true),
 		},
 	}
 

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -350,6 +350,71 @@ func TestAutodiscoverLimit(t *testing.T) {
 	require.Len(t, grs, cfg.Logs.Groups.AutodiscoverConfig.Limit)
 }
 
+func TestAutodiscoverAccountIdentifiers(t *testing.T) {
+	mc := &mockClient{}
+
+	testAccountID := "123456789012"
+
+	mc.On(
+		"DescribeLogGroups",
+		mock.Anything,
+		mock.MatchedBy(func(input *cloudwatchlogs.DescribeLogGroupsInput) bool {
+			for _, accountID := range input.AccountIdentifiers {
+				if accountID == testAccountID {
+					return true
+				}
+			}
+			return false
+		}),
+		mock.Anything,
+	).Return(
+		&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{
+				{
+					LogGroupName: &testLogGroupName,
+				},
+			},
+			NextToken: nil,
+		}, nil)
+
+	// Otherwise, return no groups
+	mc.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return(
+		&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []types.LogGroup{},
+			NextToken: nil,
+		}, nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.Groups = GroupConfig{
+		AutodiscoverConfig: &AutodiscoverConfig{
+			Limit:              1,
+			AccountIdentifiers: []string{testAccountID},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	alertRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	alertRcvr.client = mc
+
+	grs, err := alertRcvr.discoverGroups(t.Context(), cfg.Logs.Groups.AutodiscoverConfig)
+	require.NoError(t, err)
+	require.Len(t, grs, 1)
+	require.Equal(t, testLogGroupName, grs[0].groupName())
+	mc.AssertExpectations(t)
+
+	// Filtering by a different account ID does not return any groups
+	cfg.Logs.Groups.AutodiscoverConfig.AccountIdentifiers = []string{"987654321098"}
+	grs, err = alertRcvr.discoverGroups(t.Context(), cfg.Logs.Groups.AutodiscoverConfig)
+	require.NoError(t, err)
+	require.Empty(t, grs)
+	mc.AssertExpectations(t)
+}
+
 func TestShutdownCheckpointer(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Region = "us-west-1"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds support for filtering AWS CloudWatch log groups by account ID. This PR simply sets the already existing `req.AccountIdentifiers` and `req.IncludeLinkedAccounts` fields for cloud watch to filter by.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38391

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added test

<!--Describe the documentation added.-->
#### Documentation
Updated docs

<!--Please delete paragraphs that you did not use before submitting.-->
