### PR TITLE
[chore] [exporter/elasticsearch] fix integration tests

### DIFF
--- a/exporter/elasticsearchexporter/integrationtest/collector.go
+++ b/exporter/elasticsearchexporter/integrationtest/collector.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
@@ -148,6 +149,7 @@ func newRecreatableOtelCol(tb testing.TB) *recreatableOtelCol {
 		debugexporter.NewFactory(),
 	)
 	require.NoError(tb, err)
+	factories.Telemetry = otelconftelemetry.NewFactory()
 	return &recreatableOtelCol{
 		tempDir:   testutil.TempDir(tb),
 		factories: factories,

--- a/exporter/elasticsearchexporter/integrationtest/go.mod
+++ b/exporter/elasticsearchexporter/integrationtest/go.mod
@@ -29,6 +29,7 @@ require (
 	go.opentelemetry.io/collector/receiver v1.46.1-0.20251120204106-2e9c82787618
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.140.1-0.20251120204106-2e9c82787618
 	go.opentelemetry.io/collector/receiver/receivertest v0.140.1-0.20251120204106-2e9c82787618
+	go.opentelemetry.io/collector/service v0.140.1-0.20251120204106-2e9c82787618
 	go.uber.org/zap v1.27.1
 	golang.org/x/sync v0.18.0
 )
@@ -207,7 +208,6 @@ require (
 	go.opentelemetry.io/collector/processor/xprocessor v0.140.1-0.20251120204106-2e9c82787618 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.140.1-0.20251120204106-2e9c82787618 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.140.1-0.20251120204106-2e9c82787618 // indirect
-	go.opentelemetry.io/collector/service v0.140.1-0.20251120204106-2e9c82787618 // indirect
 	go.opentelemetry.io/collector/service/hostcapabilities v0.140.1-0.20251120204106-2e9c82787618 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.13.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect


### PR DESCRIPTION
#### Description

The integration tests are broken, because they use otelcol but are not supplying a telemetry factory.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44311

#### Testing

Tests pass locally, and are actually sending non-zero workload now.

#### Documentation

N/A