### PR TITLE
[chore] Fix grammar in prometheusreceiver README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md">Observability</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md">Security</a>
-    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
   </strong>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/observability.md">Observability</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md">Security</a>
+    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
   </strong>
 </p>
 

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -21,10 +21,10 @@ Receives metric data in [Prometheus](https://prometheus.io/) format. See the
 ## ⚠️ Warning
 
 Note: This component is currently work in progress. It has several limitations
-and please don't use it if the following limitations is a concern:
+and please don't use it if the following limitations are a concern:
 
 * Collector cannot auto-scale the scraping yet when multiple replicas of the
-  collector is run. 
+  collector are run. 
 * When running multiple replicas of the collector with the same config, it will
   scrape the targets multiple times.
 * Users need to configure each replica with different scraping configuration


### PR DESCRIPTION
#### Description

Fixed grammar errors in the prometheusreceiver README warning section:
- Changed "limitations is" to "limitations are" (subject-verb agreement)
- Changed "collector is run" to "collector are run" for consistency with plural "replicas"

#### Link to tracking issue
N/A - Minor documentation grammar fix

#### Testing
No testing required - this is a documentation-only change that fixes grammar errors.

#### Documentation
This PR fixes grammar issues in the prometheusreceiver README.md file, specifically in the warning section that describes component limitations.