### PR TITLE
[chore][receiver/webhookeventreceiver] run make modernize

### DIFF
--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -424,13 +424,13 @@ func TestReqToLog(t *testing.T) {
 				// Create multiple JSON objects that together exceed 64KB
 				// This reproduces the issue from PR #41350 where large payloads fail
 				var buf bytes.Buffer
-				for i := 0; i < 800; i++ {
+				for i := range 800 {
 					// Each JSON object is ~100 bytes, total ~80KB (exceeds 64KB default limit)
 					buf.WriteString(`{"event":"webhook","index":`)
 					buf.WriteString(string(rune('0' + (i % 10))))
 					buf.WriteString(`,"data":"`)
 					// Add padding
-					for j := 0; j < 60; j++ {
+					for range 60 {
 						buf.WriteByte('X')
 					}
 					buf.WriteString(`"}`)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

