### PR TITLE
Use pointer when passing TransformContext around or calling into

### DIFF
--- a/.chloggen/use-pointer-for-context.yaml
+++ b/.chloggen/use-pointer-for-context.yaml
@@ -1,0 +1,35 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use pointer when passing TransformContext around or calling into.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44541]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Change Expr/Parser/Getter/Setter and all ottl related funcs to accept pointers to avoid unnecessary copy of a large
+  TransformContext(96B). Avoid allocating a new pcommon.Map every time a new context is created by using a Borrow/Return
+  pattern and reuse objects between calls. Deprecated funcs are:
+  - `ottlspan.NewTransformContext` in favor of `ottlspan.BorrowContext`;
+  - `filtermprocessor.DefaultSpanFunctions` in favor of `filtermprocessor.DefaultSpanFunctionsNew`
+  - `filtermprocessor.WithSpanFunctions` in favor of `filtermprocessor.WithSpanFunctionsNew`
+  - `transformprocessor.DefaultSpanFunctions` in favor of `transformprocessor.DefaultSpanFunctionsNew`
+  - `transformprocessor.WithSpanFunctions` in favor of `transformprocessor.WithSpanFunctionsNew`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/connector/countconnector/counter_test.go
+++ b/connector/countconnector/counter_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func Test_update_attribute_inheritance(t *testing.T) {
-	spanMetricDefs := make(map[string]metricDef[ottlspan.TransformContext])
-	spanMetricDefs[defaultMetricNameSpans] = metricDef[ottlspan.TransformContext]{
+	spanMetricDefs := make(map[string]metricDef[*ottlspan.TransformContext])
+	spanMetricDefs[defaultMetricNameSpans] = metricDef[*ottlspan.TransformContext]{
 		desc: defaultMetricDescSpans,
 		attrs: []AttributeConfig{
 			{
@@ -129,8 +129,8 @@ func Test_update_attribute_inheritance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spansCounter := newCounter[ottlspan.TransformContext](spanMetricDefs)
-			err := spansCounter.update(t.Context(), tt.spanAttr, tt.scopeAttr, tt.resourceAttr, ottlspan.TransformContext{})
+			spansCounter := newCounter[*ottlspan.TransformContext](spanMetricDefs)
+			err := spansCounter.update(t.Context(), tt.spanAttr, tt.scopeAttr, tt.resourceAttr, &ottlspan.TransformContext{})
 			require.NoError(t, err)
 			require.NotNil(t, spansCounter)
 			m := spansCounter.counts[defaultMetricNameSpans]
@@ -215,15 +215,15 @@ func Test_update_attributes_types(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		spanMetricDefs := make(map[string]metricDef[ottlspan.TransformContext])
-		spanMetricDefs[defaultMetricNameSpans] = metricDef[ottlspan.TransformContext]{
+		spanMetricDefs := make(map[string]metricDef[*ottlspan.TransformContext])
+		spanMetricDefs[defaultMetricNameSpans] = metricDef[*ottlspan.TransformContext]{
 			desc:  defaultMetricDescSpans,
 			attrs: tt.config,
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			spansCounter := newCounter(spanMetricDefs)
-			err := spansCounter.update(t.Context(), pcommon.NewMap(), pcommon.NewMap(), tt.inputAttr, ottlspan.TransformContext{})
+			err := spansCounter.update(t.Context(), pcommon.NewMap(), pcommon.NewMap(), tt.inputAttr, &ottlspan.TransformContext{})
 			require.NoError(t, err)
 			require.NotNil(t, spansCounter)
 			m := spansCounter.counts[defaultMetricNameSpans]

--- a/connector/countconnector/factory.go
+++ b/connector/countconnector/factory.go
@@ -50,9 +50,9 @@ func createTracesToMetrics(
 ) (connector.Traces, error) {
 	c := cfg.(*Config)
 
-	spanMetricDefs := make(map[string]metricDef[ottlspan.TransformContext], len(c.Spans))
+	spanMetricDefs := make(map[string]metricDef[*ottlspan.TransformContext], len(c.Spans))
 	for name, info := range c.Spans {
-		md := metricDef[ottlspan.TransformContext]{
+		md := metricDef[*ottlspan.TransformContext]{
 			desc:  info.Description,
 			attrs: info.Attributes,
 		}

--- a/connector/routingconnector/functions.go
+++ b/connector/routingconnector/functions.go
@@ -33,10 +33,10 @@ func standardFunctions[K any]() map[string]ottl.Factory[K] {
 	return funcs
 }
 
-func spanFunctions() map[string]ottl.Factory[ottlspan.TransformContext] {
-	funcs := standardFunctions[ottlspan.TransformContext]()
+func spanFunctions() map[string]ottl.Factory[*ottlspan.TransformContext] {
+	funcs := standardFunctions[*ottlspan.TransformContext]()
 
-	isRootSpan := ottlfuncs.NewIsRootSpanFactory()
+	isRootSpan := ottlfuncs.NewIsRootSpanFactoryNew()
 	funcs[isRootSpan.Name()] = isRootSpan
 
 	return funcs

--- a/connector/routingconnector/functions_test.go
+++ b/connector/routingconnector/functions_test.go
@@ -22,7 +22,7 @@ func TestSpanFunctions(t *testing.T) {
 	funcs := spanFunctions()
 	assertStandardFunctions(t, funcs)
 
-	isRouteFuncName := ottlfuncs.NewIsRootSpanFactory().Name()
+	isRouteFuncName := ottlfuncs.NewIsRootSpanFactoryNew().Name()
 	val, ok := funcs[isRouteFuncName]
 
 	require.True(t, ok)

--- a/connector/routingconnector/router.go
+++ b/connector/routingconnector/router.go
@@ -32,7 +32,7 @@ type consumerProvider[C any] func(...pipeline.ID) (C, error)
 // consumer.Logs.
 type router[C any] struct {
 	resourceParser   ottl.Parser[ottlresource.TransformContext]
-	spanParser       ottl.Parser[ottlspan.TransformContext]
+	spanParser       ottl.Parser[*ottlspan.TransformContext]
 	metricParser     ottl.Parser[ottlmetric.TransformContext]
 	dataPointParser  ottl.Parser[ottldatapoint.TransformContext]
 	logParser        ottl.Parser[ottllog.TransformContext]
@@ -74,7 +74,7 @@ type routingItem[C any] struct {
 	consumer           C
 	requestCondition   *requestCondition
 	resourceStatement  *ottl.Statement[ottlresource.TransformContext]
-	spanStatement      *ottl.Statement[ottlspan.TransformContext]
+	spanStatement      *ottl.Statement[*ottlspan.TransformContext]
 	metricStatement    *ottl.Statement[ottlmetric.TransformContext]
 	dataPointStatement *ottl.Statement[ottldatapoint.TransformContext]
 	logStatement       *ottl.Statement[ottllog.TransformContext]

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -87,7 +87,8 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 		case "span":
 			ptraceutil.MoveSpansWithContextIf(td, matched,
 				func(rs ptrace.ResourceSpans, ss ptrace.ScopeSpans, s ptrace.Span) bool {
-					mtx := ottlspan.NewTransformContext(s, ss.Scope(), rs.Resource(), ss, rs)
+					mtx := ottlspan.NewTransformContextPtr(s, ss.Scope(), rs.Resource(), ss, rs)
+					defer mtx.Close()
 					_, isMatch, err := route.spanStatement.Execute(ctx, mtx)
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {

--- a/connector/signaltometricsconnector/factory.go
+++ b/connector/signaltometricsconnector/factory.go
@@ -50,10 +50,10 @@ func createTracesToMetrics(
 		return nil, fmt.Errorf("failed to create OTTL statement parser for spans: %w", err)
 	}
 
-	metricDefs := make([]model.MetricDef[ottlspan.TransformContext], 0, len(c.Spans))
+	metricDefs := make([]model.MetricDef[*ottlspan.TransformContext], 0, len(c.Spans))
 	for i := range c.Spans {
 		info := c.Spans[i]
-		var md model.MetricDef[ottlspan.TransformContext]
+		var md model.MetricDef[*ottlspan.TransformContext]
 		if err := md.FromMetricInfo(info, parser, set.TelemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to parse provided metric information; %w", err)
 		}

--- a/connector/signaltometricsconnector/internal/customottl/adjustedcount.go
+++ b/connector/signaltometricsconnector/internal/customottl/adjustedcount.go
@@ -12,16 +12,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 )
 
-func NewAdjustedCountFactory() ottl.Factory[ottlspan.TransformContext] {
+func NewAdjustedCountFactory() ottl.Factory[*ottlspan.TransformContext] {
 	return ottl.NewFactory("AdjustedCount", nil, createAdjustedCountFunction)
 }
 
-func createAdjustedCountFunction(ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[ottlspan.TransformContext], error) {
+func createAdjustedCountFunction(ottl.FunctionContext, ottl.Arguments) (ottl.ExprFunc[*ottlspan.TransformContext], error) {
 	return adjustedCount()
 }
 
-func adjustedCount() (ottl.ExprFunc[ottlspan.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlspan.TransformContext) (any, error) {
+func adjustedCount() (ottl.ExprFunc[*ottlspan.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlspan.TransformContext) (any, error) {
 		tracestate := tCtx.GetSpan().TraceState().AsRaw()
 		w3cTraceState, err := sampling.NewW3CTraceState(tracestate)
 		if err != nil {

--- a/connector/signaltometricsconnector/internal/customottl/adjustedcount_test.go
+++ b/connector/signaltometricsconnector/internal/customottl/adjustedcount_test.go
@@ -33,13 +33,9 @@ func Test_AdjustedCount(t *testing.T) {
 			require.NoError(t, err)
 			span := ptrace.NewSpan()
 			span.TraceState().FromRaw(tc.tracestate)
-			result, err := exprFunc(nil, ottlspan.NewTransformContext(
-				span,
-				pcommon.NewInstrumentationScope(),
-				pcommon.NewResource(),
-				ptrace.NewScopeSpans(),
-				ptrace.NewResourceSpans(),
-			))
+			tCtx := ottlspan.NewTransformContextPtr(span, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			defer tCtx.Close()
+			result, err := exprFunc(nil, tCtx)
 			if tc.errMsg != "" {
 				require.ErrorContains(t, err, tc.errMsg)
 				return

--- a/connector/signaltometricsconnector/internal/customottl/funcs.go
+++ b/connector/signaltometricsconnector/internal/customottl/funcs.go
@@ -12,8 +12,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func SpanFuncs() map[string]ottl.Factory[ottlspan.TransformContext] {
-	common := commonFuncs[ottlspan.TransformContext]()
+func SpanFuncs() map[string]ottl.Factory[*ottlspan.TransformContext] {
+	common := commonFuncs[*ottlspan.TransformContext]()
 	adjustedCountFactory := NewAdjustedCountFactory()
 	common[adjustedCountFactory.Name()] = adjustedCountFactory
 	return common

--- a/connector/signaltometricsconnector/internal/model/model_test.go
+++ b/connector/signaltometricsconnector/internal/model/model_test.go
@@ -80,7 +80,7 @@ func TestFilterResourceAttributes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			md := MetricDef[ottlspan.TransformContext]{
+			md := MetricDef[*ottlspan.TransformContext]{
 				IncludeResourceAttributes: tc.includeResourceAttributes,
 			}
 			inputResourceAttrsM := pcommon.NewMap()
@@ -149,7 +149,7 @@ func TestFilterAttributes(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			md := MetricDef[ottlspan.TransformContext]{
+			md := MetricDef[*ottlspan.TransformContext]{
 				Attributes: tc.attributes,
 			}
 			inputAttrM := pcommon.NewMap()

--- a/connector/sumconnector/factory.go
+++ b/connector/sumconnector/factory.go
@@ -47,9 +47,9 @@ func createTracesToMetrics(
 ) (connector.Traces, error) {
 	c := cfg.(*Config)
 
-	spanMetricDefs := make(map[string]metricDef[ottlspan.TransformContext], len(c.Spans))
+	spanMetricDefs := make(map[string]metricDef[*ottlspan.TransformContext], len(c.Spans))
 	for name, info := range c.Spans {
-		md := metricDef[ottlspan.TransformContext]{
+		md := metricDef[*ottlspan.TransformContext]{
 			desc:       info.Description,
 			attrs:      info.Attributes,
 			sourceAttr: info.SourceAttribute,

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -115,7 +115,7 @@ func NewResourceSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottl
 	return NewBoolExprForResource(statements, StandardResourceFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
 }
 
-func NewSpanSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {
+func NewSpanSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[*ottlspan.TransformContext], error) {
 	statements := make([]string, 0, 2)
 	if mc.Include != nil {
 		statement, err := createStatement(*mc.Include)

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -17,15 +17,15 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
 )
 
-// NewBoolExprForSpan creates a BoolExpr[ottlspan.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForSpan creates a BoolExpr[*ottlspan.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspan.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlspan.TransformContext], error) {
+func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[*ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlspan.TransformContext], error) {
 	return NewBoolExprForSpanWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForSpanWithOptions is like NewBoolExprForSpan, but with additional options.
-func NewBoolExprForSpanWithOptions(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottlspan.TransformContext]) (*ottl.ConditionSequence[ottlspan.TransformContext], error) {
+func NewBoolExprForSpanWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlspan.TransformContext]) (*ottl.ConditionSequence[*ottlspan.TransformContext], error) {
 	parser, err := ottlspan.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err

--- a/internal/filter/filterottl/filter_test.go
+++ b/internal/filter/filterottl/filter_test.go
@@ -55,7 +55,7 @@ func Test_NewBoolExprForSpan(t *testing.T) {
 			spanBoolExpr, err := NewBoolExprForSpan(tt.conditions, StandardSpanFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, spanBoolExpr)
-			result, err := spanBoolExpr.Eval(t.Context(), ottlspan.TransformContext{})
+			result, err := spanBoolExpr.Eval(t.Context(), &ottlspan.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -68,7 +68,7 @@ func Test_NewBoolExprForSpanWithOptions(t *testing.T) {
 		StandardSpanFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottlspan.TransformContext]{ottlspan.EnablePathContextNames()},
+		[]ottl.Option[*ottlspan.TransformContext]{ottlspan.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -21,9 +21,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func StandardSpanFuncs() map[string]ottl.Factory[ottlspan.TransformContext] {
-	m := ottlfuncs.StandardConverters[ottlspan.TransformContext]()
-	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
+func StandardSpanFuncs() map[string]ottl.Factory[*ottlspan.TransformContext] {
+	m := ottlfuncs.StandardConverters[*ottlspan.TransformContext]()
+	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactoryNew()
 	m[isRootSpanFactory.Name()] = isRootSpanFactory
 	return m
 }

--- a/internal/filter/filterspan/filterspan.go
+++ b/internal/filter/filterspan/filterspan.go
@@ -30,11 +30,11 @@ var useOTTLBridge = featuregate.GlobalRegistry().MustRegister(
 // NewSkipExpr creates a BoolExpr that on evaluation returns true if a span should NOT be processed or kept.
 // The logic determining if a span should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
-func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {
+func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[*ottlspan.TransformContext], error) {
 	if useOTTLBridge.IsEnabled() {
 		return filterottl.NewSpanSkipExprBridge(mp)
 	}
-	var matchers []expr.BoolExpr[ottlspan.TransformContext]
+	var matchers []expr.BoolExpr[*ottlspan.TransformContext]
 	inclExpr, err := newExpr(mp.Include)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ type propertiesMatcher struct {
 }
 
 // newExpr creates a BoolExpr that matches based on the given MatchProperties.
-func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[ottlspan.TransformContext], error) {
+func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[*ottlspan.TransformContext], error) {
 	if mp == nil {
 		return nil, nil
 	}
@@ -115,7 +115,7 @@ func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[ottlspan.Transform
 
 // Eval matches a span and service to a set of properties.
 // see filterconfig.MatchProperties for more details
-func (mp *propertiesMatcher) Eval(_ context.Context, tCtx ottlspan.TransformContext) (bool, error) {
+func (mp *propertiesMatcher) Eval(_ context.Context, tCtx *ottlspan.TransformContext) (bool, error) {
 	// If a set of properties was not in the mp, all spans are considered to match on that property
 	if mp.serviceFilters != nil {
 		// Check resource and spans for service.name

--- a/internal/filter/filterspan/filterspan_test.go
+++ b/internal/filter/filterspan/filterspan_test.go
@@ -178,7 +178,10 @@ func TestSpan_Matching_False(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, expr)
 
-			val, err := expr.Eval(t.Context(), ottlspan.NewTransformContext(span, library, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans()))
+			tCtx := ottlspan.NewTransformContextPtr(span, library, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			defer tCtx.Close()
+
+			val, err := expr.Eval(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.False(t, val)
 		})
@@ -196,7 +199,9 @@ func TestSpan_MissingServiceName(t *testing.T) {
 	assert.NotNil(t, mp)
 
 	emptySpan := ptrace.NewSpan()
-	val, err := mp.Eval(t.Context(), ottlspan.NewTransformContext(emptySpan, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans()))
+	tCtx := ottlspan.NewTransformContextPtr(emptySpan, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	defer tCtx.Close()
+	val, err := mp.Eval(t.Context(), tCtx)
 	require.NoError(t, err)
 	assert.False(t, val)
 }
@@ -287,7 +292,9 @@ func TestSpan_Matching_True(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotNil(t, mp)
 
-			val, err := mp.Eval(t.Context(), ottlspan.NewTransformContext(span, library, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans()))
+			tCtx := ottlspan.NewTransformContextPtr(span, library, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			defer tCtx.Close()
+			val, err := mp.Eval(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.True(t, val)
 		})
@@ -1209,7 +1216,8 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			scope.SetName("scope")
 			scope.SetVersion("0.1.0")
 
-			tCtx := ottlspan.NewTransformContext(span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			tCtx := ottlspan.NewTransformContextPtr(span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.condition)
 			require.NoError(t, err)
@@ -1277,7 +1285,8 @@ func BenchmarkFilterspan_NewSkipExpr(b *testing.B) {
 
 		scope := pcommon.NewInstrumentationScope()
 
-		tCtx := ottlspan.NewTransformContext(span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+		tCtx := ottlspan.NewTransformContextPtr(span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+		defer tCtx.Close()
 
 		b.Run(tt.name, func(b *testing.B) {
 			for b.Loop() {

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -6,6 +6,7 @@ package ottlspan // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -20,6 +21,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
 
 // ContextName is the name of the context for spans.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
@@ -38,7 +45,7 @@ type TransformContext struct {
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("span", logging.Span(tCtx.span)))
@@ -49,7 +56,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		span:                 span,
@@ -65,28 +72,50 @@ func NewTransformContext(span ptrace.Span, instrumentationScope pcommon.Instrume
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.span = span
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.scopeSpans = scopeSpans
+	tCtx.resourceSpans = resourceSpans
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.cache.Clear()
+	tcPool.Put(tCtx)
+}
+
 // GetSpan returns the span from the TransformContext.
-func (tCtx TransformContext) GetSpan() ptrace.Span {
+func (tCtx *TransformContext) GetSpan() ptrace.Span {
 	return tCtx.span
 }
 
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetResourceSchemaURLItem returns the schema URL item for the resource from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceSpans
 }
 
 // GetScopeSchemaURLItem returns the schema URL item for the scope from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 
@@ -95,9 +124,9 @@ func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ctxspan.Name,
 			ctxresource.Name,
 			ctxscope.LegacyName,
@@ -107,17 +136,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -126,17 +155,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -146,10 +175,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new span parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -169,19 +198,19 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("enum symbol not provided")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
-	return ctxcommon.PathExpressionParser(
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
+	return ctxcommon.PathExpressionParser[*TransformContext](
 		ctxspan.Name,
 		ctxspan.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
-			ctxspan.Name:        ctxspan.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxspan.Name:        ctxspan.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -58,14 +58,14 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -76,10 +76,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -92,7 +92,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_id",
 			},
 			orig:   pcommon.TraceID(traceID),
@@ -103,7 +103,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "span_id",
 			},
 			orig:   pcommon.SpanID(spanID),
@@ -114,9 +114,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_id",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -128,9 +128,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "span_id",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -142,7 +142,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_state",
 			},
 			orig:   "key1=val1,key2=val2",
@@ -153,10 +153,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state key",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_state",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("key1"),
 					},
 				},
@@ -169,7 +169,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "parent_span_id",
 			},
 			orig:   pcommon.SpanID(spanID2),
@@ -180,7 +180,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "name",
 			},
 			orig:   "bear",
@@ -191,7 +191,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "kind",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "kind",
 			},
 			orig:   int64(2),
@@ -202,9 +202,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "string kind",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "kind",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -216,9 +216,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "deprecated string kind",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "kind",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "deprecated_string",
 				},
 			},
@@ -230,7 +230,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -241,7 +241,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "end_time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -252,7 +252,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
@@ -263,7 +263,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "end_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
@@ -274,7 +274,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refSpan.Attributes(),
@@ -285,10 +285,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -301,10 +301,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -317,10 +317,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -333,10 +333,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -349,10 +349,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -365,10 +365,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -384,10 +384,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -403,10 +403,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -422,10 +422,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -441,10 +441,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -460,10 +460,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -481,10 +481,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -502,16 +502,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -528,16 +528,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -555,7 +555,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -566,7 +566,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "events",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "events",
 			},
 			orig:   refSpan.Events(),
@@ -580,7 +580,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_events_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_events_count",
 			},
 			orig:   int64(20),
@@ -591,7 +591,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "links",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "links",
 			},
 			orig:   refSpan.Links(),
@@ -605,7 +605,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_links_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_links_count",
 			},
 			orig:   int64(30),
@@ -616,7 +616,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "status",
 			},
 			orig:   refSpan.Status(),
@@ -627,9 +627,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status code",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "status",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "code",
 				},
 			},
@@ -641,9 +641,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status message",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "status",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "message",
 				},
 			},
@@ -659,16 +659,16 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxspan.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a controlled cache map for testing
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -676,7 +676,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			span, il, resource := createTelemetry()
 
-			tCtx := NewTransformContext(span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			tCtx := NewTransformContextPtr(span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+			defer tCtx.Close()
 
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -704,19 +705,20 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := pcommon.NewInstrumentationScope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContext(ptrace.NewSpan(), instrumentationScope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	tCtx := NewTransformContextPtr(ptrace.NewSpan(), instrumentationScope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	defer tCtx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("foo"),
 					},
 				},
@@ -725,8 +727,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("foo"),
 				},
 			}},
@@ -734,22 +736,22 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name:     "instrumentation_scope",
-			path:     &pathtest.Path[TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "instrumentation_scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "instrumentation_scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope",
-			path:     &pathtest.Path[TransformContext]{N: "scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 	}
@@ -759,7 +761,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 			accessor, err := pathExpressionParser(getCache)(tt.path)
 			require.NoError(t, err)
 
-			got, err := accessor.Get(t.Context(), ctx)
+			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
 		})
@@ -767,11 +769,11 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 }
 
 func TestHigherContextCacheAccessError(t *testing.T) {
-	path := &pathtest.Path[TransformContext]{
+	path := &pathtest.Path[*TransformContext]{
 		N: "cache",
 		C: ctxresource.Name,
-		KeySlice: []ottl.Key[TransformContext]{
-			&pathtest.Key[TransformContext]{
+		KeySlice: []ottl.Key[*TransformContext]{
+			&pathtest.Key[*TransformContext]{
 				S: ottltest.Strp("key"),
 			},
 		},

--- a/pkg/ottl/ottlfuncs/func_is_root_span.go
+++ b/pkg/ottl/ottlfuncs/func_is_root_span.go
@@ -10,16 +10,27 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 )
 
+// Deprecated: [v0.142.0] use NewIsRootSpanFactoryNew.
 func NewIsRootSpanFactory() ottl.Factory[ottlspan.TransformContext] {
+	return ottl.NewFactory("IsRootSpan", nil, createIsRootSpanFunctionLegacy)
+}
+
+func createIsRootSpanFunctionLegacy(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[ottlspan.TransformContext], error) {
+	return func(_ context.Context, tCtx ottlspan.TransformContext) (any, error) {
+		return tCtx.GetSpan().ParentSpanID().IsEmpty(), nil
+	}, nil
+}
+
+func NewIsRootSpanFactoryNew() ottl.Factory[*ottlspan.TransformContext] {
 	return ottl.NewFactory("IsRootSpan", nil, createIsRootSpanFunction)
 }
 
-func createIsRootSpanFunction(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[ottlspan.TransformContext], error) {
+func createIsRootSpanFunction(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[*ottlspan.TransformContext], error) {
 	return isRootSpan()
 }
 
-func isRootSpan() (ottl.ExprFunc[ottlspan.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlspan.TransformContext) (any, error) {
+func isRootSpan() (ottl.ExprFunc[*ottlspan.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlspan.TransformContext) (any, error) {
 		return tCtx.GetSpan().ParentSpanID().IsEmpty(), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_is_root_span_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_root_span_test.go
@@ -23,7 +23,9 @@ func Test_IsRootSpan(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0,
 	})
 
-	value, err := exprFunc(nil, ottlspan.NewTransformContext(spanRoot, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans()))
+	rootCtx := ottlspan.NewTransformContextPtr(spanRoot, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	defer rootCtx.Close()
+	value, err := exprFunc(nil, rootCtx)
 	require.NoError(t, err)
 	require.Equal(t, true, value)
 
@@ -33,7 +35,9 @@ func Test_IsRootSpan(t *testing.T) {
 		1, 0, 0, 0, 0, 0, 0, 0,
 	})
 
-	value, err = exprFunc(nil, ottlspan.NewTransformContext(spanNonRoot, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans()))
+	nonRootCtx := ottlspan.NewTransformContextPtr(spanNonRoot, pcommon.NewInstrumentationScope(), pcommon.NewResource(), ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	defer nonRootCtx.Close()
+	value, err = exprFunc(nil, nonRootCtx)
 	require.NoError(t, err)
 	require.Equal(t, false, value)
 }

--- a/processor/attributesprocessor/attributes_trace.go
+++ b/processor/attributesprocessor/attributes_trace.go
@@ -17,13 +17,13 @@ import (
 type spanAttributesProcessor struct {
 	logger   *zap.Logger
 	attrProc *attraction.AttrProc
-	skipExpr expr.BoolExpr[ottlspan.TransformContext]
+	skipExpr expr.BoolExpr[*ottlspan.TransformContext]
 }
 
 // newTracesProcessor returns a processor that modifies attributes of a span.
 // To construct the attributes processors, the use of the factory methods are required
 // in order to validate the inputs.
-func newSpanAttributesProcessor(logger *zap.Logger, attrProc *attraction.AttrProc, skipExpr expr.BoolExpr[ottlspan.TransformContext]) *spanAttributesProcessor {
+func newSpanAttributesProcessor(logger *zap.Logger, attrProc *attraction.AttrProc, skipExpr expr.BoolExpr[*ottlspan.TransformContext]) *spanAttributesProcessor {
 	return &spanAttributesProcessor{
 		logger:   logger,
 		attrProc: attrProc,
@@ -44,7 +44,9 @@ func (a *spanAttributesProcessor) processTraces(ctx context.Context, td ptrace.T
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if a.skipExpr != nil {
-					skip, err := a.skipExpr.Eval(ctx, ottlspan.NewTransformContext(span, scope, resource, ils, rs))
+					tCtx := ottlspan.NewTransformContextPtr(span, scope, resource, ils, rs)
+					skip, err := a.skipExpr.Eval(ctx, tCtx)
+					tCtx.Close()
 					if err != nil {
 						return td, err
 					}

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	logFunctions       map[string]ottl.Factory[ottllog.TransformContext]
 	metricFunctions    map[string]ottl.Factory[ottlmetric.TransformContext]
 	spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
-	spanFunctions      map[string]ottl.Factory[ottlspan.TransformContext]
+	spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions   map[string]ottl.Factory[ottlprofile.TransformContext]
 }
 

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -32,7 +32,7 @@ func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	for _, f := range DefaultMetricFunctions() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
 	}
-	for _, f := range DefaultSpanFunctions() {
+	for _, f := range DefaultSpanFunctionsNew() {
 		assert.Contains(t, config.spanFunctions, f.Name(), "missing span function %v", f.Name())
 	}
 	for _, f := range DefaultSpanEventFunctions() {

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -34,7 +34,7 @@ type filterProcessorFactory struct {
 	logFunctions                        map[string]ottl.Factory[ottllog.TransformContext]
 	metricFunctions                     map[string]ottl.Factory[ottlmetric.TransformContext]
 	spanEventFunctions                  map[string]ottl.Factory[ottlspanevent.TransformContext]
-	spanFunctions                       map[string]ottl.Factory[ottlspan.TransformContext]
+	spanFunctions                       map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions                    map[string]ottl.Factory[ottlprofile.TransformContext]
 	defaultResourceFunctionsOverridden  bool
 	defaultDataPointFunctionsOverridden bool
@@ -108,12 +108,21 @@ func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[ottlspanevent.Tran
 	}
 }
 
-// WithSpanFunctions will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
-// Subsequent uses of WithSpanFunctions will merge the provided spanFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] use WithSpanFunctionsNew.
 func WithSpanFunctions(spanFunctions []ottl.Factory[ottlspan.TransformContext]) FactoryOption {
+	newSpanFunctions := make([]ottl.Factory[*ottlspan.TransformContext], 0, len(spanFunctions))
+	for _, spanFunction := range spanFunctions {
+		newSpanFunctions = append(newSpanFunctions, ottl.NewFactory[*ottlspan.TransformContext](spanFunction.Name(), spanFunction.CreateDefaultArguments(), fromNonPointerFunction(spanFunction.CreateFunction)))
+	}
+	return WithSpanFunctionsNew(newSpanFunctions)
+}
+
+// WithSpanFunctionsNew will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
+// Subsequent uses of WithSpanFunctions will merge the provided spanFunctions with the previously registered functions.
+func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultSpanFunctionsOverridden {
-			factory.spanFunctions = map[string]ottl.Factory[ottlspan.TransformContext]{}
+			factory.spanFunctions = map[string]ottl.Factory[*ottlspan.TransformContext]{}
 			factory.defaultSpanFunctionsOverridden = true
 		}
 		factory.spanFunctions = mergeFunctionsToMap(factory.spanFunctions, spanFunctions)
@@ -275,4 +284,16 @@ func (f *filterProcessorFactory) createProfilesProcessor(
 		nextConsumer,
 		fp.processProfiles,
 		xprocessorhelper.WithCapabilities(processorCapabilities))
+}
+
+func fromNonPointerFunction[K any](legacy func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[K], error)) func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[*K], error) {
+	return func(fCtx ottl.FunctionContext, args ottl.Arguments) (ottl.ExprFunc[*K], error) {
+		legacyExpr, err := legacy(fCtx, args)
+		if err != nil {
+			return nil, err
+		}
+		return func(ctx context.Context, tCtx *K) (any, error) {
+			return legacyExpr(ctx, *tCtx)
+		}, nil
+	}
 }

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -203,8 +203,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
@@ -217,7 +217,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
@@ -229,7 +229,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 			},
 		},
 		{
@@ -241,7 +241,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 			},
 		},
 		{
@@ -252,7 +252,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
@@ -266,7 +266,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanEventFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},

--- a/processor/filterprocessor/functions.go
+++ b/processor/filterprocessor/functions.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
 func DefaultResourceFunctions() []ottl.Factory[ottlresource.TransformContext] {
@@ -34,7 +35,15 @@ func DefaultDataPointFunctions() []ottl.Factory[ottldatapoint.TransformContext] 
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultSpanFunctionsNew.
 func DefaultSpanFunctions() []ottl.Factory[ottlspan.TransformContext] {
+	funcs := ottlfuncs.StandardConverters[ottlspan.TransformContext]()
+	isRootSpanFactory := ottlfuncs.NewIsRootSpanFactory()
+	funcs[isRootSpanFactory.Name()] = isRootSpanFactory
+	return slices.Collect(maps.Values(funcs))
+}
+
+func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
 }
 
@@ -62,7 +71,7 @@ func defaultDataPointFunctionsMap() map[string]ottl.Factory[ottldatapoint.Transf
 	return filterottl.StandardDataPointFuncs()
 }
 
-func defaultSpanFunctionsMap() map[string]ottl.Factory[ottlspan.TransformContext] {
+func defaultSpanFunctionsMap() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	return filterottl.StandardSpanFuncs()
 }
 

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -21,7 +21,7 @@ import (
 type spanProcessor struct {
 	config           Config
 	toAttributeRules []toAttributeRule
-	skipExpr         expr.BoolExpr[ottlspan.TransformContext]
+	skipExpr         expr.BoolExpr[*ottlspan.TransformContext]
 }
 
 // toAttributeRule is the compiled equivalent of config.ToAttributes field.
@@ -79,7 +79,9 @@ func (sp *spanProcessor) processTraces(ctx context.Context, td ptrace.Traces) (p
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if sp.skipExpr != nil {
-					skip, err := sp.skipExpr.Eval(ctx, ottlspan.NewTransformContext(span, scope, resource, ils, rs))
+					tCtx := ottlspan.NewTransformContextPtr(span, scope, resource, ils, rs)
+					skip, err := sp.skipExpr.Eval(ctx, tCtx)
+					tCtx.Close()
 					if err != nil {
 						return td, err
 					}

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -19,7 +19,7 @@ import (
 )
 
 type ottlConditionFilter struct {
-	sampleSpanExpr      *ottl.ConditionSequence[ottlspan.TransformContext]
+	sampleSpanExpr      *ottl.ConditionSequence[*ottlspan.TransformContext]
 	sampleSpanEventExpr *ottl.ConditionSequence[ottlspanevent.TransformContext]
 	errorMode           ottl.ErrorMode
 	logger              *zap.Logger
@@ -88,7 +88,9 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 
 				// Span evaluation
 				if ocf.sampleSpanExpr != nil {
-					ok, err = ocf.sampleSpanExpr.Eval(ctx, ottlspan.NewTransformContext(span, scope, resource, ss, rs))
+					tCtx := ottlspan.NewTransformContextPtr(span, scope, resource, ss, rs)
+					ok, err = ocf.sampleSpanExpr.Eval(ctx, tCtx)
+					tCtx.Close()
 					if err != nil {
 						return samplingpolicy.Error, err
 					}

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -54,7 +54,7 @@ type Config struct {
 	logFunctions       map[string]ottl.Factory[ottllog.TransformContext]
 	metricFunctions    map[string]ottl.Factory[ottlmetric.TransformContext]
 	spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
-	spanFunctions      map[string]ottl.Factory[ottlspan.TransformContext]
+	spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions   map[string]ottl.Factory[ottlprofile.TransformContext]
 }
 

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -43,7 +43,7 @@ func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	for _, f := range DefaultMetricFunctions() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
 	}
-	for _, f := range DefaultSpanFunctions() {
+	for _, f := range DefaultSpanFunctionsNew() {
 		assert.Contains(t, config.spanFunctions, f.Name(), "missing span function %v", f.Name())
 	}
 	for _, f := range DefaultSpanEventFunctions() {
@@ -919,8 +919,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
@@ -934,7 +934,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},
@@ -947,7 +947,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("testSpanFunc")}),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("testSpanFunc")}),
 			},
 		},
 		{
@@ -960,7 +960,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions([]ottl.Factory[ottlspan.TransformContext]{createTestFuncFactory[ottlspan.TransformContext]("TestSpanFunc")}),
+				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
 			},
 		},
 		{
@@ -972,7 +972,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
@@ -987,7 +987,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestSpanEventFunc"`,
 			factoryOptions: []FactoryOption{
-				WithSpanFunctions(DefaultSpanFunctions()),
+				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanEventFunctions(DefaultSpanEventFunctions()),
 			},
 		},

--- a/processor/transformprocessor/functions.go
+++ b/processor/transformprocessor/functions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlprofile"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/profiles"
@@ -32,7 +33,21 @@ func DefaultDataPointFunctions() []ottl.Factory[ottldatapoint.TransformContext] 
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultSpanFunctionsNew.
 func DefaultSpanFunctions() []ottl.Factory[ottlspan.TransformContext] {
+	functions := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
+
+	spanFunctions := ottl.CreateFactoryMap(
+		ottlfuncs.NewIsRootSpanFactory(),
+		traces.NewSetSemconvSpanNameFactoryLegacy(),
+	)
+
+	maps.Copy(functions, spanFunctions)
+
+	return slices.Collect(maps.Values(functions))
+}
+
+func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
 }
 
@@ -56,7 +71,7 @@ func defaultDataPointFunctionsMap() map[string]ottl.Factory[ottldatapoint.Transf
 	return metrics.DataPointFunctions()
 }
 
-func defaultSpanFunctionsMap() map[string]ottl.Factory[ottlspan.TransformContext] {
+func defaultSpanFunctionsMap() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	return traces.SpanFunctions()
 }
 

--- a/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
+++ b/processor/transformprocessor/internal/traces/func_set_semconv_span_name_test.go
@@ -488,7 +488,8 @@ VALUES (@p7, @p8, @p9, @p10, @p11, @p12, @p13, @p14, @p15, @p16);
 			require.NoError(t, err)
 			require.NotNil(t, setSemconvNameFunction)
 
-			tCtx := ottlspan.NewTransformContext(span, scopeSpans.Scope(), pcommon.NewResource(), scopeSpans, resourceSpans)
+			tCtx := ottlspan.NewTransformContextPtr(span, scopeSpans.Scope(), pcommon.NewResource(), scopeSpans, resourceSpans)
+			defer tCtx.Close()
 			_, err = setSemconvNameFunction(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, tCtx.GetSpan().Name())

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -12,11 +12,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func SpanFunctions() map[string]ottl.Factory[ottlspan.TransformContext] {
-	functions := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
+func SpanFunctions() map[string]ottl.Factory[*ottlspan.TransformContext] {
+	functions := ottlfuncs.StandardFuncs[*ottlspan.TransformContext]()
 
 	spanFunctions := ottl.CreateFactoryMap(
-		ottlfuncs.NewIsRootSpanFactory(),
+		ottlfuncs.NewIsRootSpanFactoryNew(),
 		NewSetSemconvSpanNameFactory(),
 	)
 

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func Test_SpanFunctions(t *testing.T) {
-	expected := ottlfuncs.StandardFuncs[ottlspan.TransformContext]()
-	expected["IsRootSpan"] = ottlfuncs.NewIsRootSpanFactory()
+	expected := ottlfuncs.StandardFuncs[*ottlspan.TransformContext]()
+	expected["IsRootSpan"] = ottlfuncs.NewIsRootSpanFactoryNew()
 	expected["set_semconv_span_name"] = NewSetSemconvSpanNameFactory()
 
 	actual := SpanFunctions()

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -22,7 +22,7 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, spanFunctions map[string]ottl.Factory[ottlspan.TransformContext], spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]) (*Processor, error) {
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, spanFunctions map[string]ottl.Factory[*ottlspan.TransformContext], spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]) (*Processor, error) {
 	pc, err := common.NewTraceParserCollection(settings, common.WithSpanParser(spanFunctions), common.WithSpanEventParser(spanEventFunctions), common.WithTraceErrorMode(errorMode))
 	if err != nil {
 		return nil, err

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -1421,7 +1421,7 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 		name               string
 		statements         []common.ContextStatements
 		wantErrorWith      string
-		spanFunctions      map[string]ottl.Factory[ottlspan.TransformContext]
+		spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
 		spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
 	}
 
@@ -1434,9 +1434,9 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestSpanFunc())`},
 				},
 			},
-			spanFunctions: map[string]ottl.Factory[ottlspan.TransformContext]{
+			spanFunctions: map[string]ottl.Factory[*ottlspan.TransformContext]{
 				"set":          DefaultSpanFunctions["set"],
-				"TestSpanFunc": NewTestSpanFuncFactory[ottlspan.TransformContext](),
+				"TestSpanFunc": NewTestSpanFuncFactory[*ottlspan.TransformContext](),
 			},
 			spanEventFunctions: DefaultSpanEventFunctions,
 		},
@@ -1531,6 +1531,8 @@ func BenchmarkTwoSpans(b *testing.B) {
 
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
 			processor, err := NewProcessor([]common.ContextStatements{{Context: "span", Statements: tt.statements}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
 			require.NoError(b, err)
 			b.ResetTimer()
@@ -1582,6 +1584,25 @@ func BenchmarkHundredSpans(b *testing.B) {
 				require.NoError(b, err)
 			}
 		})
+	}
+}
+
+// Benchmark that do not re-allocate data and does not change data to measure only overhead of calling the ottl framework.
+func BenchmarkSetName(b *testing.B) {
+	processor, err := NewProcessor([]common.ContextStatements{{
+		Context:    "span",
+		Statements: []string{`set(name, "operationA") where name == "operationA"`},
+	}}, ottl.IgnoreError, componenttest.NewNopTelemetrySettings(), DefaultSpanFunctions, DefaultSpanEventFunctions)
+	require.NoError(b, err)
+
+	td := constructTraces()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err = processor.ProcessTraces(b.Context(), td)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR changes only the `ottlspan.TransformContext`, if gets approved will file separate PRs for all contexts.
* In OTTL Expr and Getter/Setter the TransformContext is no longer pass as value avoiding a copy of 12 words (96B) every time an Expr/Getter/Setter of even simple Get* on the context itself funcs are called.
* Avoid allocating a new pcommon.Map every time, very costly when is not needed.

Comparing existing benchmarks:

**Before:**
```
BenchmarkTwoSpans
BenchmarkTwoSpans/no_processing
BenchmarkTwoSpans/no_processing-12         	  841123	      1327 ns/op	    2592 B/op	      46 allocs/op
BenchmarkTwoSpans/set_attribute
BenchmarkTwoSpans/set_attribute-12         	  743674	      1600 ns/op	    2640 B/op	      49 allocs/op
BenchmarkTwoSpans/keep_keys_attribute
BenchmarkTwoSpans/keep_keys_attribute-12   	  715513	      1685 ns/op	    2656 B/op	      50 allocs/op
BenchmarkTwoSpans/no_match
BenchmarkTwoSpans/no_match-12              	  702061	      1554 ns/op	    2624 B/op	      48 allocs/op
BenchmarkTwoSpans/inner_field
BenchmarkTwoSpans/inner_field-12           	  721738	      1621 ns/op	    2624 B/op	      48 allocs/op
BenchmarkTwoSpans/inner_field_both_spans
BenchmarkTwoSpans/inner_field_both_spans-12         	  716055	      1713 ns/op	    2656 B/op	      50 allocs/op
```

**After:**
```
BenchmarkTwoSpans
BenchmarkTwoSpans/no_processing
BenchmarkTwoSpans/no_processing-12         	 1000000	      1244 ns/op	    2337 B/op	      40 allocs/op
BenchmarkTwoSpans/set_attribute
BenchmarkTwoSpans/set_attribute-12         	  885855	      1369 ns/op	    2385 B/op	      43 allocs/op
BenchmarkTwoSpans/keep_keys_attribute
BenchmarkTwoSpans/keep_keys_attribute-12   	  812374	      1448 ns/op	    2401 B/op	      44 allocs/op
BenchmarkTwoSpans/no_match
BenchmarkTwoSpans/no_match-12              	  886906	      1331 ns/op	    2369 B/op	      42 allocs/op
BenchmarkTwoSpans/inner_field
BenchmarkTwoSpans/inner_field-12           	  871096	      1374 ns/op	    2369 B/op	      42 allocs/op
BenchmarkTwoSpans/inner_field_both_spans
BenchmarkTwoSpans/inner_field_both_spans-12         	  866323	      1417 ns/op	    2401 B/op	      44 allocs/op
```

Comparing benchmarks that do not need to allocate the data again every iteration and does not change the data to measure only the OTTL overhead:

**Before:**
```
BenchmarkSetName
BenchmarkSetName-12    	 9204532	       122.0 ns/op	      32 B/op	       2 allocs/op
```

**After:**
```
BenchmarkSetName
BenchmarkSetName-12    	 3745602	       305.7 ns/op	     288 B/op	       8 allocs/op
```

For the current performance benchmarks which are not allocating new TransformContext, here only benefit is because of the object copy part:

**Before:**
```
BenchmarkStatementSequenceExecuteSpans
BenchmarkStatementSequenceExecuteSpans/small
BenchmarkStatementSequenceExecuteSpans/small-12         	 1000000	      1004 ns/op	     264 B/op	      16 allocs/op
BenchmarkStatementSequenceExecuteSpans/medium
BenchmarkStatementSequenceExecuteSpans/medium-12        	  189889	      6194 ns/op	    1464 B/op	      86 allocs/op
BenchmarkStatementSequenceExecuteSpans/large
BenchmarkStatementSequenceExecuteSpans/large-12         	   29114	     39433 ns/op	    6000 B/op	     350 allocs/op
```

**After:**
```
BenchmarkStatementSequenceExecuteSpans
BenchmarkStatementSequenceExecuteSpans/small
BenchmarkStatementSequenceExecuteSpans/small-12         	 1915495	       603.9 ns/op	     264 B/op	      16 allocs/op
BenchmarkStatementSequenceExecuteSpans/medium
BenchmarkStatementSequenceExecuteSpans/medium-12        	  279411	      4292 ns/op	    1464 B/op	      86 allocs/op
BenchmarkStatementSequenceExecuteSpans/large
BenchmarkStatementSequenceExecuteSpans/large-12         	   34627	     34848 ns/op	    6000 B/op	     350 allocs/op
```
