### PR TITLE
[chore] replace NewSimpleClientset of k8s.io/client-go/kubernetes/fake with NewClientset

### DIFF
--- a/internal/metadataproviders/aws/eks/metadata_test.go
+++ b/internal/metadataproviders/aws/eks/metadata_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestGetK8sInstanceMetadata(t *testing.T) {
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewClientset()
 	mockEC2 := ec2.NewFromConfig(aws.Config{})
 
 	tests := []struct {
@@ -246,7 +246,7 @@ func TestGetInstanceMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset()
+			clientset := fake.NewClientset()
 			eksProvider := &metadataClient{
 				ec2Client: mockClient(tt.ec2DescOutput),
 				clientset: clientset,

--- a/internal/metadataproviders/k8snode/metadata_test.go
+++ b/internal/metadataproviders/k8snode/metadata_test.go
@@ -30,7 +30,7 @@ func TestNewProvider(t *testing.T) {
 }
 
 func TestNodeUID(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := fake.NewClientset()
 	err := setupNodes(client)
 	assert.NoError(t, err)
 

--- a/internal/metadataproviders/kubeadm/metadata_test.go
+++ b/internal/metadataproviders/kubeadm/metadata_test.go
@@ -26,7 +26,7 @@ func TestNewProvider(t *testing.T) {
 }
 
 func TestClusterName(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := fake.NewClientset()
 	err := setupConfigMap(client)
 	assert.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestClusterName(t *testing.T) {
 }
 
 func TestClusterUID(t *testing.T) {
-	client := fake.NewSimpleClientset()
+	client := fake.NewClientset()
 	err := setupNamespace(client)
 	assert.NoError(t, err)
 

--- a/processor/k8sattributesprocessor/client_test.go
+++ b/processor/k8sattributesprocessor/client_test.go
@@ -43,7 +43,7 @@ func selectors() (labels.Selector, fields.Selector) {
 
 // newFakeClient instantiates a new FakeClient object and satisfies the ClientProvider type
 func newFakeClient(_ component.TelemetrySettings, _ k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformersFactoryList, _ bool, _ time.Duration) (kube.Client, error) {
-	cs := fake.NewSimpleClientset()
+	cs := fake.NewClientset()
 
 	ls, fs := selectors()
 	return &fakeClient{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newFakeAPIClientset(_ k8sconfig.APIConfig) (kubernetes.Interface, error) {
-	return fake.NewSimpleClientset(), nil
+	return fake.NewClientset(), nil
 }
 
 func newPodIdentifier(from, name, value string) PodIdentifier {

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -34,7 +34,7 @@ var mockClient = new(MockClient)
 type mockK8sClient struct{}
 
 func (*mockK8sClient) GetClientSet() kubernetes.Interface {
-	return fake.NewSimpleClientset()
+	return fake.NewClientset()
 }
 
 func (*mockK8sClient) GetEpClient() k8sclient.EpClient {

--- a/receiver/k8sclusterreceiver/factory_test.go
+++ b/receiver/k8sclusterreceiver/factory_test.go
@@ -90,10 +90,10 @@ func newTestReceiver(t *testing.T, cfg *Config) *kubernetesReceiver {
 	rcvr, ok := r.(*kubernetesReceiver)
 	require.True(t, ok)
 	rcvr.resourceWatcher.makeClient = func(_ k8sconfig.APIConfig) (kubernetes.Interface, error) {
-		return fake.NewSimpleClientset(), nil
+		return fake.NewClientset(), nil
 	}
 	rcvr.resourceWatcher.makeOpenShiftQuotaClient = func(_ k8sconfig.APIConfig) (quotaclientset.Interface, error) {
-		return fakeQuota.NewSimpleClientset(), nil
+		return fakeQuota.NewClientset(), nil
 	}
 	return rcvr
 }

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -53,7 +53,7 @@ func TestReceiver(t *testing.T) {
 	}()
 
 	client := newFakeClientWithAllResources()
-	osQuotaClient := fakeQuota.NewSimpleClientset()
+	osQuotaClient := fakeQuota.NewClientset()
 	sink := new(consumertest.MetricsSink)
 
 	r := setupReceiver(client, osQuotaClient, sink, nil, 10*time.Second, tt, nil, component.MustNewID("foo"))
@@ -102,7 +102,7 @@ func TestReceiverWithLeaderElection(t *testing.T) {
 	}
 
 	client := newFakeClientWithAllResources()
-	osQuotaClient := fakeQuota.NewSimpleClientset()
+	osQuotaClient := fakeQuota.NewClientset()
 	sink := new(consumertest.MetricsSink)
 	tt := componenttest.NewTelemetry()
 	kr := setupReceiver(client, osQuotaClient, sink, nil, 10*time.Second, tt, nil, component.MustNewID("k8s_leader_elector"))
@@ -138,7 +138,7 @@ func TestNamespacedReceiver(t *testing.T) {
 	}()
 
 	client := newFakeClientWithAllResources()
-	osQuotaClient := fakeQuota.NewSimpleClientset()
+	osQuotaClient := fakeQuota.NewClientset()
 	sink := new(consumertest.MetricsSink)
 
 	r := setupReceiver(client, osQuotaClient, sink, nil, 10*time.Second, tt, []string{"test"}, component.MustNewID("foo"))
@@ -188,7 +188,7 @@ func TestNamespacedReceiverWithMultipleNamespaces(t *testing.T) {
 	}()
 
 	client := newFakeClientWithAllResources()
-	osQuotaClient := fakeQuota.NewSimpleClientset()
+	osQuotaClient := fakeQuota.NewClientset()
 	sink := new(consumertest.MetricsSink)
 
 	observedNamespaces := []string{"test-0", "test-1"}
@@ -258,7 +258,7 @@ func TestReceiverWithManyResources(t *testing.T) {
 	}()
 
 	client := newFakeClientWithAllResources()
-	osQuotaClient := fakeQuota.NewSimpleClientset()
+	osQuotaClient := fakeQuota.NewClientset()
 	sink := new(consumertest.MetricsSink)
 
 	r := setupReceiver(client, osQuotaClient, sink, nil, 10*time.Second, tt, nil, component.MustNewID("foo"))

--- a/receiver/k8seventsreceiver/factory_test.go
+++ b/receiver/k8seventsreceiver/factory_test.go
@@ -48,7 +48,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	// Override for test.
 	rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {
-		return fake.NewSimpleClientset(), nil
+		return fake.NewClientset(), nil
 	}
 	r, err = createLogsReceiver(
 		t.Context(),

--- a/receiver/k8seventsreceiver/receiver_test.go
+++ b/receiver/k8seventsreceiver/receiver_test.go
@@ -27,7 +27,7 @@ import (
 func TestNewReceiver(t *testing.T) {
 	rCfg := createDefaultConfig().(*Config)
 	rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {
-		return fake.NewSimpleClientset(), nil
+		return fake.NewClientset(), nil
 	}
 	r, err := newReceiver(
 		receivertest.NewNopSettings(metadata.Type),
@@ -139,7 +139,7 @@ func TestReceiverWithLeaderElection(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.K8sLeaderElector = &leaderID
 	cfg.makeClient = func(_ k8sconfig.APIConfig) (k8s.Interface, error) {
-		return fake.NewSimpleClientset(), nil
+		return fake.NewClientset(), nil
 	}
 
 	sink := new(consumertest.LogsSink)


### PR DESCRIPTION
This PR replaces the usage of `NewSimpleClientset` (deprecated) of `k8s.io/client-go/kubernetes/fake` with `NewClientset`.

ref: https://github.com/kubernetes/client-go/blob/a296bd743c2dd954f56664f6ee7bc8558f7d8e32/kubernetes/fake/clientset_generated.go#L147-L150