### PR TITLE
[chore] Remove trailing bullet separator in README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md">Observability</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md">Security</a>
-    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
   </strong>
 </p>
 


### PR DESCRIPTION
#### Description

Fixed a formatting issue in the README where there was a trailing bullet separator (`&nbsp;&nbsp;&bull;&nbsp;&nbsp;`) with no link after it in the navigation section. The navigation section now properly ends after the "Security" link without an extra bullet point.

#### Link to tracking issue
N/A - Minor documentation formatting fix

#### Testing
No testing required - this is a documentation-only change that removes a formatting artifact.

#### Documentation
This PR fixes a formatting issue in the main README.md file by removing a trailing bullet separator in the navigation section (line 36).
