### PR TITLE
[chore][processor/groupbytrace] fix flaky TestEventShutdown

### DIFF
--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -425,6 +425,9 @@ func TestEventShutdown(t *testing.T) {
 	// verify
 	assert.Equal(t, int64(1), traceReceivedFired.Load())
 
+	// wait until the shutdown has returned
+	shutdownWg.Wait()
+
 	// If the code is wrong, there's a chance that the test will still pass
 	// in case the event is processed after the assertion.
 	// Verify that the expired event is not processed (should remain 0)
@@ -432,9 +435,6 @@ func TestEventShutdown(t *testing.T) {
 		return traceExpiredFired.Load() == 0
 	}, 100*time.Millisecond, 5*time.Millisecond)
 	assert.Equal(t, int64(0), traceExpiredFired.Load())
-
-	// wait until the shutdown has returned
-	shutdownWg.Wait()
 }
 
 func TestPeriodicMetrics(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

We should wait for the shutdown call to return before checking for expired events, because the shutdown goroutine might not be able to acquire the lock in a timely manner.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44533
