### PR TITLE
[receiver/kafkareceiver] Handle ctx cancel before processing

### DIFF
--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -310,6 +310,17 @@ func (c *franzConsumer) consume(ctx context.Context, size int) bool {
 			)
 			return
 		}
+		if pcErr := assign.ctx.Err(); pcErr != nil {
+			// If the context is canceled, for example due to the partition getting
+			// lost, then log and return.
+			c.settings.Logger.Warn(
+				"attempted to process records for a partition with context done",
+				zap.Error(pcErr),
+				zap.String("topic", tp.topic),
+				zap.Int64("partition", int64(tp.partition)),
+			)
+			return
+		}
 		// Try to add a new in-flight message processing goroutine to the
 		// partition consumer. Return immediately if the partition has been
 		// lost or reassigned.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The partition context is canceled when the partition is lost ([ref](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b75724fa0e299c91bc1426068c8ddfd04d49da5e/receiver/kafkareceiver/consumer_franz.go#L503-L505)). This leads to a race condition if the `fetch` has already fetched data for the lost topic-partition. The PR logs this case and returns without processing further, however, we could still have some processing since it is a race-condition.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
N/A

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
