### PR TITLE
[receiver/googlecloudpubsub] Add exp backoff for reconnect (#44741)

### DIFF
--- a/.chloggen/googlepubsub_receiver_exponential_backoff.yaml
+++ b/.chloggen/googlepubsub_receiver_exponential_backoff.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudpubsub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exponential backoff streaming restarts
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44741]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudpubsubreceiver/internal/handler_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/handler_test.go
@@ -5,6 +5,8 @@ package internal
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -65,4 +67,42 @@ func TestCancelStream(t *testing.T) {
 		handler.CancelNow()
 	}()
 	handler.Wait()
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	tests := []struct {
+		retry int
+		max   time.Duration
+	}{
+		{
+			retry: 0,
+			max:   time.Duration(0),
+		},
+	}
+	for i := 1; i <= 11; i++ {
+		maxBackoff := time.Duration(250.0*math.Pow(2, float64(i-1))) * time.Millisecond
+		if maxBackoff > time.Duration(2)*time.Minute {
+			maxBackoff = time.Duration(2) * time.Minute
+		}
+		tests = append(tests, struct {
+			retry int
+			max   time.Duration
+		}{
+			retry: i,
+			max:   maxBackoff,
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("retry-%d", tt.retry), func(t *testing.T) {
+			for i := 0; i < 10; i++ {
+				backoff := exponentialBackoff(tt.retry)
+				minBackoffDueToJitter := time.Duration(0.7*float64(tt.max.Milliseconds())) * time.Millisecond
+				assert.Condition(t, func() bool { return backoff <= tt.max },
+					"exponentialBackoff %s should not go over max %s", backoff.String(), tt.max.String())
+				assert.Condition(t, func() bool { return backoff >= minBackoffDueToJitter },
+					"exponentialBackoff %s should not go under min (due to jitter) %s", backoff.String(), minBackoffDueToJitter.String())
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### Description
A Pub/Sub streaming connection regularly rebalances by closing the connection on the server side. The current implementation has a fixed 250 ms pause for each reconnect in case something goes wrong. Replace this with exponential backoff (250 ms exponential steps) starting with no pause for the first retry, with a maximum of 2 minutes.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44741

#### Testing
Added test for the exponential backoff function

#### Documentation
No extra documentation needed