### PR TITLE
[receiver/kafkareceiver] Remove redundant config unmarshal

### DIFF
--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -116,7 +116,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 		c.MessageMarking.OnPermanentError = c.MessageMarking.OnError
 	}
 
-	return conf.Unmarshal(c)
+	return nil
 }
 
 // TopicEncodingConfig holds signal-specific topic and encoding configuration.


### PR DESCRIPTION
#### Motivation
The `Unmarshal` method in `config.go` was performing `conf.Unmarshal(c)` twice:
1. Once at the start of the function to populate the initial configuration.
3. Once at the very end of the function.

Between these two calls, the method performs manual logic to handle deprecated fields (migrating global `topic/encoding` to signal-specific configs) and sets defaults for `message_marking`.

The second unmarshal call is redundant and potentially risky, as it re-processes the raw configuration after custom logic has already modified the struct. Removing it improves code clarity and ensures that the manual adjustments made for backward compatibility are preserved without unnecessary overhead.

#### Changes
- Removed the final `return conf.Unmarshal(c)` in `receiver/kafkareceiver/config.go`.
- Changed the return statement to `return nil` to signal successful unmarshaling after the custom logic executes.

#### Consequences
- **Optimization**: Removes an unnecessary reflection-based unmarshaling step during startup.
- **Stability**: Eliminates the risk of the second unmarshal overwriting the manual field migrations or defaults set during the custom logic block.
- **Behavior**: No functional change is expected for end-users; existing configurations will load exactly as before.

#### Testing
- Existing configuration tests should pass without modification.