### PR TITLE
[chore][receiver/googlecloudspannerreceiver] run make modernize

### DIFF
--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -6,6 +6,7 @@ package googlecloudspannerreceiver // import "github.com/open-telemetry/opentele
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
@@ -94,10 +95,8 @@ func (instance Instance) Validate() error {
 		return errors.New("field \"databases\" is required and cannot be empty for instance configuration")
 	}
 
-	for _, database := range instance.Databases {
-		if database == "" {
-			return errors.New("field \"databases\" contains empty database names")
-		}
+	if slices.Contains(instance.Databases, "") {
+		return errors.New("field \"databases\" contains empty database names")
 	}
 
 	return nil

--- a/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
@@ -37,7 +37,7 @@ const (
 func assertGroupedByKey(t *testing.T, items []*Item, groupedItems map[time.Time][]*Item, key time.Time, offsetInItems int) {
 	assert.Len(t, groupedItems[key], 3)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		assert.Equal(t, items[i+offsetInItems].SeriesKey, groupedItems[key][i].SeriesKey)
 	}
 }

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
@@ -68,7 +68,7 @@ func TestPullTimestampsWithDifference(t *testing.T) {
 
 	expectedTimestamp = lowerBound.Add(time.Minute)
 
-	for i := 0; i < expectedAmountOfTimestamps; i++ {
+	for i := range expectedAmountOfTimestamps {
 		assert.Equal(t, expectedTimestamp, timestamps[i])
 		expectedTimestamp = expectedTimestamp.Add(time.Minute)
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run the `make modernize` tool.

https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI.

There are no changes in the component behaviour.
