### PR TITLE
[receiver/splunkhecreceiver] Add JSON array support

### DIFF
--- a/.chloggen/splunk_splunkhecreceiver-json-array.yaml
+++ b/.chloggen/splunk_splunkhecreceiver-json-array.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support parsing JSON array payloads in Splunk HEC receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43941]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/splunk_splunkhecreceiver-json-array.yaml
+++ b/.chloggen/splunk_splunkhecreceiver-json-array.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/splunkhecreceiver
+component: receiver/splunk_hec
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support parsing JSON array payloads in Splunk HEC receiver

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -148,6 +148,215 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple events",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+				splunkMetricMsg := buildSplunkHecMetricsMsg("metric", currentTime, 10, 2)
+				splunkMetricMsg2 := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
+
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg2)
+				require.NoError(t, err)
+
+				msgBytes3, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				metricMsgBytes, err := json.Marshal(splunkMetricMsg)
+				require.NoError(t, err)
+
+				metricMsgBytes2, err := json.Marshal(splunkMetricMsg2)
+				require.NoError(t, err)
+
+				combined := strings.Join(
+					[]string{
+						string(msgBytes),
+						string(msgBytes2),
+						string(msgBytes3),
+						string(metricMsgBytes),
+						string(metricMsgBytes2),
+					},
+					"",
+				)
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 3)
+			},
+			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, sink.DataPointCount(), 2)
+			},
+		},
+		{
+			name: "empty JSON array",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte("[]")))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{
+					"text": "No data",
+					"code": float64(5),
+				}, body)
+			},
+		},
+		{
+			name: "one object in JSON array",
+			req: func() *http.Request {
+				messages := []*splunk.Event{splunkMsg}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 1)
+			},
+		},
+		{
+			name: "multiple objects in JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+				splunkMetricMsg := buildSplunkHecMetricsMsg("metric", currentTime, 10, 2)
+				splunkMetricMsg2 := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2, splunkMsg3, splunkMetricMsg, splunkMetricMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 3)
+			},
+			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, sink.DataPointCount(), 2)
+			},
+		},
+		{
+			name: "multiple JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages1 := []*splunk.Event{splunkMsg, splunkMsg2}
+				messages2 := []*splunk.Event{splunkMsg3}
+
+				msgBytes, err := json.Marshal(messages1)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(messages2)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
+			name: "JSON array first with objects",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
+			name: "objects first with JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes2), string(msgBytes)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", http.NoBody)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -195,11 +195,11 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
 				assert.Len(t, sink.AllLogs(), 1)
-				assert.Equal(t, sink.LogRecordCount(), 3)
+				assert.Equal(t, 3, sink.LogRecordCount())
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
 				assert.Len(t, sink.AllMetrics(), 1)
-				assert.Equal(t, sink.DataPointCount(), 2)
+				assert.Equal(t, 2, sink.DataPointCount())
 			},
 		},
 		{
@@ -240,7 +240,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
 				assert.Len(t, sink.AllLogs(), 1)
-				assert.Equal(t, sink.LogRecordCount(), 1)
+				assert.Equal(t, 1, sink.LogRecordCount())
 			},
 		},
 		{
@@ -270,11 +270,11 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
 				assert.Len(t, sink.AllLogs(), 1)
-				assert.Equal(t, sink.LogRecordCount(), 3)
+				assert.Equal(t, 3, sink.LogRecordCount())
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
 				assert.Len(t, sink.AllMetrics(), 1)
-				assert.Equal(t, sink.DataPointCount(), 2)
+				assert.Equal(t, 2, sink.DataPointCount())
 			},
 		},
 		{
@@ -292,7 +292,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes2, err := json.Marshal(messages2)
 				require.NoError(t, err)
 
-				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+				combined := string(msgBytes) + string(msgBytes2)
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")
@@ -318,7 +318,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes2, err := json.Marshal(splunkMsg3)
 				require.NoError(t, err)
 
-				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+				combined := string(msgBytes) + string(msgBytes2)
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")
@@ -344,7 +344,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes2, err := json.Marshal(splunkMsg3)
 				require.NoError(t, err)
 
-				combined := strings.Join([]string{string(msgBytes2), string(msgBytes)}, "")
+				combined := string(msgBytes2) + string(msgBytes)
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add JSON array support to Splunk HEC receiver.  ie. support 
```
curl -X POST http://localhost:8088/services/collector \
  -H "Authorization: Splunk YOUR_TOKEN" \
  -d '[{"event": "test event", "sourcetype": "manual"},{"event": "test event 2", "sourcetype": "manual"},{"event": "test event 3", "sourcetype": "manual"}]'
{"text": "Success", "code": 0}
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [43941](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43941)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
splunkhecreceiver unit tests

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
