### PR TITLE
[chore] Give up on scoped tests for PRs with too many changes

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -25,31 +25,43 @@ jobs:
         id: changes
         env:
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        # Skip scoped tests if too many files are changed
         run: |
           changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files
           echo "$changed_files"
+          LIMIT=50
 
           go_sources=$(echo "$changed_files" | tr ' ' '\n' | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
           echo go_sources
           echo "$go_sources"
           if [[ -n "$go_sources" ]]; then
-            {
-              echo 'go_sources<<EOF'
-              echo "$go_sources"
-              echo EOF
-            } >> "$GITHUB_OUTPUT"
+            count=$(echo "$go_sources" | wc -l)
+            if [ "$count" -gt "$LIMIT" ]; then
+              echo "Skipping scoped go_sources: This PR modified $count .go files which is over the $LIMIT files threshold."
+            else
+              {
+                echo 'go_sources<<EOF'
+                echo "$go_sources"
+                echo EOF
+              } >> "$GITHUB_OUTPUT"
+            fi
           fi
 
           go_tests=$(echo "$changed_files" | tr ' ' '\n' | grep -E '.*_test\.go$' || true)
           echo go_tests
           echo "$go_tests"
           if [[ -n "$go_tests" ]]; then
-            {
-              echo 'go_tests<<EOF'
-              echo "$go_tests"
-              echo EOF
-            } >> "$GITHUB_OUTPUT"
+            count=$(echo "$go_tests" | wc -l)
+            if [ "$count" -gt "$LIMIT" ]; then
+              echo "Skipping scoped go_tests: This PR modified $count test files which is over the $LIMIT files threshold."
+            else
+              {
+                echo 'go_tests<<EOF'
+                echo "$go_tests"
+                echo EOF
+              } >> "$GITHUB_OUTPUT"
+            fi
           fi
 
   scoped-tests-matrix:
@@ -97,8 +109,14 @@ jobs:
         if: needs.changedfiles.outputs.go_sources
         env:
           CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
+        shell: bash
+        # Only run linter on windows-2025 to avoid redundant runs
         run: |
-          make for-affected-components CMD="make lint test-twice"
+          if [[ "${{ matrix.runner }}" == "windows-2025" ]]; then
+            make for-affected-components CMD="make lint test-twice"
+          else
+            make for-affected-components CMD="make test-twice"
+          fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

3+ hours is too many for the scoped tests, as we saw in #44581.

This:
- Skips linting except for `windows-2025`, since AFAICT linting will give the same result for the same set of build tags.
- Gives up on scoped tests entirely if there are more than 50 changes
