### PR TITLE
[chore][exporter/coralogix] Duplicate endpoint setting logic within Unmarshal

### DIFF
--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -125,7 +125,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	}
 
 	if isEmpty(c.Metrics.Endpoint) {
-		c.Metrics.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+		c.Metrics.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
 	}
 
 	if !isEmpty(c.Domain) && isEmpty(c.Traces.Endpoint) {
@@ -136,7 +136,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	}
 
 	if isEmpty(c.Traces.Endpoint) {
-		c.Traces.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+		c.Traces.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
 	}
 
 	if !isEmpty(c.Domain) && isEmpty(c.Logs.Endpoint) {
@@ -147,7 +147,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	}
 
 	if isEmpty(c.Logs.Endpoint) {
-		c.Logs.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+		c.Logs.Endpoint = ensureHTTPScheme(c.DomainSettings.Endpoint)
 	}
 
 	if !isEmpty(c.Domain) && isEmpty(c.Profiles.Endpoint) {
@@ -291,7 +291,7 @@ func setMergedTransportConfigWithConf(conf *confmap.Conf, c *Config, signalConfi
 //
 // NOTE: This function modifies *Config and *TransportConfig passed as arguments.
 // DO NOT ADD FURTHER USES OUTSIDE OF Unmarshal, see github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
-func setMergedTransportConfig(c *Config, merged *TransportConfig, signalConfig *TransportConfig) *TransportConfig {
+func setMergedTransportConfig(c *Config, merged, signalConfig *TransportConfig) *TransportConfig {
 	if signalConfig.ProxyURL != "" {
 		merged.ProxyURL = signalConfig.ProxyURL
 	}

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
@@ -96,6 +97,67 @@ type Config struct {
 	SubSystem string `mapstructure:"subsystem_name"`
 
 	RateLimiter RateLimiterConfig `mapstructure:"rate_limiter"`
+}
+
+var _ confmap.Unmarshaler = (*Config)(nil)
+
+// ensureHTTPScheme ensures the endpoint has an https:// scheme
+func ensureHTTPScheme(endpoint string) string {
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return "https://" + endpoint
+	}
+	return endpoint
+}
+
+func (c *Config) Unmarshal(conf *confmap.Conf) error {
+	if err := conf.Unmarshal(c); err != nil {
+		return err
+	}
+
+	_ = setDomainGrpcSettings(c)
+	var err error
+
+	if !isEmpty(c.Domain) && isEmpty(c.Metrics.Endpoint) {
+		c.Metrics, err = setMergedTransportConfigWithConf(conf, c, &c.Metrics)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isEmpty(c.Metrics.Endpoint) {
+		c.Metrics.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+	}
+
+	if !isEmpty(c.Domain) && isEmpty(c.Traces.Endpoint) {
+		c.Traces, err = setMergedTransportConfigWithConf(conf, c, &c.Traces)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isEmpty(c.Traces.Endpoint) {
+		c.Traces.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+	}
+
+	if !isEmpty(c.Domain) && isEmpty(c.Logs.Endpoint) {
+		c.Logs, err = setMergedTransportConfigWithConf(conf, c, &c.Logs)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isEmpty(c.Logs.Endpoint) {
+		c.Logs.Endpoint = ensureHTTPScheme(c.DomainSettings.ClientConfig.Endpoint)
+	}
+
+	if !isEmpty(c.Domain) && isEmpty(c.Profiles.Endpoint) {
+		tCfg, err := setMergedTransportConfigWithConf(conf, c, &TransportConfig{ClientConfig: c.Profiles})
+		if err != nil {
+			return err
+		}
+		c.Profiles = tCfg.ClientConfig
+	}
+	return nil
 }
 
 type RateLimiterConfig struct {
@@ -189,7 +251,7 @@ func (c *Config) getMetadataFromResource(res pcommon.Resource) (appName, subsyst
 	return appName, subsystem
 }
 
-func (c *Config) getDomainGrpcSettings() *configgrpc.ClientConfig {
+func setDomainGrpcSettings(c *Config) string {
 	settings := c.DomainSettings.ClientConfig
 	domain := c.Domain
 
@@ -201,14 +263,35 @@ func (c *Config) getDomainGrpcSettings() *configgrpc.ClientConfig {
 		settings.Endpoint = fmt.Sprintf("ingress.%s:443", domain)
 	}
 
-	return &settings
+	return settings.Endpoint
 }
 
-// getMergedTransportConfig returns a TransportConfig that merges signal-specific settings with domain settings.
+// setMergedTransportConfigWithConf returns a TransportConfig that merges signal-specific settings with domain settings.
 // Signal-specific settings take precedence over domain settings.
-func (c *Config) getMergedTransportConfig(signalConfig *TransportConfig) *TransportConfig {
-	merged := c.DomainSettings
+// This is used when unmarshaling from confmap to get domain settings.
+// We pass the conf to get a fresh copy of the domain settings from the confmap.
+//
+// NOTE: This function modifies *Config and *TransportConfig passed as arguments.
+// DO NOT ADD FURTHER USES OUTSIDE OF Unmarshal, see github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
+func setMergedTransportConfigWithConf(conf *confmap.Conf, c *Config, signalConfig *TransportConfig) (TransportConfig, error) {
+	var domainSettings TransportConfig
+	sub, err := conf.Sub("domain_settings")
+	if err != nil {
+		return TransportConfig{}, err
+	}
+	if unmarshalErr := sub.Unmarshal(&domainSettings); unmarshalErr != nil {
+		return TransportConfig{}, unmarshalErr
+	}
 
+	return *setMergedTransportConfig(c, &domainSettings, signalConfig), nil
+}
+
+// setMergedTransportConfig returns a TransportConfig that merges signal-specific settings with domain settings.
+// Signal-specific settings take precedence over domain settings.
+//
+// NOTE: This function modifies *Config and *TransportConfig passed as arguments.
+// DO NOT ADD FURTHER USES OUTSIDE OF Unmarshal, see github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
+func setMergedTransportConfig(c *Config, merged *TransportConfig, signalConfig *TransportConfig) *TransportConfig {
 	if signalConfig.ProxyURL != "" {
 		merged.ProxyURL = signalConfig.ProxyURL
 	}
@@ -248,10 +331,10 @@ func (c *Config) getMergedTransportConfig(signalConfig *TransportConfig) *Transp
 	}
 
 	if isEmpty(signalConfig.Endpoint) {
-		merged.Endpoint = c.getDomainGrpcSettings().Endpoint
+		merged.Endpoint = setDomainGrpcSettings(c)
 	} else {
 		merged.Endpoint = signalConfig.Endpoint
 	}
 
-	return &merged
+	return merged
 }

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -397,8 +397,8 @@ func TestGetDomainGrpcSettings(t *testing.T) {
 				},
 			}
 
-			settings := cfg.getDomainGrpcSettings()
-			assert.Equal(t, tt.expectedEndpoint, settings.Endpoint)
+			endpoint := setDomainGrpcSettings(cfg)
+			assert.Equal(t, tt.expectedEndpoint, endpoint)
 		})
 	}
 }

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -279,8 +279,8 @@ func TestCreateTracesWithPrivateLink(t *testing.T) {
 	require.NotNil(t, consumer)
 
 	// Verify the endpoint is correctly set to private link
-	settings := cfg.getDomainGrpcSettings()
-	assert.Equal(t, "ingress.private.coralogix.com:443", settings.Endpoint)
+	endpoint := setDomainGrpcSettings(cfg)
+	assert.Equal(t, "ingress.private.coralogix.com:443", endpoint)
 
 	err = consumer.Start(t.Context(), componenttest.NewNopHost())
 	assert.NoError(t, err)
@@ -306,8 +306,8 @@ func TestCreateMetricsWithPrivateLink(t *testing.T) {
 	require.NotNil(t, consumer)
 
 	// Verify the endpoint is correctly set to private link
-	settings := cfg.getDomainGrpcSettings()
-	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", settings.Endpoint)
+	endpoint := setDomainGrpcSettings(cfg)
+	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", endpoint)
 
 	err = consumer.Shutdown(t.Context())
 	assert.NoError(t, err)
@@ -327,8 +327,8 @@ func TestCreateLogsWithPrivateLink(t *testing.T) {
 	require.NotNil(t, consumer)
 
 	// Verify the endpoint is correctly set to private link
-	settings := cfg.getDomainGrpcSettings()
-	assert.Equal(t, "ingress.private.coralogix.us:443", settings.Endpoint)
+	endpoint := setDomainGrpcSettings(cfg)
+	assert.Equal(t, "ingress.private.coralogix.us:443", endpoint)
 
 	err = consumer.Shutdown(t.Context())
 	assert.NoError(t, err)
@@ -348,8 +348,8 @@ func TestCreateTracesWithDomainAlreadyContainingPrivate(t *testing.T) {
 	require.NotNil(t, consumer)
 
 	// Verify the endpoint does not duplicate "private"
-	settings := cfg.getDomainGrpcSettings()
-	assert.Equal(t, "ingress.private.coralogix.com:443", settings.Endpoint)
+	endpoint := setDomainGrpcSettings(cfg)
+	assert.Equal(t, "ingress.private.coralogix.com:443", endpoint)
 
 	err = consumer.Start(t.Context(), componenttest.NewNopHost())
 	assert.NoError(t, err)
@@ -375,8 +375,8 @@ func TestCreateMetricsWithDomainAlreadyContainingPrivate(t *testing.T) {
 	require.NotNil(t, consumer)
 
 	// Verify the endpoint does not duplicate "private"
-	settings := cfg.getDomainGrpcSettings()
-	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", settings.Endpoint)
+	endpoint := setDomainGrpcSettings(cfg)
+	assert.Equal(t, "ingress.private.eu2.coralogix.com:443", endpoint)
 
 	err = consumer.Shutdown(t.Context())
 	assert.NoError(t, err)

--- a/exporter/coralogixexporter/http_exporter.go
+++ b/exporter/coralogixexporter/http_exporter.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
@@ -45,18 +44,12 @@ func (e *httpError) Error() string {
 	return e.Message
 }
 
-// ensureHTTPScheme ensures the endpoint has an https:// scheme
-func ensureHTTPScheme(endpoint string) string {
-	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
-		return "https://" + endpoint
-	}
-	return endpoint
-}
-
 func newHTTPLogsExporter(client *http.Client, config *Config) httpLogsExporter {
+	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
+	// See TODO
 	endpoint := config.Logs.Endpoint
 	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(config.getDomainGrpcSettings().Endpoint)
+		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
 	}
 
 	return httpLogsExporter{
@@ -68,9 +61,11 @@ func newHTTPLogsExporter(client *http.Client, config *Config) httpLogsExporter {
 }
 
 func newHTTPMetricsExporter(client *http.Client, config *Config) httpMetricsExporter {
+	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
+	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
 	endpoint := config.Metrics.Endpoint
 	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(config.getDomainGrpcSettings().Endpoint)
+		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
 	}
 
 	return httpMetricsExporter{
@@ -82,9 +77,11 @@ func newHTTPMetricsExporter(client *http.Client, config *Config) httpMetricsExpo
 }
 
 func newHTTPTracesExporter(client *http.Client, config *Config) httpTracesExporter {
+	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
+	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
 	endpoint := config.Traces.Endpoint
 	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(config.getDomainGrpcSettings().Endpoint)
+		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
 	}
 
 	return httpTracesExporter{

--- a/exporter/coralogixexporter/http_exporter.go
+++ b/exporter/coralogixexporter/http_exporter.go
@@ -46,7 +46,7 @@ func (e *httpError) Error() string {
 
 func newHTTPLogsExporter(client *http.Client, config *Config) httpLogsExporter {
 	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
-	// See TODO
+	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
 	endpoint := config.Logs.Endpoint
 	if isEmpty(endpoint) {
 		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -135,7 +135,8 @@ func (e *signalExporter) startSignalExporter(ctx context.Context, host component
 
 	var transportConfig *TransportConfig
 	if !isEmpty(e.config.Domain) && isEmpty(signalConfig.GetEndpoint()) {
-		transportConfig = e.config.getMergedTransportConfig(signalConfigWrapper.config)
+		// TODO: Remove this function call, already done in Unmarshal, see github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
+		transportConfig = setMergedTransportConfig(e.config, &e.config.DomainSettings, signalConfigWrapper.config)
 	} else {
 		transportConfig = signalConfigWrapper.config
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This partially moves the TransportConfig duplication logic to Unmarshal.

The goal is that at validation time each ClientConfig is valid.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Unblocks open-telemetry/opentelemetry-collector/pull/14221