### PR TITLE
optimize map allocation

### DIFF
--- a/.chloggen/prometheusremotewritereceiver-optimize-map-allocation.yaml
+++ b/.chloggen/prometheusremotewritereceiver-optimize-map-allocation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Map.PutStr causes excessive memory allocations due to repeated slice expansions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44612]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -737,7 +737,9 @@ func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, bucket
 // extractAttributes return all attributes different from job, instance, metric name and scope name/version
 func extractAttributes(ls labels.Labels) pcommon.Map {
 	attrs := pcommon.NewMap()
-	for labelName, labelValue := range ls.Map() {
+	labelMap := ls.Map()
+	attrs.EnsureCapacity(len(labelMap) - 5) // Exclude job, instance, metric name and scope name/version
+	for labelName, labelValue := range labelMap {
 		if labelName == "instance" || labelName == "job" || // Become resource attributes
 			labelName == labels.MetricName || // Becomes metric name
 			labelName == "otel_scope_name" || labelName == "otel_scope_version" { // Becomes scope name and version

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -738,7 +738,7 @@ func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, bucket
 func extractAttributes(ls labels.Labels) pcommon.Map {
 	attrs := pcommon.NewMap()
 	labelMap := ls.Map()
-	// job, instance and metric name will always become labels, but scope name and version may or may not be present
+	// job, instance and metric name will always become labels
 	attrs.EnsureCapacity(len(labelMap) - 3)
 	for labelName, labelValue := range labelMap {
 		if labelName == "instance" || labelName == "job" || // Become resource attributes

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -738,7 +738,8 @@ func convertAbsoluteBuckets(spans []writev2.BucketSpan, counts []float64, bucket
 func extractAttributes(ls labels.Labels) pcommon.Map {
 	attrs := pcommon.NewMap()
 	labelMap := ls.Map()
-	attrs.EnsureCapacity(len(labelMap) - 5) // Exclude job, instance, metric name and scope name/version
+	// job, instance and metric name will always become labels, but scope name and version may or may not be present
+	attrs.EnsureCapacity(len(labelMap) - 3)
 	for labelName, labelValue := range labelMap {
 		if labelName == "instance" || labelName == "job" || // Become resource attributes
 			labelName == labels.MetricName || // Becomes metric name

--- a/receiver/prometheusremotewritereceiver/receiver_bench_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_bench_test.go
@@ -1,0 +1,65 @@
+package prometheusremotewritereceiver
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// makeLabels builds a labels.Labels with the given total number of labels.
+// It always includes "job", "instance", and the metric name label, plus (total-3) extra labels.
+func makeLabels(total int) labels.Labels {
+	if total < 3 {
+		total = 3
+	}
+	m := make(map[string]string, total)
+	m["job"] = "job"
+	m["instance"] = "instance"
+	m[labels.MetricName] = "metric"
+	for i := 0; i < total-3; i++ {
+		m[fmt.Sprintf("k%d", i)] = fmt.Sprintf("v%d", i)
+	}
+	return labels.FromMap(m)
+}
+
+// extractAttributesNoEnsure is a copy of extractAttributes without the EnsureCapacity call.
+// It intentionally avoids pre-sizing the returned pcommon.Map so we can compare allocations.
+func extractAttributesNoEnsure(ls labels.Labels) pcommon.Map {
+	attrs := pcommon.NewMap()
+	labelMap := ls.Map()
+	for labelName, labelValue := range labelMap {
+		if labelName == "instance" || labelName == "job" ||
+			labelName == labels.MetricName ||
+			labelName == "otel_scope_name" || labelName == "otel_scope_version" {
+			continue
+		}
+		attrs.PutStr(labelName, labelValue)
+	}
+	return attrs
+}
+
+func BenchmarkExtractAttributes(b *testing.B) {
+	sizes := []int{5, 20, 100, 500}
+	for _, sz := range sizes {
+		ls := makeLabels(sz)
+		b.Run(fmt.Sprintf("%d_withEnsure", sz), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m := extractAttributes(ls)
+				_ = m.Len()
+			}
+		})
+
+		b.Run(fmt.Sprintf("%d_withoutEnsure", sz), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m := extractAttributesNoEnsure(ls)
+				_ = m.Len()
+			}
+		})
+	}
+}

--- a/receiver/prometheusremotewritereceiver/receiver_bench_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_bench_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // makeLabels builds a labels.Labels with the given total number of labels.
@@ -24,40 +23,15 @@ func makeLabels(total int) labels.Labels {
 	return labels.FromMap(m)
 }
 
-// extractAttributesNoEnsure is a copy of extractAttributes without the EnsureCapacity call.
-// It intentionally avoids pre-sizing the returned pcommon.Map so we can compare allocations.
-func extractAttributesNoEnsure(ls labels.Labels) pcommon.Map {
-	attrs := pcommon.NewMap()
-	labelMap := ls.Map()
-	for labelName, labelValue := range labelMap {
-		if labelName == "instance" || labelName == "job" ||
-			labelName == labels.MetricName ||
-			labelName == "otel_scope_name" || labelName == "otel_scope_version" {
-			continue
-		}
-		attrs.PutStr(labelName, labelValue)
-	}
-	return attrs
-}
-
 func BenchmarkExtractAttributes(b *testing.B) {
 	sizes := []int{5, 20, 100, 500}
 	for _, sz := range sizes {
 		ls := makeLabels(sz)
-		b.Run(fmt.Sprintf("%d_withEnsure", sz), func(b *testing.B) {
+		b.Run(fmt.Sprintf("%d", sz), func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				m := extractAttributes(ls)
-				_ = m.Len()
-			}
-		})
-
-		b.Run(fmt.Sprintf("%d_withoutEnsure", sz), func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				m := extractAttributesNoEnsure(ls)
 				_ = m.Len()
 			}
 		})

--- a/receiver/prometheusremotewritereceiver/receiver_bench_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_bench_test.go
@@ -19,7 +19,7 @@ func makeLabels(total int) labels.Labels {
 	m := make(map[string]string, total)
 	m["job"] = "job"
 	m["instance"] = "instance"
-	m[labels.MetricName] = "metric"
+	m["__name__"] = "metric"
 	for i := 0; i < total-3; i++ {
 		m[fmt.Sprintf("k%d", i)] = fmt.Sprintf("v%d", i)
 	}
@@ -27,7 +27,7 @@ func makeLabels(total int) labels.Labels {
 }
 
 func BenchmarkExtractAttributes(b *testing.B) {
-	sizes := []int{5, 20, 100, 500}
+	sizes := []int{5, 20, 100, 500, 1000, 2000}
 	for _, sz := range sizes {
 		ls := makeLabels(sz)
 		b.Run(fmt.Sprintf("%d", sz), func(b *testing.B) {

--- a/receiver/prometheusremotewritereceiver/receiver_bench_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_bench_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package prometheusremotewritereceiver
 
 import (


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

##### Summary

When adding multiple key-value pairs to a pcommon.Map using PutStr(), the underlying slice undergoes frequent reallocations and copies, leading to significant memory overhead. In production workloads with high cardinality metrics/logs, this becomes a major performance bottleneck.

##### Evidence
Memory profiling (pprof) shows that Map.EnsureCapacity accounts for 27.17% (0.94GB) of total memory allocation, even though it's never explicitly called in application code:

```shell
flat    flat%   sum%    cum     cum%
0.94GB  27.17%  60.05%  0.94GB  27.17%  go.opentelemetry.io/collector/pdata/pcommon.Map.EnsureCapacity
0.54GB  15.49%  75.55%  0.54GB  15.49%  go.opentelemetry.io/collector/pdata/pcommon.value.SetStr
0.41GB  11.82%  87.36%  0.42GB  12.17%  go.opentelemetry.io/collector/pdata/pcommon.Map.PutInt
```

##### Root Cause
The current PutStr implementation relies on Go's built-in append:

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44612

<!--Describe what testing was performed and which tests were added.-->
#### Testing

old version benchmark

```shell
go test -bench BenchmarkExtractAttributes -benchmem -run Test -count=1
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
cpu: Apple M4 Pro
BenchmarkExtractAttributes/5-14          4895226               229.4 ns/op           496 B/op          8 allocs/op
BenchmarkExtractAttributes/20-14          574508              2035 ns/op            4584 B/op         32 allocs/op
BenchmarkExtractAttributes/100-14                  66211             18260 ns/op           20264 B/op        118 allocs/op
BenchmarkExtractAttributes/500-14                   5136            221833 ns/op          123785 B/op        526 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver        5.761s
```

new version benchmark

```shell
go test -bench BenchmarkExtractAttributes -benchmem -run Test -count=1
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
cpu: Apple M4 Pro
BenchmarkExtractAttributes/5-14          5377898               206.0 ns/op           464 B/op          7 allocs/op
BenchmarkExtractAttributes/20-14          678472              1702 ns/op            3016 B/op         27 allocs/op
BenchmarkExtractAttributes/100-14                  67134             17291 ns/op           14152 B/op        111 allocs/op
BenchmarkExtractAttributes/500-14                   5365            222215 ns/op          102697 B/op        517 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver        5.717s
```

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
