### PR TITLE
[Chore] Bump to 1.24.11

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       # Unit tests without JUnit output are much faster, so it's fine to run on every PR.
       # The only time we don't run them is when we already ran them with JUnit output.
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:

--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Build test binaries
         env:
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Ensure required ports in the dynamic range are available
         run: |
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [stable, oldstable]
+        go-version: [stable, '1.24.11']
         runner: [ubuntu-24.04]
         group:
           - receiver-0
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version: ${{ matrix.go-version }}
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -268,7 +268,7 @@ jobs:
       # - On main, with the go version that we didn't run the JUnit tests with.
       - name: Run Unit Tests
         id: tests
-        if: github.ref != 'refs/heads/main' || !startsWith( matrix.go-version, 'oldstable' )
+        if: github.ref != 'refs/heads/main' || !startsWith( matrix.go-version, '1.24' )
         run: make gotest GROUP=${{ matrix.group }}
 
       # JUnit tests are super long, so we only run them for one go version.
@@ -276,16 +276,16 @@ jobs:
       # merged to main, so we don't run them on every PR.
       - name: Run Unit Tests With JUnit and Coverage
         id: tests-with-junit
-        if: startsWith( matrix.go-version, 'oldstable' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: startsWith( matrix.go-version, '1.24' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
         continue-on-error: true # Allow uploading artifacts even if the test fails
         run: make gotest-with-junit-and-cover GROUP=${{ matrix.group }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
-        if: startsWith( matrix.go-version, 'oldstable' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: startsWith( matrix.go-version, '1.24' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
           name: coverage-artifacts-${{ matrix.go-version }}-${{ matrix.runner }}-${{ matrix.group }}
           path: ${{ matrix.group }}-coverage.txt
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
-        if: startsWith( matrix.go-version, 'oldstable' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: startsWith( matrix.go-version, '1.24' ) && github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
           name: test-results-${{ matrix.go-version }}-${{ matrix.runner }}-${{ matrix.group }}
           path: internal/tools/testresults/
@@ -358,7 +358,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -388,7 +388,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -428,7 +428,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -448,7 +448,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -518,7 +518,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -567,7 +567,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -694,7 +694,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,7 +37,7 @@ jobs:
       - run: ./.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
 
       - name: Ensure no changes to the CHANGELOG.md or CHANGELOG-API.md

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
 
       - name: Install tools

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
       - run: opentelemetry-collector-contrib/.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache: false
       - uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         id: otelbot-token

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,7 +31,7 @@ jobs:
       - run: opentelemetry-collector-contrib/.github/workflows/scripts/free-disk-space.sh
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'opentelemetry-collector-contrib/go.mod'
           cache: false
       - uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
         id: otelbot-token

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'opentelemetry-collector-contrib/go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         id: go-setup
         with:
-          go-version: oldstable
+          go-version-file: 'go.mod'
           cache-dependency-path: "**/*.sum"
       - name: Install dependencies
         if: steps.go-setup.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -178,21 +178,17 @@ endif
 	@echo "Updating all module go.mod files..."
 	@find . -name "go.mod" -type f -not -path "./go.mod" -exec sed -i '' -E 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(VERSION)/g' {} \;
 	
-	# 3. Update GitHub Actions workflows to use go-version-file instead of oldstable
-	@echo "Updating GitHub Actions workflows..."
-	@find .github/workflows -name "*.yml" -o -name "*.yaml" | xargs sed -i '' -E '/go-version: oldstable/s/go-version: oldstable/go-version-file: '\''go.mod'\''/g'
-	
-	# 3a. Fix workflows that checkout to a subdirectory
-	@echo "Fixing workflows with subdirectory checkouts..."
-	@sed -i '' -E "s|go-version-file: 'go.mod'|go-version-file: 'opentelemetry-collector-contrib/go.mod'|g" .github/workflows/prometheus-compliance-tests.yml
-	@sed -i '' -E "s|go-version-file: 'go.mod'|go-version-file: 'opentelemetry-collector-contrib/go.mod'|g" .github/workflows/prepare-release.yml
+	# 3. Update the matrix version in build-and-test.yml
+	@echo "Updating matrix test version..."
+	@sed -i '' -E "s/go-version: \[stable, '[0-9]+\.[0-9]+\.[0-9]+'\]/go-version: [stable, '$(VERSION)']/" .github/workflows/build-and-test.yml
 	
 	@echo ""
 	@echo "✓ Successfully bumped Go version to $(VERSION)"
 	@echo ""
-	@echo "Next steps:"
-	@echo "  1. Review the changed workflow files: git diff .github/workflows/"
-	@echo "  2. Optionally run: make gotidy (takes ~5-10 minutes)"
+	@echo "Note: GitHub Actions workflows automatically read the version from go.mod"
+	@echo "      Each workflow has 'go-version-file: go.mod' configured in its"
+	@echo "      actions/setup-go step, which tells the action to read from go.mod"
+	@echo "Next: Optionally run 'make gotidy' (takes ~5-10 minutes)"
 
 .PHONY: remove-toolchain
 remove-toolchain:

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,11 @@ endif
 	@echo "Updating GitHub Actions workflows..."
 	@find .github/workflows -name "*.yml" -o -name "*.yaml" | xargs sed -i '' -E '/go-version: oldstable/s/go-version: oldstable/go-version-file: '\''go.mod'\''/g'
 	
+	# 3a. Fix workflows that checkout to a subdirectory
+	@echo "Fixing workflows with subdirectory checkouts..."
+	@sed -i '' -E "s|go-version-file: 'go.mod'|go-version-file: 'opentelemetry-collector-contrib/go.mod'|g" .github/workflows/prometheus-compliance-tests.yml
+	@sed -i '' -E "s|go-version-file: 'go.mod'|go-version-file: 'opentelemetry-collector-contrib/go.mod'|g" .github/workflows/prepare-release.yml
+	
 	@echo ""
 	@echo "✓ Successfully bumped Go version to $(VERSION)"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,16 @@ endif
 	@echo "Updating all module go.mod files..."
 	@find . -name "go.mod" -type f -not -path "./go.mod" -exec sed -i '' -E 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(VERSION)/g' {} \;
 	
+	# 3. Update GitHub Actions workflows to use go-version-file instead of oldstable
+	@echo "Updating GitHub Actions workflows..."
+	@find .github/workflows -name "*.yml" -o -name "*.yaml" | xargs sed -i '' -E '/go-version: oldstable/s/go-version: oldstable/go-version-file: '\''go.mod'\''/g'
+	
 	@echo ""
 	@echo "✓ Successfully bumped Go version to $(VERSION)"
 	@echo ""
-	@echo "Next, optionally run: make gotidy (takes ~5-10 minutes)"
+	@echo "Next steps:"
+	@echo "  1. Review the changed workflow files: git diff .github/workflows/"
+	@echo "  2. Optionally run: make gotidy (takes ~5-10 minutes)"
 
 .PHONY: remove-toolchain
 remove-toolchain:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ OTEL_STABLE_VERSION=main
 VERSION=$(shell git describe --always --match "v[0-9]*" HEAD)
 TRIMMED_VERSION=$(shell grep -o 'v[^-]*' <<< "$(VERSION)" | cut -c 2-)
 CORE_VERSIONS=$(SRC_PARENT_DIR)/opentelemetry-collector/versions.yaml
+GO_COMPAT_VERSION=$(shell grep '^go ' go.mod | awk '{print $$2}')
 
 COMP_REL_PATH=cmd/otelcontribcol/components.go
 MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib
@@ -159,8 +160,28 @@ tidylist: $(CROSSLINK)
 gotidy:
 	@for mod in $$(cat internal/tidylist/tidylist.txt); do \
 		echo "Tidying $$mod"; \
-		(cd $$mod && rm -rf go.sum && $(GOCMD) mod tidy -compat=1.24.0 && $(GOCMD) get toolchain@none) || exit $?; \
+		(cd $$mod && rm -rf go.sum && $(GOCMD) mod tidy -compat=$(GO_COMPAT_VERSION) && $(GOCMD) get toolchain@none) || exit $?; \
 	done
+
+.PHONY: bump-go-version
+bump-go-version:
+ifndef VERSION
+	$(error VERSION is required. Usage: make bump-go-version VERSION=1.24.11)
+endif
+	@echo "Bumping Go version to $(VERSION)..."
+	
+	# 1. Update main go.mod
+	@echo "Updating main go.mod..."
+	@sed -i '' -E 's/^go [0-9]+\.[0-9]+.*/go $(VERSION)/' go.mod
+	
+	# 2. Update all module go.mod files
+	@echo "Updating all module go.mod files..."
+	@find . -name "go.mod" -type f -not -path "./go.mod" -exec sed -i '' -E 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(VERSION)/g' {} \;
+	
+	@echo ""
+	@echo "✓ Successfully bumped Go version to $(VERSION)"
+	@echo ""
+	@echo "Next, optionally run: make gotidy (takes ~5-10 minutes)"
 
 .PHONY: remove-toolchain
 remove-toolchain:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -292,7 +292,7 @@ modernize: $(MODERNIZE)
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.24.0
+	$(GOCMD) mod tidy -compat=$(GO_COMPAT_VERSION)
 
 .PHONY: toolchain
 toolchain:

--- a/cmd/codecovgen/go.mod
+++ b/cmd/codecovgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/codecovgen
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/cmd/golden/go.mod
+++ b/cmd/golden/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/golden
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/cmd/telemetrygen/go.mod
+++ b/cmd/telemetrygen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/cmd/telemetrygen/internal/e2etest/go.mod
+++ b/cmd/telemetrygen/internal/e2etest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/e2etest
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen v0.141.0

--- a/confmap/provider/aesprovider/go.mod
+++ b/confmap/provider/aesprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/confmap/provider/googlesecretmanagerprovider/go.mod
+++ b/confmap/provider/googlesecretmanagerprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/secretmanager v1.15.0

--- a/confmap/provider/s3provider/go.mod
+++ b/confmap/provider/s3provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/confmap/provider/secretsmanagerprovider/go.mod
+++ b/confmap/provider/secretsmanagerprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.1

--- a/connector/countconnector/go.mod
+++ b/connector/countconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.141.0

--- a/connector/exceptionsconnector/go.mod
+++ b/connector/exceptionsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/connector/failoverconnector/go.mod
+++ b/connector/failoverconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/grafanacloudconnector/go.mod
+++ b/connector/grafanacloudconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/metricsaslogsconnector/go.mod
+++ b/connector/metricsaslogsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/otlpjsonconnector/go.mod
+++ b/connector/otlpjsonconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/connector/roundrobinconnector/go.mod
+++ b/connector/roundrobinconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.141.0

--- a/connector/servicegraphconnector/go.mod
+++ b/connector/servicegraphconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/connector/slowsqlconnector/go.mod
+++ b/connector/slowsqlconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/connector/spanmetricsconnector/go.mod
+++ b/connector/spanmetricsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/sumconnector/go.mod
+++ b/connector/sumconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0

--- a/exporter/alertmanagerexporter/go.mod
+++ b/exporter/alertmanagerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.83

--- a/exporter/awscloudwatchlogsexporter/go.mod
+++ b/exporter/awscloudwatchlogsexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/smithy-go v1.23.2

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/exporter/awss3exporter/go.mod
+++ b/exporter/awss3exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/exporter/azureblobexporter/go.mod
+++ b/exporter/azureblobexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/exporter/azuredataexplorerexporter/go.mod
+++ b/exporter/azuredataexplorerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-kusto-go/azkustodata v1.1.0

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/microsoft/ApplicationInsights-Go v0.4.4

--- a/exporter/bmchelixexporter/go.mod
+++ b/exporter/bmchelixexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/exporter/cassandraexporter/go.mod
+++ b/exporter/cassandraexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/apache/cassandra-gocql-driver/v2 v2.0.0

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.3

--- a/exporter/coralogixexporter/go.mod
+++ b/exporter/coralogixexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.177

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/integrationtest
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.177

--- a/exporter/datasetexporter/go.mod
+++ b/exporter/datasetexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/dorisexporter/go.mod
+++ b/exporter/dorisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	// https://github.com/go-sql-driver/mysql/issues/1602; https://github.com/apache/doris/pull/32177

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/exporter/elasticsearchexporter/integrationtest/go.mod
+++ b/exporter/elasticsearchexporter/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/integrationtest
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/elastic/go-docappender/v2 v2.12.0

--- a/exporter/faroexporter/go.mod
+++ b/exporter/faroexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.54.0

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.3.0

--- a/exporter/googlecloudstorageexporter/go.mod
+++ b/exporter/googlecloudstorageexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.54.0

--- a/exporter/honeycombmarkerexporter/go.mod
+++ b/exporter/honeycombmarkerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0

--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.1

--- a/exporter/logicmonitorexporter/go.mod
+++ b/exporter/logicmonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/logicmonitor/lm-data-sdk-go v1.3.4

--- a/exporter/logzioexporter/go.mod
+++ b/exporter/logzioexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3

--- a/exporter/mezmoexporter/go.mod
+++ b/exporter/mezmoexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/opensearchexporter/go.mod
+++ b/exporter/opensearchexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.141.0

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/pulsarexporter/go.mod
+++ b/exporter/pulsarexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/apache/pulsar-client-go v0.17.0

--- a/exporter/rabbitmqexporter/go.mod
+++ b/exporter/rabbitmqexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/sematextexporter/go.mod
+++ b/exporter/sematextexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/sentryexporter/go.mod
+++ b/exporter/sentryexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/getsentry/sentry-go v0.39.0

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/stefexporter/go.mod
+++ b/exporter/stefexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/klauspost/compress v1.18.1

--- a/exporter/syslogexporter/go.mod
+++ b/exporter/syslogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/tencentcloudlogserviceexporter/go.mod
+++ b/exporter/tencentcloudlogserviceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/exporter/tinybirdexporter/go.mod
+++ b/exporter/tinybirdexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/exporter/zipkinexporter/go.mod
+++ b/exporter/zipkinexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/extension/ackextension/go.mod
+++ b/extension/ackextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/extension/asapauthextension/go.mod
+++ b/extension/asapauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.14.3

--- a/extension/awsproxy/go.mod
+++ b/extension/awsproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy v0.141.0

--- a/extension/azureauthextension/go.mod
+++ b/extension/azureauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/extension/basicauthextension/go.mod
+++ b/extension/basicauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/extension/cgroupruntimeextension/go.mod
+++ b/extension/cgroupruntimeextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.73.0-rc.9

--- a/extension/encoding/avrologencodingextension/go.mod
+++ b/extension/encoding/avrologencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/linkedin/goavro/v2 v2.14.1

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/awslogsencodingextension/go.mod
+++ b/extension/encoding/awslogsencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-lambda-go v1.50.0

--- a/extension/encoding/azureencodingextension/go.mod
+++ b/extension/encoding/azureencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.141.0

--- a/extension/encoding/go.mod
+++ b/extension/encoding/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding
 
-go 1.24.0
+go 1.24.11
 
 require (
 	go.opentelemetry.io/collector/extension v1.47.0

--- a/extension/encoding/googlecloudlogentryencodingextension/go.mod
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/jaegerencodingextension/go.mod
+++ b/extension/encoding/jaegerencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/otlpencodingextension/go.mod
+++ b/extension/encoding/otlpencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.141.0

--- a/extension/encoding/skywalkingencodingextension/go.mod
+++ b/extension/encoding/skywalkingencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking v0.141.0

--- a/extension/encoding/textencodingextension/go.mod
+++ b/extension/encoding/textencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.141.0

--- a/extension/encoding/zipkinencodingextension/go.mod
+++ b/extension/encoding/zipkinencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.141.0

--- a/extension/googleclientauthextension/go.mod
+++ b/extension/googleclientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
 
-go 1.24.0
+go 1.24.11
 
 exclude github.com/knadh/koanf v1.5.0
 

--- a/extension/headerssetterextension/go.mod
+++ b/extension/headerssetterextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/extension/healthcheckv2extension/go.mod
+++ b/extension/healthcheckv2extension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/extension/httpforwarderextension/go.mod
+++ b/extension/httpforwarderextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/fortytw2/leaktest v1.3.0

--- a/extension/k8sleaderelector/go.mod
+++ b/extension/k8sleaderelector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/oauth2clientauthextension/go.mod
+++ b/extension/oauth2clientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/observer/cfgardenobserver/go.mod
+++ b/extension/observer/cfgardenobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	code.cloudfoundry.org/garden v0.0.0-20241023020423-a21e43a17f84

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/extension/observer/go.mod
+++ b/extension/observer/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/observer/hostobserver/go.mod
+++ b/extension/observer/hostobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.141.0

--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/observer/kafkatopicsobserver/go.mod
+++ b/extension/observer/kafkatopicsobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/coreos/go-oidc/v3 v3.16.0

--- a/extension/opampcustommessages/go.mod
+++ b/extension/opampcustommessages/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages
 
-go 1.24.0
+go 1.24.11
 
 require github.com/open-telemetry/opamp-go v0.22.0
 

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/pprofextension/go.mod
+++ b/extension/pprofextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/extension/remotetapextension/go.mod
+++ b/extension/remotetapextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/extension/solarwindsapmsettingsextension/go.mod
+++ b/extension/solarwindsapmsettingsextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/storage/dbstorage/go.mod
+++ b/extension/storage/dbstorage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/extension/storage/filestorage/go.mod
+++ b/extension/storage/filestorage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/storage/go.mod
+++ b/extension/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/storage/redisstorageextension/go.mod
+++ b/extension/storage/redisstorageextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/go-redis/redismock/v9 v9.2.0

--- a/extension/sumologicextension/go.mod
+++ b/extension/sumologicextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib
 // For the OpenTelemetry Collector Contrib distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 
-go 1.24
+go 1.24.11
 
 retract (
 	v0.76.2

--- a/internal/aws/awsutil/go.mod
+++ b/internal/aws/awsutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/internal/aws/containerinsight/go.mod
+++ b/internal/aws/containerinsight/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/aws/cwlogs/go.mod
+++ b/internal/aws/cwlogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/internal/aws/ecsutil/go.mod
+++ b/internal/aws/ecsutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/internal/aws/k8s/go.mod
+++ b/internal/aws/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/internal/aws/metrics/go.mod
+++ b/internal/aws/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/aws/proxy/go.mod
+++ b/internal/aws/proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/internal/aws/xray/testdata/sampleapp/go.mod
+++ b/internal/aws/xray/testdata/sampleapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/internal/aws/xray/testdata/sampleserver/go.mod
+++ b/internal/aws/xray/testdata/sampleserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleserver
 
-go 1.24.0
+go 1.24.11
 
 require github.com/aws/aws-xray-sdk-go/v2 v2.0.0
 

--- a/internal/collectd/go.mod
+++ b/internal/collectd/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd
 
-go 1.24.0
+go 1.24.11

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/common
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/datadog/e2e/go.mod
+++ b/internal/datadog/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog/e2e
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.141.0

--- a/internal/datadog/go.mod
+++ b/internal/datadog/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.73.0-rc.9

--- a/internal/docker/go.mod
+++ b/internal/docker/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/internal/exp/metrics/go.mod
+++ b/internal/exp/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/expr-lang/expr v1.17.6

--- a/internal/gopsutilenv/go.mod
+++ b/internal/gopsutilenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/shirou/gopsutil/v4 v4.25.11

--- a/internal/grpcutil/go.mod
+++ b/internal/grpcutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil
 
-go 1.24.0
+go 1.24.11
 
 require github.com/stretchr/testify v1.11.1
 

--- a/internal/healthcheck/go.mod
+++ b/internal/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235

--- a/internal/k8sinventory/go.mod
+++ b/internal/k8sinventory/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/internal/kubelet/go.mod
+++ b/internal/kubelet/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/internal/metadataproviders/go.mod
+++ b/internal/metadataproviders/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/internal/otelarrow/go.mod
+++ b/internal/otelarrow/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/klauspost/compress v1.18.1

--- a/internal/pdatautil/go.mod
+++ b/internal/pdatautil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/internal/rabbitmq/go.mod
+++ b/internal/rabbitmq/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/rabbitmq
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/rabbitmq/amqp091-go v1.10.0

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/internal/sqlquery/go.mod
+++ b/internal/sqlquery/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/batchpersignal/go.mod
+++ b/pkg/batchpersignal/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/core/xidutils/go.mod
+++ b/pkg/core/xidutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.73.0-rc.9

--- a/pkg/experimentalmetricmetadata/go.mod
+++ b/pkg/experimentalmetricmetadata/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/golden/go.mod
+++ b/pkg/golden/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.141.0

--- a/pkg/kafka/configkafka/go.mod
+++ b/pkg/kafka/configkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/pkg/kafka/topic/go.mod
+++ b/pkg/kafka/topic/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic
 
-go 1.24.0
+go 1.24.11

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/pkg/pdatatest/go.mod
+++ b/pkg/pdatatest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/pkg/pdatautil/go.mod
+++ b/pkg/pdatautil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/resourcetotelemetry/go.mod
+++ b/pkg/resourcetotelemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/pkg/sampling/go.mod
+++ b/pkg/sampling/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/pkg/status/go.mod
+++ b/pkg/status/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/translator/azure/go.mod
+++ b/pkg/translator/azure/go.mod
@@ -1,6 +1,6 @@
 //module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/pkg/translator/azurelogs/go.mod
+++ b/pkg/translator/azurelogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azurelogs
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/pkg/translator/faro/go.mod
+++ b/pkg/translator/faro/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/faro
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/go-logfmt/logfmt v0.6.1

--- a/pkg/translator/jaeger/go.mod
+++ b/pkg/translator/jaeger/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/go-logfmt/logfmt v0.6.1

--- a/pkg/translator/opencensus/go.mod
+++ b/pkg/translator/opencensus/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: this functionality is no longer maintained and will be removed.
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.4.1

--- a/pkg/translator/pprof/go.mod
+++ b/pkg/translator/pprof/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/pprof
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/pprof v0.0.0-20251007162407-5df77e3f7d1d

--- a/pkg/translator/prometheus/go.mod
+++ b/pkg/translator/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/translator/signalfx/go.mod
+++ b/pkg/translator/signalfx/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/pkg/translator/skywalking/go.mod
+++ b/pkg/translator/skywalking/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/pkg/translator/zipkin/go.mod
+++ b/pkg/translator/zipkin/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/pkg/winperfcounters/go.mod
+++ b/pkg/winperfcounters/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/xk8stest/go.mod
+++ b/pkg/xk8stest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/coralogixprocessor/go.mod
+++ b/processor/coralogixprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/cumulativetodeltaprocessor/go.mod
+++ b/processor/cumulativetodeltaprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0

--- a/processor/datadogsemanticsprocessor/go.mod
+++ b/processor/datadogsemanticsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.73.0-rc.9

--- a/processor/deltatocumulativeprocessor/go.mod
+++ b/processor/deltatocumulativeprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/processor/deltatorateprocessor/go.mod
+++ b/processor/deltatorateprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/dnslookupprocessor/go.mod
+++ b/processor/dnslookupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/geoipprocessor/go.mod
+++ b/processor/geoipprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/maxmind/MaxMind-DB v0.0.0-20240605211347-880f6b4b5eb6

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.141.0

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.141.0

--- a/processor/intervalprocessor/go.mod
+++ b/processor/intervalprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.141.0

--- a/processor/isolationforestprocessor/go.mod
+++ b/processor/isolationforestprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/processor/logdedupprocessor/go.mod
+++ b/processor/logdedupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.141.0

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/processor/metricstarttimeprocessor/go.mod
+++ b/processor/metricstarttimeprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.141.0

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/probabilisticsamplerprocessor/go.mod
+++ b/processor/probabilisticsamplerprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.141.0

--- a/processor/redactionprocessor/go.mod
+++ b/processor/redactionprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.73.0-rc.9

--- a/processor/remotetapprocessor/go.mod
+++ b/processor/remotetapprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/processor/resourceprocessor/go.mod
+++ b/processor/resourceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/schemaprocessor/go.mod
+++ b/processor/schemaprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/sumologicprocessor/go.mod
+++ b/processor/sumologicprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/processor/unrollprocessor/go.mod
+++ b/processor/unrollprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/receiver/activedirectorydsreceiver/go.mod
+++ b/receiver/activedirectorydsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/aerospikereceiver/go.mod
+++ b/receiver/aerospikereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.4.2

--- a/receiver/apachereceiver/go.mod
+++ b/receiver/apachereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/apachesparkreceiver/go.mod
+++ b/receiver/apachesparkreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/receiver/awscontainerinsightreceiver/go.mod
+++ b/receiver/awscontainerinsightreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-lambda-go v1.50.0

--- a/receiver/awss3receiver/go.mod
+++ b/receiver/awss3receiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.40.0

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-event-hubs-go/v3 v3.6.2

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-amqp-common-go/v4 v4.2.0

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/receiver/bigipreceiver/go.mod
+++ b/receiver/bigipreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/receiver/chronyreceiver/go.mod
+++ b/receiver/chronyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/facebook/time v0.0.0-20240510113249-fa89cc575891

--- a/receiver/ciscoosreceiver/go.mod
+++ b/receiver/ciscoosreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/cloudflarereceiver/go.mod
+++ b/receiver/cloudflarereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/receiver/cloudfoundryreceiver/go.mod
+++ b/receiver/cloudfoundryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	code.cloudfoundry.org/go-loggregator v7.4.0+incompatible

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.141.0

--- a/receiver/couchdbreceiver/go.mod
+++ b/receiver/couchdbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.176

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/envoyalsreceiver/go.mod
+++ b/receiver/envoyalsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0

--- a/receiver/expvarreceiver/go.mod
+++ b/receiver/expvarreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/faroreceiver/go.mod
+++ b/receiver/faroreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.141.0

--- a/receiver/filestatsreceiver/go.mod
+++ b/receiver/filestatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/receiver/flinkmetricsreceiver/go.mod
+++ b/receiver/flinkmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.141.0

--- a/receiver/githubreceiver/go.mod
+++ b/receiver/githubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/receiver/gitlabreceiver/go.mod
+++ b/receiver/gitlabreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/googlecloudmonitoringreceiver/go.mod
+++ b/receiver/googlecloudmonitoringreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/receiver/googlecloudpubsubpushreceiver/go.mod
+++ b/receiver/googlecloudpubsubpushreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/storage v1.57.2

--- a/receiver/googlecloudpubsubreceiver/go.mod
+++ b/receiver/googlecloudpubsubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.3.0

--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cloud.google.com/go/spanner v1.83.0

--- a/receiver/haproxyreceiver/go.mod
+++ b/receiver/haproxyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/huaweicloudcesreceiver/go.mod
+++ b/receiver/huaweicloudcesreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/icmpcheckreceiver/go.mod
+++ b/receiver/icmpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/iisreceiver/go.mod
+++ b/receiver/iisreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.141.0

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.141.0

--- a/receiver/k8slogreceiver/go.mod
+++ b/receiver/k8slogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.141.0

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/libhoneyreceiver/go.mod
+++ b/receiver/libhoneyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/klauspost/compress v1.18.1

--- a/receiver/lokireceiver/go.mod
+++ b/receiver/lokireceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/receiver/macosunifiedloggingreceiver/go.mod
+++ b/receiver/macosunifiedloggingreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/mongodbreceiver/go.mod
+++ b/receiver/mongodbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.73.0-rc.9

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/receiver/netflowreceiver/go.mod
+++ b/receiver/netflowreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/netsampler/goflow2/v2 v2.2.3

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/nsxtreceiver/go.mod
+++ b/receiver/nsxtreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/ntpreceiver/go.mod
+++ b/receiver/ntpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/beevik/ntp v1.5.0

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.73.0-rc.9

--- a/receiver/osqueryreceiver/go.mod
+++ b/receiver/osqueryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.141.0

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.141.0

--- a/receiver/podmanreceiver/go.mod
+++ b/receiver/podmanreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/receiver/pprofreceiver/go.mod
+++ b/receiver/pprofreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/receiver/pulsarreceiver/go.mod
+++ b/receiver/pulsarreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/apache/pulsar-client-go v0.17.0

--- a/receiver/purefareceiver/go.mod
+++ b/receiver/purefareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.141.0

--- a/receiver/purefbreceiver/go.mod
+++ b/receiver/purefbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.141.0

--- a/receiver/rabbitmqreceiver/go.mod
+++ b/receiver/rabbitmqreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/expr-lang/expr v1.17.6

--- a/receiver/redfishreceiver/go.mod
+++ b/receiver/redfishreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/riakreceiver/go.mod
+++ b/receiver/riakreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/saphanareceiver/go.mod
+++ b/receiver/saphanareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/SAP/go-hdb v1.14.13

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
+++ b/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.141.0

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/gosnmp/gosnmp v1.42.1

--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/receiver/solacereceiver/go.mod
+++ b/receiver/solacereceiver/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/Azure/go-amqp v1.5.0

--- a/receiver/splunkenterprisereceiver/go.mod
+++ b/receiver/splunkenterprisereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.73.0-rc.9

--- a/receiver/sshcheckreceiver/go.mod
+++ b/receiver/sshcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/receiver/stefreceiver/go.mod
+++ b/receiver/stefreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter v0.141.0

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/receiver/systemdreceiver/go.mod
+++ b/receiver/systemdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/containerd/cgroups/v3 v3.1.1

--- a/receiver/tcpcheckreceiver/go.mod
+++ b/receiver/tcpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.141.0

--- a/receiver/tlscheckreceiver/go.mod
+++ b/receiver/tlscheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.141.0

--- a/receiver/vcenterreceiver/go.mod
+++ b/receiver/vcenterreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/basgys/goxml2json v1.1.0

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.141.0

--- a/receiver/webhookeventreceiver/go.mod
+++ b/receiver/webhookeventreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.141.0

--- a/receiver/windowsservicereceiver/go.mod
+++ b/receiver/windowsservicereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/yanggrpcreceiver/go.mod
+++ b/receiver/yanggrpcreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/jaegertracing/jaeger-idl v0.6.0

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.141.0

--- a/scraper/zookeeperscraper/go.mod
+++ b/scraper/zookeeperscraper/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/scraper/zookeeperscraper
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/fluent/fluent-logger-golang v1.10.1

--- a/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatasenders/mockdatadogagentexporter
 
-go 1.24.0
+go 1.24.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Currently there are failing CI jobs due to `govulncheck` detecting old go versions. I think there are two causes here, the github actions tasks reference `oldstable` which seems to be pulling `1.24.10` rather than `1.24.11` which fixes some [CVEs](https://go.dev/doc/devel/release#go1.24.0). Here's [an example](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/19874372311/job/56958068640?pr=43882)

This PR bumps the current go version to 1.24.11 and adds a new make task `bump-go-version`, that can be used by running `make bump-go-version VERSION=1.24.11` to make this easy / repeatable. I couldn't find an existing task that did this.

I'm not certain if both the github actions changes and the go mod changes are needed, or if just one is standard practice here.

#### Link to tracking issue
none<!--Describe what testing was performed and which tests were added.-->
#### Testing

I'm not sure if there are any additional tests adding for version bumps

#### Documentation

none