### PR TITLE
[chore][receiver/awslambdareceiver] improve linting

### DIFF
--- a/receiver/awslambdareceiver/internal/s3_test.go
+++ b/receiver/awslambdareceiver/internal/s3_test.go
@@ -61,7 +61,8 @@ func TestS3ServiceReadObject(t *testing.T) {
 		client := s3ServiceClient{api: mockAPI}
 		_, err := client.ReadObject(t.Context(), bucketName, objectKey)
 		require.Error(t, err)
-		require.IsType(t, &consumererror.Error{}, err)
+		var consumerErr *consumererror.Error
+		require.ErrorAs(t, err, &consumerErr)
 	})
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Improve linting for `receiver/awslambda`.

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.

```sh
Error: receiver/awslambdareceiver/internal/s3_test.go:64:3: error-is-as: use require.ErrorIs or require.ErrorAs depending on the case (testifylint)
		require.IsType(t, &consumererror.Error{}, err)
		^
```