### PR TITLE
[exporter/googlecloudpubsub] Add encoding extension support

### DIFF
--- a/.chloggen/googlecloudpubsub-exporter-support-encoding.yaml
+++ b/.chloggen/googlecloudpubsub-exporter-support-encoding.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add encoding extension support
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42270,41834]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Add encoding extension support for the payload on Pub/Sub. As having custom extensions means the Pub/Sub attributes
+  cannot be auto discovered additional functionality has been added to set the message attributes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/googlecloudpubsubexporter/README.md
+++ b/exporter/googlecloudpubsubexporter/README.md
@@ -30,7 +30,7 @@ The following configuration options are supported:
   drift is set to 0, the maximum drift from the clock is allowed (only applicable to `earliest`).
 * `endpoint` (Optional): Override the default Pubsub Endpoint, useful when connecting to the PubSub emulator instance
   or switching between [global and regional service endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints).
-* `insecure` (Optional): allows performing “insecure” SSL connections and transfers, useful when connecting to a local
+* `insecure` (Optional): Allows performing “insecure” SSL connections and transfers, useful when connecting to a local
   emulator instance. Only has effect if Endpoint is not ""
 * `ordering`: Configures the [PubSub ordering](https://cloud.google.com/pubsub/docs/ordering) feature, see 
   [ordering](#ordering) section for more info.
@@ -40,6 +40,11 @@ The following configuration options are supported:
     ordered for this resource.
   * `remove_resource_attribute` (default = `false`): if the ordering key resource attribute specified 
     `from_resource_attribute` should be removed from the resource attributes.
+* `traces`, `metrics` and `logs` (Optional): Allows overriding the standard OTLP Protobuf 
+  [encoding and the message attributes](#encoding-and-message-attributes). 
+  attributes.
+  * `encoding` (Optional): An encoding extension, if not specified it uses the default Protobuf marshaller.
+  * `attributes` (Optional): Attributes that will be added to the Pub/Sub message. 
 
 ```yaml
 exporters:
@@ -160,3 +165,34 @@ for more details.
 
 PubSub requires one publish request per ordering key value, so this exporter groups the signals per ordering key before 
 publishing.
+
+## Encoding and message attributes
+
+The `traces`, `metrics` and `logs` section allows you to specify Encoding Extensions for marshalling the messages on
+the topic and the attributes on the Pub/Sub message. All the signals have the same config options.
+
+It's important to note that when you use an extension all the CloudEvent attributes are removed as you use your own
+encoder as the exporter can't know what valute to set. You have the opportunity to manually set them.
+
+```yaml
+extensions:
+  otlp_encoding:
+    protocol: otlp_json
+
+exporters:
+  googlecloudpubsub:
+    project: my-project
+    topic: projects/my-project/topics/otlp-traces
+    traces:
+      encoding: otlp_encoding
+      attributes:
+        "ce-type": "org.opentelemetry.otlp.traces.v1"
+        "content-type": "application/json"
+```
+
+The `encoding` option allows you to specify Encoding Extensions for marshalling the messages on the topic. An
+extension need to be configured in the `extensions` section, and added to pipeline in the collectors configuration file.
+
+The `attributes` option allows you to set any attributes, the values are key/value pairs. You can avoid the removal of
+CloudEvent attributes if you manually specify the `ce-type` and `content-type` to an appropriate value for the chosen
+encoding.

--- a/exporter/googlecloudpubsubexporter/config.go
+++ b/exporter/googlecloudpubsubexporter/config.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/multierr"
@@ -38,6 +39,12 @@ type Config struct {
 	Watermark WatermarkConfig `mapstructure:"watermark"`
 	// Ordering configures the ordering keys
 	Ordering OrderingConfig `mapstructure:"ordering"`
+	// LogsSignalConfig allows for custom log configuration
+	LogsSignalConfig SignalConfig `mapstructure:"logs"`
+	// MetricsSignalConfig allows for custom log configuration
+	MetricsSignalConfig SignalConfig `mapstructure:"metrics"`
+	// TracesSignalConfig allows for custom log configuration
+	TracesSignalConfig SignalConfig `mapstructure:"traces"`
 }
 
 // WatermarkConfig customizes the behavior of the watermark
@@ -58,6 +65,14 @@ type OrderingConfig struct {
 	FromResourceAttribute string `mapstructure:"from_resource_attribute"`
 	// RemoveResourceAttribute indicates if the ordering key should be removed from the resource attributes.
 	RemoveResourceAttribute bool `mapstructure:"remove_resource_attribute"`
+}
+
+// SignalConfig holds signal-specific configuration for the Kafka exporter.
+type SignalConfig struct {
+	// Encoding is a custom encoding for the marshaling the data onto the message
+	Encoding component.ID `mapstructure:"encoding"`
+	// Attributes are custom Pub/Sub message attributes
+	Attributes map[string]string `mapstructure:"attributes"`
 }
 
 func (config *Config) Validate() error {

--- a/exporter/googlecloudpubsubexporter/exporter.go
+++ b/exporter/googlecloudpubsubexporter/exporter.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 )
 
 type pubsubExporter struct {
@@ -28,10 +30,13 @@ type pubsubExporter struct {
 	ceCompression        compression
 	config               *Config
 	tracesMarshaler      ptrace.Marshaler
+	tracesAttributes     map[string]string
 	tracesWatermarkFunc  tracesWatermarkFunc
 	metricsMarshaler     pmetric.Marshaler
+	metricsAttributes    map[string]string
 	metricsWatermarkFunc metricsWatermarkFunc
 	logsMarshaler        plog.Marshaler
+	logsAttributes       map[string]string
 	logsWatermarkFunc    logsWatermarkFunc
 
 	// To be overridden in tests
@@ -39,12 +44,12 @@ type pubsubExporter struct {
 	makeClient func(ctx context.Context, cfg *Config, userAgent string) (publisherClient, error)
 }
 
-type encoding int
+type signal int
 
 const (
-	otlpProtoTrace  encoding = iota
-	otlpProtoMetric          = iota
-	otlpProtoLog             = iota
+	signalTrace  signal = iota
+	signalMetric        = iota
+	signalLog           = iota
 )
 
 type compression int
@@ -61,16 +66,27 @@ const (
 	earliest                   = iota
 )
 
-func (ex *pubsubExporter) start(ctx context.Context, _ component.Host) error {
+func (ex *pubsubExporter) start(ctx context.Context, host component.Host) error {
 	ctx, ex.cancel = context.WithCancel(ctx)
+	var err error
+	err = ex.initTraces(host)
+	if err != nil {
+		return err
+	}
+	err = ex.initMetrics(host)
+	if err != nil {
+		return err
+	}
+	err = ex.initLogs(host)
+	if err != nil {
+		return err
+	}
 
 	if ex.client == nil {
-		client, err := ex.makeClient(ctx, ex.config, ex.userAgent)
+		ex.client, err = ex.makeClient(ctx, ex.config, ex.userAgent)
 		if err != nil {
 			return fmt.Errorf("failed creating the gRPC client to Pubsub: %w", err)
 		}
-
-		ex.client = client
 	}
 	return nil
 }
@@ -85,37 +101,140 @@ func (ex *pubsubExporter) shutdown(_ context.Context) error {
 	return client.Close()
 }
 
-func (ex *pubsubExporter) getMessageAttributes(encoding encoding, watermark time.Time) (map[string]string, error) {
-	id, err := ex.makeUUID()
-	if err != nil {
-		return nil, err
+func (ex *pubsubExporter) initTraces(host component.Host) error {
+	var err error
+	signalConfig := ex.config.TracesSignalConfig
+	if signalConfig.Encoding.String() != "" {
+		err = ex.setTracesMarshalerFromExtension(host, signalConfig.Encoding)
+		if err != nil {
+			return err
+		}
+	} else {
+		ex.tracesMarshaler = &ptrace.ProtoMarshaler{}
+		ex.tracesAttributes["ce-type"] = "org.opentelemetry.otlp.traces.v1"
+		ex.tracesAttributes["content-type"] = "application/protobuf"
 	}
-	ceTime, err := watermark.MarshalText()
-	if err != nil {
-		return nil, err
+	if len(signalConfig.Attributes) > 0 {
+		for k, v := range signalConfig.Attributes {
+			ex.tracesAttributes[k] = v
+		}
 	}
+	return nil
+}
 
-	attributes := map[string]string{
-		"ce-specversion": "1.0",
-		"ce-id":          id.String(),
-		"ce-source":      ex.ceSource,
-		"ce-time":        string(ceTime),
+func (ex *pubsubExporter) initMetrics(host component.Host) error {
+	var err error
+	signalConfig := ex.config.MetricsSignalConfig
+	if signalConfig.Encoding.String() != "" {
+		err = ex.setMetricsMarshalerFromExtension(host, signalConfig.Encoding)
+		if err != nil {
+			return err
+		}
+	} else {
+		ex.metricsMarshaler = &pmetric.ProtoMarshaler{}
+		ex.metricsAttributes["ce-type"] = "org.opentelemetry.otlp.metrics.v1"
+		ex.metricsAttributes["content-type"] = "application/protobuf"
 	}
-	switch encoding {
-	case otlpProtoTrace:
-		attributes["ce-type"] = "org.opentelemetry.otlp.traces.v1"
-		attributes["content-type"] = "application/protobuf"
-	case otlpProtoMetric:
-		attributes["ce-type"] = "org.opentelemetry.otlp.metrics.v1"
-		attributes["content-type"] = "application/protobuf"
-	case otlpProtoLog:
-		attributes["ce-type"] = "org.opentelemetry.otlp.logs.v1"
-		attributes["content-type"] = "application/protobuf"
+	if len(signalConfig.Attributes) > 0 {
+		for k, v := range signalConfig.Attributes {
+			ex.metricsAttributes[k] = v
+		}
 	}
-	if ex.ceCompression == gZip {
-		attributes["content-encoding"] = "gzip"
+	return nil
+}
+
+func (ex *pubsubExporter) initLogs(host component.Host) error {
+	var err error
+	signalConfig := ex.config.LogsSignalConfig
+	if signalConfig.Encoding.String() != "" {
+		err = ex.setLogsMarshalerFromExtension(host, signalConfig.Encoding)
+		if err != nil {
+			return err
+		}
+	} else {
+		ex.logsMarshaler = &plog.ProtoMarshaler{}
+		ex.logsAttributes["ce-type"] = "org.opentelemetry.otlp.logs.v1"
+		ex.logsAttributes["content-type"] = "application/protobuf"
 	}
-	return attributes, err
+	if len(signalConfig.Attributes) > 0 {
+		for k, v := range signalConfig.Attributes {
+			ex.logsAttributes[k] = v
+		}
+	}
+	return nil
+}
+
+func (ex *pubsubExporter) setTracesMarshalerFromExtension(host component.Host, extensionID component.ID) error {
+	extensions := host.GetExtensions()
+	if extension, ok := extensions[extensionID]; ok {
+		ex.tracesMarshaler, ok = extension.(encoding.TracesMarshalerExtension)
+		if !ok {
+			return fmt.Errorf("cannot start receiver: extension %q is not a trace unmarshaler", extensionID)
+		}
+	} else {
+		return fmt.Errorf("cannot start receiver: extension %q not found for traces", extensionID)
+	}
+	return nil
+}
+
+func (ex *pubsubExporter) setMetricsMarshalerFromExtension(host component.Host, extensionID component.ID) error {
+	extensions := host.GetExtensions()
+	if extension, ok := extensions[extensionID]; ok {
+		ex.metricsMarshaler, ok = extension.(encoding.MetricsMarshalerExtension)
+		if !ok {
+			return fmt.Errorf("cannot start receiver: extension %q is not a metric unmarshaler", extensionID)
+		}
+	} else {
+		return fmt.Errorf("cannot start receiver: extension %q not found for metrics", extensionID)
+	}
+	return nil
+}
+
+func (ex *pubsubExporter) setLogsMarshalerFromExtension(host component.Host, extensionID component.ID) error {
+	extensions := host.GetExtensions()
+	if extension, ok := extensions[extensionID]; ok {
+		ex.logsMarshaler, ok = extension.(encoding.LogsMarshalerExtension)
+		if !ok {
+			return fmt.Errorf("cannot start receiver: extension %q is not a log unmarshaler", extensionID)
+		}
+	} else {
+		return fmt.Errorf("cannot start receiver: extension %q not found for logs", extensionID)
+	}
+	return nil
+}
+
+func (ex *pubsubExporter) getMessageAttributes(signal signal, watermark time.Time) (map[string]string, error) {
+	attributes := map[string]string{}
+	var source map[string]string
+	switch signal {
+	case signalTrace:
+		source = ex.tracesAttributes
+	case signalMetric:
+		source = ex.metricsAttributes
+	case signalLog:
+		source = ex.logsAttributes
+	}
+	for k, v := range source {
+		attributes[k] = v
+	}
+	if attributes["ce-type"] != "" {
+		id, err := ex.makeUUID()
+		if err != nil {
+			return nil, err
+		}
+		ceTime, err := watermark.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+		attributes["ce-specversion"] = "1.0"
+		attributes["ce-id"] = id.String()
+		attributes["ce-source"] = ex.ceSource
+		attributes["ce-time"] = string(ceTime)
+		if ex.ceCompression == gZip {
+			attributes["content-encoding"] = "gzip"
+		}
+	}
+	return attributes, nil
 }
 
 func (ex *pubsubExporter) consumeTraces(ctx context.Context, traces ptrace.Traces) error {
@@ -160,7 +279,7 @@ func (ex *pubsubExporter) consumeTraces(ctx context.Context, traces ptrace.Trace
 
 func (ex *pubsubExporter) publishTraces(ctx context.Context, tracesForKey ptrace.Traces, orderingKey string) error {
 	watermark := ex.tracesWatermarkFunc(tracesForKey, time.Now(), ex.config.Watermark.AllowedDrift).UTC()
-	attributes, attributesErr := ex.getMessageAttributes(otlpProtoTrace, watermark)
+	attributes, attributesErr := ex.getMessageAttributes(signalTrace, watermark)
 	if attributesErr != nil {
 		return fmt.Errorf("error while preparing pubsub message attributes: %w", attributesErr)
 	}
@@ -215,7 +334,7 @@ func (ex *pubsubExporter) consumeMetrics(ctx context.Context, metrics pmetric.Me
 
 func (ex *pubsubExporter) publishMetrics(ctx context.Context, metricsForKey pmetric.Metrics, orderingKey string) error {
 	watermark := ex.metricsWatermarkFunc(metricsForKey, time.Now(), ex.config.Watermark.AllowedDrift).UTC()
-	attributes, attributesErr := ex.getMessageAttributes(otlpProtoMetric, watermark)
+	attributes, attributesErr := ex.getMessageAttributes(signalMetric, watermark)
 	if attributesErr != nil {
 		return fmt.Errorf("error while preparing pubsub message attributes: %w", attributesErr)
 	}
@@ -272,7 +391,7 @@ func (ex *pubsubExporter) consumeLogs(ctx context.Context, logs plog.Logs) error
 
 func (ex *pubsubExporter) publishLogs(ctx context.Context, logs plog.Logs, orderingKey string) error {
 	watermark := ex.logsWatermarkFunc(logs, time.Now(), ex.config.Watermark.AllowedDrift).UTC()
-	attributes, attributesErr := ex.getMessageAttributes(otlpProtoLog, watermark)
+	attributes, attributesErr := ex.getMessageAttributes(signalLog, watermark)
 	if attributesErr != nil {
 		return fmt.Errorf("error while preparing pubsub message attributes: %w", attributesErr)
 	}

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -45,15 +45,18 @@ func ensureExporter(params exporter.Settings, pCfg *Config) *pubsubExporter {
 		return exp
 	}
 	exp = &pubsubExporter{
-		logger:           params.Logger,
-		userAgent:        strings.ReplaceAll(pCfg.UserAgent, "{{version}}", params.BuildInfo.Version),
-		ceSource:         fmt.Sprintf("/opentelemetry/collector/%s/%s", metadata.Type.String(), params.BuildInfo.Version),
-		config:           pCfg,
-		tracesMarshaler:  &ptrace.ProtoMarshaler{},
-		metricsMarshaler: &pmetric.ProtoMarshaler{},
-		logsMarshaler:    &plog.ProtoMarshaler{},
-		makeUUID:         uuid.NewRandom,
-		makeClient:       newPublisherClient,
+		logger:            params.Logger,
+		userAgent:         strings.ReplaceAll(pCfg.UserAgent, "{{version}}", params.BuildInfo.Version),
+		ceSource:          fmt.Sprintf("/opentelemetry/collector/%s/%s", metadata.Type.String(), params.BuildInfo.Version),
+		config:            pCfg,
+		tracesMarshaler:   &ptrace.ProtoMarshaler{},
+		tracesAttributes:  map[string]string{},
+		metricsMarshaler:  &pmetric.ProtoMarshaler{},
+		metricsAttributes: map[string]string{},
+		logsMarshaler:     &plog.ProtoMarshaler{},
+		logsAttributes:    map[string]string{},
+		makeUUID:          uuid.NewRandom,
+		makeClient:        newPublisherClient,
 	}
 	// we ignore the error here as the config is already validated with the same method
 	exp.ceCompression, _ = pCfg.parseCompression()

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub/v2 v2.3.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.15.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.140.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.46.1-0.20251120204106-2e9c82787618
 	go.opentelemetry.io/collector/component/componenttest v0.140.1-0.20251120204106-2e9c82787618
@@ -29,7 +30,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -46,7 +47,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/client v1.46.1-0.20251120204106-2e9c82787618 // indirect
 	go.opentelemetry.io/collector/config/configoptional v1.46.1-0.20251120204106-2e9c82787618 // indirect
@@ -91,3 +92,5 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding => ../../extension/encoding

--- a/exporter/googlecloudpubsubexporter/go.sum
+++ b/exporter/googlecloudpubsubexporter/go.sum
@@ -13,8 +13,9 @@ github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F9
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f h1:Y8xYupdHxryycyPlc9Y+bSQAYZnetRJ70VMVKm5CKI0=
 github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f/go.mod h1:HlzOvOjVBOfTGSRXRyY0OiCS/3J1akRGQQpRO/7zyF4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.13.5-0.20251024222203-75eaa193e329 h1:K+fnvUM0VZ7ZFJf0n4L/BRlnsb9pL/GuDG6FqaH+PwM=
 github.com/envoyproxy/go-control-plane/envoy v1.35.0 h1:ixjkELDE+ru6idPxcHLj8LBVc2bFP7iBytj353BoHUo=
 github.com/envoyproxy/go-control-plane/envoy v1.35.0/go.mod h1:09qwbGVuSWWAyN5t/b3iyVfz5+z8QWGrzkoqm/8SbEs=
@@ -70,8 +71,9 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
#### Description
Add encoding extension support for the payload on Pub/Sub. As having custom extensions means 
the Pub/Sub attributes cannot be auto discovered additional functionality has been added to set the
message attributes.

#### Link to tracking issue
Fixes
* https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42270
* https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41834

#### Testing
Added new test testing the new functionality. Also tested end-to-end (with the pub/sub receiver)

#### Documentation
Added section in the README.md describing the extra functionality and options in the config
