### PR TITLE
Fix TrimPrefix/TrimSuffix function name

### DIFF
--- a/.chloggen/fix-trim.yaml
+++ b/.chloggen/fix-trim.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix TrimPrefix/TrimSuffix function name.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44630]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change also adds a featuregate "ottl.PanicDuplicateName" to control the behavior of panicing when duplicate
+  names are registered for the same function.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/zeebo/xxh3 v1.0.2
 	go.opentelemetry.io/collector/component v1.46.1-0.20251127085441-73f090cd0d59
 	go.opentelemetry.io/collector/component/componenttest v0.140.1-0.20251127085441-73f090cd0d59
+	go.opentelemetry.io/collector/featuregate v1.46.1-0.20251127085441-73f090cd0d59
 	go.opentelemetry.io/collector/pdata v1.46.1-0.20251127085441-73f090cd0d59
 	go.opentelemetry.io/collector/pdata/pprofile v0.140.1-0.20251127085441-73f090cd0d59
 	go.opentelemetry.io/otel v1.38.0
@@ -45,7 +46,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.140.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/collector/featuregate v1.46.1-0.20251127085441-73f090cd0d59 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect

--- a/pkg/ottl/ottlfuncs/func_trim_prefix.go
+++ b/pkg/ottl/ottlfuncs/func_trim_prefix.go
@@ -17,7 +17,7 @@ type TrimPrefixArguments[K any] struct {
 }
 
 func NewTrimPrefixFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("Trim", &TrimPrefixArguments[K]{}, createTrimPrefixFunction[K])
+	return ottl.NewFactory("TrimPrefix", &TrimPrefixArguments[K]{}, createTrimPrefixFunction[K])
 }
 
 func createTrimPrefixFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/pkg/ottl/ottlfuncs/func_trim_suffix.go
+++ b/pkg/ottl/ottlfuncs/func_trim_suffix.go
@@ -17,7 +17,7 @@ type TrimSuffixArguments[K any] struct {
 }
 
 func NewTrimSuffixFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("Trim", &TrimSuffixArguments[K]{}, createTrimSuffixFunction[K])
+	return ottl.NewFactory("TrimSuffix", &TrimSuffixArguments[K]{}, createTrimSuffixFunction[K])
 }
 
 func createTrimSuffixFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {


### PR DESCRIPTION
This PR also adds a beta featuregate to enable duplicate names mistakes.

Unfortunately in version v0.139.0 and v0.140.[0|1] this manifest by replacing the classic "Trim" function with "TrimSuffix" so will create unexpected bugs for our customers and we don't have a work around for this.