### PR TITLE
Use pointer when passing TransformContext around or calling into

### DIFF
--- a/.chloggen/use-pointer-for-context.yaml
+++ b/.chloggen/use-pointer-for-context.yaml
@@ -24,14 +24,14 @@ subtext: |
   - `ottlmetric.NewTransformContext` in favor of `ottlmetric.NewTransformContextPtr`;
   - `ottlspan.NewTransformContext` in favor of `ottlspan.NewTransformContextPtr`;
   - `ottlspanevent.NewTransformContext` in favor of `ottlspanevent.NewTransformContextPtr`;
-  - `filtermprocessor.DefaultDataPointFunctions` in favor of `filtermprocessor.DefaultDataPointFunctionsNew`
-  - `filtermprocessor.WithDataPointFunctions` in favor of `filtermprocessor.WithDataPointFunctionsNew`
-  - `filtermprocessor.DefaultLogFunctions` in favor of `filtermprocessor.DefaultLogFunctionsNew`
-  - `filtermprocessor.WithLogFunctions` in favor of `filtermprocessor.WithLogFunctionsNew`
-  - `filtermprocessor.DefaultMetricFunctions` in favor of `filtermprocessor.DefaultMetricFunctionsNew`
-  - `filtermprocessor.WithMetricFunctions` in favor of `filtermprocessor.WithMetricFunctionsNew`
-  - `filtermprocessor.DefaultSpanFunctions` in favor of `filtermprocessor.DefaultSpanFunctionsNew`
-  - `filtermprocessor.WithSpanFunctions` in favor of `filtermprocessor.WithSpanFunctionsNew`
+  - `filterprocessor.DefaultDataPointFunctions` in favor of `filtermprocessor.DefaultDataPointFunctionsNew`
+  - `filterprocessor.WithDataPointFunctions` in favor of `filterprocessor.WithDataPointFunctionsNew`
+  - `filterprocessor.DefaultLogFunctions` in favor of `filterprocessor.DefaultLogFunctionsNew`
+  - `filterprocessor.WithLogFunctions` in favor of `filterprocessor.WithLogFunctionsNew`
+  - `filterprocessor.DefaultMetricFunctions` in favor of `filterprocessor.DefaultMetricFunctionsNew`
+  - `filterprocessor.WithMetricFunctions` in favor of `filterprocessor.WithMetricFunctionsNew`
+  - `filterprocessor.DefaultSpanFunctions` in favor of `filterprocessor.DefaultSpanFunctionsNew`
+  - `filterprocessor.WithSpanFunctions` in favor of `filterprocessor.WithSpanFunctionsNew`
   - `filtermprocessor.DefaultSpanEventFunctions` in favor of `filtermprocessor.DefaultSpanEventFunctionsNew`
   - `filtermprocessor.WithSpanEventFunctions` in favor of `filtermprocessor.WithSpanEventFunctionsNew`
   - `transformprocessor.DefaultDataPointFunctions` in favor of `transformprocessor.DefaultDataPointFunctionsNew`

--- a/.chloggen/use-pointer-for-context.yaml
+++ b/.chloggen/use-pointer-for-context.yaml
@@ -19,11 +19,31 @@ subtext: |
   Change Expr/Parser/Getter/Setter and all ottl related funcs to accept pointers to avoid unnecessary copy of a large
   TransformContext(96B). Avoid allocating a new pcommon.Map every time a new context is created by using a Borrow/Return
   pattern and reuse objects between calls. Deprecated funcs are:
-  - `ottlspan.NewTransformContext` in favor of `ottlspan.BorrowContext`;
+  - `ottldatapoint.NewTransformContext` in favor of `ottldatapoint.NewTransformContextPtr`;
+  - `ottllog.NewTransformContext` in favor of `ottllog.NewTransformContextPtr`;
+  - `ottlmetric.NewTransformContext` in favor of `ottlmetric.NewTransformContextPtr`;
+  - `ottlspan.NewTransformContext` in favor of `ottlspan.NewTransformContextPtr`;
+  - `ottlspanevent.NewTransformContext` in favor of `ottlspanevent.NewTransformContextPtr`;
+  - `filtermprocessor.DefaultDataPointFunctions` in favor of `filtermprocessor.DefaultDataPointFunctionsNew`
+  - `filtermprocessor.WithDataPointFunctions` in favor of `filtermprocessor.WithDataPointFunctionsNew`
+  - `filtermprocessor.DefaultLogFunctions` in favor of `filtermprocessor.DefaultLogFunctionsNew`
+  - `filtermprocessor.WithLogFunctions` in favor of `filtermprocessor.WithLogFunctionsNew`
+  - `filtermprocessor.DefaultMetricFunctions` in favor of `filtermprocessor.DefaultMetricFunctionsNew`
+  - `filtermprocessor.WithMetricFunctions` in favor of `filtermprocessor.WithMetricFunctionsNew`
   - `filtermprocessor.DefaultSpanFunctions` in favor of `filtermprocessor.DefaultSpanFunctionsNew`
   - `filtermprocessor.WithSpanFunctions` in favor of `filtermprocessor.WithSpanFunctionsNew`
+  - `filtermprocessor.DefaultSpanEventFunctions` in favor of `filtermprocessor.DefaultSpanEventFunctionsNew`
+  - `filtermprocessor.WithSpanEventFunctions` in favor of `filtermprocessor.WithSpanEventFunctionsNew`
+  - `transformprocessor.DefaultDataPointFunctions` in favor of `transformprocessor.DefaultDataPointFunctionsNew`
+  - `transformprocessor.WithDataPointFunctions` in favor of `transformprocessor.WithDataPointFunctionsNew`
+  - `transformprocessor.DefaultLogFunctions` in favor of `transformprocessor.DefaultLogFunctionsNew`
+  - `transformprocessor.WithLogFunctions` in favor of `transformprocessor.WithLogFunctionsNew`
+  - `transformprocessor.DefaultMetricFunctions` in favor of `transformprocessor.DefaultMetricFunctionsNew`
+  - `transformprocessor.WithMetricFunctions` in favor of `transformprocessor.WithMetricFunctionsNew`
   - `transformprocessor.DefaultSpanFunctions` in favor of `transformprocessor.DefaultSpanFunctionsNew`
   - `transformprocessor.WithSpanFunctions` in favor of `transformprocessor.WithSpanFunctionsNew`
+  - `transformprocessor.DefaultSpanEventFunctions` in favor of `transformprocessor.DefaultSpanEventFunctionsNew`
+  - `transformprocessor.WithSpanEventFunctions` in favor of `transformprocessor.WithSpanEventFunctionsNew`
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -33,10 +33,10 @@ type count struct {
 	component.ShutdownFunc
 
 	spansMetricDefs      map[string]metricDef[*ottlspan.TransformContext]
-	spanEventsMetricDefs map[string]metricDef[ottlspanevent.TransformContext]
-	metricsMetricDefs    map[string]metricDef[ottlmetric.TransformContext]
-	dataPointsMetricDefs map[string]metricDef[ottldatapoint.TransformContext]
-	logsMetricDefs       map[string]metricDef[ottllog.TransformContext]
+	spanEventsMetricDefs map[string]metricDef[*ottlspanevent.TransformContext]
+	metricsMetricDefs    map[string]metricDef[*ottlmetric.TransformContext]
+	dataPointsMetricDefs map[string]metricDef[*ottldatapoint.TransformContext]
+	logsMetricDefs       map[string]metricDef[*ottllog.TransformContext]
 	profilesMetricDefs   map[string]metricDef[ottlprofile.TransformContext]
 }
 
@@ -52,7 +52,7 @@ func (c *count) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 		resourceSpan := td.ResourceSpans().At(i)
 		resourceAttrs := resourceSpan.Resource().Attributes()
 		spansCounter := newCounter[*ottlspan.TransformContext](c.spansMetricDefs)
-		spanEventsCounter := newCounter[ottlspanevent.TransformContext](c.spanEventsMetricDefs)
+		spanEventsCounter := newCounter[*ottlspanevent.TransformContext](c.spanEventsMetricDefs)
 
 		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
 			scopeSpan := resourceSpan.ScopeSpans().At(j)
@@ -69,8 +69,9 @@ func (c *count) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 				for l := 0; l < span.Events().Len(); l++ {
 					event := span.Events().At(l)
 					spanEventsCounter.updateTimestamp(event.Timestamp())
-					eCtx := ottlspanevent.NewTransformContext(event, span, scopeSpan.Scope(), resourceSpan.Resource(), scopeSpan, resourceSpan)
+					eCtx := ottlspanevent.NewTransformContextPtr(event, span, scopeSpan.Scope(), resourceSpan.Resource(), scopeSpan, resourceSpan)
 					multiError = errors.Join(multiError, spanEventsCounter.update(ctx, event.Attributes(), scopeAttrs, resourceAttrs, eCtx))
+					eCtx.Close()
 				}
 			}
 		}
@@ -102,8 +103,8 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		resourceMetric := md.ResourceMetrics().At(i)
 		resourceAttrs := resourceMetric.Resource().Attributes()
-		metricsCounter := newCounter[ottlmetric.TransformContext](c.metricsMetricDefs)
-		dataPointsCounter := newCounter[ottldatapoint.TransformContext](c.dataPointsMetricDefs)
+		metricsCounter := newCounter[*ottlmetric.TransformContext](c.metricsMetricDefs)
+		dataPointsCounter := newCounter[*ottldatapoint.TransformContext](c.dataPointsMetricDefs)
 
 		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
 			scopeMetrics := resourceMetric.ScopeMetrics().At(j)
