### PR TITLE
[chore] Add testbed test where you have both the batching processor and the exporterhelper batcher

### DIFF
--- a/testbed/tests/batcher_test.go
+++ b/testbed/tests/batcher_test.go
@@ -86,6 +86,17 @@ func TestLog10kDPSNoProcessors(t *testing.T) {
 				ExpectedMaxRAM: 120,
 			},
 		},
+		{
+			name:                "Batch size 1000 with batch processor and exporter batcher, queue",
+			withBatchProcessor:  true,
+			withExporterBatcher: true,
+			withQueue:           true,
+			batchSize:           1000,
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 120,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds separate test with both batch processor and exporter helper batcher

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Follows #36206

Relates to open-telemetry/opentelemetry-collector/issues/13894

Relates to open-telemetry/opentelemetry-helm-charts/issues/1903