### PR TITLE
[Chore] Add `make bump-go-version` task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ OTEL_STABLE_VERSION=main
 VERSION=$(shell git describe --always --match "v[0-9]*" HEAD)
 TRIMMED_VERSION=$(shell grep -o 'v[^-]*' <<< "$(VERSION)" | cut -c 2-)
 CORE_VERSIONS=$(SRC_PARENT_DIR)/opentelemetry-collector/versions.yaml
+GO_COMPAT_VERSION=$(shell grep '^go ' go.mod | awk '{print $$2}')
 
 COMP_REL_PATH=cmd/otelcontribcol/components.go
 MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib
@@ -159,8 +160,29 @@ tidylist: $(CROSSLINK)
 gotidy:
 	@for mod in $$(cat internal/tidylist/tidylist.txt); do \
 		echo "Tidying $$mod"; \
-		(cd $$mod && rm -rf go.sum && $(GOCMD) mod tidy -compat=1.24.0 && $(GOCMD) get toolchain@none) || exit $?; \
+		(cd $$mod && rm -rf go.sum && $(GOCMD) mod tidy -compat=$(GO_COMPAT_VERSION) && $(GOCMD) get toolchain@none) || exit $?; \
 	done
+
+.PHONY: bump-go-version
+bump-go-version:
+ifndef VERSION
+	$(error VERSION is required. Usage: make bump-go-version VERSION=1.24.11)
+endif
+	@echo "Bumping Go version to $(VERSION)..."
+	
+	# Update main go.mod
+	@echo "Updating main go.mod..."
+	@sed -i '' -E 's/^go [0-9]+\.[0-9]+.*/go $(VERSION)/' go.mod
+	
+	# Update all module go.mod files
+	@echo "Updating all module go.mod files..."
+	@find . -name "go.mod" -type f -not -path "./go.mod" -exec sed -i '' -E 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(VERSION)/g' {} \;
+	
+	@echo ""
+	@echo "✓ Successfully bumped Go version to $(VERSION)"
+	@echo ""
+	@echo "Note: GitHub Actions workflows use 'oldstable' regardless of the Go version in go.mod"
+	@echo "Next: Optionally run 'make gotidy' (takes ~5-10 minutes)"
 
 .PHONY: remove-toolchain
 remove-toolchain:

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ endif
 	@find . -name "go.mod" -type f -not -path "./go.mod" -exec sed -i '' -E 's/^go [0-9]+\.[0-9]+\.[0-9]+/go $(VERSION)/g' {} \;
 	
 	@echo ""
-	@echo "✓ Successfully bumped Go version to $(VERSION)"
+	@echo "✓ Successfully bumped golang version to $(VERSION)"
 	@echo ""
 	@echo "Note: GitHub Actions workflows use 'oldstable' regardless of the Go version in go.mod"
 	@echo "Next: Optionally run 'make gotidy' (takes ~5-10 minutes)"

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -292,7 +292,7 @@ modernize: $(MODERNIZE)
 .PHONY: tidy
 tidy:
 	rm -fr go.sum
-	$(GOCMD) mod tidy -compat=1.24.0
+	$(GOCMD) mod tidy -compat=$(GO_COMPAT_VERSION)
 
 .PHONY: toolchain
 toolchain:


### PR DESCRIPTION
#### Description

This new make task makes updating the go version across 300+ mod files simpler and more predictable.

It can be run with `make bump-go-version VERSION=x.y.z`

This changeset also makes sure that tidying uses the same version as present in go.mod to make updating versions easier.

See also [this CNCF slack discussion](https://cloud-native.slack.com/archives/C07CCCMRXBK/p1764772840812709?thread_ts=1764723382.034999&cid=C07CCCMRXBK) with @mx-psi .

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

None
<!--Describe what testing was performed and which tests were added.-->
#### Testing

Try running `make bump-go-version VERSION=1.24.11` and validate the results.

<!--Describe the documentation added.-->
#### Documentation

None
<!--Please delete paragraphs that you did not use before submitting.-->