@@ -111,8 +112,9 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContext(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+				mCtx := ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 				multiError = errors.Join(multiError, metricsCounter.update(ctx, pcommon.NewMap(), scopeAttrs, resourceAttrs, mCtx))
+				mCtx.Close()
 
 				//exhaustive:enforce
 				switch metric.Type() {
@@ -121,40 +123,45 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContext(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeSum:
 					dps := metric.Sum().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContext(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeSummary:
 					dps := metric.Summary().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContext(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeHistogram:
 					dps := metric.Histogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContext(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					dps := metric.ExponentialHistogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContext(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeEmpty:
 					multiError = errors.Join(multiError, fmt.Errorf("metric %q: invalid metric type: %v", metric.Name(), metric.Type()))
@@ -189,7 +196,7 @@ func (c *count) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		resourceLog := ld.ResourceLogs().At(i)
 		resourceAttrs := resourceLog.Resource().Attributes()
-		counter := newCounter[ottllog.TransformContext](c.logsMetricDefs)
+		counter := newCounter[*ottllog.TransformContext](c.logsMetricDefs)
 
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLogs := resourceLog.ScopeLogs().At(j)
@@ -198,8 +205,9 @@ func (c *count) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
 				logRecord := scopeLogs.LogRecords().At(k)
 				counter.updateTimestamp(logRecord.Timestamp())
-				lCtx := ottllog.NewTransformContext(logRecord, scopeLogs.Scope(), resourceLog.Resource(), scopeLogs, resourceLog)
+				lCtx := ottllog.NewTransformContextPtr(logRecord, scopeLogs.Scope(), resourceLog.Resource(), scopeLogs, resourceLog)
 				multiError = errors.Join(multiError, counter.update(ctx, logRecord.Attributes(), scopeAttrs, resourceAttrs, lCtx))
+				lCtx.Close()
 			}
 		}
 

--- a/connector/countconnector/factory.go
+++ b/connector/countconnector/factory.go
@@ -64,9 +64,9 @@ func createTracesToMetrics(
 		spanMetricDefs[name] = md
 	}
 
-	spanEventMetricDefs := make(map[string]metricDef[ottlspanevent.TransformContext], len(c.SpanEvents))
+	spanEventMetricDefs := make(map[string]metricDef[*ottlspanevent.TransformContext], len(c.SpanEvents))
 	for name, info := range c.SpanEvents {
-		md := metricDef[ottlspanevent.TransformContext]{
+		md := metricDef[*ottlspanevent.TransformContext]{
 			desc:  info.Description,
 			attrs: info.Attributes,
 		}
@@ -94,9 +94,9 @@ func createMetricsToMetrics(
 ) (connector.Metrics, error) {
 	c := cfg.(*Config)
 
-	metricMetricDefs := make(map[string]metricDef[ottlmetric.TransformContext], len(c.Metrics))
+	metricMetricDefs := make(map[string]metricDef[*ottlmetric.TransformContext], len(c.Metrics))
 	for name, info := range c.Metrics {
-		md := metricDef[ottlmetric.TransformContext]{
+		md := metricDef[*ottlmetric.TransformContext]{
 			desc: info.Description,
 		}
 		if len(info.Conditions) > 0 {
@@ -107,9 +107,9 @@ func createMetricsToMetrics(
 		metricMetricDefs[name] = md
 	}
 
-	dataPointMetricDefs := make(map[string]metricDef[ottldatapoint.TransformContext], len(c.DataPoints))
+	dataPointMetricDefs := make(map[string]metricDef[*ottldatapoint.TransformContext], len(c.DataPoints))
 	for name, info := range c.DataPoints {
-		md := metricDef[ottldatapoint.TransformContext]{
+		md := metricDef[*ottldatapoint.TransformContext]{
 			desc:  info.Description,
 			attrs: info.Attributes,
 		}
@@ -137,9 +137,9 @@ func createLogsToMetrics(
 ) (connector.Logs, error) {
 	c := cfg.(*Config)
 
-	metricDefs := make(map[string]metricDef[ottllog.TransformContext], len(c.Logs))
+	metricDefs := make(map[string]metricDef[*ottllog.TransformContext], len(c.Logs))
 	for name, info := range c.Logs {
-		md := metricDef[ottllog.TransformContext]{
+		md := metricDef[*ottllog.TransformContext]{
 			desc:  info.Description,
 			attrs: info.Attributes,
 		}

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -87,8 +87,9 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		case "log":
 			plogutil.MoveRecordsWithContextIf(ld, matched,
 				func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
-					ltx := ottllog.NewTransformContext(lr, sl.Scope(), rl.Resource(), sl, rl)
+					ltx := ottllog.NewTransformContextPtr(lr, sl.Scope(), rl.Resource(), sl, rl)
 					_, isMatch, err := route.logStatement.Execute(ctx, ltx)
+					ltx.Close()
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {
 						errs = errors.Join(errs, err)

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -437,9 +437,9 @@ func TestLogsConnectorDetailed(t *testing.T) {
 
 	// IsMap and IsString are just candidate for Standard Converter Function to prevent any unknown regressions for this component
 	isBodyString := `IsString(body) == true`
-	require.Contains(t, standardFunctions[ottllog.TransformContext](), "IsString")
+	require.Contains(t, standardFunctions[*ottllog.TransformContext](), "IsString")
 	isBodyMap := `IsMap(body) == true`
-	require.Contains(t, standardFunctions[ottllog.TransformContext](), "IsMap")
+	require.Contains(t, standardFunctions[*ottllog.TransformContext](), "IsMap")
 
 	isScopeCFromLowerContext := `instrumentation_scope.name == "scopeC"`
 	isScopeDFromLowerContext := `instrumentation_scope.name == "scopeD"`

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -88,8 +88,9 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		case "metric":
 			pmetricutil.MoveMetricsWithContextIf(md, matched,
 				func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) bool {
-					mtx := ottlmetric.NewTransformContext(m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
+					mtx := ottlmetric.NewTransformContextPtr(m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
 					_, isMatch, err := route.metricStatement.Execute(ctx, mtx)
+					mtx.Close()
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {
 						errs = errors.Join(errs, err)
@@ -101,8 +102,9 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		case "datapoint":
 			pmetricutil.MoveDataPointsWithContextIf(md, matched,
 				func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dp any) bool {
-					dptx := ottldatapoint.NewTransformContext(dp, m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
+					dptx := ottldatapoint.NewTransformContextPtr(dp, m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
 					_, isMatch, err := route.dataPointStatement.Execute(ctx, dptx)
+					dptx.Close()
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {
 						errs = errors.Join(errs, err)

--- a/connector/routingconnector/router.go
+++ b/connector/routingconnector/router.go
@@ -33,9 +33,9 @@ type consumerProvider[C any] func(...pipeline.ID) (C, error)
 type router[C any] struct {
 	resourceParser   ottl.Parser[ottlresource.TransformContext]
 	spanParser       ottl.Parser[*ottlspan.TransformContext]
-	metricParser     ottl.Parser[ottlmetric.TransformContext]
-	dataPointParser  ottl.Parser[ottldatapoint.TransformContext]
-	logParser        ottl.Parser[ottllog.TransformContext]
+	metricParser     ottl.Parser[*ottlmetric.TransformContext]
+	dataPointParser  ottl.Parser[*ottldatapoint.TransformContext]
+	logParser        ottl.Parser[*ottllog.TransformContext]
 	defaultConsumer  C
 	logger           *zap.Logger
 	routes           map[string]routingItem[C]
@@ -75,9 +75,9 @@ type routingItem[C any] struct {
 	requestCondition   *requestCondition
 	resourceStatement  *ottl.Statement[ottlresource.TransformContext]
 	spanStatement      *ottl.Statement[*ottlspan.TransformContext]
-	metricStatement    *ottl.Statement[ottlmetric.TransformContext]
-	dataPointStatement *ottl.Statement[ottldatapoint.TransformContext]
-	logStatement       *ottl.Statement[ottllog.TransformContext]
+	metricStatement    *ottl.Statement[*ottlmetric.TransformContext]
+	dataPointStatement *ottl.Statement[*ottldatapoint.TransformContext]
+	logStatement       *ottl.Statement[*ottllog.TransformContext]
 	statementContext   string
 }
 
@@ -123,7 +123,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildMetric {
 		parser, err := ottlmetric.NewParser(
-			standardFunctions[ottlmetric.TransformContext](),
+			standardFunctions[*ottlmetric.TransformContext](),
 			settings,
 		)
 		if err == nil {
@@ -134,7 +134,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildDataPoint {
 		parser, err := ottldatapoint.NewParser(
-			standardFunctions[ottldatapoint.TransformContext](),
+			standardFunctions[*ottldatapoint.TransformContext](),
 			settings,
 		)
 		if err == nil {
@@ -145,7 +145,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	}
 	if buildLog {
 		parser, err := ottllog.NewParser(
-			standardFunctions[ottllog.TransformContext](),
+			standardFunctions[*ottllog.TransformContext](),
 			settings,
 		)
 		if err == nil {

--- a/connector/signaltometricsconnector/factory.go
+++ b/connector/signaltometricsconnector/factory.go
@@ -82,10 +82,10 @@ func createMetricsToMetrics(
 		return nil, fmt.Errorf("failed to create OTTL statement parser for datapoints: %w", err)
 	}
 
-	metricDefs := make([]model.MetricDef[ottldatapoint.TransformContext], 0, len(c.Datapoints))
+	metricDefs := make([]model.MetricDef[*ottldatapoint.TransformContext], 0, len(c.Datapoints))
 	for i := range c.Datapoints {
 		info := c.Datapoints[i]
-		var md model.MetricDef[ottldatapoint.TransformContext]
+		var md model.MetricDef[*ottldatapoint.TransformContext]
 		if err := md.FromMetricInfo(info, parser, set.TelemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to parse provided metric information; %w", err)
 		}
@@ -114,10 +114,10 @@ func createLogsToMetrics(
 		return nil, fmt.Errorf("failed to create OTTL statement parser for logs: %w", err)
 	}
 
-	metricDefs := make([]model.MetricDef[ottllog.TransformContext], 0, len(c.Logs))
+	metricDefs := make([]model.MetricDef[*ottllog.TransformContext], 0, len(c.Logs))
 	for i := range c.Logs {
 		info := c.Logs[i]
-		var md model.MetricDef[ottllog.TransformContext]
+		var md model.MetricDef[*ottllog.TransformContext]
 		if err := md.FromMetricInfo(info, parser, set.TelemetrySettings); err != nil {
 			return nil, fmt.Errorf("failed to parse provided metric information; %w", err)
 		}

--- a/connector/signaltometricsconnector/internal/customottl/funcs.go
+++ b/connector/signaltometricsconnector/internal/customottl/funcs.go
@@ -19,12 +19,12 @@ func SpanFuncs() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	return common
 }
 
-func DatapointFuncs() map[string]ottl.Factory[ottldatapoint.TransformContext] {
-	return commonFuncs[ottldatapoint.TransformContext]()
+func DatapointFuncs() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
+	return commonFuncs[*ottldatapoint.TransformContext]()
 }
 
-func LogFuncs() map[string]ottl.Factory[ottllog.TransformContext] {
-	return commonFuncs[ottllog.TransformContext]()
+func LogFuncs() map[string]ottl.Factory[*ottllog.TransformContext] {
+	return commonFuncs[*ottllog.TransformContext]()
 }
 
 func ProfileFuncs() map[string]ottl.Factory[ottlprofile.TransformContext] {

--- a/connector/sumconnector/connector.go
+++ b/connector/sumconnector/connector.go
@@ -30,10 +30,10 @@ type sum struct {
 	component.ShutdownFunc
 
 	spansMetricDefs      map[string]metricDef[*ottlspan.TransformContext]
-	spanEventsMetricDefs map[string]metricDef[ottlspanevent.TransformContext]
-	metricsMetricDefs    map[string]metricDef[ottlmetric.TransformContext]
-	dataPointsMetricDefs map[string]metricDef[ottldatapoint.TransformContext]
-	logsMetricDefs       map[string]metricDef[ottllog.TransformContext]
+	spanEventsMetricDefs map[string]metricDef[*ottlspanevent.TransformContext]
+	metricsMetricDefs    map[string]metricDef[*ottlmetric.TransformContext]
+	dataPointsMetricDefs map[string]metricDef[*ottldatapoint.TransformContext]
+	logsMetricDefs       map[string]metricDef[*ottllog.TransformContext]
 }
 
 func (*sum) Capabilities() consumer.Capabilities {
@@ -47,7 +47,7 @@ func (c *sum) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceSpan := td.ResourceSpans().At(i)
 		spansSummer := newSummer[*ottlspan.TransformContext](c.spansMetricDefs)
-		spanEventsSummer := newSummer[ottlspanevent.TransformContext](c.spanEventsMetricDefs)
+		spanEventsSummer := newSummer[*ottlspanevent.TransformContext](c.spanEventsMetricDefs)
 
 		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
 			scopeSpan := resourceSpan.ScopeSpans().At(j)
@@ -60,8 +60,9 @@ func (c *sum) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 
 				for l := 0; l < span.Events().Len(); l++ {
 					event := span.Events().At(l)
-					eCtx := ottlspanevent.NewTransformContext(event, span, scopeSpan.Scope(), resourceSpan.Resource(), scopeSpan, resourceSpan)
+					eCtx := ottlspanevent.NewTransformContextPtr(event, span, scopeSpan.Scope(), resourceSpan.Resource(), scopeSpan, resourceSpan)
 					multiError = errors.Join(multiError, spanEventsSummer.update(ctx, event.Attributes(), eCtx))
+					eCtx.Close()
 				}
 			}
 		}
@@ -91,16 +92,17 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	sumMetrics.ResourceMetrics().EnsureCapacity(md.ResourceMetrics().Len())
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		resourceMetric := md.ResourceMetrics().At(i)
-		metricsSummer := newSummer[ottlmetric.TransformContext](c.metricsMetricDefs)
-		dataPointsSummer := newSummer[ottldatapoint.TransformContext](c.dataPointsMetricDefs)
+		metricsSummer := newSummer[*ottlmetric.TransformContext](c.metricsMetricDefs)
+		dataPointsSummer := newSummer[*ottldatapoint.TransformContext](c.dataPointsMetricDefs)
 
 		for j := 0; j < resourceMetric.ScopeMetrics().Len(); j++ {
 			scopeMetrics := resourceMetric.ScopeMetrics().At(j)
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContext(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+				mCtx := ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 				multiError = errors.Join(multiError, metricsSummer.update(ctx, pcommon.NewMap(), mCtx))
+				mCtx.Close()
 
 				//exhaustive:enforce
 				//  For metric types each must be handled in exactly the same way
@@ -109,32 +111,37 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 				case pmetric.MetricTypeGauge:
 					dps := metric.Gauge().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContext(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeSum:
 					dps := metric.Sum().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContext(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeSummary:
 					dps := metric.Summary().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContext(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeHistogram:
 					dps := metric.Histogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContext(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					dps := metric.ExponentialHistogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContext(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
+						dCtx.Close()
 					}
 				case pmetric.MetricTypeEmpty:
 					multiError = errors.Join(multiError, fmt.Errorf("metric %q: invalid metric type: %v", metric.Name(), metric.Type()))
@@ -167,7 +174,7 @@ func (c *sum) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	sumMetrics.ResourceMetrics().EnsureCapacity(ld.ResourceLogs().Len())
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		resourceLog := ld.ResourceLogs().At(i)
-		summer := newSummer[ottllog.TransformContext](c.logsMetricDefs)
+		summer := newSummer[*ottllog.TransformContext](c.logsMetricDefs)
 
 		for j := 0; j < resourceLog.ScopeLogs().Len(); j++ {
 			scopeLogs := resourceLog.ScopeLogs().At(j)
@@ -175,8 +182,9 @@ func (c *sum) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
 				logRecord := scopeLogs.LogRecords().At(k)
 
-				lCtx := ottllog.NewTransformContext(logRecord, scopeLogs.Scope(), resourceLog.Resource(), scopeLogs, resourceLog)
+				lCtx := ottllog.NewTransformContextPtr(logRecord, scopeLogs.Scope(), resourceLog.Resource(), scopeLogs, resourceLog)
 				multiError = errors.Join(multiError, summer.update(ctx, logRecord.Attributes(), lCtx))
+				lCtx.Close()
 			}
 		}
 

--- a/connector/sumconnector/factory.go
+++ b/connector/sumconnector/factory.go
@@ -62,9 +62,9 @@ func createTracesToMetrics(
 		spanMetricDefs[name] = md
 	}
 
-	spanEventMetricDefs := make(map[string]metricDef[ottlspanevent.TransformContext], len(c.SpanEvents))
+	spanEventMetricDefs := make(map[string]metricDef[*ottlspanevent.TransformContext], len(c.SpanEvents))
 	for name, info := range c.SpanEvents {
-		md := metricDef[ottlspanevent.TransformContext]{
+		md := metricDef[*ottlspanevent.TransformContext]{
 			desc:       info.Description,
 			attrs:      info.Attributes,
 			sourceAttr: info.SourceAttribute,
@@ -93,9 +93,9 @@ func createMetricsToMetrics(
 ) (connector.Metrics, error) {
 	c := cfg.(*Config)
 
-	metricMetricDefs := make(map[string]metricDef[ottlmetric.TransformContext], len(c.Metrics))
+	metricMetricDefs := make(map[string]metricDef[*ottlmetric.TransformContext], len(c.Metrics))
 	for name, info := range c.Metrics {
-		md := metricDef[ottlmetric.TransformContext]{
+		md := metricDef[*ottlmetric.TransformContext]{
 			desc:       info.Description,
 			sourceAttr: info.SourceAttribute,
 		}
@@ -107,9 +107,9 @@ func createMetricsToMetrics(
 		metricMetricDefs[name] = md
 	}
 
-	dataPointMetricDefs := make(map[string]metricDef[ottldatapoint.TransformContext], len(c.DataPoints))
+	dataPointMetricDefs := make(map[string]metricDef[*ottldatapoint.TransformContext], len(c.DataPoints))
 	for name, info := range c.DataPoints {
-		md := metricDef[ottldatapoint.TransformContext]{
+		md := metricDef[*ottldatapoint.TransformContext]{
 			desc:       info.Description,
 			attrs:      info.Attributes,
 			sourceAttr: info.SourceAttribute,
@@ -138,9 +138,9 @@ func createLogsToMetrics(
 ) (connector.Logs, error) {
 	c := cfg.(*Config)
 
-	metricDefs := make(map[string]metricDef[ottllog.TransformContext], len(c.Logs))
+	metricDefs := make(map[string]metricDef[*ottllog.TransformContext], len(c.Logs))
 	for name, info := range c.Logs {
-		md := metricDef[ottllog.TransformContext]{
+		md := metricDef[*ottllog.TransformContext]{
 			desc:       info.Description,
 			attrs:      info.Attributes,
 			sourceAttr: info.SourceAttribute,

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -34,7 +34,7 @@ const (
 
 type marker struct {
 	Marker
-	logBoolExpr *ottl.ConditionSequence[ottllog.TransformContext]
+	logBoolExpr *ottl.ConditionSequence[*ottllog.TransformContext]
 }
 
 type honeycombLogsExporter struct {
@@ -83,19 +83,22 @@ func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs)
 			logs := slogs.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
 				logRecord := logs.At(k)
-				tCtx := ottllog.NewTransformContext(logRecord, slogs.Scope(), rlogs.Resource(), slogs, rlogs)
+				tCtx := ottllog.NewTransformContextPtr(logRecord, slogs.Scope(), rlogs.Resource(), slogs, rlogs)
 				for _, m := range e.markers {
 					match, err := m.logBoolExpr.Eval(ctx, tCtx)
 					if err != nil {
+						tCtx.Close()
 						return err
 					}
 					if match {
-						err := e.sendMarker(ctx, m, logRecord)
+						err = e.sendMarker(ctx, m, logRecord)
 						if err != nil {
+							tCtx.Close()
 							return err
 						}
 					}
 				}
+				tCtx.Close()
 			}
 		}
 	}

--- a/internal/filter/filterlog/filterlog.go
+++ b/internal/filter/filterlog/filterlog.go
@@ -27,11 +27,11 @@ var useOTTLBridge = featuregate.GlobalRegistry().MustRegister(
 // NewSkipExpr creates a BoolExpr that on evaluation returns true if a log should NOT be processed or kept.
 // The logic determining if a log should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
-func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[ottllog.TransformContext], error) {
+func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[*ottllog.TransformContext], error) {
 	if useOTTLBridge.IsEnabled() {
 		return filterottl.NewLogSkipExprBridge(mp)
 	}
-	var matchers []expr.BoolExpr[ottllog.TransformContext]
+	var matchers []expr.BoolExpr[*ottllog.TransformContext]
 	inclExpr, err := newExpr(mp.Include)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ type propertiesMatcher struct {
 }
 
 // NewMatcher creates a LogRecord Matcher that matches based on the given MatchProperties.
-func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[ottllog.TransformContext], error) {
+func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[*ottllog.TransformContext], error) {
 	if mp == nil {
 		return nil, nil
 	}
@@ -114,7 +114,7 @@ func newExpr(mp *filterconfig.MatchProperties) (expr.BoolExpr[ottllog.TransformC
 // At least one of log record names or attributes must be specified. It is
 // supported to have more than one of these specified, and all specified must
 // evaluate to true for a match to occur.
-func (mp *propertiesMatcher) Eval(_ context.Context, tCtx ottllog.TransformContext) (bool, error) {
+func (mp *propertiesMatcher) Eval(_ context.Context, tCtx *ottllog.TransformContext) (bool, error) {
 	lr := tCtx.GetLogRecord()
 	if mp.bodyFilters != nil && !mp.bodyFilters.Matches(lr.Body().AsString()) {
 		return false, nil

--- a/internal/filter/filtermetric/expr_matcher.go
+++ b/internal/filter/filtermetric/expr_matcher.go
@@ -26,7 +26,7 @@ func newExprMatcher(expressions []string) (*exprMatcher, error) {
 	return m, nil
 }
 
-func (m *exprMatcher) Eval(_ context.Context, tCtx ottlmetric.TransformContext) (bool, error) {
+func (m *exprMatcher) Eval(_ context.Context, tCtx *ottlmetric.TransformContext) (bool, error) {
 	for _, matcher := range m.matchers {
 		matched, err := matcher.MatchMetric(tCtx.GetMetric())
 		if err != nil {

--- a/internal/filter/filtermetric/filtermetric.go
+++ b/internal/filter/filtermetric/filtermetric.go
@@ -22,11 +22,11 @@ var UseOTTLBridge = featuregate.GlobalRegistry().MustRegister(
 // NewSkipExpr creates a BoolExpr that on evaluation returns true if a metric should NOT be processed or kept.
 // The logic determining if a metric should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
-func NewSkipExpr(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
+func NewSkipExpr(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[*ottlmetric.TransformContext], error) {
 	if UseOTTLBridge.IsEnabled() {
 		return filterottl.NewMetricSkipExprBridge(include, exclude)
 	}
-	var matchers []expr.BoolExpr[ottlmetric.TransformContext]
+	var matchers []expr.BoolExpr[*ottlmetric.TransformContext]
 	inclExpr, err := newExpr(include)
 	if err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func NewSkipExpr(include, exclude *filterconfig.MetricMatchProperties) (expr.Boo
 
 // NewMatcher constructs a metric Matcher. If an 'expr' match type is specified,
 // returns an expr matcher, otherwise a name matcher.
-func newExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
+func newExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[*ottlmetric.TransformContext], error) {
 	if mp == nil {
 		return nil, nil
 	}

--- a/internal/filter/filtermetric/filtermetric_test.go
+++ b/internal/filter/filtermetric/filtermetric_test.go
@@ -82,7 +82,9 @@ func TestMatcherMatches(t *testing.T) {
 			assert.NotNil(t, matcher)
 			assert.NoError(t, err)
 
-			matches, err := matcher.Eval(t.Context(), ottlmetric.NewTransformContext(test.metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(test.metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			matches, err := matcher.Eval(t.Context(), tCtx)
+			tCtx.Close()
 			assert.NoError(t, err)
 			assert.Equal(t, test.shouldMatch, matches)
 		})
@@ -187,7 +189,8 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 
 			scope := pcommon.NewInstrumentationScope()
 
-			tCtx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), scope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), scope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.include, tt.exclude)
 			require.NoError(t, err)

--- a/internal/filter/filtermetric/name_matcher.go
+++ b/internal/filter/filtermetric/name_matcher.go
@@ -32,6 +32,6 @@ func newNameMatcher(mp *filterconfig.MetricMatchProperties) (*nameMatcher, error
 
 // Eval matches a metric using the metric properties configured on the nameMatcher.
 // A metric only matches if every metric property configured on the nameMatcher is a match.
-func (m *nameMatcher) Eval(_ context.Context, tCtx ottlmetric.TransformContext) (bool, error) {
+func (m *nameMatcher) Eval(_ context.Context, tCtx *ottlmetric.TransformContext) (bool, error) {
 	return m.nameFilters.Matches(tCtx.GetMetric().Name()), nil
 }

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -59,7 +59,7 @@ const (
 	severityNumberStatement = `((severity_number == SEVERITY_NUMBER_UNSPECIFIED and %v) or (severity_number != SEVERITY_NUMBER_UNSPECIFIED and severity_number >= %d))`
 )
 
-func NewLogSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottllog.TransformContext], error) {
+func NewLogSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[*ottllog.TransformContext], error) {
 	statements := make([]string, 0, 2)
 	if mc.Include != nil {
 		if err := mc.Include.ValidateForLogs(); err != nil {
@@ -348,7 +348,7 @@ func createSeverityNumberConditions(severityNumberProperties *filterconfig.LogSe
 	return &severityNumberCondition
 }
 
-func NewMetricSkipExprBridge(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlmetric.TransformContext], error) {
+func NewMetricSkipExprBridge(include, exclude *filterconfig.MetricMatchProperties) (expr.BoolExpr[*ottlmetric.TransformContext], error) {
 	statements := make([]string, 0, 2)
 	if include != nil {
 		statement, err := createMetricStatement(*include)

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -38,15 +38,15 @@ func NewBoolExprForSpanWithOptions(conditions []string, functions map[string]ott
 	return &c, nil
 }
 
-// NewBoolExprForSpanEvent creates a BoolExpr[ottlspanevent.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForSpanEvent creates a BoolExpr[*ottlspanevent.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspanevent.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlspanevent.TransformContext], error) {
+func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[*ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlspanevent.TransformContext], error) {
 	return NewBoolExprForSpanEventWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForSpanEventWithOptions is like NewBoolExprForSpanEvent, but with additional options.
-func NewBoolExprForSpanEventWithOptions(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottlspanevent.TransformContext]) (*ottl.ConditionSequence[ottlspanevent.TransformContext], error) {
+func NewBoolExprForSpanEventWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlspanevent.TransformContext]) (*ottl.ConditionSequence[*ottlspanevent.TransformContext], error) {
 	parser, err := ottlspanevent.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
@@ -59,15 +59,15 @@ func NewBoolExprForSpanEventWithOptions(conditions []string, functions map[strin
 	return &c, nil
 }
 
-// NewBoolExprForMetric creates a BoolExpr[ottlmetric.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForMetric creates a BoolExpr[*ottlmetric.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlmetric.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlmetric.TransformContext], error) {
+func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[*ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlmetric.TransformContext], error) {
 	return NewBoolExprForMetricWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForMetricWithOptions is like NewBoolExprForMetric, but with additional options.
-func NewBoolExprForMetricWithOptions(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottlmetric.TransformContext]) (*ottl.ConditionSequence[ottlmetric.TransformContext], error) {
+func NewBoolExprForMetricWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlmetric.TransformContext]) (*ottl.ConditionSequence[*ottlmetric.TransformContext], error) {
 	parser, err := ottlmetric.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
@@ -80,15 +80,15 @@ func NewBoolExprForMetricWithOptions(conditions []string, functions map[string]o
 	return &c, nil
 }
 
-// NewBoolExprForDataPoint creates a BoolExpr[ottldatapoint.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForDataPoint creates a BoolExpr[*ottldatapoint.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottldatapoint.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottldatapoint.TransformContext], error) {
+func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[*ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottldatapoint.TransformContext], error) {
 	return NewBoolExprForDataPointWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForDataPointWithOptions is like NewBoolExprForDataPoint, but with additional options.
-func NewBoolExprForDataPointWithOptions(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottldatapoint.TransformContext]) (*ottl.ConditionSequence[ottldatapoint.TransformContext], error) {
+func NewBoolExprForDataPointWithOptions(conditions []string, functions map[string]ottl.Factory[*ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottldatapoint.TransformContext]) (*ottl.ConditionSequence[*ottldatapoint.TransformContext], error) {
 	parser, err := ottldatapoint.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
@@ -101,15 +101,15 @@ func NewBoolExprForDataPointWithOptions(conditions []string, functions map[strin
 	return &c, nil
 }
 
-// NewBoolExprForLog creates a BoolExpr[ottllog.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForLog creates a BoolExpr[*ottllog.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottllog.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottllog.TransformContext], error) {
+func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[*ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottllog.TransformContext], error) {
 	return NewBoolExprForLogWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForLogWithOptions is like NewBoolExprForLog, but with additional options.
-func NewBoolExprForLogWithOptions(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottllog.TransformContext]) (*ottl.ConditionSequence[ottllog.TransformContext], error) {
+func NewBoolExprForLogWithOptions(conditions []string, functions map[string]ottl.Factory[*ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottllog.TransformContext]) (*ottl.ConditionSequence[*ottllog.TransformContext], error) {
 	parser, err := ottllog.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err

--- a/internal/filter/filterottl/filter_test.go
+++ b/internal/filter/filterottl/filter_test.go
@@ -108,7 +108,7 @@ func Test_NewBoolExprForSpanEvent(t *testing.T) {
 			spanEventBoolExpr, err := NewBoolExprForSpanEvent(tt.conditions, StandardSpanEventFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, spanEventBoolExpr)
-			result, err := spanEventBoolExpr.Eval(t.Context(), ottlspanevent.TransformContext{})
+			result, err := spanEventBoolExpr.Eval(t.Context(), &ottlspanevent.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -121,7 +121,7 @@ func Test_NewBoolExprForSpanEventWithOptions(t *testing.T) {
 		StandardSpanEventFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottlspanevent.TransformContext]{ottlspanevent.EnablePathContextNames()},
+		[]ottl.Option[*ottlspanevent.TransformContext]{ottlspanevent.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }
@@ -161,7 +161,7 @@ func Test_NewBoolExprForMetric(t *testing.T) {
 			metricBoolExpr, err := NewBoolExprForMetric(tt.conditions, StandardMetricFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, metricBoolExpr)
-			result, err := metricBoolExpr.Eval(t.Context(), ottlmetric.TransformContext{})
+			result, err := metricBoolExpr.Eval(t.Context(), &ottlmetric.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -174,7 +174,7 @@ func Test_NewBoolExprForMetricWithOptions(t *testing.T) {
 		StandardMetricFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottlmetric.TransformContext]{ottlmetric.EnablePathContextNames()},
+		[]ottl.Option[*ottlmetric.TransformContext]{ottlmetric.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }
@@ -214,7 +214,7 @@ func Test_NewBoolExprForDataPoint(t *testing.T) {
 			dataPointBoolExpr, err := NewBoolExprForDataPoint(tt.conditions, StandardDataPointFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, dataPointBoolExpr)
-			result, err := dataPointBoolExpr.Eval(t.Context(), ottldatapoint.TransformContext{})
+			result, err := dataPointBoolExpr.Eval(t.Context(), &ottldatapoint.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -227,7 +227,7 @@ func Test_NewBoolExprForDataPointWithOptions(t *testing.T) {
 		StandardDataPointFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottldatapoint.TransformContext]{ottldatapoint.EnablePathContextNames()},
+		[]ottl.Option[*ottldatapoint.TransformContext]{ottldatapoint.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }
@@ -267,7 +267,7 @@ func Test_NewBoolExprForLog(t *testing.T) {
 			logBoolExpr, err := NewBoolExprForLog(tt.conditions, StandardLogFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, logBoolExpr)
-			result, err := logBoolExpr.Eval(t.Context(), ottllog.TransformContext{})
+			result, err := logBoolExpr.Eval(t.Context(), &ottllog.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -280,7 +280,7 @@ func Test_NewBoolExprForLogWithOptions(t *testing.T) {
 		StandardLogFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottllog.TransformContext]{ottllog.EnablePathContextNames()},
+		[]ottl.Option[*ottllog.TransformContext]{ottllog.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -28,12 +28,12 @@ func StandardSpanFuncs() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	return m
 }
 
-func StandardSpanEventFuncs() map[string]ottl.Factory[ottlspanevent.TransformContext] {
-	return ottlfuncs.StandardConverters[ottlspanevent.TransformContext]()
+func StandardSpanEventFuncs() map[string]ottl.Factory[*ottlspanevent.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottlspanevent.TransformContext]()
 }
 
-func StandardMetricFuncs() map[string]ottl.Factory[ottlmetric.TransformContext] {
-	m := ottlfuncs.StandardConverters[ottlmetric.TransformContext]()
+func StandardMetricFuncs() map[string]ottl.Factory[*ottlmetric.TransformContext] {
+	m := ottlfuncs.StandardConverters[*ottlmetric.TransformContext]()
 	hasAttributeOnDatapointFactory := newHasAttributeOnDatapointFactory()
 	hasAttributeKeyOnDatapointFactory := newHasAttributeKeyOnDatapointFactory()
 	m[hasAttributeOnDatapointFactory.Name()] = hasAttributeOnDatapointFactory
@@ -41,16 +41,16 @@ func StandardMetricFuncs() map[string]ottl.Factory[ottlmetric.TransformContext] 
 	return m
 }
 
-func StandardDataPointFuncs() map[string]ottl.Factory[ottldatapoint.TransformContext] {
-	return ottlfuncs.StandardConverters[ottldatapoint.TransformContext]()
+func StandardDataPointFuncs() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottldatapoint.TransformContext]()
 }
 
 func StandardScopeFuncs() map[string]ottl.Factory[ottlscope.TransformContext] {
 	return ottlfuncs.StandardConverters[ottlscope.TransformContext]()
 }
 
-func StandardLogFuncs() map[string]ottl.Factory[ottllog.TransformContext] {
-	return ottlfuncs.StandardConverters[ottllog.TransformContext]()
+func StandardLogFuncs() map[string]ottl.Factory[*ottllog.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottllog.TransformContext]()
 }
 
 func StandardProfileFuncs() map[string]ottl.Factory[ottlprofile.TransformContext] {
@@ -66,11 +66,28 @@ type hasAttributeOnDatapointArguments struct {
 	ExpectedVal string
 }
 
-func newHasAttributeOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
+// TODO: Remove when deprecated DefaultMetricFunctions is removed.
+func NewHasAttributeOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
+	return ottl.NewFactory("HasAttrOnDatapoint", &hasAttributeOnDatapointArguments{}, createHasAttributeOnDatapointFunctionLegacy)
+}
+
+func createHasAttributeOnDatapointFunctionLegacy(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+	args, ok := oArgs.(*hasAttributeOnDatapointArguments)
+
+	if !ok {
+		return nil, errors.New("hasAttributeOnDatapointFactory args must be of type *hasAttributeOnDatapointArguments")
+	}
+
+	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+		return checkDataPoints(&tCtx, args.Key, &args.ExpectedVal)
+	}, nil
+}
+
+func newHasAttributeOnDatapointFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("HasAttrOnDatapoint", &hasAttributeOnDatapointArguments{}, createHasAttributeOnDatapointFunction)
 }
 
-func createHasAttributeOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createHasAttributeOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*hasAttributeOnDatapointArguments)
 
 	if !ok {
@@ -80,8 +97,8 @@ func createHasAttributeOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Ar
 	return hasAttributeOnDatapoint(args.Key, args.ExpectedVal)
 }
 
-func hasAttributeOnDatapoint(key, expectedVal string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func hasAttributeOnDatapoint(key, expectedVal string) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		return checkDataPoints(tCtx, key, &expectedVal)
 	}, nil
 }
@@ -90,11 +107,28 @@ type hasAttributeKeyOnDatapointArguments struct {
 	Key string
 }
 
-func newHasAttributeKeyOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
+// TODO: Remove when deprecated DefaultMetricFunctions is removed.
+func NewHasAttributeKeyOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
+	return ottl.NewFactory("HasAttrKeyOnDatapoint", &hasAttributeKeyOnDatapointArguments{}, createHasAttributeKeyOnDatapointFunctionLegacy)
+}
+
+func createHasAttributeKeyOnDatapointFunctionLegacy(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+	args, ok := oArgs.(*hasAttributeKeyOnDatapointArguments)
+
+	if !ok {
+		return nil, errors.New("hasAttributeKeyOnDatapointFactory args must be of type *hasAttributeOnDatapointArguments")
+	}
+
+	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+		return checkDataPoints(&tCtx, args.Key, nil)
+	}, nil
+}
+
+func newHasAttributeKeyOnDatapointFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("HasAttrKeyOnDatapoint", &hasAttributeKeyOnDatapointArguments{}, createHasAttributeKeyOnDatapointFunction)
 }
 
-func createHasAttributeKeyOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createHasAttributeKeyOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*hasAttributeKeyOnDatapointArguments)
 
 	if !ok {
@@ -104,13 +138,13 @@ func createHasAttributeKeyOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl
 	return hasAttributeKeyOnDatapoint(args.Key)
 }
 
-func hasAttributeKeyOnDatapoint(key string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func hasAttributeKeyOnDatapoint(key string) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		return checkDataPoints(tCtx, key, nil)
 	}, nil
 }
 
-func checkDataPoints(tCtx ottlmetric.TransformContext, key string, expectedVal *string) (any, error) {
+func checkDataPoints(tCtx *ottlmetric.TransformContext, key string, expectedVal *string) (any, error) {
 	metric := tCtx.GetMetric()
 	//exhaustive:enforce
 	switch metric.Type() {

--- a/internal/filter/filterottl/functions_test.go
+++ b/internal/filter/filterottl/functions_test.go
@@ -125,7 +125,9 @@ func Test_HasAttrKeyOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeKeyOnDatapoint(tt.key)
 			assert.NoError(t, err)
-			result, err := exprFunc(t.Context(), ottlmetric.NewTransformContext(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -350,7 +352,9 @@ func Test_HasAttrOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeOnDatapoint(tt.key, tt.expectedVal)
 			assert.NoError(t, err)
-			result, err := exprFunc(t.Context(), ottlmetric.NewTransformContext(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -6,6 +6,7 @@ package ottldatapoint // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -21,6 +22,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
 
 // ContextName is the name of the context for datapoints.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
@@ -46,7 +53,7 @@ type TransformContext struct {
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("metric", logging.Metric(tCtx.metric)))
@@ -68,7 +75,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(dataPoint any, metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		dataPoint:            dataPoint,
@@ -86,38 +93,69 @@ func NewTransformContext(dataPoint any, metric pmetric.Metric, metrics pmetric.M
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(dataPoint any, metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.dataPoint = dataPoint
+	tCtx.metric = metric
+	tCtx.metrics = metrics
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.scopeMetrics = scopeMetrics
+	tCtx.resourceMetrics = resourceMetrics
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.dataPoint = nil
+	tCtx.metric = pmetric.Metric{}
+	tCtx.metrics = pmetric.MetricSlice{}
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.scopeMetrics = pmetric.ScopeMetrics{}
+	tCtx.resourceMetrics = pmetric.ResourceMetrics{}
+	tcPool.Put(tCtx)
+}
+
 // GetDataPoint returns the datapoint from the TransformContext.
-func (tCtx TransformContext) GetDataPoint() any {
+func (tCtx *TransformContext) GetDataPoint() any {
 	return tCtx.dataPoint
 }
 
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetMetric returns the metric from the TransformContext.
-func (tCtx TransformContext) GetMetric() pmetric.Metric {
+func (tCtx *TransformContext) GetMetric() pmetric.Metric {
 	return tCtx.metric
 }
 
 // GetMetrics returns the metric slice from the TransformContext.
-func (tCtx TransformContext) GetMetrics() pmetric.MetricSlice {
+func (tCtx *TransformContext) GetMetrics() pmetric.MetricSlice {
 	return tCtx.metrics
 }
 
 // GetScopeSchemaURLItem returns the scope schema URL item from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
 // GetResourceSchemaURLItem returns the resource schema URL item from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 
@@ -126,9 +164,9 @@ func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem 
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ctxdatapoint.Name,
 			ctxresource.Name,
 			ctxscope.LegacyName,
@@ -138,17 +176,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 	}
 }
 
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -156,17 +194,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 	return s
 }
 
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -176,10 +214,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new Datapoint parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -199,20 +237,20 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("enum symbol not provided")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxdatapoint.Name,
 		ctxdatapoint.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
-			ctxmetric.Name:      ctxmetric.PathGetSetter[TransformContext],
-			ctxdatapoint.Name:   ctxdatapoint.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxmetric.Name:      ctxmetric.PathGetSetter[*TransformContext],
+			ctxdatapoint.Name:   ctxdatapoint.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -25,7 +25,7 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      ottl.Path[TransformContext]
+		path      ottl.Path[*TransformContext]
 		orig      any
 		newVal    any
 		modified  func(cache pcommon.Map)
@@ -33,7 +33,7 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 	}{
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -44,10 +44,10 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -64,15 +64,15 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxdatapoint.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -80,7 +80,8 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 
-			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -113,7 +114,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      ottl.Path[TransformContext]
+		path      ottl.Path[*TransformContext]
 		orig      any
 		newVal    any
 		modified  func(pmetric.NumberDataPoint)
@@ -121,7 +122,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -132,7 +133,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "start_time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
@@ -143,7 +144,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
@@ -154,7 +155,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -165,7 +166,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_double",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "value_double",
 			},
 			orig:   1.1,
@@ -177,7 +178,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "value_int",
 			},
 			orig:   int64(1),
@@ -188,7 +189,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "flags",
 			},
 			orig:   int64(0),
@@ -199,7 +200,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "exemplars",
 			},
 			orig:   refNumberDataPoint.Exemplars(),
@@ -210,7 +211,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refNumberDataPoint.Attributes(),
@@ -221,10 +222,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -237,10 +238,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -253,10 +254,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -269,10 +270,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -285,10 +286,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -301,10 +302,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -320,10 +321,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -339,10 +340,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -358,10 +359,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -377,10 +378,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -396,10 +397,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -417,10 +418,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -438,16 +439,16 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -464,16 +465,16 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -495,15 +496,15 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxdatapoint.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -511,7 +512,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 
-			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -562,14 +564,14 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.HistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -580,7 +582,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -591,7 +593,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "flags",
 			},
 			orig:   int64(0),
@@ -602,7 +604,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "count",
 			},
 			orig:   int64(2),
@@ -613,7 +615,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "sum",
 			},
 			orig:   10.1,
@@ -624,7 +626,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "bucket_counts",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "bucket_counts",
 			},
 			orig:   []uint64{1, 1},
@@ -635,7 +637,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "explicit_bounds",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "explicit_bounds",
 			},
 			orig:   []float64{1, 2},
@@ -646,7 +648,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "exemplars",
 			},
 			orig:   refHistogramDataPoint.Exemplars(),
@@ -657,7 +659,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refHistogramDataPoint.Attributes(),
@@ -668,10 +670,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -684,10 +686,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -700,10 +702,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -716,10 +718,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -732,10 +734,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -748,10 +750,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -767,10 +769,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -786,10 +788,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -805,10 +807,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -824,10 +826,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -843,10 +845,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -864,10 +866,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -885,16 +887,16 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -911,16 +913,16 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -942,15 +944,15 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxdatapoint.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -958,7 +960,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 			histogramDataPoint := createHistogramDataPointTelemetry()
 
-			ctx := NewTransformContext(histogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(histogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -1015,14 +1018,14 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.ExponentialHistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -1033,7 +1036,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -1044,7 +1047,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "flags",
 			},
 			orig:   int64(0),
@@ -1055,7 +1058,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "count",
 			},
 			orig:   int64(2),
@@ -1066,7 +1069,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "sum",
 			},
 			orig:   10.1,
@@ -1077,7 +1080,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "scale",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "scale",
 			},
 			orig:   int64(1),
@@ -1088,7 +1091,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "zero_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "zero_count",
 			},
 			orig:   int64(1),
@@ -1099,7 +1102,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "positive",
 			},
 			orig:   refExpoHistogramDataPoint.Positive(),
@@ -1110,9 +1113,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive offset",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "positive",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "offset",
 				},
 			},
@@ -1124,9 +1127,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive bucket_counts",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "positive",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "bucket_counts",
 				},
 			},
@@ -1138,7 +1141,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "negative",
 			},
 			orig:   refExpoHistogramDataPoint.Negative(),
@@ -1149,9 +1152,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative offset",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "negative",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "offset",
 				},
 			},
@@ -1163,9 +1166,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative bucket_counts",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "negative",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "bucket_counts",
 				},
 			},
@@ -1177,7 +1180,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "exemplars",
 			},
 			orig:   refExpoHistogramDataPoint.Exemplars(),
@@ -1188,7 +1191,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refExpoHistogramDataPoint.Attributes(),
@@ -1199,10 +1202,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -1215,10 +1218,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -1231,10 +1234,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -1247,10 +1250,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -1263,10 +1266,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -1279,10 +1282,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -1298,10 +1301,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -1317,10 +1320,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -1336,10 +1339,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -1355,10 +1358,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -1374,10 +1377,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -1395,10 +1398,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -1416,16 +1419,16 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -1442,16 +1445,16 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -1473,15 +1476,15 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxdatapoint.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -1489,7 +1492,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 			expoHistogramDataPoint := createExpoHistogramDataPointTelemetry()
 
-			ctx := NewTransformContext(expoHistogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(expoHistogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -1547,14 +1551,14 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.SummaryDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -1565,7 +1569,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -1576,7 +1580,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "flags",
 			},
 			orig:   int64(0),
@@ -1587,7 +1591,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "count",
 			},
 			orig:   int64(2),
@@ -1598,7 +1602,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "sum",
 			},
 			orig:   10.1,
@@ -1609,7 +1613,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "quantile_values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "quantile_values",
 			},
 			orig:   refSummaryDataPoint.QuantileValues(),
@@ -1620,7 +1624,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refSummaryDataPoint.Attributes(),
@@ -1631,10 +1635,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -1647,10 +1651,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -1663,10 +1667,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -1679,10 +1683,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -1695,10 +1699,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -1711,10 +1715,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -1730,10 +1734,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -1749,10 +1753,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -1768,10 +1772,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -1787,10 +1791,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -1806,10 +1810,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -1827,10 +1831,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -1848,16 +1852,16 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -1874,16 +1878,16 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -1905,15 +1909,15 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxdatapoint.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -1921,7 +1925,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 			summaryDataPoint := createSummaryDataPointTelemetry()
 
-			ctx := NewTransformContext(summaryDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(summaryDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -1995,16 +2000,16 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(metric pmetric.Metric)
 	}{
 		{
 			name: "metric name",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "name",
 				},
 			},
@@ -2016,9 +2021,9 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "description",
 				},
 			},
@@ -2030,9 +2035,9 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "unit",
 				},
 			},
@@ -2044,9 +2049,9 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "type",
 				},
 			},
@@ -2057,9 +2062,9 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "aggregation_temporality",
 				},
 			},
@@ -2071,9 +2076,9 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metric",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "is_monotonic",
 				},
 			},
@@ -2085,7 +2090,7 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric field with context",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				C: "metric",
 				N: "type",
 			},
@@ -2102,7 +2107,8 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 			metric := createMetricTelemetry()
 
-			ctx := NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -2231,7 +2237,7 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := pcommon.NewInstrumentationScope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContext(
+	ctx := NewTransformContextPtr(
 		pmetric.NewNumberDataPoint(),
 		metric,
 		pmetric.NewMetricSlice(),
@@ -2239,18 +2245,19 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		resource,
 		pmetric.NewScopeMetrics(),
 		pmetric.NewResourceMetrics())
+	defer ctx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("foo"),
 					},
 				},
@@ -2259,8 +2266,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("foo"),
 				},
 			}},
@@ -2268,32 +2275,32 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name:     "metric",
-			path:     &pathtest.Path[TransformContext]{N: "metric", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "metric", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: metric.Name(),
 		},
 		{
 			name:     "metric with context",
-			path:     &pathtest.Path[TransformContext]{C: "metric", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "metric", N: "name"},
 			expected: metric.Name(),
 		},
 		{
 			name:     "instrumentation_scope",
-			path:     &pathtest.Path[TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "instrumentation_scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "instrumentation_scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope",
-			path:     &pathtest.Path[TransformContext]{N: "scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 	}

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -21,6 +22,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
 
 // ContextName is the name of the context for logs.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
@@ -64,7 +71,7 @@ func (l logRecord) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("log_record", logRecord(tCtx.logRecord)))
@@ -75,7 +82,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(logRecord plog.LogRecord, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeLogs plog.ScopeLogs, resourceLogs plog.ResourceLogs, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		logRecord:            logRecord,
@@ -91,28 +98,55 @@ func NewTransformContext(logRecord plog.LogRecord, instrumentationScope pcommon.
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(logRecord plog.LogRecord, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeLogs plog.ScopeLogs, resourceLogs plog.ResourceLogs, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.logRecord = logRecord
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.scopeLogs = scopeLogs
+	tCtx.resourceLogs = resourceLogs
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.logRecord = plog.LogRecord{}
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.scopeLogs = plog.ScopeLogs{}
+	tCtx.resourceLogs = plog.ResourceLogs{}
+	tcPool.Put(tCtx)
+}
+
 // GetLogRecord returns the log record from the TransformContext.
-func (tCtx TransformContext) GetLogRecord() plog.LogRecord {
+func (tCtx *TransformContext) GetLogRecord() plog.LogRecord {
 	return tCtx.logRecord
 }
 
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetScopeSchemaURLItem returns the scope schema URL item from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeLogs
 }
 
 // GetResourceSchemaURLItem returns the resource schema URL item from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceLogs
 }
 
@@ -121,9 +155,9 @@ func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem 
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ctxlog.Name,
 			ctxscope.LegacyName,
 			ctxscope.Name,
@@ -133,17 +167,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -152,17 +186,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -172,10 +206,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new log parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -195,19 +229,19 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("enum symbol not provided")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxlog.Name,
 		ctxlog.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
-			ctxlog.Name:         ctxlog.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxlog.Name:         ctxlog.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -53,7 +53,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
@@ -61,7 +61,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	}{
 		{
 			name: "time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
@@ -72,7 +72,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -83,7 +83,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "observed_time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "observed_time_unix_nano",
 			},
 			orig:   int64(500_000_000),
@@ -94,7 +94,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "observed time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "observed_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
@@ -105,7 +105,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_number",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "severity_number",
 			},
 			orig:   int64(plog.SeverityNumberFatal),
@@ -116,7 +116,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_text",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "severity_text",
 			},
 			orig:   "blue screen of death",
@@ -127,7 +127,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "body",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
 			},
 			orig:   "body",
@@ -138,7 +138,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "map body",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
 			},
 			orig: func() pcommon.Map {
@@ -153,10 +153,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "map body index",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("key"),
 					},
 				},
@@ -170,7 +170,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "slice body",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
 			},
 			orig: func() pcommon.Slice {
@@ -185,10 +185,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "slice body index",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -202,9 +202,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "body string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "body",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -217,7 +217,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "flags",
 			},
 			orig:   int64(4),
@@ -228,7 +228,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_id",
 			},
 			orig:   pcommon.TraceID(traceID),
@@ -239,7 +239,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "span_id",
 			},
 			orig:   pcommon.SpanID(spanID),
@@ -250,9 +250,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "trace_id",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -264,9 +264,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "span_id",
-				NextPath: &pathtest.Path[TransformContext]{
+				NextPath: &pathtest.Path[*TransformContext]{
 					N: "string",
 				},
 			},
@@ -278,7 +278,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -289,10 +289,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -305,7 +305,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refLog.Attributes(),
@@ -316,10 +316,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -332,10 +332,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -348,10 +348,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -364,10 +364,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -380,10 +380,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -396,10 +396,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -415,10 +415,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -434,10 +434,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -453,10 +453,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -472,10 +472,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -491,10 +491,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -512,10 +512,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -533,16 +533,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -559,16 +559,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -586,7 +586,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -601,7 +601,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxlog.Name
 		testWithContext.path = &pathWithContext
 		tests = append(tests, testWithContext)
@@ -610,7 +610,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -618,12 +618,14 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			log, il, resource := createTelemetry(tt.bodyType)
 
-			tCtx := NewTransformContext(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+			tCtx := NewTransformContextPtr(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
-			tCtx = NewTransformContext(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+			newCtx := NewTransformContextPtr(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+			defer newCtx.Close()
 			err = accessor.Set(t.Context(), tCtx, tt.newVal)
 			require.NoError(t, err)
 
@@ -641,19 +643,20 @@ func Test_newPathGetSetter(t *testing.T) {
 
 func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	logRec, instrumentationScope, resource := createTelemetry("string")
-	ctx := NewTransformContext(logRec, instrumentationScope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	ctx := NewTransformContextPtr(logRec, instrumentationScope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	defer ctx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -662,8 +665,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("str"),
 				},
 			}},
@@ -671,22 +674,22 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name:     "instrumentation_scope",
-			path:     &pathtest.Path[TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "instrumentation_scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "instrumentation_scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope",
-			path:     &pathtest.Path[TransformContext]{N: "scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 	}
@@ -773,10 +776,10 @@ func createTelemetry(bodyType string) (plog.LogRecord, pcommon.InstrumentationSc
 }
 
 func Test_InvalidBodyIndexing(t *testing.T) {
-	path := pathtest.Path[TransformContext]{
+	path := pathtest.Path[*TransformContext]{
 		N: "body",
-		KeySlice: []ottl.Key[TransformContext]{
-			&pathtest.Key[TransformContext]{
+		KeySlice: []ottl.Key[*TransformContext]{
+			&pathtest.Key[*TransformContext]{
 				S: ottltest.Strp("key"),
 			},
 		},
@@ -787,11 +790,13 @@ func Test_InvalidBodyIndexing(t *testing.T) {
 
 	log, il, resource := createTelemetry("string")
 
-	tCtx := NewTransformContext(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	tCtx := NewTransformContextPtr(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	defer tCtx.Close()
 	_, err = accessor.Get(t.Context(), tCtx)
 	assert.Error(t, err)
 
-	tCtx = NewTransformContext(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	newCtx := NewTransformContextPtr(log, il, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	defer newCtx.Close()
 	err = accessor.Set(t.Context(), tCtx, nil)
 	assert.Error(t, err)
 }

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -6,6 +6,7 @@ package ottlmetric // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -21,14 +22,20 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
 
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
+
 // ContextName is the name of the context for metrics.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxmetric.Name
 
 var (
-	_ ctxresource.Context = TransformContext{}
-	_ ctxscope.Context    = TransformContext{}
-	_ ctxmetric.Context   = TransformContext{}
+	_ ctxresource.Context = (*TransformContext)(nil)
+	_ ctxscope.Context    = (*TransformContext)(nil)
+	_ ctxmetric.Context   = (*TransformContext)(nil)
 )
 
 // TransformContext represents a metric and its associated hierarchy.
@@ -43,7 +50,7 @@ type TransformContext struct {
 }
 
 // MarshalLogObject serializes the metric into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("metric", logging.Metric(tCtx.metric)))
@@ -55,7 +62,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		metric:               metric,
@@ -72,33 +79,62 @@ func NewTransformContext(metric pmetric.Metric, metrics pmetric.MetricSlice, ins
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.metric = metric
+	tCtx.metrics = metrics
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.scopeMetrics = scopeMetrics
+	tCtx.resourceMetrics = resourceMetrics
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.metric = pmetric.NewMetric()
+	tCtx.metrics = pmetric.MetricSlice{}
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.scopeMetrics = pmetric.ScopeMetrics{}
+	tCtx.resourceMetrics = pmetric.ResourceMetrics{}
+	tcPool.Put(tCtx)
+}
+
 // GetMetric returns the metric from the TransformContext.
-func (tCtx TransformContext) GetMetric() pmetric.Metric {
+func (tCtx *TransformContext) GetMetric() pmetric.Metric {
 	return tCtx.metric
 }
 
 // GetMetrics returns the metric slice from the TransformContext.
-func (tCtx TransformContext) GetMetrics() pmetric.MetricSlice {
+func (tCtx *TransformContext) GetMetrics() pmetric.MetricSlice {
 	return tCtx.metrics
 }
 
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetScopeSchemaURLItem returns the scope schema URL item from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeMetrics
 }
 
 // GetResourceSchemaURLItem returns the resource schema URL item from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.resourceMetrics
 }
 
@@ -107,9 +143,9 @@ func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem 
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ctxmetric.Name,
 			ctxscope.LegacyName,
 			ctxscope.Name,
@@ -119,17 +155,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -138,17 +174,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -158,10 +194,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new metric parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -181,19 +217,19 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("enum symbol not provided")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxmetric.Name,
 		ctxmetric.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
-			ctxmetric.Name:      ctxmetric.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxmetric.Name:      ctxmetric.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -36,14 +36,14 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(metric pmetric.Metric, cache pcommon.Map)
 	}{
 		{
 			name: "metric name",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "name",
 			},
 			orig:   "name",
@@ -54,7 +54,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "description",
 			},
 			orig:   "description",
@@ -65,7 +65,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "unit",
 			},
 			orig:   "unit",
@@ -76,7 +76,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "type",
 			},
 			orig:   int64(pmetric.MetricTypeSum),
@@ -86,7 +86,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "aggregation_temporality",
 			},
 			orig:   int64(2),
@@ -97,7 +97,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "is_monotonic",
 			},
 			orig:   true,
@@ -108,7 +108,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric data points",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "data_points",
 			},
 			orig:   refMetric.Sum().DataPoints(),
@@ -119,7 +119,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metadata",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metadata",
 			},
 			orig:   pcommon.NewMap(),
@@ -130,10 +130,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metadata access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "metadata",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -146,7 +146,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -157,10 +157,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -177,16 +177,16 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxmetric.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a controlled test cache
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 
@@ -195,7 +195,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			metric := createTelemetry()
 
-			ctx := NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
 			require.NoError(t, err)
@@ -221,19 +222,20 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := pcommon.NewInstrumentationScope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContext(pmetric.NewMetric(), pmetric.NewMetricSlice(), instrumentationScope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	ctx := NewTransformContextPtr(pmetric.NewMetric(), pmetric.NewMetricSlice(), instrumentationScope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	defer ctx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("foo"),
 					},
 				},
@@ -242,8 +244,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("foo"),
 				},
 			}},
@@ -251,22 +253,22 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name:     "instrumentation_scope",
-			path:     &pathtest.Path[TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "instrumentation_scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "instrumentation_scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope",
-			path:     &pathtest.Path[TransformContext]{N: "scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 	}

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -90,7 +90,12 @@ func NewTransformContextPtr(span ptrace.Span, instrumentationScope pcommon.Instr
 // Close the current TransformContext.
 // After this function returns this instance cannot be used.
 func (tCtx *TransformContext) Close() {
+	tCtx.span = ptrace.Span{}
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
 	tCtx.cache.Clear()
+	tCtx.scopeSpans = ptrace.ScopeSpans{}
+	tCtx.resourceSpans = ptrace.ResourceSpans{}
 	tcPool.Put(tCtx)
 }
 

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -23,6 +24,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
 
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
+
 // ContextName is the name of the context for span events.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
 const ContextName = ctxspanevent.Name
@@ -37,12 +44,12 @@ type TransformContext struct {
 	resource             pcommon.Resource
 	cache                pcommon.Map
 	scopeSpans           ptrace.ScopeSpans
-	resouceSpans         ptrace.ResourceSpans
+	resourceSpans        ptrace.ResourceSpans
 	eventIndex           *int64
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("span", logging.Span(tCtx.span)))
@@ -57,7 +64,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(spanEvent ptrace.SpanEvent, span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		spanEvent:            spanEvent,
@@ -66,12 +73,43 @@ func NewTransformContext(spanEvent ptrace.SpanEvent, span ptrace.Span, instrumen
 		resource:             resource,
 		cache:                pcommon.NewMap(),
 		scopeSpans:           scopeSpans,
-		resouceSpans:         resourceSpans,
+		resourceSpans:        resourceSpans,
 	}
 	for _, opt := range options {
 		opt(&tc)
 	}
 	return tc
+}
+
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(spanEvent ptrace.SpanEvent, span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.spanEvent = spanEvent
+	tCtx.span = span
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.scopeSpans = scopeSpans
+	tCtx.resourceSpans = resourceSpans
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.spanEvent = ptrace.SpanEvent{}
+	tCtx.span = ptrace.Span{}
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.cache.Clear()
+	tCtx.scopeSpans = ptrace.ScopeSpans{}
+	tCtx.resourceSpans = ptrace.ResourceSpans{}
+	tCtx.eventIndex = nil
+	tcPool.Put(tCtx)
 }
 
 // WithEventIndex sets the index of the SpanEvent within the span, to make it accessible via the event_index property of its context.
@@ -83,38 +121,38 @@ func WithEventIndex(eventIndex int64) TransformContextOption {
 }
 
 // GetSpanEvent returns the span event from the TransformContext.
-func (tCtx TransformContext) GetSpanEvent() ptrace.SpanEvent {
+func (tCtx *TransformContext) GetSpanEvent() ptrace.SpanEvent {
 	return tCtx.spanEvent
 }
 
 // GetSpan returns the span from the TransformContext.
-func (tCtx TransformContext) GetSpan() ptrace.Span {
+func (tCtx *TransformContext) GetSpan() ptrace.Span {
 	return tCtx.span
 }
 
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetScopeSchemaURLItem returns the schema URL item for the scope from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.scopeSpans
 }
 
 // GetResourceSchemaURLItem returns the schema URL item for the resource from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
-	return tCtx.resouceSpans
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+	return tCtx.resourceSpans
 }
 
 // GetEventIndex returns the event index from the TransformContext.
 // If the event index is not set or invalid, an error is returned.
-func (tCtx TransformContext) GetEventIndex() (int64, error) {
+func (tCtx *TransformContext) GetEventIndex() (int64, error) {
 	if tCtx.eventIndex != nil {
 		if *tCtx.eventIndex < 0 {
 			return 0, errors.New("found invalid value for 'event_index'")
@@ -129,9 +167,9 @@ func (tCtx TransformContext) GetEventIndex() (int64, error) {
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ctxspanevent.Name,
 			ctxspan.Name,
 			ctxresource.Name,
@@ -142,17 +180,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -161,17 +199,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -181,10 +219,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new span event parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -204,37 +242,37 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("enum symbol not provided")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxspanevent.Name,
 		ctxspanevent.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
-			ctxspan.Name:        ctxspan.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
+			ctxspan.Name:        ctxspan.PathGetSetter[*TransformContext],
 			ctxspanevent.Name:   spanEventGetSetterWithIndex,
 		})
 }
 
-func spanEventGetSetterWithIndex(path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
+func spanEventGetSetterWithIndex(path ottl.Path[*TransformContext]) (ottl.GetSetter[*TransformContext], error) {
 	if path.Name() == "event_index" {
 		return accessSpanEventIndex(), nil
 	}
 	return ctxspanevent.PathGetSetter(path)
 }
 
-func accessSpanEventIndex() ottl.StandardGetSetter[TransformContext] {
-	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
+func accessSpanEventIndex() ottl.StandardGetSetter[*TransformContext] {
+	return ottl.StandardGetSetter[*TransformContext]{
+		Getter: func(_ context.Context, tCtx *TransformContext) (any, error) {
 			return tCtx.GetEventIndex()
 		},
-		Setter: func(_ context.Context, _ TransformContext, _ any) error {
+		Setter: func(_ context.Context, _ *TransformContext, _ any) error {
 			return errors.New("the 'event_index' path cannot be modified")
 		},
 	}

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -54,7 +54,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		path              ottl.Path[TransformContext]
+		path              ottl.Path[*TransformContext]
 		orig              any
 		newVal            any
 		expectSetterError bool
@@ -62,7 +62,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	}{
 		{
 			name: "span event time",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
@@ -73,7 +73,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -84,10 +84,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -100,7 +100,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "name",
 			},
 			orig:   "bear",
@@ -111,7 +111,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "time_unix_nano",
 			},
 			orig:   int64(100_000_000),
@@ -122,7 +122,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refSpanEvent.Attributes(),
@@ -133,10 +133,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -149,10 +149,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -165,10 +165,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -181,10 +181,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -197,10 +197,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -213,10 +213,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -232,10 +232,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -251,10 +251,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -270,10 +270,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -289,10 +289,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -308,10 +308,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -329,10 +329,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -350,16 +350,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -376,16 +376,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -403,7 +403,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -414,7 +414,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "event_index",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "event_index",
 			},
 			orig:              int64(1),
@@ -427,15 +427,15 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ctxspanevent.Name
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 
@@ -444,7 +444,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			spanEvent, span, il, resource := createTelemetry()
 
-			tCtx := NewTransformContext(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), WithEventIndex(1))
+			tCtx := NewTransformContextPtr(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), WithEventIndex(1))
+			defer tCtx.Close()
 
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -479,19 +480,20 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	instrumentationScope := pcommon.NewInstrumentationScope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContext(ptrace.NewSpanEvent(), span, instrumentationScope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	ctx := NewTransformContextPtr(ptrace.NewSpanEvent(), span, instrumentationScope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+	defer ctx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("foo"),
 					},
 				},
@@ -500,8 +502,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("foo"),
 				},
 			}},
@@ -509,32 +511,32 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name:     "instrumentation_scope",
-			path:     &pathtest.Path[TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "instrumentation_scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "instrumentation_scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "instrumentation_scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "instrumentation_scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope",
-			path:     &pathtest.Path[TransformContext]{N: "scope", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "scope", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "scope with context",
-			path:     &pathtest.Path[TransformContext]{C: "scope", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "scope", N: "name"},
 			expected: instrumentationScope.Name(),
 		},
 		{
 			name:     "span",
-			path:     &pathtest.Path[TransformContext]{N: "span", NextPath: &pathtest.Path[TransformContext]{N: "name"}},
+			path:     &pathtest.Path[*TransformContext]{N: "span", NextPath: &pathtest.Path[*TransformContext]{N: "name"}},
 			expected: span.Name(),
 		},
 		{
 			name:     "span with context",
-			path:     &pathtest.Path[TransformContext]{C: "span", N: "name"},
+			path:     &pathtest.Path[*TransformContext]{C: "span", N: "name"},
 			expected: span.Name(),
 		},
 	}
@@ -582,14 +584,15 @@ func Test_setAndGetEventIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			spanEvent, span, il, resource := createTelemetry()
 
-			var tCtx TransformContext
+			var tCtx *TransformContext
 			if tt.setEventIndex {
-				tCtx = NewTransformContext(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), WithEventIndex(tt.eventIndexValue))
+				tCtx = NewTransformContextPtr(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), WithEventIndex(tt.eventIndexValue))
 			} else {
-				tCtx = NewTransformContext(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
+				tCtx = NewTransformContextPtr(spanEvent, span, il, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
 			}
+			defer tCtx.Close()
 
-			accessor, err := pathExpressionParser(getCache)(&pathtest.Path[TransformContext]{
+			accessor, err := pathExpressionParser(getCache)(&pathtest.Path[*TransformContext]{
 				N: "event_index",
 			})
 			require.NoError(t, err)
@@ -615,11 +618,11 @@ func TestHigherContextCacheAccessError(t *testing.T) {
 	}
 	for _, higherContext := range higherContexts {
 		t.Run(higherContext, func(t *testing.T) {
-			path := &pathtest.Path[TransformContext]{
+			path := &pathtest.Path[*TransformContext]{
 				N: "cache",
 				C: higherContext,
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("key"),
 					},
 				},

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -38,17 +38,17 @@ var (
 func Test_e2e_editors(t *testing.T) {
 	tests := []struct {
 		statement string
-		want      func(tCtx ottllog.TransformContext)
+		want      func(tCtx *ottllog.TransformContext)
 	}{
 		{
 			statement: `delete_key(attributes, "http.method")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("http.method")
 			},
 		},
 		{
 			statement: `delete_matching_keys(attributes, "^http")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("http.method")
 				tCtx.GetLogRecord().Attributes().Remove("http.path")
 				tCtx.GetLogRecord().Attributes().Remove("http.url")
@@ -56,7 +56,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `keep_matching_keys(attributes, "^http")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("flags")
 				tCtx.GetLogRecord().Attributes().Remove("total.string")
 				tCtx.GetLogRecord().Attributes().Remove("foo")
@@ -67,7 +67,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `keep_matching_keys(attributes, Concat(["^", "http"], ""))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("flags")
 				tCtx.GetLogRecord().Attributes().Remove("total.string")
 				tCtx.GetLogRecord().Attributes().Remove("foo")
@@ -78,7 +78,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("foo")
 				tCtx.GetLogRecord().Attributes().Remove("conflict.conflict1")
 				tCtx.GetLogRecord().Attributes().Remove("conflict")
@@ -97,7 +97,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := pcommon.NewMap()
 				m.PutStr("test.http.method", "get")
 				m.PutStr("test.http.path", "/health")
@@ -122,7 +122,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, "test", resolveConflicts=true)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := pcommon.NewMap()
 				m.PutStr("test.http.method", "get")
 				m.PutStr("test.http.path", "/health")
@@ -150,7 +150,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, depth=1)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := pcommon.NewMap()
 				m.PutStr("http.method", "get")
 				m.PutStr("http.path", "/health")
@@ -181,7 +181,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `keep_keys(attributes, ["flags", "total.string"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("http.method")
 				tCtx.GetLogRecord().Attributes().Remove("http.path")
 				tCtx.GetLogRecord().Attributes().Remove("http.url")
@@ -193,11 +193,11 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `limit(attributes, 100, [])`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			statement: `limit(attributes, 1, ["total.string"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("http.method")
 				tCtx.GetLogRecord().Attributes().Remove("http.path")
 				tCtx.GetLogRecord().Attributes().Remove("http.url")
@@ -210,7 +210,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `merge_maps(attributes, attributes["foo"], "insert")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("bar", "pass")
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("slice")
 				v := s.AppendEmpty()
@@ -221,13 +221,13 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `merge_maps(attributes, attributes["foo"], "update")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("flags", "pass")
 			},
 		},
 		{
 			statement: `merge_maps(attributes, attributes["foo"], "upsert")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("bar", "pass")
 				tCtx.GetLogRecord().Attributes().PutStr("flags", "pass")
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("slice")
@@ -239,7 +239,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `merge_maps(attributes, {"map_literal": {"list": [{"foo":"bar"}, "test"]}}, "upsert")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				mapAttr := tCtx.GetLogRecord().Attributes().PutEmptyMap("map_literal")
 				l := mapAttr.PutEmptySlice("list")
 				l.AppendEmpty().SetEmptyMap().PutStr("foo", "bar")
@@ -248,21 +248,21 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `replace_all_matches(attributes, "*/*", "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "test")
 				tCtx.GetLogRecord().Attributes().PutStr("http.url", "test")
 			},
 		},
 		{
 			statement: `replace_all_matches(attributes, Concat(["*","/","*"],""), "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "test")
 				tCtx.GetLogRecord().Attributes().PutStr("http.url", "test")
 			},
 		},
 		{
 			statement: `replace_all_patterns(attributes, "key", "^http", "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Remove("http.method")
 				tCtx.GetLogRecord().Attributes().Remove("http.path")
 				tCtx.GetLogRecord().Attributes().Remove("http.url")
@@ -273,82 +273,82 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `replace_all_patterns(attributes, "value", "/", "@")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "@health")
 				tCtx.GetLogRecord().Attributes().PutStr("http.url", "http:@@localhost@health")
 			},
 		},
 		{
 			statement: `replace_match(attributes["http.path"], Concat(["*","/","*"],""), "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "test")
 			},
 		},
 		{
 			statement: `replace_all_patterns(attributes, "value", Concat(["/","health"],""), "@")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "@")
 				tCtx.GetLogRecord().Attributes().PutStr("http.url", "http://localhost@")
 			},
 		},
 		{
 			statement: `replace_match(attributes["http.path"], "*/*", "test")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "test")
 			},
 		},
 		{
 			statement: `replace_pattern(attributes["http.path"], "/", "@")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "@health")
 			},
 		},
 		{
 			statement: `replace_pattern(attributes["http.path"], Concat(["/","health"],""), "@")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "@")
 			},
 		},
 		{
 			statement: `replace_pattern(attributes["http.path"], "/", "@", SHA256)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "c3641f8544d7c02f3580b07c0f9887f0c6a27ff5ab1d4a3e29caf197cfc299aehealth")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], nil)`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			statement: `set(attributes["test"], "nil")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "nil")
 			},
 		},
 		{
 			statement: `set(attributes["test"], attributes["unknown"])`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			statement: `set(attributes["foo"]["test"], "pass")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				v, _ := tCtx.GetLogRecord().Attributes().Get("foo")
 				v.Map().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `truncate_all(attributes, 100)`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			statement: `truncate_all(attributes, 1)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("http.method", "g")
 				tCtx.GetLogRecord().Attributes().PutStr("http.path", "/")
 				tCtx.GetLogRecord().Attributes().PutStr("http.url", "h")
@@ -358,7 +358,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `append(attributes["foo"]["slice"], "sample_value")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				v, _ := tCtx.GetLogRecord().Attributes().Get("foo")
 				sv, _ := v.Map().Get("slice")
 				s := sv.Slice()
@@ -367,7 +367,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `append(attributes["foo"]["flags"], "sample_value")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				v, _ := tCtx.GetLogRecord().Attributes().Get("foo")
 				s := v.Map().PutEmptySlice("flags")
 				s.AppendEmpty().SetStr("pass")
@@ -376,7 +376,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `append(attributes["foo"]["slice"], values=[5,6])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				v, _ := tCtx.GetLogRecord().Attributes().Get("foo")
 				sv, _ := v.Map().Get("slice")
 				s := sv.Slice()
@@ -386,7 +386,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `append(attributes["foo"]["new_slice"], values=[5,6])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				v, _ := tCtx.GetLogRecord().Attributes().Get("foo")
 				s := v.Map().PutEmptySlice("new_slice")
 				s.AppendEmpty().SetInt(5)
@@ -408,6 +408,8 @@ func Test_e2e_editors(t *testing.T) {
 				tt.want(exTCtx)
 
 				require.NoError(t, plogtest.CompareResourceLogs(newResourceLogs(exTCtx), newResourceLogs(tCtx)))
+				tCtx.Close()
+				exTCtx.Close()
 			}
 		})
 	}
@@ -416,94 +418,94 @@ func Test_e2e_editors(t *testing.T) {
 func Test_e2e_converters(t *testing.T) {
 	tests := []struct {
 		statement string
-		want      func(tCtx ottllog.TransformContext)
+		want      func(tCtx *ottllog.TransformContext)
 		wantErr   bool
 		errMsg    string
 	}{
 		{
 			statement: `set(attributes["newOne"], attributes[1])`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "unable to resolve a string index in map: invalid key type",
 		},
 		{
 			statement: `set(attributes["array"][0.0], "bar")`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "unable to resolve an integer index in slice: could not resolve key for map/slice, expecting 'int64' but got 'float64'",
 		},
 		{
 			statement: `set(attributes["array"][ConvertCase(attributes["A|B|C"], "upper")], "bar")`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "unable to resolve an integer index in slice: could not resolve key for map/slice, expecting 'int64'",
 		},
 		{
 			statement: `set(attributes[ConvertCase(attributes["A|B|C"], "upper")], "myvalue")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("SOMETHING", "myvalue")
 			},
 		},
 		{
 			statement: `set(attributes[ConvertCase(attributes[attributes["flags"]], "upper")], "myvalue")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("SOMETHING", "myvalue")
 			},
 		},
 		{
 			statement: `set(attributes[attributes["flags"]], "something33")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("A|B|C", "something33")
 			},
 		},
 		{
 			statement: `set(attributes[attributes[attributes["flags"]]], "something2")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("something", "something2")
 			},
 		},
 		{
 			statement: `set(body, attributes["things"][Len(attributes["things"]) - 1]["name"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("bar")
 			},
 		},
 		{
 			statement: `set(body, attributes["things"][attributes["int_value"] + 1]["name"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("bar")
 			},
 		},
 		{
 			statement: `set(body, attributes[attributes["foo"][attributes["slice"]][attributes["int_value"] + 1 - 1]])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("val2")
 			},
 		},
 		{
 			statement: `set(body, attributes[attributes["foo"][attributes["slice"]][attributes["int_value"]]])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("val2")
 			},
 		},
 		{
 			statement: `set(resource.attributes[attributes["flags"]], "something33")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetResource().Attributes().PutStr("A|B|C", "something33")
 			},
 		},
 		{
 			statement: `set(resource.attributes[resource.attributes[attributes["flags"]]], "something33")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetResource().Attributes().PutStr("newValue", "something33")
 			},
 		},
 		{
 			statement: `set(attributes[resource.attributes[attributes["flags"]]], "something33")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("newValue", "something33")
 			},
 		},
 		{
 			statement: `set(body, attributes["array"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				arr := tCtx.GetLogRecord().Body().SetEmptySlice()
 				arr0 := arr.AppendEmpty()
 				arr0.SetStr("looong")
@@ -511,7 +513,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["array"][attributes["int_value"]], 3)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				arr := tCtx.GetLogRecord().Attributes().PutEmptySlice("array")
 				arr0 := arr.AppendEmpty()
 				arr0.SetInt(3)
@@ -519,165 +521,165 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Base64Decode("cGFzcw=="))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Decode("cGFzcw==", "base64"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["decoded_base64"], Decode("cGFzcw==", attributes["encoding"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("decoded_base64", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Concat(["A","B"], ":"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "A:B")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Concat(["A","B"], attributes["val"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "Aval2B")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ConvertCase(attributes["http.method"], "upper"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", http.MethodGet)
 			},
 		},
 		{
 			statement: `set(attributes["test"], ConvertCase("PASS", "lower"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ConvertCase("fooBar", "snake"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "foo_bar")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ConvertCase("foo_bar", "camel"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "FooBar")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToCamelCase("foo_bar"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "FooBar")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToSnakeCase("fooBar"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "foo_bar")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToUpperCase(attributes["http.method"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", http.MethodGet)
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToLowerCase("PASS"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ConvertAttributesToElementsXML("<Log id=\"1\"><Message>This is a log message!</Message></Log>"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", `<Log><Message>This is a log message!</Message><id>1</id></Log>`)
 			},
 		},
 		{
 			statement: `set(body, ConvertTextToElementsXML("<a><b/>foo</a>"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("<a><b></b><value>foo</value></a>")
 			},
 		},
 		{
 			statement: `set(body, ConvertTextToElementsXML("<a><b/>foo</a><c><b/>bar</c>", "/a", "custom"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Body().SetStr("<a><b></b><custom>foo</custom></a><c><b></b>bar</c>")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ParseInt("0xAF", 0))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 175)
 			},
 		},
 		{
 			statement: `set(attributes["test"], ParseInt("12345", 10))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 12345)
 			},
 		},
 		{
 			statement: `set(attributes["test"], ParseInt("AF", 16))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 175)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Double(1.0))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 1.0)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Double("1"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 1.0)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Double(true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 1.0)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Double(1))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 1.0)
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where Time("10", "%M") - Time("01", "%M") < Duration("10m")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ExtractPatterns("aa123bb", "(?P<numbers>\\d+)"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("numbers", "123")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ExtractPatterns("aa123bb", Concat(["(?P", "<numbers>", "\\d+)"], "")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("numbers", "123")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ExtractGrokPatterns("http://user:password@example.com:80/path?query=string", "%{ELB_URI}", true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("url.scheme", "http")
 				m.PutStr("url.username", "user")
@@ -689,7 +691,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ExtractGrokPatterns("http://user:password@example.com:80/path?query=string", Concat(["%{", "ELB_URI", "}"], ""), true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("url.scheme", "http")
 				m.PutStr("url.username", "user")
@@ -701,199 +703,199 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], FNV("pass"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 266877920130663416)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Format("%03d-%s", [7, "test"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "007-test")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hour(Time("12", "%H")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 12)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hours(Duration("90m")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 1.5)
 			},
 		},
 		{
 			statement: `set(attributes["test"], InsertXML("<a></a>", "/a", "<b></b>"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "<a><b></b></a>")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Int(1.0))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Int("1"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Int(true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Int(1))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1)
 			},
 		},
 		{
 			statement: `set(attributes["test"], GetXML("<a><b>1</b><c><b>2</b></c></a>", "/a//b"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "<b>1</b><b>2</b>")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex(1.0))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "3ff0000000000000")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex(true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "01")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex(12))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "000000000000000c")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex("12"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "3132")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsBool(false)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsDouble(1.0)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsMap(attributes["foo"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsList(attributes["foo"]["slice"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsMatch("aa123bb", "\\d{3}")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsString("")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Len(attributes["foo"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 4)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Log(1))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 0)
 			},
 		},
 		{
 			statement: `set(attributes["test"], IsValidLuhn("17893729974"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutBool("test", true)
 			},
 		},
 		{
 			statement: `set(attributes["test"], IsValidLuhn(17893729975))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutBool("test", false)
 			},
 		},
 		{
 			statement: `set(attributes["test"], MD5("pass"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1a1dc91c907325c69271ddf0c944bc72")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Microseconds(Duration("1ms")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1000)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Milliseconds(Duration("1s")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1000)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Minutes(Duration("1h")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 60)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Murmur3Hash128("Hello World"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "dbc2a0c1ab26631a27b4c09fcf1fe683")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Murmur3Hash("Hello World"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "ce837619")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Nanoseconds(Duration("1ms")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 1000000)
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where Now() - Now() < Duration("1h")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ParseCSV("val1;val2;val3","header1|header2|header3",";","|","strict"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("header1", "val1")
 				m.PutStr("header2", "val2")
@@ -902,7 +904,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseCSV("val1,val2,val3","header1|header2|header3",headerDelimiter="|",mode="strict"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("header1", "val1")
 				m.PutStr("header2", "val2")
@@ -911,14 +913,14 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseJSON("{\"id\":1}"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutDouble("id", 1)
 			},
 		},
 		{
 			statement: `set(attributes["test"], ParseJSON("[\"value1\",\"value2\"]"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				m.AppendEmpty().SetStr("value1")
 				m.AppendEmpty().SetStr("value2")
@@ -926,7 +928,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseKeyValue("k1=v1 k2=v2"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("k1", "v1")
 				m.PutStr("k2", "v2")
@@ -934,7 +936,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseKeyValue("k1!v1_k2!v2", "!", "_"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("k1", "v1")
 				m.PutStr("k2", "v2")
@@ -942,7 +944,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseKeyValue("k1!v1_k2!\"v2__!__v2\"", "!", "_"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("k1", "v1")
 				m.PutStr("k2", "v2__!__v2")
@@ -950,31 +952,31 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ToKeyValueString(ParseKeyValue("k1=v1 k2=v2"), "=", " ", true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "k1=v1 k2=v2")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToKeyValueString(ParseKeyValue("k1:v1,k2:v2", ":" , ","), ":", ",", true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "k1:v1,k2:v2")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToKeyValueString(ParseKeyValue("k1=v1 k2=v2"), "!", "+", true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "k1!v1+k2!v2")
 			},
 		},
 		{
 			statement: `set(attributes["test"], ToKeyValueString(ParseKeyValue("k1=v1 k2=v2=v3"), "=", " ", true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "k1=v1 k2=\"v2=v3\"")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Sort(Values({"key1": true, "key2": "value", "key3": 1})))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 
 				s.AppendEmpty().SetInt(1)
@@ -984,7 +986,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseSimplifiedXML("<Log><id>1</id><Message>This is a log message!</Message></Log>"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				attr := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				log := attr.PutEmptyMap("Log")
 				log.PutStr("id", "1")
@@ -993,7 +995,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], ParseXML("<Log id=\"1\"><Message>This is a log message!</Message></Log>"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				log := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				log.PutStr("tag", "Log")
 
@@ -1009,37 +1011,37 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], RemoveXML("<Log id=\"1\"><Message>This is a log message!</Message></Log>", "/Log/Message"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", `<Log id="1"></Log>`)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Seconds(Duration("1m")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 60)
 			},
 		},
 		{
 			statement: `set(attributes["test"], SHA1("pass"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684")
 			},
 		},
 		{
 			statement: `set(attributes["test"], SHA256("pass"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "d74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1")
 			},
 		},
 		{
 			statement: `set(attributes["test"], SHA512("pass"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "5b722b307fce6c944905d132691d5e4a2214b7fe92b738920eb3fce3a90420a19511c3010a0e7712b054daef5b57bad59ecbd93b3280f210578f547f4aed4d25")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Sort(Split(attributes["flags"], "|"), "desc"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetStr("C")
 				s.AppendEmpty().SetStr("B")
@@ -1048,7 +1050,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort(Split(attributes["flags"], attributes["split_delimiter"]), "desc"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetStr("C")
 				s.AppendEmpty().SetStr("B")
@@ -1057,7 +1059,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort([true, false, false]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetBool(false)
 				s.AppendEmpty().SetBool(false)
@@ -1066,7 +1068,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort([3, 6, 9], "desc"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetInt(9)
 				s.AppendEmpty().SetInt(6)
@@ -1075,7 +1077,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort([Double(1.5), Double(10.2), Double(2.3), Double(0.5)]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetDouble(0.5)
 				s.AppendEmpty().SetDouble(1.5)
@@ -1085,7 +1087,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort([Int(11), Double(2.2), Double(-1)]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetDouble(-1)
 				s.AppendEmpty().SetDouble(2.2)
@@ -1094,7 +1096,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Sort([false, Int(11), Double(2.2), "three"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetInt(11)
 				s.AppendEmpty().SetDouble(2.2)
@@ -1104,19 +1106,19 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(span_id, SpanID(0x0000000000000000))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().SetSpanID(pcommon.NewSpanIDEmpty())
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where String(ProfileID(0x00000000000000000000000000000001)) == "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]"`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Split(attributes["flags"], "|"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				s.AppendEmpty().SetStr("A")
 				s.AppendEmpty().SetStr("B")
@@ -1125,127 +1127,127 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], String("test"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "test")
 			},
 		},
 		{
 			statement: `set(attributes["test"], String(attributes["http.method"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "get")
 			},
 		},
 		{
 			statement: `set(attributes["test"], String(span_id))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "[1,2,3,4,5,6,7,8]")
 			},
 		},
 		{
 			statement: `set(attributes["test"], String([1,2,3]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "[1,2,3]")
 			},
 		},
 		{
 			statement: `set(attributes["test"], String(true))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "true")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Substring("pass", 0, 2))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pa")
 			},
 		},
 		{
 			statement: `set(trace_id, TraceID(0x00000000000000000000000000000000))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().SetTraceID(pcommon.NewTraceIDEmpty())
 			},
 		},
 		{
 			statement: `set(time, TruncateTime(time, Duration("1s")))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().SetTimestamp(pcommon.NewTimestampFromTime(TestLogTimestamp.AsTime().Truncate(time.Second)))
 			},
 		},
 		{
 			statement: `set(attributes["time"], FormatTime(time, "%Y-%m-%d"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("time", "2020-02-11")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where UnixMicro(time) > 0`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where UnixMilli(time) > 0`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where UnixNano(time) > 0`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where UnixSeconds(time) > 0`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsString(UUID())`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "pass") where IsString(UUIDv7())`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "\\")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "\\")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "\\\\")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "\\\\")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "\\\\\\")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "\\\\\\")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "\\\\\\\\")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "\\\\\\\\")
 			},
 		},
 		{
 			statement: `set(attributes["test"], "\"")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", `"`)
 			},
 		},
 		{
 			statement: `keep_keys(attributes["foo"], [Concat(["ba", "r"], "")])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				// keep_keys should see two arguments
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("foo")
 				m.PutStr("bar", "pass")
@@ -1253,7 +1255,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `keep_keys(attributes["foo"], ["\\", "bar"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				// keep_keys should see two arguments
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("foo")
 				m.PutStr("bar", "pass")
@@ -1261,7 +1263,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], UserAgent("curl/7.81.0"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("user_agent.original", "curl/7.81.0")
 				m.PutStr("user_agent.name", "curl")
@@ -1271,7 +1273,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["things"], ["name"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				thing1 := m.PutEmptyMap("foo")
 				thing1.PutStr("name", "foo")
@@ -1284,7 +1286,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["things"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				thing1 := m.PutEmptyMap("0")
 				thing1.PutStr("name", "foo")
@@ -1297,7 +1299,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["things"], ["name"], ["value"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutInt("foo", 2)
 				m.PutInt("bar", 5)
@@ -1305,7 +1307,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["primitiveValuesSlice"]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("0", "value1")
 				m.PutInt("1", 42)
@@ -1315,18 +1317,18 @@ func Test_e2e_converters(t *testing.T) {
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["things"], ["nonexistent_key"], ["value"]))`,
 			wantErr:   true,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "could not extract key from element",
 		},
 		{
 			statement: `set(attributes["test"], SliceToMap(attributes["things"], ["name"], ["nonexistent_value"]))`,
 			wantErr:   true,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 			errMsg:    "provided object does not contain the path",
 		},
 		{
 			statement: `set(attributes["test"], {"list":[{"foo":"bar"}]})`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m2 := m.PutEmptySlice("list").AppendEmpty().SetEmptyMap()
 				m2.PutStr("foo", "bar")
@@ -1334,7 +1336,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes, {"list":[{"foo":"bar"}]})`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().Clear()
 				m2 := tCtx.GetLogRecord().Attributes().PutEmptySlice("list").AppendEmpty().SetEmptyMap()
 				m2.PutStr("foo", "bar")
@@ -1342,7 +1344,7 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["arr"], [{"list":[{"foo":"bar"}]}, {"bar":"baz"}])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				arr := tCtx.GetLogRecord().Attributes().PutEmptySlice("arr")
 				arr.AppendEmpty().SetEmptyMap().PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("foo", "bar")
 				arr.AppendEmpty().SetEmptyMap().PutStr("bar", "baz")
@@ -1350,19 +1352,19 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], IsList([{"list":[{"foo":"bar"}]}, {"bar":"baz"}]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutBool("test", true)
 			},
 		},
 		{
 			statement: `set(attributes["test"], IsMap({"list":[{"foo":"bar"}]}))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutBool("test", true)
 			},
 		},
 		{
 			statement: `set(attributes["test"], Len([{"list":[{"foo":"bar"}]}, {"bar":"baz"}]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 2)
 			},
 		},
@@ -1380,13 +1382,13 @@ func Test_e2e_converters(t *testing.T) {
 			],
 		}
 	))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "info")
 			},
 		},
 		{
 			statement: `set(attributes["list"], Sort(Keys({"foo": "bar", "baz": "foo"})))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				attributes := tCtx.GetLogRecord().Attributes().PutEmptySlice("list")
 				attributes.AppendEmpty().SetStr("baz")
 				attributes.AppendEmpty().SetStr("foo")
@@ -1394,38 +1396,38 @@ func Test_e2e_converters(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["indexof"], Index("opentelemetry", "telemetry"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("indexof", 4)
 			},
 		},
 		{
 			statement: `set(attributes["indexof"], Index(attributes["slices"], "name"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("indexof", -1)
 			},
 		},
 		{
 			statement: `set(attributes["indexof"], Index(attributes["slices"], "slice2"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("indexof", 1)
 			},
 		},
 		{
 			// slice contains a map
 			statement: `set(attributes["indexof"], Index(attributes["slices"], attributes["slices"][2]))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("indexof", 2)
 			},
 		},
 		{
 			statement: `set(attributes["test"], XXH3("hello world"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "d447b1ea40e6988b")
 			},
 		},
 		{
 			statement: `set(attributes["test"], XXH128("hello world"))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "df8d09e93f874900a99b8775cc15b6c7")
 			},
 		},
@@ -1449,6 +1451,8 @@ func Test_e2e_converters(t *testing.T) {
 				tt.want(exTCtx)
 
 				require.NoError(t, plogtest.CompareResourceLogs(newResourceLogs(exTCtx), newResourceLogs(tCtx)))
+				tCtx.Close()
+				exTCtx.Close()
 			}
 		})
 	}
@@ -1458,141 +1462,141 @@ func Test_e2e_ottl_features(t *testing.T) {
 	tests := []struct {
 		name      string
 		statement string
-		want      func(tCtx ottllog.TransformContext)
+		want      func(tCtx *ottllog.TransformContext)
 	}{
 		{
 			name:      "where clause",
 			statement: `set(attributes["test"], "pass") where body == "operationB"`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			name:      "reach upwards",
 			statement: `set(attributes["test"], "pass") where resource.attributes["host.name"] == "localhost"`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause with dynamic indexing",
 			statement: `set(attributes["foo"], "bar") where attributes[attributes["flags"]] != nil`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("foo", "bar")
 			},
 		},
 		{
 			name:      "Using enums",
 			statement: `set(severity_number, SEVERITY_NUMBER_TRACE2) where severity_number == SEVERITY_NUMBER_TRACE`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().SetSeverityNumber(2)
 			},
 		},
 		{
 			name:      "Using HasPrefix",
 			statement: `set(attributes["test"], "pass") where HasPrefix(body, "operation")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "Using HasPrefix with dynamic prefix",
 			statement: `set(attributes["test"], "pass") where HasPrefix(body, attributes["dynamicprefix"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "Using HasSuffix",
 			statement: `set(attributes["test"], "pass") where HasSuffix(body, "tionA")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "Using HasSuffix with dynamic suffix",
 			statement: `set(attributes["test"], "pass") where HasSuffix(body, attributes["dynamicsuffix"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "Using hex",
 			statement: `set(attributes["test"], "pass") where trace_id == TraceID(0x0102030405060708090a0b0c0d0e0f10)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause without comparator",
 			statement: `set(attributes["test"], "pass") where IsMatch(body, "operation[AC]")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause without comparator dynamic pattern",
 			statement: `set(attributes["test"], "pass") where IsMatch(body, Concat(["operation", "[AC]"], ""))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause with Converter return value",
 			statement: `set(attributes["test"], "pass") where body == Concat(["operation", "A"], "")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "composing functions",
 			statement: `merge_maps(attributes, ParseJSON("{\"json_test\":\"pass\"}"), "insert") where body == "operationA"`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("json_test", "pass")
 			},
 		},
 		{
 			name:      "where clause with ContainsValue return value",
 			statement: `set(attributes["test"], "pass") where ContainsValue(["hello", "world"], "hello")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause with ContainsValue ints return value",
 			statement: `set(attributes["test"], "pass") where ContainsValue([1, 2, 3, 4], 4)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause with ContainsValue floats return value",
 			statement: `set(attributes["test"], "pass") where ContainsValue([1.1, 2.2, 3.3, 4.4], 4.4)`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      `set attribute when tag "staging" is in tags attributes slice using ContainsValue`,
 			statement: `set(attributes["staging"], "true") where ContainsValue(attributes["foo"]["slice"], "val")`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("staging", "true")
 			},
 		},
 		{
 			name:      "complex indexing found",
 			statement: `set(attributes["test"], attributes["foo"]["bar"])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "complex indexing not found",
 			statement: `set(attributes["test"], attributes["metadata"]["uid"])`,
-			want:      func(_ ottllog.TransformContext) {},
+			want:      func(*ottllog.TransformContext) {},
 		},
 		{
 			name:      "map value",
 			statement: `set(body, {"_raw": body, "test": {"result": attributes["foo"]["bar"], "time": UnixNano(time)}})`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				originalBody := tCtx.GetLogRecord().Body().AsString()
 				mapValue := tCtx.GetLogRecord().Body().SetEmptyMap()
 				mapValue.PutStr("_raw", originalBody)
@@ -1604,21 +1608,21 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "map value as input to function",
 			statement: `set(attributes["isMap"], IsMap({"foo": {"bar": "baz", "test": "pass"}}))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutBool("isMap", true)
 			},
 		},
 		{
 			name:      "extract value from Split function result slice of type []string",
 			statement: `set(attributes["my.environment.2"], Split(resource.attributes["host.name"],"h")[1])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("my.environment.2", "ost")
 			},
 		},
 		{
 			name:      "map value with nil",
 			statement: `set(body, {"value": nil})`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				mapValue := tCtx.GetLogRecord().Body().SetEmptyMap()
 				mapValue.PutEmpty("value")
 			},
@@ -1626,7 +1630,7 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "map value with quoted nil",
 			statement: `set(body, {"value": "nil"})`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				mapValue := tCtx.GetLogRecord().Body().SetEmptyMap()
 				mapValue.PutStr("value", "nil")
 			},
@@ -1634,7 +1638,7 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "slice with nil and quoted nil",
 			statement: `set(attributes["test"], [nil, "nil", nil])`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				arr := tCtx.GetLogRecord().Attributes().PutEmptySlice("test")
 				arr.AppendEmpty() // nil
 				arr.AppendEmpty().SetStr("nil")
@@ -1644,50 +1648,50 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "where clause with nil",
 			statement: `set(attributes["test"], "pass") where attributes["non_exiting_attrs"] == nil`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			name:      "where clause with quoted nil",
 			statement: `set(attributes["test"], "pass") where attributes["nil_string"] == "nil"`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "TCP", 0))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:9qr9Z1LViXcNwtLVOHZ3CL8MlyM=")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "UDP", 1))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:1viZaClxhTkWejXjxmQXaZzI8F4=")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "ICMP", 9))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:7tb0A6iknoFJCZmtLXkvScm21Ss=")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "ICMP6", 10))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:D7dVM6HJooFwvHhLnrMrNMw/UR4=")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "RSVP", 11))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:cEVbY6jymDAKgyIU4UqMu0WQHTI=")
 			},
 		},
 		{
 			statement: `set(attributes["test"], CommunityID("123.124.125.126", 12345, "55.56.57.58", 80, "SCTP", 12))`,
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "1:4KOPjy2bsV43uY/mf4HtwyZkwqM=")
 			},
 		},
@@ -1706,6 +1710,8 @@ func Test_e2e_ottl_features(t *testing.T) {
 				tt.want(exTCtx)
 
 				require.NoError(t, plogtest.CompareResourceLogs(newResourceLogs(exTCtx), newResourceLogs(tCtx)))
+				tCtx.Close()
+				exTCtx.Close()
 			}
 		})
 	}
@@ -1715,7 +1721,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 	tests := []struct {
 		name       string
 		statements []string
-		want       func(tCtx ottllog.TransformContext)
+		want       func(tCtx *ottllog.TransformContext)
 	}{
 		{
 			name: "delete key of map literal",
@@ -1723,7 +1729,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["test"], {"foo":"bar", "list":[{"test":"hello"}]})`,
 				`delete_key(attributes["test"], "foo")`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("test", "hello")
 			},
@@ -1735,7 +1741,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["dynamic_key"], "foo")`,
 				`delete_key(attributes["test"], attributes["dynamic_key"])`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("test", "hello")
 				tCtx.GetLogRecord().Attributes().PutStr("dynamic_key", "foo")
@@ -1747,7 +1753,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["test"], {"foo":"bar", "list":[{"test":"hello"}]})`,
 				`delete_matching_keys(attributes["test"], ".*oo")`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("test", "hello")
 			},
@@ -1758,7 +1764,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["test"], {"foo":"bar", "list":[{"test":"hello"}]})`,
 				`delete_matching_keys(attributes["test"], Concat([".*", "oo"], ""))`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("test", "hello")
 			},
@@ -1769,7 +1775,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["test"], {"foo":"bar", "list":[{"test":"hello"}]})`,
 				`keep_matching_keys(attributes["test"], ".*ist")`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutEmptySlice("list").AppendEmpty().SetEmptyMap().PutStr("test", "hello")
 			},
@@ -1780,7 +1786,7 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 				`set(attributes["test"], {"foo":"bar", "list":[{"test":"hello"}]})`,
 				`flatten(attributes["test"])`,
 			},
-			want: func(tCtx ottllog.TransformContext) {
+			want: func(tCtx *ottllog.TransformContext) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutStr("foo", "bar")
 				m.PutStr("list.0.test", "hello")
@@ -1805,6 +1811,8 @@ func Test_e2e_ottl_statement_sequence(t *testing.T) {
 			tt.want(exTCtx)
 
 			require.NoError(t, plogtest.CompareResourceLogs(newResourceLogs(exTCtx), newResourceLogs(tCtx)))
+			tCtx.Close()
+			exTCtx.Close()
 		})
 	}
 }
@@ -1911,13 +1919,14 @@ func Test_e2e_ottl_value_expressions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			settings := componenttest.NewNopTelemetrySettings()
-			logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings)
+			logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings)
 			require.NoError(t, err)
 			valueExpr, err := logParser.ParseValueExpression(tt.statement)
 			require.NoError(t, err)
 
 			tCtx := constructLogTransformContextValueExpressions()
 			val, err := valueExpr.Eval(t.Context(), tCtx)
+			tCtx.Close()
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.want(), val)
@@ -1965,11 +1974,11 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 func Test_ProcessSpanEvents(t *testing.T) {
 	tests := []struct {
 		statement string
-		want      func(_ ottlspanevent.TransformContext)
+		want      func(*ottlspanevent.TransformContext)
 	}{
 		{
 			statement: `set(attributes["index"], event_index)`,
-			want: func(tCtx ottlspanevent.TransformContext) {
+			want: func(tCtx *ottlspanevent.TransformContext) {
 				tCtx.GetSpanEvent().Attributes().PutInt("index", 0)
 			},
 		},
@@ -1978,7 +1987,7 @@ func Test_ProcessSpanEvents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.statement, func(t *testing.T) {
 			settings := componenttest.NewNopTelemetrySettings()
-			funcs := ottlfuncs.StandardFuncs[ottlspanevent.TransformContext]()
+			funcs := ottlfuncs.StandardFuncs[*ottlspanevent.TransformContext]()
 
 			spanEventParser, err := ottlspanevent.NewParser(funcs, settings)
 			require.NoError(t, err)
@@ -1992,13 +2001,15 @@ func Test_ProcessSpanEvents(t *testing.T) {
 			tt.want(exTCtx)
 
 			require.NoError(t, ptracetest.CompareSpanEvent(newSpanEvent(exTCtx), newSpanEvent(tCtx)))
+			tCtx.Close()
+			exTCtx.Close()
 		})
 	}
 }
 
-func parseStatementWithAndWithoutPathContext(statement string) ([]*ottl.Statement[ottllog.TransformContext], error) {
+func parseStatementWithAndWithoutPathContext(statement string) ([]*ottl.Statement[*ottllog.TransformContext], error) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parserWithoutPathCtx, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings)
+	parserWithoutPathCtx, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings)
 	if err != nil {
 		return nil, err
 	}
@@ -2008,16 +2019,16 @@ func parseStatementWithAndWithoutPathContext(statement string) ([]*ottl.Statemen
 		return nil, err
 	}
 
-	parserWithPathCtx, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
+	parserWithPathCtx, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
 	if err != nil {
 		return nil, err
 	}
 
 	pc, err := ottl.NewParserCollection(settings,
-		ottl.WithParserCollectionContext[ottllog.TransformContext, *ottl.Statement[ottllog.TransformContext]](
+		ottl.WithParserCollectionContext[*ottllog.TransformContext, *ottl.Statement[*ottllog.TransformContext]](
 			ottllog.ContextName,
 			&parserWithPathCtx,
-			ottl.WithStatementConverter(func(_ *ottl.ParserCollection[*ottl.Statement[ottllog.TransformContext]], _ ottl.StatementsGetter, parsedStatements []*ottl.Statement[ottllog.TransformContext]) (*ottl.Statement[ottllog.TransformContext], error) {
+			ottl.WithStatementConverter(func(_ *ottl.ParserCollection[*ottl.Statement[*ottllog.TransformContext]], _ ottl.StatementsGetter, parsedStatements []*ottl.Statement[*ottllog.TransformContext]) (*ottl.Statement[*ottllog.TransformContext], error) {
 				return parsedStatements[0], nil
 			})))
 	if err != nil {
@@ -2029,10 +2040,10 @@ func parseStatementWithAndWithoutPathContext(statement string) ([]*ottl.Statemen
 		return nil, err
 	}
 
-	return []*ottl.Statement[ottllog.TransformContext]{withoutPathCtxResult, withPathCtxResult}, nil
+	return []*ottl.Statement[*ottllog.TransformContext]{withoutPathCtxResult, withPathCtxResult}, nil
 }
 
-func constructLogTransformContext() ottllog.TransformContext {
+func constructLogTransformContext() *ottllog.TransformContext {
 	resource := pcommon.NewResource()
 	resource.Attributes().PutStr("host.name", "localhost")
 	resource.Attributes().PutStr("A|B|C", "newValue")
@@ -2096,10 +2107,10 @@ func constructLogTransformContext() ottllog.TransformContext {
 	s4.AppendEmpty().SetInt(42)
 	s4.AppendEmpty().SetBool(true)
 
-	return ottllog.NewTransformContext(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	return ottllog.NewTransformContextPtr(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
 }
 
-func constructLogTransformContextEditors() ottllog.TransformContext {
+func constructLogTransformContextEditors() *ottllog.TransformContext {
 	resource := pcommon.NewResource()
 	resource.Attributes().PutStr("host.name", "localhost")
 
@@ -2143,10 +2154,10 @@ func constructLogTransformContextEditors() ottllog.TransformContext {
 	thing2.PutStr("name", "bar")
 	thing2.PutInt("value", 5)
 
-	return ottllog.NewTransformContext(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	return ottllog.NewTransformContextPtr(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
 }
 
-func constructLogTransformContextValueExpressions() ottllog.TransformContext {
+func constructLogTransformContextValueExpressions() *ottllog.TransformContext {
 	resource := pcommon.NewResource()
 	resource.Attributes().PutStr("host.name", "localhost")
 	resource.Attributes().PutStr("A|B|C", "newValue")
@@ -2195,7 +2206,7 @@ func constructLogTransformContextValueExpressions() ottllog.TransformContext {
 	thing2 := s2.AppendEmpty().SetEmptyMap()
 	thing2.PutStr("name", "bar")
 
-	return ottllog.NewTransformContext(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+	return ottllog.NewTransformContextPtr(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
 }
 
 func constructSpanTransformContext() *ottlspan.TransformContext {
@@ -2210,7 +2221,7 @@ func constructSpanTransformContext() *ottlspan.TransformContext {
 	return ottlspan.NewTransformContextPtr(td, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans())
 }
 
-func constructSpanEventTransformContext() ottlspanevent.TransformContext {
+func constructSpanEventTransformContext() *ottlspanevent.TransformContext {
 	resource := pcommon.NewResource()
 
 	scope := pcommon.NewInstrumentationScope()
@@ -2222,10 +2233,10 @@ func constructSpanEventTransformContext() ottlspanevent.TransformContext {
 	ev1 := span.Events().AppendEmpty()
 	ev1.SetName("event-1")
 
-	return ottlspanevent.NewTransformContext(ev1, span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), ottlspanevent.WithEventIndex(0))
+	return ottlspanevent.NewTransformContextPtr(ev1, span, scope, resource, ptrace.NewScopeSpans(), ptrace.NewResourceSpans(), ottlspanevent.WithEventIndex(0))
 }
 
-func newResourceLogs(tCtx ottllog.TransformContext) plog.ResourceLogs {
+func newResourceLogs(tCtx *ottllog.TransformContext) plog.ResourceLogs {
 	rl := plog.NewResourceLogs()
 	tCtx.GetResource().CopyTo(rl.Resource())
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -2245,7 +2256,7 @@ func newResourceSpans(tCtx *ottlspan.TransformContext) ptrace.ResourceSpans {
 	return rl
 }
 
-func newSpanEvent(tCtx ottlspanevent.TransformContext) ptrace.SpanEvent {
+func newSpanEvent(tCtx *ottlspanevent.TransformContext) ptrace.SpanEvent {
 	dst := ptrace.NewSpanEvent()
 	tCtx.GetSpanEvent().CopyTo(dst)
 	return dst
@@ -2259,16 +2270,16 @@ func fillSpanOne(span ptrace.Span) {
 
 func Benchmark_XML_Functions(b *testing.B) {
 	testXML := `<Data><From><Test>1</Test><Test>2</Test></From><To></To></Data>`
-	tCtxWithTestBody := func() ottllog.TransformContext {
+	tCtxWithTestBody := func() *ottllog.TransformContext {
 		resource := pcommon.NewResource()
 		scope := pcommon.NewInstrumentationScope()
 		logRecord := plog.NewLogRecord()
 		logRecord.Body().SetStr(testXML)
-		return ottllog.NewTransformContext(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
+		return ottllog.NewTransformContextPtr(logRecord, scope, resource, plog.NewScopeLogs(), plog.NewResourceLogs())
 	}
 
 	settings := componenttest.NewNopTelemetrySettings()
-	logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings)
+	logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings)
 	require.NoError(b, err)
 
 	// Use a round trip composition to ensure each iteration of the benchmark is the same.
@@ -2287,6 +2298,10 @@ func Benchmark_XML_Functions(b *testing.B) {
 		_, _, _ = logStatements.Execute(b.Context(), actualCtx)
 	}
 
+	actualCtx.Close()
+
 	// Ensure correctness
-	require.NoError(b, plogtest.CompareResourceLogs(newResourceLogs(tCtxWithTestBody()), newResourceLogs(actualCtx)))
+	exCtx := tCtxWithTestBody()
+	require.NoError(b, plogtest.CompareResourceLogs(newResourceLogs(exCtx), newResourceLogs(actualCtx)))
+	exCtx.Close()
 }

--- a/pkg/ottl/performance_bench_test.go
+++ b/pkg/ottl/performance_bench_test.go
@@ -30,7 +30,7 @@ var (
 func BenchmarkParserParseStatements(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
 
-	logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
+	logParser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create log parser: %v", err)
 	}
@@ -40,7 +40,7 @@ func BenchmarkParserParseStatements(b *testing.B) {
 		b.Fatalf("failed to create span parser: %v", err)
 	}
 
-	metricParser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
+	metricParser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[*ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create metric parser: %v", err)
 	}
@@ -114,7 +114,7 @@ func BenchmarkParserParseStatements(b *testing.B) {
 
 func BenchmarkStatementSequenceExecuteLogs(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
+	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create log parser: %v", err)
 	}
@@ -137,7 +137,7 @@ func BenchmarkStatementSequenceExecuteLogs(b *testing.B) {
 		}
 		sequence := ottllog.NewStatementSequence(parsed, settings)
 
-		contexts := make([]ottllog.TransformContext, benchmarkContextPoolSize)
+		contexts := make([]*ottllog.TransformContext, benchmarkContextPoolSize)
 		for i := range contexts {
 			contexts[i] = newBenchmarkLogContext(len(scenario.statements))
 		}
@@ -151,6 +151,10 @@ func BenchmarkStatementSequenceExecuteLogs(b *testing.B) {
 				}
 			}
 		})
+
+		for i := range contexts {
+			contexts[i].Close()
+		}
 	}
 }
 
@@ -201,7 +205,7 @@ func BenchmarkStatementSequenceExecuteSpans(b *testing.B) {
 
 func BenchmarkStatementSequenceExecuteMetrics(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
+	parser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[*ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create metric parser: %v", err)
 	}
@@ -224,7 +228,7 @@ func BenchmarkStatementSequenceExecuteMetrics(b *testing.B) {
 		}
 		sequence := ottlmetric.NewStatementSequence(parsed, settings)
 
-		contexts := make([]ottlmetric.TransformContext, benchmarkContextPoolSize)
+		contexts := make([]*ottlmetric.TransformContext, benchmarkContextPoolSize)
 		for i := range contexts {
 			contexts[i] = newBenchmarkMetricContext(len(scenario.statements))
 		}
@@ -238,12 +242,16 @@ func BenchmarkStatementSequenceExecuteMetrics(b *testing.B) {
 				}
 			}
 		})
+
+		for i := range contexts {
+			contexts[i].Close()
+		}
 	}
 }
 
 func BenchmarkConditionSequenceEvalLogs(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
+	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create log parser: %v", err)
 	}
@@ -266,7 +274,7 @@ func BenchmarkConditionSequenceEvalLogs(b *testing.B) {
 		}
 		sequence := ottllog.NewConditionSequence(parsed, settings)
 
-		contexts := make([]ottllog.TransformContext, benchmarkContextPoolSize)
+		contexts := make([]*ottllog.TransformContext, benchmarkContextPoolSize)
 		for i := range contexts {
 			contexts[i] = newBenchmarkLogContext(len(scenario.predicates))
 		}
@@ -282,12 +290,15 @@ func BenchmarkConditionSequenceEvalLogs(b *testing.B) {
 				conditionSequenceResult = result
 			}
 		})
+		for i := range contexts {
+			contexts[i].Close()
+		}
 	}
 }
 
 func BenchmarkConditionSequenceEvalMetrics(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
+	parser, err := ottlmetric.NewParser(ottlfuncs.StandardFuncs[*ottlmetric.TransformContext](), settings, ottlmetric.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create metric parser: %v", err)
 	}
@@ -310,7 +321,7 @@ func BenchmarkConditionSequenceEvalMetrics(b *testing.B) {
 		}
 		sequence := ottlmetric.NewConditionSequence(parsed, settings)
 
-		contexts := make([]ottlmetric.TransformContext, benchmarkContextPoolSize)
+		contexts := make([]*ottlmetric.TransformContext, benchmarkContextPoolSize)
 		for i := range contexts {
 			contexts[i] = newBenchmarkMetricContext(len(scenario.predicates))
 		}
@@ -326,6 +337,9 @@ func BenchmarkConditionSequenceEvalMetrics(b *testing.B) {
 				conditionSequenceResult = result
 			}
 		})
+		for i := range contexts {
+			contexts[i].Close()
+		}
 	}
 }
 
@@ -367,7 +381,7 @@ func buildMetricConditions(count int) []string {
 	return result
 }
 
-func newBenchmarkMetricContext(attributeCount int) ottlmetric.TransformContext {
+func newBenchmarkMetricContext(attributeCount int) *ottlmetric.TransformContext {
 	metrics := pmetric.NewMetrics()
 	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
 	resource := resourceMetrics.Resource()
@@ -408,7 +422,7 @@ func newBenchmarkMetricContext(attributeCount int) ottlmetric.TransformContext {
 		dp.Attributes().PutStr(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
 	}
 
-	return ottlmetric.NewTransformContext(metric, scopeMetrics.Metrics(), scope, resource, scopeMetrics, resourceMetrics)
+	return ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scope, resource, scopeMetrics, resourceMetrics)
 }
 
 func buildLogStatements(count int) []string {
@@ -462,7 +476,7 @@ func buildLogConditions(count int) []string {
 	return result
 }
 
-func newBenchmarkLogContext(attributeCount int) ottllog.TransformContext {
+func newBenchmarkLogContext(attributeCount int) *ottllog.TransformContext {
 	logs := plog.NewLogs()
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
 	resource := resourceLogs.Resource()
@@ -490,7 +504,7 @@ func newBenchmarkLogContext(attributeCount int) ottllog.TransformContext {
 
 	logRecord.Body().SetStr("benchmark log record")
 
-	return ottllog.NewTransformContext(logRecord, scope, resource, scopeLogs, resourceLogs)
+	return ottllog.NewTransformContextPtr(logRecord, scope, resource, scopeLogs, resourceLogs)
 }
 
 func newBenchmarkSpanContext(attributeCount int) *ottlspan.TransformContext {
@@ -525,7 +539,7 @@ func newBenchmarkSpanContext(attributeCount int) *ottlspan.TransformContext {
 
 func BenchmarkSliceToMap(b *testing.B) {
 	settings := componenttest.NewNopTelemetrySettings()
-	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
+	parser, err := ottllog.NewParser(ottlfuncs.StandardFuncs[*ottllog.TransformContext](), settings, ottllog.EnablePathContextNames())
 	if err != nil {
 		b.Fatalf("failed to create log parser: %v", err)
 	}
@@ -579,6 +593,7 @@ func BenchmarkSliceToMap(b *testing.B) {
 					b.Fatalf("execute failed: %v", err)
 				}
 			}
+			tc.Close()
 		})
 
 		// key_only: arr is slice of maps
@@ -593,6 +608,7 @@ func BenchmarkSliceToMap(b *testing.B) {
 					b.Fatalf("execute failed: %v", err)
 				}
 			}
+			tc.Close()
 		})
 
 		// key_and_value: arr is slice of maps
@@ -607,11 +623,12 @@ func BenchmarkSliceToMap(b *testing.B) {
 					b.Fatalf("execute failed: %v", err)
 				}
 			}
+			tc.Close()
 		})
 	}
 }
 
-func newSliceContextWithPrimitiveArr(arrSize int) ottllog.TransformContext {
+func newSliceContextWithPrimitiveArr(arrSize int) *ottllog.TransformContext {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -626,10 +643,10 @@ func newSliceContextWithPrimitiveArr(arrSize int) ottllog.TransformContext {
 		arr.AppendEmpty().SetStr("v_" + strconv.Itoa(i))
 	}
 
-	return ottllog.NewTransformContext(lr, sl.Scope(), rl.Resource(), sl, rl)
+	return ottllog.NewTransformContextPtr(lr, sl.Scope(), rl.Resource(), sl, rl)
 }
 
-func newSliceContextWithMapArr(arrSize int) ottllog.TransformContext {
+func newSliceContextWithMapArr(arrSize int) *ottllog.TransformContext {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 	sl := rl.ScopeLogs().AppendEmpty()
@@ -649,5 +666,5 @@ func newSliceContextWithMapArr(arrSize int) ottllog.TransformContext {
 		nm.PutStr("k", "v_"+strconv.Itoa(i))
 	}
 
-	return ottllog.NewTransformContext(lr, sl.Scope(), rl.Resource(), sl, rl)
+	return ottllog.NewTransformContextPtr(lr, sl.Scope(), rl.Resource(), sl, rl)
 }

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -47,10 +47,10 @@ type Config struct {
 	Profiles ProfileFilters `mapstructure:"profiles"`
 
 	resourceFunctions  map[string]ottl.Factory[ottlresource.TransformContext]
-	dataPointFunctions map[string]ottl.Factory[ottldatapoint.TransformContext]
-	logFunctions       map[string]ottl.Factory[ottllog.TransformContext]
-	metricFunctions    map[string]ottl.Factory[ottlmetric.TransformContext]
-	spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
+	dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	logFunctions       map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions    map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions map[string]ottl.Factory[*ottlspanevent.TransformContext]
 	spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions   map[string]ottl.Factory[ottlprofile.TransformContext]
 }

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -23,19 +23,19 @@ import (
 
 func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	t.Helper()
-	for _, f := range DefaultLogFunctions() {
+	for _, f := range DefaultLogFunctionsNew() {
 		assert.Contains(t, config.logFunctions, f.Name(), "missing log function %v", f.Name())
 	}
-	for _, f := range DefaultDataPointFunctions() {
+	for _, f := range DefaultDataPointFunctionsNew() {
 		assert.Contains(t, config.dataPointFunctions, f.Name(), "missing data point function %v", f.Name())
 	}
-	for _, f := range DefaultMetricFunctions() {
+	for _, f := range DefaultMetricFunctionsNew() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
 	}
 	for _, f := range DefaultSpanFunctionsNew() {
 		assert.Contains(t, config.spanFunctions, f.Name(), "missing span function %v", f.Name())
 	}
-	for _, f := range DefaultSpanEventFunctions() {
+	for _, f := range DefaultSpanEventFunctionsNew() {
 		assert.Contains(t, config.spanEventFunctions, f.Name(), "missing span event function %v", f.Name())
 	}
 	for _, f := range DefaultProfileFunctions() {

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -30,10 +30,10 @@ var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 type filterProcessorFactory struct {
 	resourceFunctions                   map[string]ottl.Factory[ottlresource.TransformContext]
-	dataPointFunctions                  map[string]ottl.Factory[ottldatapoint.TransformContext]
-	logFunctions                        map[string]ottl.Factory[ottllog.TransformContext]
-	metricFunctions                     map[string]ottl.Factory[ottlmetric.TransformContext]
-	spanEventFunctions                  map[string]ottl.Factory[ottlspanevent.TransformContext]
+	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	logFunctions                        map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions                     map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions                  map[string]ottl.Factory[*ottlspanevent.TransformContext]
 	spanFunctions                       map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions                    map[string]ottl.Factory[ottlprofile.TransformContext]
 	defaultResourceFunctionsOverridden  bool
@@ -60,48 +60,84 @@ func WithResourceFunctions(resourceFunctions []ottl.Factory[ottlresource.Transfo
 	}
 }
 
-// WithDataPointFunctions will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
-// Subsequent uses of WithDataPointFunctions will merge the provided dataPointFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithDataPointFunctionsNew.
 func WithDataPointFunctions(dataPointFunctions []ottl.Factory[ottldatapoint.TransformContext]) FactoryOption {
+	newDataPointFunctions := make([]ottl.Factory[*ottldatapoint.TransformContext], 0, len(dataPointFunctions))
+	for _, dataPointFunction := range dataPointFunctions {
+		newDataPointFunctions = append(newDataPointFunctions, ottl.NewFactory[*ottldatapoint.TransformContext](dataPointFunction.Name(), dataPointFunction.CreateDefaultArguments(), fromNonPointerFunction(dataPointFunction.CreateFunction)))
+	}
+	return WithDataPointFunctionsNew(newDataPointFunctions)
+}
+
+// WithDataPointFunctionsNew will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
+// Subsequent uses of WithDataPointFunctionsNew will merge the provided dataPointFunctions with the previously registered functions.
+func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultDataPointFunctionsOverridden {
-			factory.dataPointFunctions = map[string]ottl.Factory[ottldatapoint.TransformContext]{}
+			factory.dataPointFunctions = map[string]ottl.Factory[*ottldatapoint.TransformContext]{}
 			factory.defaultDataPointFunctionsOverridden = true
 		}
 		factory.dataPointFunctions = mergeFunctionsToMap(factory.dataPointFunctions, dataPointFunctions)
 	}
 }
 
-// WithLogFunctions will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
-// Subsequent uses of WithLogFunctions will merge the provided logFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithLogFunctionsNew.
 func WithLogFunctions(logFunctions []ottl.Factory[ottllog.TransformContext]) FactoryOption {
+	newLogFunctions := make([]ottl.Factory[*ottllog.TransformContext], 0, len(logFunctions))
+	for _, logFunction := range logFunctions {
+		newLogFunctions = append(newLogFunctions, ottl.NewFactory[*ottllog.TransformContext](logFunction.Name(), logFunction.CreateDefaultArguments(), fromNonPointerFunction(logFunction.CreateFunction)))
+	}
+	return WithLogFunctionsNew(newLogFunctions)
+}
+
+// WithLogFunctionsNew will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
+// Subsequent uses of WithLogFunctionsNew will merge the provided logFunctions with the previously registered functions.
+func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultLogFunctionsOverridden {
-			factory.logFunctions = map[string]ottl.Factory[ottllog.TransformContext]{}
+			factory.logFunctions = map[string]ottl.Factory[*ottllog.TransformContext]{}
 			factory.defaultLogFunctionsOverridden = true
 		}
 		factory.logFunctions = mergeFunctionsToMap(factory.logFunctions, logFunctions)
 	}
 }
 
-// WithMetricFunctions will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
-// Subsequent uses of WithMetricFunctions will merge the provided metricFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithMetricFunctionsNew.
 func WithMetricFunctions(metricFunctions []ottl.Factory[ottlmetric.TransformContext]) FactoryOption {
+	newMetricFunctions := make([]ottl.Factory[*ottlmetric.TransformContext], 0, len(metricFunctions))
+	for _, metricFunction := range metricFunctions {
+		newMetricFunctions = append(newMetricFunctions, ottl.NewFactory[*ottlmetric.TransformContext](metricFunction.Name(), metricFunction.CreateDefaultArguments(), fromNonPointerFunction(metricFunction.CreateFunction)))
+	}
+	return WithMetricFunctionsNew(newMetricFunctions)
+}
+
+// WithMetricFunctionsNew will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
+// Subsequent uses of WithMetricFunctionsNew will merge the provided metricFunctions with the previously registered functions.
+func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultMetricFunctionsOverridden {
-			factory.metricFunctions = map[string]ottl.Factory[ottlmetric.TransformContext]{}
+			factory.metricFunctions = map[string]ottl.Factory[*ottlmetric.TransformContext]{}
 			factory.defaultMetricFunctionsOverridden = true
 		}
 		factory.metricFunctions = mergeFunctionsToMap(factory.metricFunctions, metricFunctions)
 	}
 }
 
-// WithSpanEventFunctions will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
-// Subsequent uses of WithSpanEventFunctions will merge the provided spanEventFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithSpanEventFunctionsNew.
 func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[ottlspanevent.TransformContext]) FactoryOption {
+	newSpanFunctions := make([]ottl.Factory[*ottlspanevent.TransformContext], 0, len(spanEventFunctions))
+	for _, spanEventFunction := range spanEventFunctions {
+		newSpanFunctions = append(newSpanFunctions, ottl.NewFactory[*ottlspanevent.TransformContext](spanEventFunction.Name(), spanEventFunction.CreateDefaultArguments(), fromNonPointerFunction(spanEventFunction.CreateFunction)))
+	}
+	return WithSpanEventFunctionsNew(newSpanFunctions)
+}
+
+// WithSpanEventFunctionsNew will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
+// Subsequent uses of WithSpanEventFunctionsNew will merge the provided spanEventFunctions with the previously registered functions.
+func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
 	return func(factory *filterProcessorFactory) {
 		if !factory.defaultSpanEventFunctionsOverridden {
-			factory.spanEventFunctions = map[string]ottl.Factory[ottlspanevent.TransformContext]{}
+			factory.spanEventFunctions = map[string]ottl.Factory[*ottlspanevent.TransformContext]{}
 			factory.defaultSpanEventFunctionsOverridden = true
 		}
 		factory.spanEventFunctions = mergeFunctionsToMap(factory.spanEventFunctions, spanEventFunctions)

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -205,7 +205,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
 			},
 		},
 		{
@@ -218,7 +218,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			wantErrorWith: `undefined function "TestSpanFunc"`,
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
 			},
 		},
 		{
@@ -253,8 +253,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 		{
@@ -267,7 +267,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			wantErrorWith: `undefined function "TestSpanEventFunc"`,
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctionsNew()),
 			},
 		},
 		{
@@ -278,7 +278,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 	}
@@ -376,8 +376,8 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctions(DefaultLogFunctions()),
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctionsNew(DefaultLogFunctionsNew()),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 		{
@@ -389,7 +389,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestLogFunc"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctions(DefaultLogFunctions()),
+				WithLogFunctionsNew(DefaultLogFunctionsNew()),
 			},
 		},
 		{
@@ -400,7 +400,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 		{
@@ -412,7 +412,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 	}
@@ -499,9 +499,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("TestMetricFunc")}),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -513,8 +513,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestMetricFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -525,7 +525,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
 			},
 		},
 		{
@@ -537,7 +537,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
 			},
 		},
 		{
@@ -548,9 +548,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 		{
@@ -562,8 +562,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestDataPointFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -574,7 +574,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 		{
@@ -586,7 +586,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 	}

--- a/processor/filterprocessor/functions.go
+++ b/processor/filterprocessor/functions.go
@@ -23,15 +23,35 @@ func DefaultResourceFunctions() []ottl.Factory[ottlresource.TransformContext] {
 	return slices.Collect(maps.Values(defaultResourceFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultLogFunctionsNew.
 func DefaultLogFunctions() []ottl.Factory[ottllog.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottllog.TransformContext]()))
+}
+
+func DefaultLogFunctionsNew() []ottl.Factory[*ottllog.TransformContext] {
 	return slices.Collect(maps.Values(defaultLogFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultMetricFunctionsNew.
 func DefaultMetricFunctions() []ottl.Factory[ottlmetric.TransformContext] {
+	m := ottlfuncs.StandardConverters[ottlmetric.TransformContext]()
+	hasAttributeOnDatapointFactory := filterottl.NewHasAttributeOnDatapointFactory()
+	hasAttributeKeyOnDatapointFactory := filterottl.NewHasAttributeKeyOnDatapointFactory()
+	m[hasAttributeOnDatapointFactory.Name()] = hasAttributeOnDatapointFactory
+	m[hasAttributeKeyOnDatapointFactory.Name()] = hasAttributeKeyOnDatapointFactory
+	return slices.Collect(maps.Values(m))
+}
+
+func DefaultMetricFunctionsNew() []ottl.Factory[*ottlmetric.TransformContext] {
 	return slices.Collect(maps.Values(defaultMetricFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultDataPointFunctionsNew.
 func DefaultDataPointFunctions() []ottl.Factory[ottldatapoint.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottldatapoint.TransformContext]()))
+}
+
+func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformContext] {
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
@@ -47,7 +67,12 @@ func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
 }
 
-func DefaultSpanEventFunctions() []ottl.Factory[ottlspanevent.TransformContext] {
+// Deprecated: [v0.142.0] use DefaultSpanEventFunctionsNew.
+func DefaultSpanEventFunctions() []ottl.Factory[*ottlspanevent.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[*ottlspanevent.TransformContext]()))
+}
+
+func DefaultSpanEventFunctionsNew() []ottl.Factory[*ottlspanevent.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanEventFunctionsMap()))
 }
 
@@ -59,15 +84,15 @@ func defaultResourceFunctionsMap() map[string]ottl.Factory[ottlresource.Transfor
 	return filterottl.StandardResourceFuncs()
 }
 
-func defaultLogFunctionsMap() map[string]ottl.Factory[ottllog.TransformContext] {
+func defaultLogFunctionsMap() map[string]ottl.Factory[*ottllog.TransformContext] {
 	return filterottl.StandardLogFuncs()
 }
 
-func defaultMetricFunctionsMap() map[string]ottl.Factory[ottlmetric.TransformContext] {
+func defaultMetricFunctionsMap() map[string]ottl.Factory[*ottlmetric.TransformContext] {
 	return filterottl.StandardMetricFuncs()
 }
 
-func defaultDataPointFunctionsMap() map[string]ottl.Factory[ottldatapoint.TransformContext] {
+func defaultDataPointFunctionsMap() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
 	return filterottl.StandardDataPointFuncs()
 }
 
@@ -75,7 +100,7 @@ func defaultSpanFunctionsMap() map[string]ottl.Factory[*ottlspan.TransformContex
 	return filterottl.StandardSpanFuncs()
 }
 
-func defaultSpanEventFunctionsMap() map[string]ottl.Factory[ottlspanevent.TransformContext] {
+func defaultSpanEventFunctionsMap() map[string]ottl.Factory[*ottlspanevent.TransformContext] {
 	return filterottl.StandardSpanEventFuncs()
 }
 

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -28,8 +28,8 @@ import (
 
 type filterMetricProcessor struct {
 	skipResourceExpr  expr.BoolExpr[ottlresource.TransformContext]
-	skipMetricExpr    expr.BoolExpr[ottlmetric.TransformContext]
-	skipDataPointExpr expr.BoolExpr[ottldatapoint.TransformContext]
+	skipMetricExpr    expr.BoolExpr[*ottlmetric.TransformContext]
+	skipDataPointExpr expr.BoolExpr[*ottldatapoint.TransformContext]
 	telemetry         *filterTelemetry
 	logger            *zap.Logger
 }
@@ -146,7 +146,9 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 			scope := smetrics.Scope()
 			smetrics.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 				if fmp.skipMetricExpr != nil {
-					skip, err := fmp.skipMetricExpr.Eval(ctx, ottlmetric.NewTransformContext(metric, smetrics.Metrics(), scope, resource, smetrics, rm))
+					tCtx := ottlmetric.NewTransformContextPtr(metric, smetrics.Metrics(), scope, resource, smetrics, rm)
+					skip, err := fmp.skipMetricExpr.Eval(ctx, tCtx)
+					tCtx.Close()
 					if err != nil {
 						errors = multierr.Append(errors, err)
 						return false
@@ -271,7 +273,9 @@ func newResExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlresou
 func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, dps pmetric.NumberDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
 	var errors error
 	dps.RemoveIf(func(datapoint pmetric.NumberDataPoint) bool {
-		skip, err := fmp.skipDataPointExpr.Eval(ctx, ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
+		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -284,7 +288,9 @@ func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, dp
 func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context, dps pmetric.HistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
 	var errors error
 	dps.RemoveIf(func(datapoint pmetric.HistogramDataPoint) bool {
-		skip, err := fmp.skipDataPointExpr.Eval(ctx, ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
+		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -297,7 +303,9 @@ func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context,
 func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx context.Context, dps pmetric.ExponentialHistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
 	var errors error
 	dps.RemoveIf(func(datapoint pmetric.ExponentialHistogramDataPoint) bool {
-		skip, err := fmp.skipDataPointExpr.Eval(ctx, ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
+		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -310,7 +318,9 @@ func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx conte
 func (fmp *filterMetricProcessor) handleSummaryDataPoints(ctx context.Context, dps pmetric.SummaryDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
 	var errors error
 	dps.RemoveIf(func(datapoint pmetric.SummaryDataPoint) bool {
-		skip, err := fmp.skipDataPointExpr.Eval(ctx, ottldatapoint.NewTransformContext(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
+		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -24,7 +24,7 @@ import (
 // logDedupProcessor is a logDedupProcessor that counts duplicate instances of logs.
 type logDedupProcessor struct {
 	emitInterval time.Duration
-	conditions   *ottl.ConditionSequence[ottllog.TransformContext]
+	conditions   *ottl.ConditionSequence[*ottllog.TransformContext]
 	aggregator   *logAggregator
 	remover      *fieldRemover
 	nextConsumer consumer.Logs
@@ -99,7 +99,8 @@ func (p *logDedupProcessor) ConsumeLogs(ctx context.Context, pl plog.Logs) error
 					return true
 				}
 
-				logCtx := ottllog.NewTransformContext(logRecord, scope, resource, sl, rl)
+				logCtx := ottllog.NewTransformContextPtr(logRecord, scope, resource, sl, rl)
+				defer logCtx.Close()
 				logMatch, err := p.conditions.Eval(ctx, logCtx)
 				if err != nil {
 					p.logger.Error("error matching conditions", zap.Error(err))

--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -50,10 +50,10 @@ type Config struct {
 	FlattenData bool `mapstructure:"flatten_data"`
 	logger      *zap.Logger
 
-	dataPointFunctions map[string]ottl.Factory[ottldatapoint.TransformContext]
-	logFunctions       map[string]ottl.Factory[ottllog.TransformContext]
-	metricFunctions    map[string]ottl.Factory[ottlmetric.TransformContext]
-	spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
+	dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	logFunctions       map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions    map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions map[string]ottl.Factory[*ottlspanevent.TransformContext]
 	spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions   map[string]ottl.Factory[ottlprofile.TransformContext]
 }

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -34,10 +34,10 @@ import (
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
 type transformProcessorFactory struct {
-	dataPointFunctions                  map[string]ottl.Factory[ottldatapoint.TransformContext]
-	logFunctions                        map[string]ottl.Factory[ottllog.TransformContext]
-	metricFunctions                     map[string]ottl.Factory[ottlmetric.TransformContext]
-	spanEventFunctions                  map[string]ottl.Factory[ottlspanevent.TransformContext]
+	dataPointFunctions                  map[string]ottl.Factory[*ottldatapoint.TransformContext]
+	logFunctions                        map[string]ottl.Factory[*ottllog.TransformContext]
+	metricFunctions                     map[string]ottl.Factory[*ottlmetric.TransformContext]
+	spanEventFunctions                  map[string]ottl.Factory[*ottlspanevent.TransformContext]
 	spanFunctions                       map[string]ottl.Factory[*ottlspan.TransformContext]
 	profileFunctions                    map[string]ottl.Factory[ottlprofile.TransformContext]
 	defaultDataPointFunctionsOverridden bool
@@ -51,48 +51,84 @@ type transformProcessorFactory struct {
 // FactoryOption applies changes to transformProcessorFactory.
 type FactoryOption func(factory *transformProcessorFactory)
 
-// WithDataPointFunctions will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
-// Subsequent uses of WithDataPointFunctions will merge the provided dataPointFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithDataPointFunctionsNew.
 func WithDataPointFunctions(dataPointFunctions []ottl.Factory[ottldatapoint.TransformContext]) FactoryOption {
+	newDataPointFunctions := make([]ottl.Factory[*ottldatapoint.TransformContext], 0, len(dataPointFunctions))
+	for _, dataPointFunction := range dataPointFunctions {
+		newDataPointFunctions = append(newDataPointFunctions, ottl.NewFactory[*ottldatapoint.TransformContext](dataPointFunction.Name(), dataPointFunction.CreateDefaultArguments(), fromNonPointerFunction(dataPointFunction.CreateFunction)))
+	}
+	return WithDataPointFunctionsNew(newDataPointFunctions)
+}
+
+// WithDataPointFunctionsNew will override the default OTTL datapoint context functions with the provided dataPointFunctions in resulting processor.
+// Subsequent uses of WithDataPointFunctionsNew will merge the provided dataPointFunctions with the previously registered functions.
+func WithDataPointFunctionsNew(dataPointFunctions []ottl.Factory[*ottldatapoint.TransformContext]) FactoryOption {
 	return func(factory *transformProcessorFactory) {
 		if !factory.defaultDataPointFunctionsOverridden {
-			factory.dataPointFunctions = map[string]ottl.Factory[ottldatapoint.TransformContext]{}
+			factory.dataPointFunctions = map[string]ottl.Factory[*ottldatapoint.TransformContext]{}
 			factory.defaultDataPointFunctionsOverridden = true
 		}
 		factory.dataPointFunctions = mergeFunctionsToMap(factory.dataPointFunctions, dataPointFunctions)
 	}
 }
 
-// WithLogFunctions will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
-// Subsequent uses of WithLogFunctions will merge the provided logFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithLogFunctionsNew.
 func WithLogFunctions(logFunctions []ottl.Factory[ottllog.TransformContext]) FactoryOption {
+	newLogFunctions := make([]ottl.Factory[*ottllog.TransformContext], 0, len(logFunctions))
+	for _, logFunction := range logFunctions {
+		newLogFunctions = append(newLogFunctions, ottl.NewFactory[*ottllog.TransformContext](logFunction.Name(), logFunction.CreateDefaultArguments(), fromNonPointerFunction(logFunction.CreateFunction)))
+	}
+	return WithLogFunctionsNew(newLogFunctions)
+}
+
+// WithLogFunctionsNew will override the default OTTL log context functions with the provided logFunctions in the resulting processor.
+// Subsequent uses of WithLogFunctionsNew will merge the provided logFunctions with the previously registered functions.
+func WithLogFunctionsNew(logFunctions []ottl.Factory[*ottllog.TransformContext]) FactoryOption {
 	return func(factory *transformProcessorFactory) {
 		if !factory.defaultLogFunctionsOverridden {
-			factory.logFunctions = map[string]ottl.Factory[ottllog.TransformContext]{}
+			factory.logFunctions = map[string]ottl.Factory[*ottllog.TransformContext]{}
 			factory.defaultLogFunctionsOverridden = true
 		}
 		factory.logFunctions = mergeFunctionsToMap(factory.logFunctions, logFunctions)
 	}
 }
 
-// WithMetricFunctions will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
-// Subsequent uses of WithMetricFunctions will merge the provided metricFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithMetricFunctionsNew.
 func WithMetricFunctions(metricFunctions []ottl.Factory[ottlmetric.TransformContext]) FactoryOption {
+	newMetricFunctions := make([]ottl.Factory[*ottlmetric.TransformContext], 0, len(metricFunctions))
+	for _, metricFunction := range metricFunctions {
+		newMetricFunctions = append(newMetricFunctions, ottl.NewFactory[*ottlmetric.TransformContext](metricFunction.Name(), metricFunction.CreateDefaultArguments(), fromNonPointerFunction(metricFunction.CreateFunction)))
+	}
+	return WithMetricFunctionsNew(newMetricFunctions)
+}
+
+// WithMetricFunctionsNew will override the default OTTL metric context functions with the provided metricFunctions in the resulting processor.
+// Subsequent uses of WithMetricFunctionsNew will merge the provided metricFunctions with the previously registered functions.
+func WithMetricFunctionsNew(metricFunctions []ottl.Factory[*ottlmetric.TransformContext]) FactoryOption {
 	return func(factory *transformProcessorFactory) {
 		if !factory.defaultMetricFunctionsOverridden {
-			factory.metricFunctions = map[string]ottl.Factory[ottlmetric.TransformContext]{}
+			factory.metricFunctions = map[string]ottl.Factory[*ottlmetric.TransformContext]{}
 			factory.defaultMetricFunctionsOverridden = true
 		}
 		factory.metricFunctions = mergeFunctionsToMap(factory.metricFunctions, metricFunctions)
 	}
 }
 
-// WithSpanEventFunctions will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
-// Subsequent uses of WithSpanEventFunctions will merge the provided spanEventFunctions with the previously registered functions.
+// Deprecated: [v0.142.0] Use WithSpanEventFunctionsNew.
 func WithSpanEventFunctions(spanEventFunctions []ottl.Factory[ottlspanevent.TransformContext]) FactoryOption {
+	newSpanFunctions := make([]ottl.Factory[*ottlspanevent.TransformContext], 0, len(spanEventFunctions))
+	for _, spanEventFunction := range spanEventFunctions {
+		newSpanFunctions = append(newSpanFunctions, ottl.NewFactory[*ottlspanevent.TransformContext](spanEventFunction.Name(), spanEventFunction.CreateDefaultArguments(), fromNonPointerFunction(spanEventFunction.CreateFunction)))
+	}
+	return WithSpanEventFunctionsNew(newSpanFunctions)
+}
+
+// WithSpanEventFunctionsNew will override the default OTTL spanevent context functions with the provided spanEventFunctions in the resulting processor.
+// Subsequent uses of WithSpanEventFunctionsNew will merge the provided spanEventFunctions with the previously registered functions.
+func WithSpanEventFunctionsNew(spanEventFunctions []ottl.Factory[*ottlspanevent.TransformContext]) FactoryOption {
 	return func(factory *transformProcessorFactory) {
 		if !factory.defaultSpanEventFunctionsOverridden {
-			factory.spanEventFunctions = map[string]ottl.Factory[ottlspanevent.TransformContext]{}
+			factory.spanEventFunctions = map[string]ottl.Factory[*ottlspanevent.TransformContext]{}
 			factory.defaultSpanEventFunctionsOverridden = true
 		}
 		factory.spanEventFunctions = mergeFunctionsToMap(factory.spanEventFunctions, spanEventFunctions)
@@ -109,7 +145,7 @@ func WithSpanFunctions(spanFunctions []ottl.Factory[ottlspan.TransformContext]) 
 }
 
 // WithSpanFunctionsNew will override the default OTTL span context functions with the provided spanFunctions in the resulting processor.
-// Subsequent uses of WithSpanFunctions will merge the provided spanFunctions with the previously registered functions.
+// Subsequent uses of WithSpanFunctionsNew will merge the provided spanFunctions with the previously registered functions.
 func WithSpanFunctionsNew(spanFunctions []ottl.Factory[*ottlspan.TransformContext]) FactoryOption {
 	return func(factory *transformProcessorFactory) {
 		if !factory.defaultSpanFunctionsOverridden {

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -34,13 +34,13 @@ import (
 
 func assertConfigContainsDefaultFunctions(t *testing.T, config Config) {
 	t.Helper()
-	for _, f := range DefaultLogFunctions() {
+	for _, f := range DefaultLogFunctionsNew() {
 		assert.Contains(t, config.logFunctions, f.Name(), "missing log function %v", f.Name())
 	}
-	for _, f := range DefaultDataPointFunctions() {
+	for _, f := range DefaultDataPointFunctionsNew() {
 		assert.Contains(t, config.dataPointFunctions, f.Name(), "missing data point function %v", f.Name())
 	}
-	for _, f := range DefaultMetricFunctions() {
+	for _, f := range DefaultMetricFunctionsNew() {
 		assert.Contains(t, config.metricFunctions, f.Name(), "missing metric function %v", f.Name())
 	}
 	for _, f := range DefaultSpanFunctionsNew() {
@@ -921,7 +921,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
 				WithSpanFunctionsNew([]ottl.Factory[*ottlspan.TransformContext]{createTestFuncFactory[*ottlspan.TransformContext]("TestSpanFunc")}),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -935,7 +935,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			wantErrorWith: `undefined function "TestSpanFunc"`,
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -973,8 +973,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 		{
@@ -988,7 +988,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			wantErrorWith: `undefined function "TestSpanEventFunc"`,
 			factoryOptions: []FactoryOption{
 				WithSpanFunctionsNew(DefaultSpanFunctionsNew()),
-				WithSpanEventFunctions(DefaultSpanEventFunctions()),
+				WithSpanEventFunctionsNew(DefaultSpanEventFunctions()),
 			},
 		},
 		{
@@ -1000,7 +1000,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("testSpanEventFunc")}),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("testSpanEventFunc")}),
 			},
 		},
 		{
@@ -1013,7 +1013,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
-				WithSpanEventFunctions([]ottl.Factory[ottlspanevent.TransformContext]{createTestFuncFactory[ottlspanevent.TransformContext]("TestSpanEventFunc")}),
+				WithSpanEventFunctionsNew([]ottl.Factory[*ottlspanevent.TransformContext]{createTestFuncFactory[*ottlspanevent.TransformContext]("TestSpanEventFunc")}),
 			},
 		},
 	}
@@ -1056,8 +1056,8 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctions(DefaultLogFunctions()),
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctionsNew(DefaultLogFunctionsNew()),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 		{
@@ -1070,7 +1070,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestLogFunc"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctions(DefaultLogFunctions()),
+				WithLogFunctionsNew(DefaultLogFunctionsNew()),
 			},
 		},
 		{
@@ -1082,7 +1082,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("testLogFunc")}),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("testLogFunc")}),
 			},
 		},
 		{
@@ -1095,7 +1095,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
-				WithLogFunctions([]ottl.Factory[ottllog.TransformContext]{createTestFuncFactory[ottllog.TransformContext]("TestLogFunc")}),
+				WithLogFunctionsNew([]ottl.Factory[*ottllog.TransformContext]{createTestFuncFactory[*ottllog.TransformContext]("TestLogFunc")}),
 			},
 		},
 	}
@@ -1139,9 +1139,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("TestMetricFunc")}),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -1154,8 +1154,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestMetricFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -1167,7 +1167,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("testMetricFunc")}),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("testMetricFunc")}),
 			},
 		},
 		{
@@ -1180,7 +1180,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions([]ottl.Factory[ottlmetric.TransformContext]{createTestFuncFactory[ottlmetric.TransformContext]("TestMetricFunc")}),
+				WithMetricFunctionsNew([]ottl.Factory[*ottlmetric.TransformContext]{createTestFuncFactory[*ottlmetric.TransformContext]("TestMetricFunc")}),
 			},
 		},
 		{
@@ -1192,9 +1192,9 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 		{
@@ -1207,8 +1207,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestDataPointFunc"`,
 			factoryOptions: []FactoryOption{
-				WithMetricFunctions(DefaultMetricFunctions()),
-				WithDataPointFunctions(DefaultDataPointFunctions()),
+				WithMetricFunctionsNew(DefaultMetricFunctionsNew()),
+				WithDataPointFunctionsNew(DefaultDataPointFunctionsNew()),
 			},
 		},
 		{
@@ -1220,7 +1220,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("testDataPointFunc")}),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("testDataPointFunc")}),
 			},
 		},
 		{
@@ -1233,7 +1233,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "set"`,
 			factoryOptions: []FactoryOption{
-				WithDataPointFunctions([]ottl.Factory[ottldatapoint.TransformContext]{createTestFuncFactory[ottldatapoint.TransformContext]("TestDataPointFunc")}),
+				WithDataPointFunctionsNew([]ottl.Factory[*ottldatapoint.TransformContext]{createTestFuncFactory[*ottldatapoint.TransformContext]("TestDataPointFunc")}),
 			},
 		},
 	}

--- a/processor/transformprocessor/functions.go
+++ b/processor/transformprocessor/functions.go
@@ -21,15 +21,30 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
 )
 
+// Deprecated: [v0.142.0] use DefaultLogFunctionsNew.
 func DefaultLogFunctions() []ottl.Factory[ottllog.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardConverters[ottllog.TransformContext]()))
+}
+
+func DefaultLogFunctionsNew() []ottl.Factory[*ottllog.TransformContext] {
 	return slices.Collect(maps.Values(defaultLogFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultMetricFunctionsNew.
 func DefaultMetricFunctions() []ottl.Factory[ottlmetric.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardFuncs[ottlmetric.TransformContext]()))
+}
+
+func DefaultMetricFunctionsNew() []ottl.Factory[*ottlmetric.TransformContext] {
 	return slices.Collect(maps.Values(defaultMetricFunctionsMap()))
 }
 
+// Deprecated: [v0.142.0] use DefaultDataPointFunctionsNew.
 func DefaultDataPointFunctions() []ottl.Factory[ottldatapoint.TransformContext] {
+	return slices.Collect(maps.Values(ottlfuncs.StandardFuncs[ottldatapoint.TransformContext]()))
+}
+
+func DefaultDataPointFunctionsNew() []ottl.Factory[*ottldatapoint.TransformContext] {
 	return slices.Collect(maps.Values(defaultDataPointFunctionsMap()))
 }
 
@@ -51,7 +66,7 @@ func DefaultSpanFunctionsNew() []ottl.Factory[*ottlspan.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanFunctionsMap()))
 }
 
-func DefaultSpanEventFunctions() []ottl.Factory[ottlspanevent.TransformContext] {
+func DefaultSpanEventFunctions() []ottl.Factory[*ottlspanevent.TransformContext] {
 	return slices.Collect(maps.Values(defaultSpanEventFunctionsMap()))
 }
 
@@ -59,15 +74,15 @@ func DefaultProfileFunctions() []ottl.Factory[ottlprofile.TransformContext] {
 	return slices.Collect(maps.Values(defaultProfileFunctionsMap()))
 }
 
-func defaultLogFunctionsMap() map[string]ottl.Factory[ottllog.TransformContext] {
+func defaultLogFunctionsMap() map[string]ottl.Factory[*ottllog.TransformContext] {
 	return logs.LogFunctions()
 }
 
-func defaultMetricFunctionsMap() map[string]ottl.Factory[ottlmetric.TransformContext] {
+func defaultMetricFunctionsMap() map[string]ottl.Factory[*ottlmetric.TransformContext] {
 	return metrics.MetricFunctions()
 }
 
-func defaultDataPointFunctionsMap() map[string]ottl.Factory[ottldatapoint.TransformContext] {
+func defaultDataPointFunctionsMap() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
 	return metrics.DataPointFunctions()
 }
 
@@ -75,7 +90,7 @@ func defaultSpanFunctionsMap() map[string]ottl.Factory[*ottlspan.TransformContex
 	return traces.SpanFunctions()
 }
 
-func defaultSpanEventFunctionsMap() map[string]ottl.Factory[ottlspanevent.TransformContext] {
+func defaultSpanEventFunctionsMap() map[string]ottl.Factory[*ottlspanevent.TransformContext] {
 	return traces.SpanEventFunctions()
 }
 

--- a/processor/transformprocessor/internal/common/logs.go
+++ b/processor/transformprocessor/internal/common/logs.go
@@ -21,8 +21,8 @@ type LogsConsumer interface {
 }
 
 type logStatements struct {
-	ottl.StatementSequence[ottllog.TransformContext]
-	expr.BoolExpr[ottllog.TransformContext]
+	ottl.StatementSequence[*ottllog.TransformContext]
+	expr.BoolExpr[*ottllog.TransformContext]
 }
 
 func (logStatements) Context() ContextID {
@@ -36,17 +36,20 @@ func (l logStatements) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			slogs := rlogs.ScopeLogs().At(j)
 			logs := slogs.LogRecords()
 			for k := 0; k < logs.Len(); k++ {
-				tCtx := ottllog.NewTransformContext(logs.At(k), slogs.Scope(), rlogs.Resource(), slogs, rlogs)
+				tCtx := ottllog.NewTransformContextPtr(logs.At(k), slogs.Scope(), rlogs.Resource(), slogs, rlogs)
 				condition, err := l.Eval(ctx, tCtx)
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 				if condition {
-					err := l.Execute(ctx, tCtx)
+					err = l.Execute(ctx, tCtx)
 					if err != nil {
+						tCtx.Close()
 						return err
 					}
 				}
+				tCtx.Close()
 			}
 		}
 	}
@@ -57,7 +60,7 @@ type LogParserCollection ottl.ParserCollection[LogsConsumer]
 
 type LogParserCollectionOption ottl.ParserCollectionOption[LogsConsumer]
 
-func WithLogParser(functions map[string]ottl.Factory[ottllog.TransformContext]) LogParserCollectionOption {
+func WithLogParser(functions map[string]ottl.Factory[*ottllog.TransformContext]) LogParserCollectionOption {
 	return func(pc *ottl.ParserCollection[LogsConsumer]) error {
 		logParser, err := ottllog.NewParser(functions, pc.Settings, ottllog.EnablePathContextNames())
 		if err != nil {
@@ -90,7 +93,7 @@ func NewLogParserCollection(settings component.TelemetrySettings, options ...Log
 	return &lpc, nil
 }
 
-func convertLogStatements(pc *ottl.ParserCollection[LogsConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[ottllog.TransformContext]) (LogsConsumer, error) {
+func convertLogStatements(pc *ottl.ParserCollection[LogsConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[*ottllog.TransformContext]) (LogsConsumer, error) {
 	contextStatements, err := toContextStatements(statements)
 	if err != nil {
 		return nil, err
@@ -99,7 +102,7 @@ func convertLogStatements(pc *ottl.ParserCollection[LogsConsumer], statements ot
 	if contextStatements.ErrorMode != "" {
 		errorMode = contextStatements.ErrorMode
 	}
-	var parserOptions []ottl.Option[ottllog.TransformContext]
+	var parserOptions []ottl.Option[*ottllog.TransformContext]
 	if contextStatements.Context == "" {
 		parserOptions = append(parserOptions, ottllog.EnablePathContextNames())
 	}

--- a/processor/transformprocessor/internal/common/traces.go
+++ b/processor/transformprocessor/internal/common/traces.go
@@ -39,15 +39,18 @@ func (t traceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 			for k := 0; k < spans.Len(); k++ {
 				tCtx := ottlspan.NewTransformContextPtr(spans.At(k), sspans.Scope(), rspans.Resource(), sspans, rspans)
 				condition, err := t.Eval(ctx, tCtx)
-				tCtx.Close()
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 				if condition {
-					if err := t.Execute(ctx, tCtx); err != nil {
+					err = t.Execute(ctx, tCtx)
+					if err != nil {
+						tCtx.Close()
 						return err
 					}
 				}
+				tCtx.Close()
 			}
 		}
 	}
@@ -55,8 +58,8 @@ func (t traceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 }
 
 type spanEventStatements struct {
-	ottl.StatementSequence[ottlspanevent.TransformContext]
-	expr.BoolExpr[ottlspanevent.TransformContext]
+	ottl.StatementSequence[*ottlspanevent.TransformContext]
+	expr.BoolExpr[*ottlspanevent.TransformContext]
 }
 
 func (spanEventStatements) Context() ContextID {
@@ -73,17 +76,20 @@ func (s spanEventStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces
 				span := spans.At(k)
 				spanEvents := span.Events()
 				for n := 0; n < spanEvents.Len(); n++ {
-					tCtx := ottlspanevent.NewTransformContext(spanEvents.At(n), span, sspans.Scope(), rspans.Resource(), sspans, rspans)
+					tCtx := ottlspanevent.NewTransformContextPtr(spanEvents.At(n), span, sspans.Scope(), rspans.Resource(), sspans, rspans)
 					condition, err := s.Eval(ctx, tCtx)
 					if err != nil {
+						tCtx.Close()
 						return err
 					}
 					if condition {
-						err := s.Execute(ctx, tCtx)
+						err = s.Execute(ctx, tCtx)
 						if err != nil {
+							tCtx.Close()
 							return err
 						}
 					}
+					tCtx.Close()
 				}
 			}
 		}
@@ -105,7 +111,7 @@ func WithSpanParser(functions map[string]ottl.Factory[*ottlspan.TransformContext
 	}
 }
 
-func WithSpanEventParser(functions map[string]ottl.Factory[ottlspanevent.TransformContext]) TraceParserCollectionOption {
+func WithSpanEventParser(functions map[string]ottl.Factory[*ottlspanevent.TransformContext]) TraceParserCollectionOption {
 	return func(pc *ottl.ParserCollection[TracesConsumer]) error {
 		parser, err := ottlspanevent.NewParser(functions, pc.Settings, ottlspanevent.EnablePathContextNames())
 		if err != nil {
@@ -159,7 +165,7 @@ func convertSpanStatements(pc *ottl.ParserCollection[TracesConsumer], statements
 	return traceStatements{sStatements, globalExpr}, nil
 }
 
-func convertSpanEventStatements(pc *ottl.ParserCollection[TracesConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[ottlspanevent.TransformContext]) (TracesConsumer, error) {
+func convertSpanEventStatements(pc *ottl.ParserCollection[TracesConsumer], statements ottl.StatementsGetter, parsedStatements []*ottl.Statement[*ottlspanevent.TransformContext]) (TracesConsumer, error) {
 	contextStatements, err := toContextStatements(statements)
 	if err != nil {
 		return nil, err
@@ -168,7 +174,7 @@ func convertSpanEventStatements(pc *ottl.ParserCollection[TracesConsumer], state
 	if contextStatements.ErrorMode != "" {
 		errorMode = contextStatements.ErrorMode
 	}
-	var parserOptions []ottl.Option[ottlspanevent.TransformContext]
+	var parserOptions []ottl.Option[*ottlspanevent.TransformContext]
 	if contextStatements.Context == "" {
 		parserOptions = append(parserOptions, ottlspanevent.EnablePathContextNames())
 	}

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func LogFunctions() map[string]ottl.Factory[ottllog.TransformContext] {
+func LogFunctions() map[string]ottl.Factory[*ottllog.TransformContext] {
 	// No logs-only functions yet.
-	return ottlfuncs.StandardFuncs[ottllog.TransformContext]()
+	return ottlfuncs.StandardFuncs[*ottllog.TransformContext]()
 }

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Test_LogFunctions(t *testing.T) {
-	expected := ottlfuncs.StandardFuncs[ottllog.TransformContext]()
+	expected := ottlfuncs.StandardFuncs[*ottllog.TransformContext]()
 	actual := LogFunctions()
 	require.Len(t, actual, len(expected))
 	for k := range actual {

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -23,7 +23,7 @@ type Processor struct {
 	flatMode bool
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, flatMode bool, settings component.TelemetrySettings, logFunctions map[string]ottl.Factory[ottllog.TransformContext]) (*Processor, error) {
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, flatMode bool, settings component.TelemetrySettings, logFunctions map[string]ottl.Factory[*ottllog.TransformContext]) (*Processor, error) {
 	pc, err := common.NewLogParserCollection(settings, common.WithLogParser(logFunctions), common.WithLogErrorMode(errorMode))
 	if err != nil {
 		return nil, err

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -1292,7 +1292,7 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 		name          string
 		statements    []common.ContextStatements
 		wantErrorWith string
-		logFunctions  map[string]ottl.Factory[ottllog.TransformContext]
+		logFunctions  map[string]ottl.Factory[*ottllog.TransformContext]
 	}
 
 	tests := []testCase{
@@ -1304,9 +1304,9 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestLogFunc())`},
 				},
 			},
-			logFunctions: map[string]ottl.Factory[ottllog.TransformContext]{
+			logFunctions: map[string]ottl.Factory[*ottllog.TransformContext]{
 				"set":         DefaultLogFunctions["set"],
-				"TestLogFunc": NewTestLogFuncFactory[ottllog.TransformContext](),
+				"TestLogFunc": NewTestLogFuncFactory[*ottllog.TransformContext](),
 			},
 		},
 		{

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
@@ -20,11 +20,11 @@ type aggregateOnAttributesArguments struct {
 	Attributes          ottl.Optional[[]string]
 }
 
-func newAggregateOnAttributesFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newAggregateOnAttributesFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("aggregate_on_attributes", &aggregateOnAttributesArguments{}, createAggregateOnAttributesFunction)
 }
 
-func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*aggregateOnAttributesArguments)
 
 	if !ok {
@@ -39,8 +39,8 @@ func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Argu
 	return AggregateOnAttributes(t, args.Attributes)
 }
 
-func AggregateOnAttributes(aggregationFunction aggregateutil.AggregationType, attributes ottl.Optional[[]string]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func AggregateOnAttributes(aggregationFunction aggregateutil.AggregationType, attributes ottl.Optional[[]string]) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
 		if metric.Type() == pmetric.MetricTypeSummary {

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -318,7 +318,9 @@ func Test_aggregateOnAttributes(t *testing.T) {
 			evaluate, err := AggregateOnAttributes(tt.t, tt.attributes)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			_, err = evaluate(nil, tCtx)
+			tCtx.Close()
 			assert.Equal(t, tt.wantErr, err)
 
 			actualMetric := pmetric.NewMetricSlice()

--- a/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics.go
+++ b/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics.go
@@ -23,11 +23,11 @@ type aggregateOnAttributeValueArguments struct {
 	NewValue            string
 }
 
-func newAggregateOnAttributeValueFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newAggregateOnAttributeValueFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("aggregate_on_attribute_value", &aggregateOnAttributeValueArguments{}, createAggregateOnAttributeValueFunction)
 }
 
-func createAggregateOnAttributeValueFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createAggregateOnAttributeValueFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*aggregateOnAttributeValueArguments)
 
 	if !ok {
@@ -42,8 +42,8 @@ func createAggregateOnAttributeValueFunction(_ ottl.FunctionContext, oArgs ottl.
 	return AggregateOnAttributeValue(t, args.Attribute, args.Values, args.NewValue)
 }
 
-func AggregateOnAttributeValue(aggregationType aggregateutil.AggregationType, attribute string, values []string, newValue string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func AggregateOnAttributeValue(aggregationType aggregateutil.AggregationType, attribute string, values []string, newValue string) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
 		aggregateutil.RangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {

--- a/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
@@ -487,7 +487,9 @@ func Test_aggregateOnAttributeValues(t *testing.T) {
 			evaluate, err := AggregateOnAttributeValue(tt.t, tt.attribute, tt.values, tt.newValue)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			_, err = evaluate(t.Context(), tCtx)
+			tCtx.Close()
 			require.NoError(t, err)
 
 			actualMetric := pmetric.NewMetricSlice()

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
@@ -29,12 +29,12 @@ var distributionFnMap = map[string]distAlgorithm{
 	"uniform":  uniformAlgorithm,
 }
 
-func newconvertExponentialHistToExplicitHistFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newconvertExponentialHistToExplicitHistFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("convert_exponential_histogram_to_histogram",
 		&convertExponentialHistToExplicitHistArguments{}, createconvertExponentialHistToExplicitHistFunction)
 }
 
-func createconvertExponentialHistToExplicitHistFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createconvertExponentialHistToExplicitHistFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*convertExponentialHistToExplicitHistArguments)
 
 	if !ok {
@@ -53,7 +53,7 @@ func createconvertExponentialHistToExplicitHistFunction(_ ottl.FunctionContext, 
 }
 
 // convertExponentialHistToExplicitHist converts an exponential histogram to a bucketed histogram
-func convertExponentialHistToExplicitHist(distributionFn string, explicitBounds []float64) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func convertExponentialHistToExplicitHist(distributionFn string, explicitBounds []float64) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	if len(explicitBounds) == 0 {
 		return nil, fmt.Errorf("explicit bounds cannot be empty: %v", explicitBounds)
 	}
@@ -63,7 +63,7 @@ func convertExponentialHistToExplicitHist(distributionFn string, explicitBounds 
 		return nil, fmt.Errorf("invalid distribution algorithm: %s, must be one of [upper, midpoint, random, uniform]", distributionFn)
 	}
 
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
 		// only execute on exponential histograms

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -252,11 +252,12 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
 			require.NoError(t, err)
-			_, err = exprFunc(nil, ctx)
+			_, err = exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
@@ -434,11 +435,12 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
 			require.NoError(t, err)
-			_, err = exprFunc(nil, ctx)
+			_, err = exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
@@ -563,11 +565,12 @@ func TestUniform_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
 			require.NoError(t, err)
-			_, err = exprFunc(nil, ctx)
+			_, err = exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()
@@ -692,11 +695,12 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
 			require.NoError(t, err)
-			_, err = exprFunc(nil, ctx)
+			_, err = exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
@@ -19,11 +19,11 @@ type convertGaugeToSumArguments struct {
 	Monotonic     bool
 }
 
-func newConvertGaugeToSumFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newConvertGaugeToSumFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("convert_gauge_to_sum", &convertGaugeToSumArguments{}, createConvertGaugeToSumFunction)
 }
 
-func createConvertGaugeToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createConvertGaugeToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*convertGaugeToSumArguments)
 
 	if !ok {
@@ -33,7 +33,7 @@ func createConvertGaugeToSumFunction(_ ottl.FunctionContext, oArgs ottl.Argument
 	return convertGaugeToSum(args.StringAggTemp, args.Monotonic)
 }
 
-func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	var aggTemp pmetric.AggregationTemporality
 	switch stringAggTemp {
 	case "delta":
@@ -44,7 +44,7 @@ func convertGaugeToSum(stringAggTemp string, monotonic bool) (ottl.ExprFunc[ottl
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
 
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeGauge {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -116,11 +116,12 @@ func Test_convertGaugeToSum(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)
 
-			_, err := exprFunc(nil, ctx)
+			_, err := exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge.go
@@ -12,16 +12,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
-func newConvertSumToGaugeFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newConvertSumToGaugeFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("convert_sum_to_gauge", nil, createConvertSumToGaugeFunction)
 }
 
-func createConvertSumToGaugeFunction(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createConvertSumToGaugeFunction(_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	return convertSumToGauge()
 }
 
-func convertSumToGauge() (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func convertSumToGauge() (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSum {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -84,11 +84,12 @@ func Test_convertSumToGauge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer ctx.Close()
 
 			exprFunc, _ := convertSumToGauge()
 
-			_, err := exprFunc(nil, ctx)
+			_, err := exprFunc(t.Context(), ctx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetric()

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
@@ -20,11 +20,11 @@ type convertSummaryCountValToSumArguments struct {
 	Suffix        ottl.Optional[string]
 }
 
-func newConvertSummaryCountValToSumFactory() ottl.Factory[ottldatapoint.TransformContext] {
+func newConvertSummaryCountValToSumFactory() ottl.Factory[*ottldatapoint.TransformContext] {
 	return ottl.NewFactory("convert_summary_count_val_to_sum", &convertSummaryCountValToSumArguments{}, createConvertSummaryCountValToSumFunction)
 }
 
-func createConvertSummaryCountValToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+func createConvertSummaryCountValToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
 	args, ok := oArgs.(*convertSummaryCountValToSumArguments)
 
 	if !ok {
@@ -34,7 +34,7 @@ func createConvertSummaryCountValToSumFunction(_ ottl.FunctionContext, oArgs ott
 	return convertSummaryCountValToSum(args.StringAggTemp, args.Monotonic, args.Suffix)
 }
 
-func convertSummaryCountValToSum(stringAggTemp string, monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+func convertSummaryCountValToSum(stringAggTemp string, monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
 	metricNameSuffix := "_count"
 	if !suffix.IsEmpty() {
 		metricNameSuffix = suffix.Get()
@@ -48,7 +48,7 @@ func convertSummaryCountValToSum(stringAggTemp string, monotonic bool, suffix ot
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottldatapoint.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -121,7 +121,9 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 			evaluate, err := convertSummaryCountValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge.go
@@ -18,11 +18,11 @@ type convertSummaryQuantileValToGaugeArguments struct {
 	Suffix       ottl.Optional[string]
 }
 
-func newConvertSummaryQuantileValToGaugeFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newConvertSummaryQuantileValToGaugeFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("convert_summary_quantile_val_to_gauge", &convertSummaryQuantileValToGaugeArguments{}, createConvertSummaryQuantileValToGaugeFunction)
 }
 
-func createConvertSummaryQuantileValToGaugeFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createConvertSummaryQuantileValToGaugeFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*convertSummaryQuantileValToGaugeArguments)
 
 	if !ok {
@@ -32,11 +32,11 @@ func createConvertSummaryQuantileValToGaugeFunction(_ ottl.FunctionContext, oArg
 	return convertSummaryQuantileValToGauge(args.AttributeKey, args.Suffix)
 }
 
-func convertSummaryQuantileValToGauge(attrKey, suffix ottl.Optional[string]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func convertSummaryQuantileValToGauge(attrKey, suffix ottl.Optional[string]) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	metricNameSuffix := suffix.GetOr(".quantiles")
 	attributeKey := attrKey.GetOr("quantile")
 
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
@@ -130,7 +130,9 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 			evaluate, err := convertSummaryQuantileValToGauge(tt.key, tt.suffix)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetric, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetric, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
@@ -20,11 +20,11 @@ type convertSummarySumValToSumArguments struct {
 	Suffix        ottl.Optional[string]
 }
 
-func newConvertSummarySumValToSumFactory() ottl.Factory[ottldatapoint.TransformContext] {
+func newConvertSummarySumValToSumFactory() ottl.Factory[*ottldatapoint.TransformContext] {
 	return ottl.NewFactory("convert_summary_sum_val_to_sum", &convertSummarySumValToSumArguments{}, createConvertSummarySumValToSumFunction)
 }
 
-func createConvertSummarySumValToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+func createConvertSummarySumValToSumFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
 	args, ok := oArgs.(*convertSummarySumValToSumArguments)
 
 	if !ok {
@@ -34,7 +34,7 @@ func createConvertSummarySumValToSumFunction(_ ottl.FunctionContext, oArgs ottl.
 	return convertSummarySumValToSum(args.StringAggTemp, args.Monotonic, args.Suffix)
 }
 
-func convertSummarySumValToSum(stringAggTemp string, monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+func convertSummarySumValToSum(stringAggTemp string, monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
 	metricNameSuffix := "_sum"
 	if !suffix.IsEmpty() {
 		metricNameSuffix = suffix.Get()
@@ -48,7 +48,7 @@ func convertSummarySumValToSum(stringAggTemp string, monotonic bool, suffix ottl
 	default:
 		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
 	}
-	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottldatapoint.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		if metric.Type() != pmetric.MetricTypeSummary {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -131,7 +131,9 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()

--- a/processor/transformprocessor/internal/metrics/func_copy_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric.go
@@ -12,16 +12,16 @@ import (
 )
 
 type copyMetricArguments struct {
-	Name        ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
-	Description ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
-	Unit        ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
+	Name        ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
+	Description ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
+	Unit        ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
 }
 
-func newCopyMetricFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newCopyMetricFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("copy_metric", &copyMetricArguments{}, createCopyMetricFunction)
 }
 
-func createCopyMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createCopyMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*copyMetricArguments)
 
 	if !ok {
@@ -31,8 +31,8 @@ func createCopyMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 	return copyMetric(args.Name, args.Description, args.Unit)
 }
 
-func copyMetric(name, desc, unit ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func copyMetric(name, desc, unit ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(ctx context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		cur := tCtx.GetMetric()
 		metrics := tCtx.GetMetrics()
 		newMetric := metrics.AppendEmpty()

--- a/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
@@ -19,16 +19,16 @@ import (
 func Test_copyMetric(t *testing.T) {
 	tests := []struct {
 		testName string
-		name     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
-		desc     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
-		unit     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
+		name     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
+		desc     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
+		unit     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
 		want     func(s pmetric.MetricSlice)
 	}{
 		{
 			testName: "basic copy",
-			name:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			desc:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			unit:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
+			name:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			desc:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			unit:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
 			want: func(ms pmetric.MetricSlice) {
 				metric := ms.At(0)
 				newMetric := ms.AppendEmpty()
@@ -37,13 +37,13 @@ func Test_copyMetric(t *testing.T) {
 		},
 		{
 			testName: "set name",
-			name: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			name: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new name", nil
 				},
 			}),
-			desc: ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			unit: ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
+			desc: ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			unit: ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
 			want: func(ms pmetric.MetricSlice) {
 				metric := ms.At(0)
 				newMetric := ms.AppendEmpty()
@@ -53,13 +53,13 @@ func Test_copyMetric(t *testing.T) {
 		},
 		{
 			testName: "set description",
-			name:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			desc: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			name:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			desc: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new desc", nil
 				},
 			}),
-			unit: ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
+			unit: ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
 			want: func(ms pmetric.MetricSlice) {
 				metric := ms.At(0)
 				newMetric := ms.AppendEmpty()
@@ -69,10 +69,10 @@ func Test_copyMetric(t *testing.T) {
 		},
 		{
 			testName: "set unit",
-			name:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			desc:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
-			unit: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			name:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			desc:     ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]{},
+			unit: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new unit", nil
 				},
 			}),
@@ -85,18 +85,18 @@ func Test_copyMetric(t *testing.T) {
 		},
 		{
 			testName: "set all",
-			name: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			name: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new name", nil
 				},
 			}),
-			desc: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			desc: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new desc", nil
 				},
 			}),
-			unit: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+			unit: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+				Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 					return "new unit", nil
 				},
 			}),
@@ -127,7 +127,9 @@ func Test_copyMetric(t *testing.T) {
 
 			exprFunc, err := copyMetric(tt.name, tt.desc, tt.unit)
 			require.NoError(t, err)
-			_, err = exprFunc(nil, ottlmetric.NewTransformContext(input, ms, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(input, ms, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			x := pmetric.NewScopeMetrics()

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
@@ -20,11 +20,11 @@ type extractCountMetricArguments struct {
 	Suffix    ottl.Optional[string]
 }
 
-func newExtractCountMetricFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newExtractCountMetricFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory(sumCountName, &extractCountMetricArguments{}, createExtractCountMetricFunction)
 }
 
-func createExtractCountMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createExtractCountMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*extractCountMetricArguments)
 
 	if !ok {
@@ -34,12 +34,12 @@ func createExtractCountMetricFunction(_ ottl.FunctionContext, oArgs ottl.Argumen
 	return extractCountMetric(args.Monotonic, args.Suffix)
 }
 
-func extractCountMetric(monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func extractCountMetric(monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	metricNameSuffix := "_count"
 	if !suffix.IsEmpty() {
 		metricNameSuffix = suffix.Get()
 	}
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
 		aggTemp := getAggregationTemporality(metric)

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
@@ -181,7 +181,9 @@ func Test_extractCountMetric(t *testing.T) {
 			evaluate, err := extractCountMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)
 
 			if tt.want != nil {

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric.go
@@ -22,11 +22,11 @@ type extractSumMetricArguments struct {
 	Suffix    ottl.Optional[string]
 }
 
-func newExtractSumMetricFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newExtractSumMetricFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory(sumFuncName, &extractSumMetricArguments{}, createExtractSumMetricFunction)
 }
 
-func createExtractSumMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createExtractSumMetricFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*extractSumMetricArguments)
 
 	if !ok {
@@ -46,12 +46,12 @@ type SumCountDataPoint interface {
 	Timestamp() pcommon.Timestamp
 }
 
-func extractSumMetric(monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func extractSumMetric(monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	metricNameSuffix := "_sum"
 	if !suffix.IsEmpty() {
 		metricNameSuffix = suffix.Get()
 	}
-	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 		aggTemp := getAggregationTemporality(metric)
 		if aggTemp == pmetric.AggregationTemporalityUnspecified {

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
@@ -308,7 +308,9 @@ func Test_extractSumMetric(t *testing.T) {
 			evaluate, err := extractSumMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
+			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			defer tCtx.Close()
+			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)
 
 			if tt.want != nil {

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets.go
@@ -18,11 +18,11 @@ type mergeHistogramBucketsArguments struct {
 	Bound float64
 }
 
-func newMergeHistogramBucketsFactory() ottl.Factory[ottldatapoint.TransformContext] {
+func newMergeHistogramBucketsFactory() ottl.Factory[*ottldatapoint.TransformContext] {
 	return ottl.NewFactory("merge_histogram_buckets", &mergeHistogramBucketsArguments{}, createMergeHistogramBucketsFunction)
 }
 
-func createMergeHistogramBucketsFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
+func createMergeHistogramBucketsFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
 	args, ok := oArgs.(*mergeHistogramBucketsArguments)
 	if !ok {
 		return nil, errors.New("mergeHistogramBucketsFactory args must be of type *mergeHistogramBucketsArguments")
@@ -31,8 +31,8 @@ func createMergeHistogramBucketsFunction(_ ottl.FunctionContext, oArgs ottl.Argu
 	return mergeHistogramBuckets(args.Bound)
 }
 
-func mergeHistogramBuckets(bound float64) (ottl.ExprFunc[ottldatapoint.TransformContext], error) {
-	return func(_ context.Context, tCtx ottldatapoint.TransformContext) (any, error) {
+func mergeHistogramBuckets(bound float64) (ottl.ExprFunc[*ottldatapoint.TransformContext], error) {
+	return func(_ context.Context, tCtx *ottldatapoint.TransformContext) (any, error) {
 		dataPoint := tCtx.GetDataPoint()
 		if dataPoint == nil {
 			return nil, nil

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -150,7 +150,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			dp.BucketCounts().FromRaw(tt.inputCounts)
 			dp.ExplicitBounds().FromRaw(tt.inputBounds)
 
-			ctx := ottldatapoint.NewTransformContext(
+			ctx := ottldatapoint.NewTransformContextPtr(
 				dp,
 				metric,
 				pmetric.NewMetricSlice(),
@@ -159,6 +159,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 				pmetric.NewScopeMetrics(),
 				pmetric.NewResourceMetrics(),
 			)
+			defer ctx.Close()
 
 			result, err := exprFunc(t.Context(), ctx)
 
@@ -208,7 +209,8 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exprFunc)
 
-	ctx := ottldatapoint.NewTransformContext(dp, metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	ctx := ottldatapoint.NewTransformContextPtr(dp, metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	defer ctx.Close()
 	result, err := exprFunc(t.Context(), ctx)
 
 	require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_scale.go
+++ b/processor/transformprocessor/internal/metrics/func_scale.go
@@ -16,14 +16,14 @@ import (
 
 type ScaleArguments struct {
 	Multiplier float64
-	Unit       ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]
+	Unit       ottl.Optional[ottl.StringGetter[*ottlmetric.TransformContext]]
 }
 
-func newScaleMetricFactory() ottl.Factory[ottlmetric.TransformContext] {
+func newScaleMetricFactory() ottl.Factory[*ottlmetric.TransformContext] {
 	return ottl.NewFactory("scale_metric", &ScaleArguments{}, createScaleFunction)
 }
 
-func createScaleFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func createScaleFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*ScaleArguments)
 
 	if !ok {
@@ -33,8 +33,8 @@ func createScaleFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.Exp
 	return Scale(*args)
 }
 
-func Scale(args ScaleArguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+func Scale(args ScaleArguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+	return func(ctx context.Context, tCtx *ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
 		var unit *string

--- a/processor/transformprocessor/internal/metrics/func_scale_test.go
+++ b/processor/transformprocessor/internal/metrics/func_scale_test.go
@@ -37,8 +37,8 @@ func TestScale(t *testing.T) {
 			},
 			args: ScaleArguments{
 				Multiplier: 10.0,
-				Unit: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-					Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
+				Unit: ottl.NewTestingOptional[ottl.StringGetter[*ottlmetric.TransformContext]](ottl.StandardStringGetter[*ottlmetric.TransformContext]{
+					Getter: func(context.Context, *ottlmetric.TransformContext) (any, error) {
 						return "kWh", nil
 					},
 				}),
@@ -161,7 +161,7 @@ func TestScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := ottlmetric.NewTransformContext(
+			target := ottlmetric.NewTransformContextPtr(
 				tt.valueFunc(),
 				pmetric.NewMetricSlice(),
 				pcommon.NewInstrumentationScope(),
@@ -169,6 +169,7 @@ func TestScale(t *testing.T) {
 				pmetric.NewScopeMetrics(),
 				pmetric.NewResourceMetrics(),
 			)
+			defer target.Close()
 
 			expressionFunc, _ := Scale(tt.args)
 			_, err := expressionFunc(t.Context(), target)

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -21,8 +21,8 @@ var UseConvertBetweenSumAndGaugeMetricContext = featuregate.GlobalRegistry().Mus
 	featuregate.WithRegisterToVersion("v0.114.0"),
 )
 
-func DataPointFunctions() map[string]ottl.Factory[ottldatapoint.TransformContext] {
-	functions := ottlfuncs.StandardFuncs[ottldatapoint.TransformContext]()
+func DataPointFunctions() map[string]ottl.Factory[*ottldatapoint.TransformContext] {
+	functions := ottlfuncs.StandardFuncs[*ottldatapoint.TransformContext]()
 
 	datapointFunctions := ottl.CreateFactoryMap(
 		newConvertSummarySumValToSumFactory(),
@@ -35,8 +35,8 @@ func DataPointFunctions() map[string]ottl.Factory[ottldatapoint.TransformContext
 	return functions
 }
 
-func MetricFunctions() map[string]ottl.Factory[ottlmetric.TransformContext] {
-	functions := ottlfuncs.StandardFuncs[ottlmetric.TransformContext]()
+func MetricFunctions() map[string]ottl.Factory[*ottlmetric.TransformContext] {
+	functions := ottlfuncs.StandardFuncs[*ottlmetric.TransformContext]()
 
 	metricFunctions := ottl.CreateFactoryMap(
 		newExtractSumMetricFactory(),

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -33,7 +33,7 @@ func Test_DataPointFunctions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expected := ottlfuncs.StandardFuncs[ottldatapoint.TransformContext]()
+			expected := ottlfuncs.StandardFuncs[*ottldatapoint.TransformContext]()
 			expected["convert_summary_sum_val_to_sum"] = newConvertSummarySumValToSumFactory()
 			expected["convert_summary_count_val_to_sum"] = newConvertSummaryCountValToSumFactory()
 			expected["merge_histogram_buckets"] = newMergeHistogramBucketsFactory()
@@ -50,7 +50,7 @@ func Test_DataPointFunctions(t *testing.T) {
 }
 
 func Test_MetricFunctions(t *testing.T) {
-	expected := ottlfuncs.StandardFuncs[ottlmetric.TransformContext]()
+	expected := ottlfuncs.StandardFuncs[*ottlmetric.TransformContext]()
 	expected["convert_sum_to_gauge"] = newConvertSumToGaugeFactory()
 	expected["convert_gauge_to_sum"] = newConvertGaugeToSumFactory()
 	expected["aggregate_on_attributes"] = newAggregateOnAttributesFactory()

--- a/processor/transformprocessor/internal/metrics/processor.go
+++ b/processor/transformprocessor/internal/metrics/processor.go
@@ -22,7 +22,7 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, metricFunctions map[string]ottl.Factory[ottlmetric.TransformContext], dataPointFunctions map[string]ottl.Factory[ottldatapoint.TransformContext]) (*Processor, error) {
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, metricFunctions map[string]ottl.Factory[*ottlmetric.TransformContext], dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]) (*Processor, error) {
 	pc, err := common.NewMetricParserCollection(settings, common.WithMetricParser(metricFunctions), common.WithDataPointParser(dataPointFunctions), common.WithMetricErrorMode(errorMode))
 	if err != nil {
 		return nil, err

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -2063,8 +2063,8 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 		name               string
 		statements         []common.ContextStatements
 		wantErrorWith      string
-		metricFunctions    map[string]ottl.Factory[ottlmetric.TransformContext]
-		dataPointFunctions map[string]ottl.Factory[ottldatapoint.TransformContext]
+		metricFunctions    map[string]ottl.Factory[*ottlmetric.TransformContext]
+		dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]
 	}
 
 	tests := []testCase{
@@ -2076,9 +2076,9 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 					Statements: []string{`set(cache["attr"], TestMetricFunc())`},
 				},
 			},
-			metricFunctions: map[string]ottl.Factory[ottlmetric.TransformContext]{
+			metricFunctions: map[string]ottl.Factory[*ottlmetric.TransformContext]{
 				"set":            DefaultMetricFunctions["set"],
-				"TestMetricFunc": NewTestMetricFuncFactory[ottlmetric.TransformContext](),
+				"TestMetricFunc": NewTestMetricFuncFactory[*ottlmetric.TransformContext](),
 			},
 			dataPointFunctions: DefaultDataPointFunctions,
 		},
@@ -2103,9 +2103,9 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 				},
 			},
 			metricFunctions: DefaultMetricFunctions,
-			dataPointFunctions: map[string]ottl.Factory[ottldatapoint.TransformContext]{
+			dataPointFunctions: map[string]ottl.Factory[*ottldatapoint.TransformContext]{
 				"set":               DefaultDataPointFunctions["set"],
-				"TestDataPointFunc": NewTestDataPointFuncFactory[ottldatapoint.TransformContext](),
+				"TestDataPointFunc": NewTestDataPointFuncFactory[*ottldatapoint.TransformContext](),
 			},
 		},
 		{

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -25,7 +25,7 @@ func SpanFunctions() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	return functions
 }
 
-func SpanEventFunctions() map[string]ottl.Factory[ottlspanevent.TransformContext] {
+func SpanEventFunctions() map[string]ottl.Factory[*ottlspanevent.TransformContext] {
 	// No trace-only functions yet.
-	return ottlfuncs.StandardFuncs[ottlspanevent.TransformContext]()
+	return ottlfuncs.StandardFuncs[*ottlspanevent.TransformContext]()
 }

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -27,7 +27,7 @@ func Test_SpanFunctions(t *testing.T) {
 }
 
 func Test_SpanEventFunctions(t *testing.T) {
-	expected := ottlfuncs.StandardFuncs[ottlspanevent.TransformContext]()
+	expected := ottlfuncs.StandardFuncs[*ottlspanevent.TransformContext]()
 	actual := SpanEventFunctions()
 	require.Len(t, actual, len(expected))
 	for k := range actual {

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -22,7 +22,7 @@ type Processor struct {
 	logger   *zap.Logger
 }
 
-func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, spanFunctions map[string]ottl.Factory[*ottlspan.TransformContext], spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]) (*Processor, error) {
+func NewProcessor(contextStatements []common.ContextStatements, errorMode ottl.ErrorMode, settings component.TelemetrySettings, spanFunctions map[string]ottl.Factory[*ottlspan.TransformContext], spanEventFunctions map[string]ottl.Factory[*ottlspanevent.TransformContext]) (*Processor, error) {
 	pc, err := common.NewTraceParserCollection(settings, common.WithSpanParser(spanFunctions), common.WithSpanEventParser(spanEventFunctions), common.WithTraceErrorMode(errorMode))
 	if err != nil {
 		return nil, err

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -1422,7 +1422,7 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 		statements         []common.ContextStatements
 		wantErrorWith      string
 		spanFunctions      map[string]ottl.Factory[*ottlspan.TransformContext]
-		spanEventFunctions map[string]ottl.Factory[ottlspanevent.TransformContext]
+		spanEventFunctions map[string]ottl.Factory[*ottlspanevent.TransformContext]
 	}
 
 	tests := []testCase{
@@ -1461,9 +1461,9 @@ func Test_NewProcessor_NonDefaultFunctions(t *testing.T) {
 				},
 			},
 			spanFunctions: DefaultSpanFunctions,
-			spanEventFunctions: map[string]ottl.Factory[ottlspanevent.TransformContext]{
+			spanEventFunctions: map[string]ottl.Factory[*ottlspanevent.TransformContext]{
 				"set":               DefaultSpanEventFunctions["set"],
-				"TestSpanEventFunc": NewTestSpanEventFuncFactory[ottlspanevent.TransformContext](),
+				"TestSpanEventFunc": NewTestSpanEventFuncFactory[*ottlspanevent.TransformContext](),
 			},
 		},
 		{


### PR DESCRIPTION
Continuation of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44541 for Log/Metric/DataPoint/SpanEvent context.