### PR TITLE
[feat][processor/k8sattributes]: retrieve only metadata for replicasets

### DIFF
--- a/.chloggen/poc.yaml
+++ b/.chloggen/poc.yaml
@@ -1,0 +1,26 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+  enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component:
+  processor/k8sattributes
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "ReplicaSet handling now supports PartialObjectMetadata, reducing cold-start memory/time compared to typed informers."
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44407]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: In in-process cold-start benchmarks (no API server), PartialObjectMetadata reduced memory by ~57–59%, exact impact depends on cluster size and selectors.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/poc.yaml
+++ b/.chloggen/poc.yaml
@@ -5,7 +5,7 @@ change_type:
   enhancement
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component:
-  processor/k8sattributes
+  processor/k8s_attributes
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "ReplicaSet handling now supports PartialObjectMetadata, reducing cold-start memory/time compared to typed informers."
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
+	clientmeta "k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 
 	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
@@ -39,6 +40,7 @@ type WatchClient struct {
 	deleteMut              sync.Mutex
 	logger                 *zap.Logger
 	kc                     kubernetes.Interface
+	mc                     clientmeta.Interface
 	informer               cache.SharedInformer
 	namespaceInformer      cache.SharedInformer
 	nodeInformer           cache.SharedInformer
@@ -130,6 +132,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
+
 	c := &WatchClient{
 		logger:                 set.Logger,
 		Rules:                  rules,
@@ -152,15 +155,16 @@ func New(
 	c.StatefulSets = map[string]*StatefulSet{}
 	c.DaemonSets = map[string]*DaemonSet{}
 	c.Jobs = map[string]*Job{}
-	if newClientSet == nil {
-		newClientSet = k8sconfig.MakeClient
-	}
 
-	kc, err := newClientSet(apiCfg)
+	if newClientSet == nil {
+		newClientSet = k8sconfig.MakeClientBundle
+	}
+	bundle, err := newClientSet(apiCfg)
 	if err != nil {
 		return nil, err
 	}
-	c.kc = kc
+	c.kc = bundle.K8s
+	c.mc = bundle.Meta
 
 	labelSelector, fieldSelector, err := selectorsFromFilters(c.Filters)
 	if err != nil {
@@ -211,19 +215,10 @@ func New(
 		if informersFactory.newReplicaSetInformer == nil {
 			informersFactory.newReplicaSetInformer = newReplicaSetSharedInformer
 		}
-		c.replicasetInformer = informersFactory.newReplicaSetInformer(c.kc, c.Filters.Namespace)
-		err = c.replicasetInformer.SetTransform(
-			func(object any) (any, error) {
-				originalReplicaset, success := object.(*apps_v1.ReplicaSet)
-				if !success { // means this is a cache.DeletedFinalStateUnknown, in which case we do nothing
-					return object, nil
-				}
 
-				return removeUnnecessaryReplicaSetData(originalReplicaset), nil
-			},
-		)
-		if err != nil {
-			return nil, err
+		c.replicasetInformer = informersFactory.newReplicaSetInformer(c.mc, c.Filters.Namespace)
+		if c.replicasetInformer == nil {
+			return nil, errors.New("failed to create ReplicaSet informer")
 		}
 	}
 
@@ -246,7 +241,6 @@ func New(
 	if c.extractJobLabelsAnnotations() || rules.CronJobUID {
 		c.jobInformer = newJobSharedInformer(c.kc, c.Filters.Namespace)
 	}
-
 	return c, err
 }
 
@@ -948,6 +942,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 						}
 					}
 				}
+
 			case "DaemonSet":
 				if c.Rules.DaemonSetUID {
 					tags[string(conventions.K8SDaemonSetUIDKey)] = string(ref.UID)
@@ -1876,11 +1871,12 @@ func (c *WatchClient) handleReplicaSetAdd(obj any) {
 	if metadata.ProcessorK8sattributesTelemetryEnableNewFormatMetricsFeatureGate.IsEnabled() {
 		c.telemetryBuilder.K8sWatcherReplicasetAdded.Add(context.Background(), 1)
 	}
-	if replicaset, ok := obj.(*apps_v1.ReplicaSet); ok {
-		c.addOrUpdateReplicaSet(replicaset)
-	} else {
-		c.logger.Error("object received was not of type apps_v1.ReplicaSet", zap.Any("received", obj))
+	rsMeta, ok := obj.(*meta_v1.PartialObjectMetadata)
+	if !ok {
+		c.logger.Error("object received was not PartialObjectMetadata for ReplicaSet add", zap.Any("received", obj))
+		return
 	}
+	c.addOrUpdateReplicaSet(rsMeta)
 }
 
 func (c *WatchClient) handleReplicaSetUpdate(_, newRS any) {
@@ -1890,11 +1886,12 @@ func (c *WatchClient) handleReplicaSetUpdate(_, newRS any) {
 	if metadata.ProcessorK8sattributesTelemetryEnableNewFormatMetricsFeatureGate.IsEnabled() {
 		c.telemetryBuilder.K8sWatcherReplicasetUpdated.Add(context.Background(), 1)
 	}
-	if replicaset, ok := newRS.(*apps_v1.ReplicaSet); ok {
-		c.addOrUpdateReplicaSet(replicaset)
-	} else {
-		c.logger.Error("object received was not of type apps_v1.ReplicaSet", zap.Any("received", newRS))
+	rsMeta, ok := newRS.(*meta_v1.PartialObjectMetadata)
+	if !ok {
+		c.logger.Error("object received was not PartialObjectMetadata for ReplicaSet add", zap.Any("received", newRS))
+		return
 	}
+	c.addOrUpdateReplicaSet(rsMeta)
 }
 
 func (c *WatchClient) handleReplicaSetDelete(obj any) {
@@ -1904,51 +1901,52 @@ func (c *WatchClient) handleReplicaSetDelete(obj any) {
 	if metadata.ProcessorK8sattributesTelemetryEnableNewFormatMetricsFeatureGate.IsEnabled() {
 		c.telemetryBuilder.K8sWatcherReplicasetDeleted.Add(context.Background(), 1)
 	}
-	if replicaset, ok := ignoreDeletedFinalStateUnknown(obj).(*apps_v1.ReplicaSet); ok {
-		c.m.Lock()
-		key := string(replicaset.UID)
-		delete(c.ReplicaSets, key)
-		c.m.Unlock()
-	} else {
-		c.logger.Error("object received was not of type apps_v1.ReplicaSet", zap.Any("received", obj))
+
+	// Unwrap DeletedFinalStateUnknown if present
+	o := ignoreDeletedFinalStateUnknown(obj)
+	rsMeta, ok := o.(*meta_v1.PartialObjectMetadata)
+	if !ok {
+		c.logger.Error("object received was not a ReplicaSet (apps_v1 or PartialObjectMetadata)", zap.Any("received", obj))
 	}
+	uid := string(rsMeta.GetUID())
+	if uid == "" {
+		c.logger.Warn("received ReplicaSet delete without UID")
+		return
+	}
+
+	c.m.Lock()
+	delete(c.ReplicaSets, uid)
+	c.m.Unlock()
 }
 
-func (c *WatchClient) addOrUpdateReplicaSet(replicaset *apps_v1.ReplicaSet) {
-	newReplicaSet := &ReplicaSet{
-		Name:      replicaset.Name,
-		Namespace: replicaset.Namespace,
-		UID:       string(replicaset.UID),
+func (c *WatchClient) addOrUpdateReplicaSet(obj any) {
+	rs, ok := obj.(*meta_v1.PartialObjectMetadata)
+	if !ok {
+		c.logger.Error("unexpected ReplicaSet object type", zap.Any("received", obj))
 	}
 
-	for _, ownerReference := range replicaset.OwnerReferences {
-		if ownerReference.Kind == "Deployment" && ownerReference.Controller != nil && *ownerReference.Controller {
+	uid := string(rs.GetUID())
+	newReplicaSet := &ReplicaSet{
+		Name:      rs.GetName(),
+		Namespace: rs.GetNamespace(),
+		UID:       uid,
+	}
+
+	for _, owner := range rs.GetOwnerReferences() {
+		if owner.Kind == "Deployment" && owner.Controller != nil && *owner.Controller {
 			newReplicaSet.Deployment = Deployment{
-				Name: ownerReference.Name,
-				UID:  string(ownerReference.UID),
+				Name: owner.Name,
+				UID:  string(owner.UID),
 			}
 			break
 		}
 	}
 
 	c.m.Lock()
-	if replicaset.UID != "" {
-		c.ReplicaSets[string(replicaset.UID)] = newReplicaSet
+	if uid != "" {
+		c.ReplicaSets[uid] = newReplicaSet
 	}
 	c.m.Unlock()
-}
-
-// This function removes all data from the ReplicaSet except what is required by extraction rules
-func removeUnnecessaryReplicaSetData(replicaset *apps_v1.ReplicaSet) *apps_v1.ReplicaSet {
-	transformedReplicaset := apps_v1.ReplicaSet{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      replicaset.GetName(),
-			Namespace: replicaset.GetNamespace(),
-			UID:       replicaset.GetUID(),
-		},
-	}
-	transformedReplicaset.SetOwnerReferences(replicaset.GetOwnerReferences())
-	return &transformedReplicaset
 }
 
 // runInformerWithDependencies starts the given informer. The second argument is a list of other informers that should complete

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -1919,20 +1919,15 @@ func (c *WatchClient) handleReplicaSetDelete(obj any) {
 	c.m.Unlock()
 }
 
-func (c *WatchClient) addOrUpdateReplicaSet(obj any) {
-	rs, ok := obj.(*meta_v1.PartialObjectMetadata)
-	if !ok {
-		c.logger.Error("unexpected ReplicaSet object type", zap.Any("received", obj))
-	}
-
-	uid := string(rs.GetUID())
+func (c *WatchClient) addOrUpdateReplicaSet(replicaSet *meta_v1.PartialObjectMetadata) {
+	uid := string(replicaSet.GetUID())
 	newReplicaSet := &ReplicaSet{
-		Name:      rs.GetName(),
-		Namespace: rs.GetNamespace(),
+		Name:      replicaSet.GetName(),
+		Namespace: replicaSet.GetNamespace(),
 		UID:       uid,
 	}
 
-	for _, owner := range rs.GetOwnerReferences() {
+	for _, owner := range replicaSet.GetOwnerReferences() {
 		if owner.Kind == "Deployment" && owner.Controller != nil && *owner.Controller {
 			newReplicaSet.Deployment = Deployment{
 				Name: owner.Name,

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -24,18 +24,23 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	clientmeta "k8s.io/client-go/metadata"
+	clientmetafake "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/metadata"
 )
 
-func newFakeAPIClientset(_ k8sconfig.APIConfig) (kubernetes.Interface, error) {
-	return fake.NewClientset(), nil
+func newFakeAPIClientset(_ k8sconfig.APIConfig) (k8sconfig.ClientBundle, error) {
+	kc := fake.NewClientset()
+	mc := clientmetafake.NewSimpleMetadataClient(runtime.NewScheme())
+	return k8sconfig.ClientBundle{K8s: kc, Meta: mc}, nil
 }
 
 func newPodIdentifier(from, name, value string) PodIdentifier {
@@ -198,9 +203,9 @@ func TestConstructorErrors(t *testing.T) {
 		apiCfg := k8sconfig.APIConfig{
 			AuthType: "test-auth-type",
 		}
-		clientProvider := func(c k8sconfig.APIConfig) (kubernetes.Interface, error) {
+		clientProvider := func(c k8sconfig.APIConfig) (k8sconfig.ClientBundle, error) {
 			gotAPIConfig = c
-			return nil, errors.New("error creating k8s client")
+			return k8sconfig.ClientBundle{}, errors.New("error creating k8s client")
 		}
 		factory := InformersFactoryList{
 			newInformer:          NewFakeInformer,
@@ -232,12 +237,12 @@ func TestReplicaSetHandler(t *testing.T) {
 	c, _ := newTestClient(t)
 	assert.Empty(t, c.ReplicaSets)
 
-	replicaset := &apps_v1.ReplicaSet{}
+	replicaset := &meta_v1.PartialObjectMetadata{}
 	c.handleReplicaSetAdd(replicaset)
 	assert.Empty(t, c.ReplicaSets)
 
 	// test add replicaset
-	replicaset = &apps_v1.ReplicaSet{}
+	replicaset = &meta_v1.PartialObjectMetadata{}
 	replicaset.Name = "deployment-aaa"
 	replicaset.Namespace = "namespaceA"
 	replicaset.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -685,7 +690,7 @@ func TestExtractionRules(t *testing.T) {
 	}
 
 	isController := true
-	replicaset := &apps_v1.ReplicaSet{
+	replicaset := &meta_v1.PartialObjectMetadata{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      "auth-service-66f5996c7c",
 			Namespace: "ns1",
@@ -1123,13 +1128,13 @@ func TestExtractionRules(t *testing.T) {
 			maps.Copy(podCopy.Annotations, tc.additionalAnnotations)
 			maps.Copy(podCopy.Labels, tc.additionalLabels)
 			transformedPod := removeUnnecessaryPodData(podCopy, c.Rules)
+			c.handleReplicaSetAdd(replicaset)
 
 			if tc.rules.Node || tc.rules.NodeUID {
 				assert.Equal(t, podCopy.Spec.NodeName, transformedPod.Spec.NodeName, "NodeName should be preserved when Node or NodeUID rule is enabled")
 			}
 
-			transformedReplicaset := removeUnnecessaryReplicaSetData(replicaset)
-			c.handleReplicaSetAdd(transformedReplicaset)
+			c.handleReplicaSetAdd(replicaset)
 			c.handlePodAdd(transformedPod)
 			p, ok := c.GetPod(newPodIdentifier("connection", "", podCopy.Status.PodIP))
 			require.True(t, ok)
@@ -1145,48 +1150,6 @@ func TestExtractionRules(t *testing.T) {
 }
 
 func TestReplicaSetExtractionRules(t *testing.T) {
-	c, _ := newTestClientWithRulesAndFilters(t, Filters{})
-	// Disable saving ip into k8s.pod.ip
-	c.Associations[0].Sources[0].Name = ""
-
-	pod := &api_v1.Pod{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:              "auth-service-abc12-xyz3",
-			UID:               "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-			Namespace:         "ns1",
-			CreationTimestamp: meta_v1.Now(),
-			Labels: map[string]string{
-				"label1": "lv1",
-				"label2": "k1=v1 k5=v5 extra!",
-			},
-			Annotations: map[string]string{
-				"annotation1": "av1",
-			},
-			OwnerReferences: []meta_v1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "ReplicaSet",
-					Name:       "auth-service-66f5996c7c",
-					UID:        "207ea729-c779-401d-8347-008ecbc137e3",
-				},
-			},
-		},
-		Spec: api_v1.PodSpec{
-			NodeName: "node1",
-		},
-		Status: api_v1.PodStatus{
-			PodIP: "1.1.1.1",
-		},
-	}
-
-	replicaset := &apps_v1.ReplicaSet{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      "auth-service-66f5996c7c",
-			Namespace: "ns1",
-			UID:       "207ea729-c779-401d-8347-008ecbc137e3",
-		},
-	}
-
 	isController := true
 	isNotController := false
 	testCases := []struct {
@@ -1278,14 +1241,56 @@ func TestReplicaSetExtractionRules(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c.Rules = tc.rules
-			replicaset.OwnerReferences = tc.ownerReferences
+			c, _ := newTestClientWithRulesAndFilters(t, Filters{})
+			// Disable saving ip into k8s.pod.ip
+			c.Associations[0].Sources[0].Name = ""
 
-			// manually call the data removal functions here
-			// normally the informer does this, but fully emulating the informer in this test is annoying
+			// fresh pod and replicaset per test
+			pod := &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:              "auth-service-abc12-xyz3",
+					UID:               "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					Namespace:         "ns1",
+					CreationTimestamp: meta_v1.Now(),
+					Labels: map[string]string{
+						"label1": "lv1",
+						"label2": "k1=v1 k5=v5 extra!",
+					},
+					Annotations: map[string]string{
+						"annotation1": "av1",
+					},
+					OwnerReferences: []meta_v1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "auth-service-66f5996c7c",
+							UID:        "207ea729-c779-401d-8347-008ecbc137e3",
+						},
+					},
+				},
+				Spec: api_v1.PodSpec{
+					NodeName: "node1",
+				},
+				Status: api_v1.PodStatus{
+					PodIP: "1.1.1.1",
+				},
+			}
+
+			rs := &meta_v1.PartialObjectMetadata{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      "auth-service-66f5996c7c",
+					Namespace: "ns1",
+					UID:       "207ea729-c779-401d-8347-008ecbc137e3",
+				},
+			}
+
+			// apply per-case rules and RS owner refs
+			c.Rules = tc.rules
+			rs.OwnerReferences = tc.ownerReferences
+
+			// transform and feed events
 			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
-			transformedReplicaset := removeUnnecessaryReplicaSetData(replicaset)
-			c.handleReplicaSetAdd(transformedReplicaset)
+			c.handleReplicaSetAdd(rs)
 			c.handlePodAdd(transformedPod)
 			p, ok := c.GetPod(newPodIdentifier("connection", "", pod.Status.PodIP))
 			require.True(t, ok)
@@ -3606,6 +3611,7 @@ func newTestClientWithRulesAndFilters(t *testing.T, f Filters) (*WatchClient, *o
 		newNamespaceInformer:  NewFakeNamespaceInformer,
 		newReplicaSetInformer: NewFakeReplicaSetInformer,
 	}
+
 	c, err := New(set, k8sconfig.APIConfig{}, ExtractionRules{}, f, associations, exclude, newFakeAPIClientset, factory, false, 10*time.Second)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
@@ -4152,9 +4158,9 @@ func (i *trackableInformer) hasRun() bool {
 	return i.runCalled
 }
 
-func newTrackableInformer(client kubernetes.Interface, namespace string, labelSelector labels.Selector, fieldSelector fields.Selector) cache.SharedInformer {
+func newTrackableInformer(client clientmeta.Interface, namespace string) cache.SharedInformer {
 	return &trackableInformer{
-		SharedInformer: NewFakeInformer(client, namespace, labelSelector, fieldSelector),
+		SharedInformer: NewFakeReplicaSetInformer(client, namespace),
 	}
 }
 
@@ -4194,11 +4200,9 @@ func TestReplicaSetInformerConditionalStart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := InformersFactoryList{
-				newInformer:          NewFakeInformer,
-				newNamespaceInformer: NewFakeNamespaceInformer,
-				newReplicaSetInformer: func(kc kubernetes.Interface, ns string) cache.SharedInformer {
-					return newTrackableInformer(kc, ns, labels.Everything(), fields.Everything())
-				},
+				newInformer:           NewFakeInformer,
+				newNamespaceInformer:  NewFakeNamespaceInformer,
+				newReplicaSetInformer: newTrackableInformer,
 			}
 
 			c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, tt.rules, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, factory, false, 10*time.Second)
@@ -4554,9 +4558,7 @@ func TestHandleDaemonSetDelete(t *testing.T) {
 			Namespace: "default",
 			UID:       "daemonset-uid-123",
 		},
-	}
-
-	// Add daemonset
+	} // Add daemonset
 	c.handleDaemonSetAdd(daemonset)
 	assert.Len(t, c.DaemonSets, 1)
 
@@ -4625,4 +4627,61 @@ func TestHandleJobDelete(t *testing.T) {
 	_, ok := c.GetJob(string(job.UID))
 	assert.False(t, ok)
 	assert.Empty(t, c.Jobs)
+}
+
+func TestCreateRestConfigFailure(t *testing.T) {
+	// Simulate a failure in CreateRestConfig by returning nil for the informer
+	factory := InformersFactoryList{
+		newReplicaSetInformer: func(_ clientmeta.Interface, _ string) cache.SharedInformer {
+			return nil // Simulate failure
+		},
+	}
+
+	// Set a rule to enable deployment monitoring
+	rules := ExtractionRules{
+		DeploymentName: true, // This ensures that the replicasetInformer is created
+	}
+
+	c, err := New(
+		componenttest.NewNopTelemetrySettings(),
+		k8sconfig.APIConfig{}, // Invalid API config
+		rules,                 // Pass the rules for deployment monitoring
+		Filters{},
+		[]Association{},
+		Excludes{},
+		newFakeAPIClientset,
+		factory,
+		false,
+		10*time.Second,
+	)
+
+	// Assert that the client is nil and an error is returned
+	assert.Nil(t, c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create ReplicaSet informer")
+}
+
+func TestMetadataNewForConfigFailure(t *testing.T) {
+	factory := InformersFactoryList{
+		newInformer: NewFakeInformer,
+	}
+	clientProvider := func(_ k8sconfig.APIConfig) (k8sconfig.ClientBundle, error) {
+		return k8sconfig.ClientBundle{}, errors.New("metadata.NewForConfig failed")
+	}
+
+	c, err := New(
+		componenttest.NewNopTelemetrySettings(),
+		k8sconfig.APIConfig{},
+		ExtractionRules{},
+		Filters{},
+		[]Association{},
+		Excludes{},
+		clientProvider,
+		factory,
+		false,
+		10*time.Second,
+	)
+	assert.Nil(t, c)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "metadata.NewForConfig failed")
 }

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -98,7 +99,7 @@ type FakeReplicaSetInformer struct {
 }
 
 func NewFakeReplicaSetInformer(
-	_ kubernetes.Interface,
+	_ metadata.Interface,
 	_ string,
 ) cache.SharedInformer {
 	return &FakeInformer{

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
@@ -106,7 +105,7 @@ type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, Extra
 
 // APIClientsetProvider defines a func type that initializes and return a new kubernetes
 // Clientset object.
-type APIClientsetProvider func(config k8sconfig.APIConfig) (kubernetes.Interface, error)
+type APIClientsetProvider func(config k8sconfig.APIConfig) (k8sconfig.ClientBundle, error)
 
 // Pod represents a kubernetes pod.
 type Pod struct {

--- a/processor/k8sattributesprocessor/internal/kube/partialmetadata_benchmark_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/partialmetadata_benchmark_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/component/componenttest"
+	apps_v1 "k8s.io/api/apps/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func genTypedRS(n int) []*apps_v1.ReplicaSet {
+	out := make([]*apps_v1.ReplicaSet, n)
+	for i := range out {
+		name := fmt.Sprintf("deploy-%d-abc123defg", i)
+		out[i] = &apps_v1.ReplicaSet{
+			TypeMeta: meta_v1.TypeMeta{APIVersion: "apps/v1", Kind: "ReplicaSet"},
+			ObjectMeta: meta_v1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("uid-%d", i)),
+				OwnerReferences: []meta_v1.OwnerReference{
+					{APIVersion: "apps/v1", Kind: "Deployment", Name: fmt.Sprintf("deploy-%d", i), UID: types.UID(fmt.Sprintf("depuid-%d", i)), Controller: ptr(true)},
+				},
+			},
+		}
+	}
+	return out
+}
+
+func prebuiltRSList(rs []*apps_v1.ReplicaSet) *apps_v1.ReplicaSetList {
+	list := &apps_v1.ReplicaSetList{Items: make([]apps_v1.ReplicaSet, len(rs))}
+	for i := range rs {
+		list.Items[i] = *rs[i]
+	}
+	return list
+}
+
+func typedClientWithList(list *apps_v1.ReplicaSetList) *fake.Clientset {
+	fc := fake.NewClientset()
+	fc.PrependReactor("list", "replicasets", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, list, nil
+	})
+	fc.PrependWatchReactor("replicasets", func(_ ktesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil
+	})
+	return fc
+}
+
+func Benchmark_RS_ResourceSweep_InProcess(b *testing.B) {
+	ns := []int{10000, 200000}
+
+	for _, n := range ns {
+		b.Run(fmt.Sprintf("Typed_RS_N=%d", n), func(b *testing.B) {
+			rs := genTypedRS(n)
+			list := prebuiltRSList(rs)
+
+			rules := ExtractionRules{
+				DeploymentName: true,
+				// Optional: avoid starting pod/node/namespace informers
+				PodName: false, Namespace: false, Node: false,
+			}
+			filters := Filters{}
+			set := componenttest.NewNopTelemetrySettings()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+
+				fc := typedClientWithList(list)
+				factory := InformersFactoryList{
+					newInformer:           NewFakeInformer,
+					newNamespaceInformer:  NewNoOpInformer,
+					newReplicaSetInformer: newReplicaSetSharedInformer,
+				}
+				newClientSet := func(_ k8sconfig.APIConfig) (k8sconfig.ClientBundle, error) {
+					return k8sconfig.ClientBundle{K8s: fc}, nil
+				}
+
+				c, err := New(set, k8sconfig.APIConfig{}, rules, filters, nil, Excludes{}, newClientSet, factory, false, 0)
+				if err != nil {
+					b.Fatalf("New: %v", err)
+				}
+
+				b.StartTimer()
+
+				if err := c.Start(); err != nil {
+					b.Fatalf("start: %v", err)
+				}
+				_ = wait.PollUntilContextTimeout(
+					b.Context(), time.Millisecond, 5*time.Second, true,
+					func(context.Context) (bool, error) { return true, nil },
+				)
+
+				b.StopTimer()
+				c.Stop()
+				b.StartTimer()
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description

Implementing suggestions in #44407 retrieving only metadata for replicaset instead of the entire object, added a benchmark test to show improvements, summary available [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44407#issuecomment-3640624682)

fixes #44407 
