### PR TITLE
[exporter/elasticsearch] Update ecs mapping for span name to map to `transaction.name` for Elastic transactions

### DIFF
--- a/.chloggen/ex-exporter-span-name-elastic-transaction.yaml
+++ b/.chloggen/ex-exporter-span-name-elastic-transaction.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update ecs mapping for span name to map to transaction.name for Elastic transactions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44769]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -544,10 +544,20 @@ Otherwise, it is mapped to an empty string ("").
 
 In case the record contains `timestamp`, this value is used. Otherwise, the `observed timestamp` is used.
 
-### `messaging.destination.name`
 
-Maps to `span.message.queue.name` for regular spans, but to `transaction.message.queue.name` when the `processor.event` attribute equals "transaction".
-This attribute is only applicable at the trace level. 
+### Elastic span and transactions
+ECS mappings may differ based on the span type (Elastic span and transactions) for the fields listed below.
+By default, all spans are considered Elastic spans. 
+Elastic transactions are identified when the span attribute `processor.event` equals `transaction`.
+These attribute mappings are only applicable at the span level.
+
+| Elastic Span Type | SemConv Value              | ECS Value                      |
+|-------------------|----------------------------|--------------------------------|
+| span              | span.Name                  | span.name                      |
+| transaction       | span.Name                  | transaction.name               |
+| span              | messaging.destination.name | span.name                      |
+| transaction       | messaging.destination.name | transaction.message.queue.name |
+
 
 ## Setting a document id dynamically
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -257,11 +257,13 @@ func (ecsModeEncoder) encodeSpan(
 
 	// Finally, try to map record-level attributes to ECS fields.
 
-	// determine the correct message queue name based on the trace type (Elastic span or transaction)
+	// handle mappings that are specific to the span type (Elastic span or transaction)
 	messageQueueName := "span.message.queue.name"
+	spanName := "span.name"
 	processor, _ := span.Attributes().Get("processor.event")
 	if processor.Str() == "transaction" {
 		messageQueueName = "transaction.message.queue.name"
+		spanName = "transaction.name"
 	}
 
 	spanAttrsConversionMap := map[string]string{
@@ -281,7 +283,7 @@ func (ecsModeEncoder) encodeSpan(
 	document.AddTimestamp("@timestamp", span.StartTimestamp())
 	document.AddTraceID("trace.id", span.TraceID())
 	document.AddSpanID("span.id", span.SpanID())
-	document.AddString("span.name", span.Name())
+	document.AddString(spanName, span.Name())
 	document.AddSpanID("parent.id", span.ParentSpanID())
 	if span.Status().Code() == ptrace.StatusCodeOk {
 		document.AddString("event.outcome", "success")


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
- Spans that represent an Elastic transaction may contain a `transaction.name` which should equal the span name. The current ecs mapping logic will map the span name to `span.name` which results in a span with both attributes: `transaction.name` & `span.name`
- This PR updates the ecs mapping for the span name to correctly handle Elastic transactions to avoid adding `span.name`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Updated unit test
- Setup a local collector with the elasticsearch exporter to validate indexed documents

<!--Describe the documentation added.-->
#### Documentation
- Added mapping to `README.md`
