### PR TITLE
[chore][receiver/windowsperfcountersreceiver] run make modernize

### DIFF
--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -7,6 +7,7 @@ package windowsperfcountersreceiver // import "github.com/open-telemetry/opentel
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -207,10 +208,8 @@ func instancesFromConfig(oc ObjectConfig) []string {
 		return []string{""}
 	}
 
-	for _, instance := range oc.Instances {
-		if instance == "*" {
-			return []string{"*"}
-		}
+	if slices.Contains(oc.Instances, "*") {
+		return []string{"*"}
 	}
 
 	return oc.Instances


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
