### PR TITLE
[chore] Ensure "update-otel workflow failed" issues have logs from all job steps

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -50,10 +50,12 @@ jobs:
           max_attempts: 2
           retry_on: error 
           command: |
+            exec > >(tee -a log.out) 2>&1
             cd opentelemetry-collector-contrib
             make update-otel OTEL_STABLE_VERSION=${{ env.LAST_COMMIT }} OTEL_VERSION=${{ env.LAST_COMMIT }}
       - name: Push and create PR
-        run: |  
+        run: |
+          exec > >(tee -a log.out) 2>&1
           cd opentelemetry-collector-contrib
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
           gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector modules to open-telemetry/opentelemetry-collector@${{ env.LAST_COMMIT }}" --draft


### PR DESCRIPTION
#### Description

When the `update-otel` workflow fails, an issue titled "update-otel workflow failed" is created, containing the last 100 lines of the CI's log output to help diagnose the problem. However, we've recently seen failures in steps that aren't covered by this log capture, which makes the output useless. (Example: #44580, where the failure was while creating the PR)

This PR ensures we capture logs from all steps in the `update-otel` job.
