### PR TITLE
[receiver/prometheusreceiver] Fix normalization of info metrics

### DIFF
--- a/.chloggen/fix-info-suffix.yaml
+++ b/.chloggen/fix-info-suffix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix normalization of info typed metrics, resulting in keeping their _info suffixes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44732]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -54,7 +54,7 @@ func metadataForMetric(metricName string, mc scrape.MetricMetadataStore) (*scrap
 	// try with suffixes trimmed, in-case it is a "merged" metric type.
 	normalizedName := normalizeMetricName(metricName)
 	if metadata, ok := mc.GetMetadata(normalizedName); ok {
-		if metadata.Type == model.MetricTypeCounter {
+		if metadata.Type == model.MetricTypeCounter || metadata.Type == model.MetricTypeInfo {
 			return &metadata, metricName
 		}
 		return &metadata, normalizedName

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -253,7 +253,7 @@ func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pme
 	ts1 := getTS(metrics1)
 	e1 := []metricExpectation{
 		{
-			"foo",
+			"foo_info",
 			pmetric.MetricTypeSum,
 			"",
 			[]dataPointExpectation{


### PR DESCRIPTION
#### Description

Today, `metadataForMetric` could fail to normalize info metrics when metadata is found for their base name.
In case of type metrics (and also for statesets?) there's no logic to preserve their original name, resulting in trimmed MetricFamily.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

`receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go` expected the wrong name, so it has been updated.

Tried it out in a local setup and the fix works.
