### PR TITLE
[chore][processor/resourcedetectionprocessor] run make modernize

### DIFF
--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -719,7 +719,7 @@ func TestProcessorWithMultipleResources(t *testing.T) {
 
 		td := ptrace.NewTraces()
 		// Add 3 resource spans
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			rs := td.ResourceSpans().AppendEmpty()
 			rs.Resource().Attributes().PutStr("original", "value")
 		}
@@ -741,7 +741,7 @@ func TestProcessorWithMultipleResources(t *testing.T) {
 		defer func() { _ = mp.Shutdown(ctx) }()
 
 		md := pmetric.NewMetrics()
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			rm := md.ResourceMetrics().AppendEmpty()
 			rm.Resource().Attributes().PutStr("original", "value")
 		}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
