### PR TITLE
[chore][processor/tailsamplingprocessor] run make modernize

### DIFF
--- a/processor/tailsamplingprocessor/internal/sampling/bytes_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/bytes_limiting_test.go
@@ -155,7 +155,7 @@ func TestBytesLimitingConcurrency(t *testing.T) {
 	// Test concurrent access doesn't cause race conditions
 	results := make(chan samplingpolicy.Decision, 10)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			decision, err := filter.Evaluate(t.Context(), pcommon.TraceID([16]byte{byte(id)}), trace)
 			assert.NoError(t, err)
@@ -165,7 +165,7 @@ func TestBytesLimitingConcurrency(t *testing.T) {
 
 	// Collect results
 	var sampled, notSampled int
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		decision := <-results
 		if decision == samplingpolicy.Sampled {
 			sampled++


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

