### PR TITLE
[CHORE] Workaround deleting temporary files on windows

### DIFF
--- a/exporter/elasticsearchexporter/integrationtest/collector.go
+++ b/exporter/elasticsearchexporter/integrationtest/collector.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
@@ -148,7 +149,7 @@ func newRecreatableOtelCol(tb testing.TB) *recreatableOtelCol {
 	)
 	require.NoError(tb, err)
 	return &recreatableOtelCol{
-		tempDir:   tb.TempDir(),
+		tempDir:   testutil.TempDir(tb),
 		factories: factories,
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Scoped tests from elasticsearch exporter is failing in several unrelated PRs[[1](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43614)][[2](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/19584471481/job/56125594056?pr=43053)][[3](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/19635699006/job/56225905647?pr=43896)] due to failures when deleting files on Windows.

This problem happened before and we solved by not using `testing.TempDir()`. I'm applying the same strategy here