### PR TITLE
[receiver/prometheus] fix yaml marshaling for prometheus secrets

### DIFF
--- a/.chloggen/fix_prom-receiver-basic-auth-password-marshaling.yaml
+++ b/.chloggen/fix_prom-receiver-basic-auth-password-marshaling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes yaml marshaling of prometheus/common/config.Secret types"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44445]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -189,7 +189,7 @@ func reloadPromConfig(dst *PromConfig, src any) error {
 	yamlOut, err := yaml.MarshalWithOptions(
 		src,
 		yaml.CustomMarshaler(func(s commonconfig.Secret) ([]byte, error) {
-			return []byte(s), nil
+			return yaml.Marshal(string(s))
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
#### Description

This fixes a bug where the custom marshaler for [`prometheus/common/config.Secret`](https://github.com/prometheus/common/blob/d80d8544703e59a080a204b6f7429ac6561fb24f/config/config.go#L28) types was interpreting the value as a yaml document.
* This caused strings starting with `%` to be treated as a [YAML directive](https://yaml.org/spec/1.2.2/#3234-directives).
* The custom marshaler exists because the values would otherwise be masked upon reload, due to the prometheus config library (https://github.com/prometheus/common/blob/d80d8544703e59a080a204b6f7429ac6561fb24f/config/config.go#L36).

Instead of returning the raw bytes, we let the yaml library marshal it as a string, rather than of type `Secret`.

#### Link to tracking issue
Fixes #44445

#### Testing

* Added a unit test to verify the behaviour.

#### Documentation

N/A
