### PR TITLE
[reveicer/prometheusreceiver] Add feature gate for extra scrape metrics in Prometheus receiver

### DIFF
--- a/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
+++ b/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: reveicer/prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add feature gate for extra scrape metrics in Prometheus receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 44181 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: deprecation of extra scrape metrics in Prometheus receiver will be removed in the next major release.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
+++ b/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
@@ -15,7 +15,7 @@ issues: [ 44181 ]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: deprecation of extra scrape metrics in Prometheus receiver will be removed in the next major release.
+subtext: deprecation of extra scrape metrics in Prometheus receiver will be removed eventually.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
+++ b/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
@@ -4,7 +4,7 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: reveicer/prometheusreceiver
+component: reveicer/prometheus
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add feature gate for extra scrape metrics in Prometheus receiver

--- a/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
+++ b/.chloggen/feat_prometheusreceiver-featuregate-extrascrapemetrics.yaml
@@ -4,7 +4,7 @@
 change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: reveicer/prometheus
+component: receiver/prometheus
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add feature gate for extra scrape metrics in Prometheus receiver

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -88,7 +88,7 @@ The prometheus receiver also supports additional top-level options:
 - **trim_metric_suffixes**: [**Experimental**] When set to true, this enables trimming unit and some counter type suffixes from metric names. For example, it would cause `singing_duration_seconds_total` to be trimmed to `singing_duration`. This can be useful when trying to restore the original metric names used in OpenTelemetry instrumentation. Defaults to false.
 - **use_start_time_metric**: When set to true, this enables retrieving the start time of all counter metrics from the process_start_time_seconds metric. This is only correct if all counters on that endpoint started after the process start time, and the process is the only actor exporting the metric after the process started. It should not be used in "exporters" which export counters that may have started before the process itself. Use only if you know what you are doing, as this may result in incorrect rate calculations. Defaults to false.
 - **start_time_metric_regex**: The regular expression for the start time metric, and is only applied when use_start_time_metric is enabled.  Defaults to process_start_time_seconds.
-- **report_extra_scrape_metrics**: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`
+- **report_extra_scrape_metrics**: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`. Deprecated; use the feature gate `receiver.prometheusreceiver.EnableReportExtraScrapeMetrics` instead.
 
 Example configuration:
 
@@ -97,7 +97,6 @@ receivers:
     prometheus:
       trim_metric_suffixes: true
       use_start_time_metric: true
-      report_extra_scrape_metrics: true
       start_time_metric_regex: foo_bar_.*
       config:
         scrape_configs:
@@ -183,7 +182,8 @@ More info about querying `/api/v1/` and the data format that is returned can be 
 ## Feature gates
 
 - `receiver.prometheusreceiver.EnableReportExtraScrapeMetrics`: Extra Prometheus scrape metrics 
-  can be reported by setting this feature gate option:
+  can be reported by setting this feature gate option. This replaces the deprecated
+  `report_extra_scrape_metrics` configuration flag:
 
 ```shell
 "--feature-gates=receiver.prometheusreceiver.EnableReportExtraScrapeMetrics"

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -182,6 +182,13 @@ More info about querying `/api/v1/` and the data format that is returned can be 
 
 ## Feature gates
 
+- `receiver.prometheusreceiver.EnableReportExtraScrapeMetrics`: Extra Prometheus scrape metrics 
+  can be reported by setting this feature gate option:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.EnableReportExtraScrapeMetrics"
+```
+
 - `receiver.prometheusreceiver.UseCreatedMetric`: Start time for Summary, Histogram 
   and Sum metrics can be retrieved from `_created` metrics. Currently, this behaviour
   is disabled by default. To enable it, use the following feature gate option:

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -38,8 +38,8 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
-// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
-	// 
+	// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
+	//
 	// Deprecated: use the feature gate "receiver.prometheusreceiver.EnableReportExtraScrapeMetrics" instead.
 	ReportExtraScrapeMetrics bool `mapstructure:"report_extra_scrape_metrics"`
 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -38,7 +38,8 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
