### PR TITLE
[pkg/translator/opencensus] deprecate the package

### DIFF
--- a/.chloggen/deprecate_pkg_opencensus.yaml
+++ b/.chloggen/deprecate_pkg_opencensus.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/opencensus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the package
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44641]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/translator/opencensus/go.mod
+++ b/pkg/translator/opencensus/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: this functionality is no longer maintained and will be removed.
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus
 
 go 1.24.0

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -26,6 +26,7 @@ type labelKeysAndType struct {
 
 // ResourceMetricsToOC converts pmetric.ResourceMetrics to OC data format,
 // may be used only by OpenCensus receiver and exporter implementations.
+//
 // Deprecated: this functionality is no longer maintained and will be removed.
 func ResourceMetricsToOC(rm pmetric.ResourceMetrics) (*occommon.Node, *ocresource.Resource, []*ocmetrics.Metric) {
 	node, resource := internalResourceToOC(rm.Resource())

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -26,6 +26,7 @@ type labelKeysAndType struct {
 
 // ResourceMetricsToOC converts pmetric.ResourceMetrics to OC data format,
 // may be used only by OpenCensus receiver and exporter implementations.
+// Deprecated: this functionality is no longer maintained and will be removed.
 func ResourceMetricsToOC(rm pmetric.ResourceMetrics) (*occommon.Node, *ocresource.Resource, []*ocmetrics.Metric) {
 	node, resource := internalResourceToOC(rm.Resource())
 	ilms := rm.ScopeMetrics()

--- a/pkg/translator/opencensus/oc_to_metrics.go
+++ b/pkg/translator/opencensus/oc_to_metrics.go
@@ -13,6 +13,7 @@ import (
 
 // OCToMetrics converts OC data format to pmetric.Metrics,
 // may be used only by OpenCensus receiver and exporter implementations.
+// Deprecated: this functionality is no longer maintained and will be removed.
 func OCToMetrics(node *occommon.Node, resource *ocresource.Resource, metrics []*ocmetrics.Metric) pmetric.Metrics {
 	dest := pmetric.NewMetrics()
 	if node == nil && resource == nil && len(metrics) == 0 {

--- a/pkg/translator/opencensus/oc_to_metrics.go
+++ b/pkg/translator/opencensus/oc_to_metrics.go
@@ -13,6 +13,7 @@ import (
 
 // OCToMetrics converts OC data format to pmetric.Metrics,
 // may be used only by OpenCensus receiver and exporter implementations.
+//
 // Deprecated: this functionality is no longer maintained and will be removed.
 func OCToMetrics(node *occommon.Node, resource *ocresource.Resource, metrics []*ocmetrics.Metric) pmetric.Metrics {
 	dest := pmetric.NewMetrics()

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -23,6 +23,7 @@ import (
 //
 // Deprecated: use ptrace.Traces instead.
 // TODO: move this function to OpenCensus package.
+//
 // Deprecated: this functionality is no longer maintained and will be removed.
 func OCToTraces(node *occommon.Node, resource *ocresource.Resource, spans []*octrace.Span) ptrace.Traces {
 	traceData := ptrace.NewTraces()

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -23,6 +23,7 @@ import (
 //
 // Deprecated: use ptrace.Traces instead.
 // TODO: move this function to OpenCensus package.
+// Deprecated: this functionality is no longer maintained and will be removed.
 func OCToTraces(node *occommon.Node, resource *ocresource.Resource, spans []*octrace.Span) ptrace.Traces {
 	traceData := ptrace.NewTraces()
 	if node == nil && resource == nil && len(spans) == 0 {

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -24,6 +24,7 @@ import (
 //
 // Deprecated: Use ptrace.Traces.
 // TODO: move this function to OpenCensus package.
+//
 // Deprecated: this functionality is no longer maintained and will be removed.
 func ResourceSpansToOC(rs ptrace.ResourceSpans) (*occommon.Node, *ocresource.Resource, []*octrace.Span) {
 	node, resource := internalResourceToOC(rs.Resource())

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -24,6 +24,7 @@ import (
 //
 // Deprecated: Use ptrace.Traces.
 // TODO: move this function to OpenCensus package.
+// Deprecated: this functionality is no longer maintained and will be removed.
 func ResourceSpansToOC(rs ptrace.ResourceSpans) (*occommon.Node, *ocresource.Resource, []*octrace.Span) {
 	node, resource := internalResourceToOC(rs.Resource())
 	ilss := rs.ScopeSpans()


### PR DESCRIPTION
This package is no longer in use in the repository and was used by opencensus receiver and exporter, which have been deprecated and removed.

It is time to deprecate and remove this package.