### PR TITLE
[receiver/googlecloudpubsub] Acknowledge messages at restart (#44706)

### DIFF
--- a/.chloggen/googlepubsub_receiver_ackid_at_restart.yaml
+++ b/.chloggen/googlepubsub_receiver_ackid_at_restart.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Acknowledge messages at restart
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44706]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Rewrote the control flow loop so the acknowledgment of messages is more reliable. At stream restart, the messages
+  ackIds are resent immediately without an explicit acknowledgment. Outstanding ackIds are only cleared when the
+  acknowledgment is sent successfully.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
#### Description
Rewrote the control flow loop so the acknowledgment of messages is more reliable. At stream restart, the messages ackIds are resent immediately without an explicit acknowledgment. Outstanding ackIds are only cleared when the acknowledgment is sent successfully.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44706

#### Testing
Manually tested; no new tests added.

#### Documentation
No new documentation required
