### PR TITLE
[extension/datadog] Reduce payload interval and add TTL field

### DIFF
--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -28,7 +28,10 @@ import (
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 )
 
-const payloadSendingInterval = 30 * time.Minute
+const (
+	payloadSendingInterval = 5 * time.Minute
+	payloadTTL             = payloadSendingInterval * 2
+)
 
 // uuidProvider defines an interface for generating UUIDs, allowing for mocking in tests.
 type uuidProvider interface {
@@ -121,6 +124,7 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		fullConfig,
 		e.configs.extension.DeploymentType,
 		buildInfo,
+		int64(payloadTTL),
 	)
 
 	// Populate resource attributes collected from TelemetrySettings.Resource

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	payloadSendingInterval = 5 * time.Minute
-	payloadTTL             = payloadSendingInterval * 2
+	payloadTTL             = payloadSendingInterval * 3
 )
 
 // uuidProvider defines an interface for generating UUIDs, allowing for mocking in tests.

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -359,6 +359,7 @@ func createTestOtelCollectorPayload() *payload.OtelCollectorPayload {
 		fullConfig,
 		"unknown",
 		buildInfo,
+		int64(payloadTTL),
 	)
 
 	// Populate with realistic component data
@@ -566,6 +567,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 		fullConfig,
 		"unknown",
 		buildInfo,
+		int64(payloadTTL),
 	)
 	if activeComponents != nil {
 		otelMetadata.ActiveComponents = *activeComponents
@@ -725,6 +727,7 @@ func TestHTTPServerConfigIntegration(t *testing.T) {
 		"{}",
 		"unknown",
 		buildInfo,
+		int64(payloadTTL),
 	)
 
 	// Test different server configurations
@@ -814,6 +817,7 @@ func TestHTTPServerConcurrentAccess(t *testing.T) {
 		"{}",
 		"unknown",
 		buildInfo,
+		int64(payloadTTL),
 	)
 
 	// Create server

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -220,7 +220,7 @@ const successfulInstanceResponse = `{
     "health_status": "",
     "collector_resource_attributes": {},
     "collector_deployment_type": "unknown",
-    "ttl": 0
+    "ttl": 900000000000
   },
   "uuid": "test-uuid"
 }`
@@ -298,6 +298,7 @@ func TestHandleMetadata(t *testing.T) {
 						ActiveComponents:            []payload.ServiceComponent{},
 						CollectorResourceAttributes: map[string]string{},
 						CollectorDeploymentType:     "unknown", // Default value set by config validation
+						TTL:                         int64(5 * time.Minute * 3),
 					},
 				},
 			}

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -219,7 +219,8 @@ const successfulInstanceResponse = `{
     "full_configuration": "",
     "health_status": "",
     "collector_resource_attributes": {},
-    "collector_deployment_type": "unknown"
+    "collector_deployment_type": "unknown",
+	"ttl": 0
   },
   "uuid": "test-uuid"
 }`

--- a/extension/datadogextension/internal/httpserver/httpserver_test.go
+++ b/extension/datadogextension/internal/httpserver/httpserver_test.go
@@ -220,7 +220,7 @@ const successfulInstanceResponse = `{
     "health_status": "",
     "collector_resource_attributes": {},
     "collector_deployment_type": "unknown",
-	"ttl": 0
+    "ttl": 0
   },
   "uuid": "test-uuid"
 }`

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -37,6 +37,7 @@ type OtelCollector struct {
 	HealthStatus                string             `json:"health_status"`      // JSON passed as string
 	CollectorResourceAttributes map[string]string  `json:"collector_resource_attributes"`
 	CollectorDeploymentType     string             `json:"collector_deployment_type"` // deployment type: gateway, daemonset, or unknown
+	TTL                         int64              `json:"ttl"`
 }
 
 type CollectorModule struct {
@@ -91,6 +92,7 @@ func PrepareOtelCollectorMetadata(
 	fullConfig,
 	deploymentType string,
 	buildInfo CustomBuildInfo,
+	ttl int64,
 ) OtelCollector {
 	return OtelCollector{
 		HostKey:                 "",
@@ -103,5 +105,6 @@ func PrepareOtelCollectorMetadata(
 		BuildInfo:               buildInfo,
 		FullConfiguration:       fullConfig,
 		CollectorDeploymentType: deploymentType,
+		TTL:                     ttl,
 	}
 }

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -168,7 +168,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 		fullConfig,
 		deploymentType,
 		buildInfo,
-		int64(5*time.Minute*2),
+		int64(5*time.Minute*3),
 	)
 
 	// Add full components (what would come from module info)
@@ -436,7 +436,7 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 				"{}",
 				tt.deploymentType,
 				buildInfo,
-				int64(5*time.Minute*2),
+				int64(5*time.Minute*3),
 			)
 
 			assert.Equal(t, tt.deploymentType, metadata.CollectorDeploymentType)

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -168,6 +168,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 		fullConfig,
 		deploymentType,
 		buildInfo,
+		int64(5*time.Minute*2),
 	)
 
 	// Add full components (what would come from module info)
@@ -435,6 +436,7 @@ func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 				"{}",
 				tt.deploymentType,
 				buildInfo,
+				int64(5*time.Minute*2),
 			)
 
 			assert.Equal(t, tt.deploymentType, metadata.CollectorDeploymentType)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Reduces Datadog Extension payload interval from 30 minutes to 5 minutes in order to prevent stale payloads when rebooting a collector. Also adds a field `ttl` for the backend to read and set liveness appropriately.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
OTAGENT-678

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