-	// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
+// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
+	// 
 	// Deprecated: use the feature gate "receiver.prometheusreceiver.EnableReportExtraScrapeMetrics" instead.
 	ReportExtraScrapeMetrics bool `mapstructure:"report_extra_scrape_metrics"`
 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
 	// ReportExtraScrapeMetrics - enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
+	// Deprecated: use the feature gate "receiver.prometheusreceiver.EnableReportExtraScrapeMetrics" instead.
 	ReportExtraScrapeMetrics bool `mapstructure:"report_extra_scrape_metrics"`
 
 	TargetAllocator configoptional.Optional[targetallocator.Config] `mapstructure:"target_allocator"`

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -40,6 +40,13 @@ var enableCreatedTimestampZeroIngestionGate = featuregate.GlobalRegistry().MustR
 		" Created timestamps are injected as 0 valued samples when appropriate."),
 )
 
+var enableReportExtraScrapeMetricsGate = featuregate.GlobalRegistry().MustRegister(
+	"receiver.prometheusreceiver.EnableReportExtraScrapeMetrics",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Enables reporting of extra scrape metrics."+
+		" Extra scrape metrics are metrics that are not scraped by Prometheus but are reported by the Prometheus server."),
+)
+
 // NewFactory creates a new Prometheus receiver factory.
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -227,7 +227,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, logger *slog.L
 func (r *pReceiver) initScrapeOptions() *scrape.Options {
 	opts := &scrape.Options{
 		PassMetadataInContext: true,
-		ExtraMetrics:          r.cfg.ReportExtraScrapeMetrics,
+		ExtraMetrics:          enableReportExtraScrapeMetricsGate.IsEnabled() || r.cfg.ReportExtraScrapeMetrics,
 		HTTPClientOptions: []commonconfig.HTTPClientOption{
 			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
 		},

--- a/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 )
 
@@ -49,13 +49,12 @@ func TestReportExtraScrapeMetrics(t *testing.T) {
 
 // starts prometheus receiver with custom config, retrieves metrics from MetricsSink
 func testScraperMetrics(t *testing.T, targets []*testData, reportExtraScrapeMetrics bool) {
+	defer testutil.SetFeatureGateForTest(t, enableReportExtraScrapeMetricsGate, reportExtraScrapeMetrics)()
+
 	ctx := t.Context()
 	mp, cfg, err := setupMockPrometheus(targets...)
 	require.NoErrorf(t, err, "Failed to create Prometheus config: %v", err)
 	defer mp.Close()
-
-	err = featuregate.GlobalRegistry().Set("receiver.prometheusreceiver.EnableReportExtraScrapeMetrics", reportExtraScrapeMetrics)
-	require.NoError(t, err)
 
 	cms := new(consumertest.MetricsSink)
 	receiver, err := newPrometheusReceiver(receivertest.NewNopSettings(metadata.Type), &Config{
@@ -72,8 +71,6 @@ func testScraperMetrics(t *testing.T, targets []*testData, reportExtraScrapeMetr
 		assert.Lenf(t, flattenTargets(receiver.scrapeManager.TargetsAll()), len(targets), "expected %v targets to be running", len(targets))
 		require.NoError(t, receiver.Shutdown(t.Context()))
 		assert.Empty(t, flattenTargets(receiver.scrapeManager.TargetsAll()), "expected scrape manager to have no targets")
-		err := featuregate.GlobalRegistry().Set("receiver.prometheusreceiver.EnableReportExtraScrapeMetrics", false)
-		require.NoError(t, err)
 	})
 
 	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen


### PR DESCRIPTION
#### Description
Add feature gate for extra scape metrics in prometheus receiver along side current configuration. Change should not change any current behavior, just adds new additional input stream, which needs to be migrated later

#### Link to tracking issue
Fixes #44181


#### Testing
Updated tests to support mainly new input - feature gate, due to the fact of deprecation of configuration setup