### PR TITLE
[chore][receiver/prometheusreceiver] run make modernize

### DIFF
--- a/receiver/prometheusreceiver/internal/metadata_test.go
+++ b/receiver/prometheusreceiver/internal/metadata_test.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -135,9 +136,7 @@ type fakeMetadataStore struct {
 func newFakeMetadataStore(init map[string]scrape.MetricMetadata) *fakeMetadataStore {
 	// copy defensively to avoid external mutation
 	cp := make(map[string]scrape.MetricMetadata, len(init))
-	for k, v := range init {
-		cp[k] = v
-	}
+	maps.Copy(cp, init)
 	return &fakeMetadataStore{data: cp}
 }
 

--- a/receiver/prometheusreceiver/internal/transaction_bench_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_bench_test.go
@@ -219,11 +219,11 @@ func newBenchmarkTransaction(b *testing.B) *transaction {
 func generateLabelSets(seriesCount, cardinality int) []labels.Labels {
 	result := make([]labels.Labels, seriesCount)
 
-	for i := 0; i < seriesCount; i++ {
+	for i := range seriesCount {
 		lbls := labels.NewBuilder(labels.EmptyLabels())
 		lbls.Set(model.MetricNameLabel, fmt.Sprintf("metric_%d", i))
 
-		for j := 0; j < cardinality; j++ {
+		for j := range cardinality {
 			lbls.Set(fmt.Sprintf("label_%d", j), fmt.Sprintf("value_%d_%d", i, j))
 		}
 
@@ -238,7 +238,7 @@ func generateLabelSets(seriesCount, cardinality int) []labels.Labels {
 func generateNativeHistograms(count int) []*histogram.Histogram {
 	result := make([]*histogram.Histogram, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// Use tsdbutil.GenerateTestHistogram to create realistic native histograms
 		// The parameter controls the histogram ID, which varies the bucket counts slightly
 		result[i] = tsdbutil.GenerateTestHistogram(int64(i))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

