### PR TITLE
[receiver/datadogreceiver] Add `EnableMultiTagParsing` feature gate

### DIFF
--- a/.chloggen/datadogreceiver_multi-tag-parsing.yaml
+++ b/.chloggen/datadogreceiver_multi-tag-parsing.yaml
@@ -10,7 +10,7 @@ component: datadogreceiver
 note: Add `receiver.datadogreceiver.EnableMultiTagParsing` feature gate
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [] # TODO (PR number)
+issues: [44747]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/datadogreceiver_multi-tag-parsing.yaml
+++ b/.chloggen/datadogreceiver_multi-tag-parsing.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `receiver.datadogreceiver.EnableMultiTagParsing` feature gate
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [] # TODO (PR number)
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The feature flag changes the logic that converts Datadog tags to OpenTelemetry attributes.
+  When the flag is enabled, data points that have multiple tags starting with the same `key:` prefix
+  will be turned into an attribute slice (instead of a string) containing all the suffix values.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/datadogreceiver_multi-tag-parsing.yaml
+++ b/.chloggen/datadogreceiver_multi-tag-parsing.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: datadogreceiver
+component: receiver/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `receiver.datadogreceiver.EnableMultiTagParsing` feature gate

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -87,6 +87,14 @@ receivers:
           fail_on_invalid_key: true
 ```
 
+### Metric Tag→Attribute Conversion
+
+Datadog [metric tags](https://docs.datadoghq.com/getting_started/tagging/) are expected to be in a `key:value` format.
+Tags not in this format will be given an `unnamed_` prefix when added to the attribute map (e.g. the tag `prod` will be converted to `unnamed_prod = prod`).
+
+By default, multiple tags for the same data point with the same `key:` prefix will only have the last tag retained (e.g. `["env:a","env:b"]` will be converted to `{env = b}`).
+If the `receiver.datadogreceiver.EnableMultiTagParsing` feature gate is enabled, multiple tags with the same key will instead be stored as a slice (e.g. `["env:a","env:b"]` will be converted to `{env = [a,b]}`).
+
 ### Default Attributes
 
 - `dd.span.Resource`: The datadog resource name (as distinct from the span name)

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -17,7 +17,7 @@ var MultiTagParsingFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("When enabled, parses `key:value` tags with duplicate keys into a slice attribute."),
 	featuregate.WithRegisterFromVersion("v0.142.0"),
-	featuregate.WithRegisterReferenceURL("TODO (PR link)"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44747"),
 )
 
 // See:

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -7,8 +7,17 @@ import (
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+)
+
+var MultiTagParsingFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"receiver.datadogreceiver.EnableMultiTagParsing",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, parses `key:value` tags with duplicate keys into a slice attribute."),
+	featuregate.WithRegisterFromVersion("v0.142.0"),
+	featuregate.WithRegisterReferenceURL("TODO (PR link)"),
 )
 
 // See:
@@ -185,7 +194,31 @@ func tagsToAttributes(tags []string, host string, stringPool *StringPool) attrib
 				// type string[]
 				attrs.resource.PutEmptySlice(key).AppendEmpty().SetStr(val)
 			} else {
-				attrs.dp.PutStr(key, val)
+				if !MultiTagParsingFeatureGate.IsEnabled() {
+					attrs.dp.PutStr(key, val)
+				} else {
+					// Datadog does, semantically, generate tags with the same key prefix but different values
+					// (e.g. the `kube_service` tag when using the `kubelet` integration)
+					// (https://docs.datadoghq.com/containers/kubernetes/tag/)
+					// and we handle this by using a slice whenever there is more than one value for the same key
+					value, exists := attrs.dp.Get(key)
+					if exists {
+						switch value.Type() {
+						case pcommon.ValueTypeSlice:
+							value.Slice().AppendEmpty().SetStr(val)
+						default:
+							oldValue := pcommon.NewValueEmpty()
+							value.CopyTo(oldValue)
+							attrs.dp.Remove(key)
+							slice := attrs.dp.PutEmptySlice(key)
+							firstValue := slice.AppendEmpty()
+							oldValue.CopyTo(firstValue)
+							slice.AppendEmpty().SetStr(val)
+						}
+					} else {
+						attrs.dp.PutStr(key, val)
+					}
+				}
 			}
 		}
 	}

--- a/receiver/datadogreceiver/internal/translator/tags_test.go
+++ b/receiver/datadogreceiver/internal/translator/tags_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
@@ -182,4 +184,32 @@ func TestHTTPHeaders(t *testing.T) {
 	header, found = attrs.resource.Get("http.response.header.header")
 	assert.True(t, found)
 	assert.Equal(t, expected, header.AsString())
+}
+
+func TestKeyOverlapWithFeatureGate(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set(MultiTagParsingFeatureGate.ID(), true))
+
+	expected := "[\"value1\",\"value2\"]"
+	tags := []string{"env:prod", "foo", "kube_service:value1", "kube_service:value2"}
+	host := "host"
+	pool := newStringPool()
+
+	attrs := tagsToAttributes(tags, host, pool)
+	kubeService, found := attrs.dp.Get("kube_service")
+	assert.True(t, found)
+	assert.Equal(t, expected, kubeService.AsString())
+}
+
+func TestKeyOverlapWithoutFeatureGate(t *testing.T) {
+	require.NoError(t, featuregate.GlobalRegistry().Set(MultiTagParsingFeatureGate.ID(), false))
+
+	expected := "value2"
+	tags := []string{"env:prod", "foo", "kube_service:value1", "kube_service:value2"}
+	host := "host"
+	pool := newStringPool()
+
+	attrs := tagsToAttributes(tags, host, pool)
+	kubeService, found := attrs.dp.Get("kube_service")
+	assert.True(t, found)
+	assert.Equal(t, expected, kubeService.AsString())
 }


### PR DESCRIPTION
#### Description

Datadog's metric model treats tags on data points as arbitrary strings. However, the product has special support for tags formatted as a `key:value` string. `key:value` tags allow slicing metrics in powerful ways and are core to many of Datadog's offerings.

Since Datadog tags are arbitrary strings, there's nothing to stop users from recording tags with the same `key:` prefix on the same data point. In fact, Datadog's own integrations can do this: The `kube_service` tag from [the `kubelet` integration](https://docs.datadoghq.com/containers/kubernetes/tag/) will have one entry per Kubernetes service that fronts a pod. (An example set of tags might look something like `[...,"kube_service:datadog-cluster-agent-metrics-api","kube_service:datadog-cluster-agent-admission-controller",...]`).

Currently, when the `datadogreceiver` receives multiple tags for a data point that share the same key, it only retains the last `key:value` pair as an OpenTelemetry attribe. In the above example, the attribute map would have an entry `kube_service = datadog-cluster-agent-admission-controller` - "datadog-cluster-agent-metrics-api" would have been discarded.

This change introduces a feature gate that changes the tag parsing behaviour to support tags that share the same key. Instead of overwriting the previous `Str` entry in the attribute map, it converts the attribute map to a `Slice` and stores all values for that key. This conversion only happens if more than one value is encountered for the same key, so even with the feature flag enabled, there will not be any behaviour change for users who do not send tags that share the same key.

I chose to implement this as a feature flag instead of a config setting because I believe this is technically correct behaviour, and should be the default in some future release of the OpenTelemetry Collector. Feedback on this decision is appreciated.

#### Testing

Unit tests have been added against `tagsToAttributes` to make sure attribute conversion works as expected both with and without the feature gate.  The collector has been built and run locally, confirming that exporters receive the expected (slice) attributes when multiple tags with the same key are received.

#### Documentation

The README for the receiver now describes how tags are processed, both with and without the feature gate.