### PR TITLE
[pkg/ottl] Add Encode converter

### DIFF
--- a/.chloggen/ottl-add-encode-converter.yaml
+++ b/.chloggen/ottl-add-encode-converter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Encode converter as inverse of Decode function
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31543]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -536,6 +536,12 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Encode("pass", "base64"))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "cGFzcw==")
+			},
+		},
+		{
 			statement: `set(attributes["test"], Concat(["A","B"], ":"))`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "A:B")

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -464,6 +464,7 @@ Available Converters:
 - [Day](#day)
 - [Double](#double)
 - [Duration](#duration)
+- [Encode](#encode)
 - [ExtractPatterns](#extractpatterns)
 - [ExtractGrokPatterns](#extractgrokpatterns)
 - [FNV](#fnv)
@@ -765,6 +766,22 @@ Examples:
 - `Duration("3s")`
 - `Duration("333ms")`
 - `Duration("1000000h")`
+
+### Encode
+
+`Encode(value, encoding)`
+
+The `Encode` Converter takes a string or byte array and returns it encoded with the specified encoding.
+
+`value` is a string or byte array.
+
+`encoding` is a valid encoding name included in the [IANA encoding index](https://www.iana.org/assignments/character-sets/character-sets.xhtml) or one of `base64`, `base64-raw`, `base64-url` or `base64-raw-url`.
+
+Examples:
+
+- `Encode("hello world", "base64")` returns `"aGVsbG8gd29ybGQ="`
+
+- `Encode(attributes["data"], "base64-url")`
 
 ### ExtractPatterns
 

--- a/pkg/ottl/ottlfuncs/func_encode.go
+++ b/pkg/ottl/ottlfuncs/func_encode.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type EncodeArguments[K any] struct {
+	Target   ottl.Getter[K]
+	Encoding ottl.StringGetter[K]
+}
+
+func NewEncodeFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Encode", &EncodeArguments[K]{}, createEncodeFunction[K])
+}
+
+func createEncodeFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*EncodeArguments[K])
+	if !ok {
+		return nil, errors.New("EncodeFactory args must be of type *EncodeArguments[K]")
+	}
+
+	return Encode(args.Target, args.Encoding), nil
+}
+
+func Encode[K any](target ottl.Getter[K], encoding ottl.StringGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		encodingVal, err := encoding.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		var stringValue string
+
+		switch v := val.(type) {
+		case []byte:
+			stringValue = string(v)
+		case *string:
+			stringValue = *v
+		case string:
+			stringValue = v
+		case pcommon.ByteSlice:
+			stringValue = string(v.AsRaw())
+		case *pcommon.ByteSlice:
+			stringValue = string(v.AsRaw())
+		case pcommon.Value:
+			stringValue = v.AsString()
+		case *pcommon.Value:
+			stringValue = v.AsString()
+		default:
+			return nil, fmt.Errorf("unsupported type provided to Encode function: %T", v)
+		}
+
+		switch encodingVal {
+		// base64 is not in IANA index, so we have to deal with this encoding separately
+		case "base64":
+			return base64.StdEncoding.EncodeToString([]byte(stringValue)), nil
+		case "base64-raw":
+			return base64.RawStdEncoding.EncodeToString([]byte(stringValue)), nil
+		case "base64-url":
+			return base64.URLEncoding.EncodeToString([]byte(stringValue)), nil
+		case "base64-raw-url":
+			return base64.RawURLEncoding.EncodeToString([]byte(stringValue)), nil
+		default:
+			e, err := textutils.LookupEncoding(encodingVal)
+			if err != nil {
+				return nil, err
+			}
+
+			encodedString, err := e.NewEncoder().String(stringValue)
+			if err != nil {
+				return nil, fmt.Errorf("could not encode: %w", err)
+			}
+
+			return encodedString, nil
+		}
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_encode_test.go
+++ b/pkg/ottl/ottlfuncs/func_encode_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func TestEncode(t *testing.T) {
+	testByteSlice := pcommon.NewByteSlice()
+	testByteSlice.FromRaw([]byte("hello world"))
+
+	testValue := pcommon.NewValueEmpty()
+	_ = testValue.FromRaw("hello world")
+
+	type testCase struct {
+		name          string
+		value         any
+		encoding      string
+		want          any
+		expectedError string
+	}
+	tests := []testCase{
+		{
+			name:     "encode string to base64",
+			value:    "hello world",
+			encoding: "base64",
+			want:     "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "encode byte array to base64",
+			value:    []byte("test\n"),
+			encoding: "base64",
+			want:     "dGVzdAo=",
+		},
+		{
+			name:     "encode ByteSlice to base64",
+			value:    testByteSlice,
+			encoding: "base64",
+			want:     "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "encode Value to base64",
+			value:    testValue,
+			encoding: "base64",
+			want:     "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "encode ByteSlice pointer to base64",
+			value:    &testByteSlice,
+			encoding: "base64",
+			want:     "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "encode Value pointer to base64",
+			value:    &testValue,
+			encoding: "base64",
+			want:     "aGVsbG8gd29ybGQ=",
+		},
+		{
+			name:     "encode empty string to base64",
+			value:    "",
+			encoding: "base64",
+			want:     "",
+		},
+		{
+			name:     "encode string with url-safe sensitive characters to base64",
+			value:    "Go?/Z~x",
+			encoding: "base64",
+			want:     "R28/L1p+eA==",
+		},
+		{
+			name:     "encode string with url-safe sensitive characters to base64-raw",
+			value:    "Go?/Z~x",
+			encoding: "base64-raw",
+			want:     "R28/L1p+eA",
+		},
+		{
+			name:     "encode string with url-safe sensitive characters to base64-url",
+			value:    "Go?/Z~x",
+			encoding: "base64-url",
+			want:     "R28_L1p-eA==",
+		},
+		{
+			name:     "encode string with url-safe sensitive characters to base64-raw-url",
+			value:    "Go?/Z~x",
+			encoding: "base64-raw-url",
+			want:     "R28_L1p-eA",
+		},
+		{
+			name:     "encode us-ascii string",
+			value:    "test string",
+			encoding: "us-ascii",
+			want:     "test string",
+		},
+		{
+			name:     "encode UTF-8 string",
+			value:    "test string",
+			encoding: "UTF-8",
+			want:     "test string",
+		},
+		{
+			name:     "encode ISO-8859-1 string",
+			value:    "test string",
+			encoding: "ISO-8859-1",
+			want:     "test string",
+		},
+		{
+			name:          "non-string input",
+			value:         10,
+			encoding:      "base64",
+			expectedError: "unsupported type provided to Encode function: int",
+		},
+		{
+			name:          "nil input",
+			value:         nil,
+			encoding:      "base64",
+			expectedError: "unsupported type provided to Encode function: <nil>",
+		},
+		{
+			name:          "unsupported encoding",
+			value:         "test",
+			encoding:      "invalid-encoding",
+			expectedError: "unsupported encoding",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressionFunc, err := createEncodeFunction[any](ottl.FunctionContext{}, &EncodeArguments[any]{
+				Target: &ottl.StandardGetSetter[any]{
+					Getter: func(context.Context, any) (any, error) {
+						return tt.value, nil
+					},
+				},
+				Encoding: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.encoding, nil
+					},
+				},
+			})
+
+			require.NoError(t, err)
+
+			result, err := expressionFunc(nil, nil)
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -49,6 +49,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewDayFactory[K](),
 		NewDoubleFactory[K](),
 		NewDurationFactory[K](),
+		NewEncodeFactory[K](),
 		NewExtractPatternsFactory[K](),
 		NewExtractGrokPatternsFactory[K](),
 		NewFnvFactory[K](),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds the Encode converter as the inverse of the existing Decode function. Supports base64 variants and IANA character encodings.

This was mentioned as a nice feature in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31543#issuecomment-1998517484 and I would find it very useful personally

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [#31543](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31543#issuecomment-1998517484)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tests were added for the encode function as well as e2e

<!--Describe the documentation added.-->
#### Documentation
Encode documentation was added to the ottl README and a changelog entry was created

Let me know if I need to make any changes. I read through the contributing doc and tried to follow all the guidelines, but this is my first contribution here.