### PR TITLE
[chore][cmd/opampsupervisor] run make modernize

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2257,7 +2257,7 @@ func TestRemoteConfigConcurrentAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-startSignal
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			if i%2 == 0 {
 				s.remoteConfig.Store(config1)
 			} else {
@@ -2270,7 +2270,7 @@ func TestRemoteConfigConcurrentAccess(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-startSignal
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			cfg := s.remoteConfig.Load()
 			if cfg != nil {
 				_ = cfg.GetConfigHash()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

