### PR TITLE
Fix context initialization for metric/datapoint context

### DIFF
--- a/.chloggen/fix-context-initialization.yaml
+++ b/.chloggen/fix-context-initialization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix context initialization for metric/datapoint context
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44813]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -112,7 +112,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+				mCtx := ottlmetric.NewTransformContextPtr(resourceMetric, scopeMetrics, metric)
 				multiError = errors.Join(multiError, metricsCounter.update(ctx, pcommon.NewMap(), scopeAttrs, resourceAttrs, mCtx))
 				mCtx.Close()
 
@@ -123,7 +123,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -132,7 +132,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -141,7 +141,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -150,7 +150,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}
@@ -159,7 +159,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 					for i := 0; i < dps.Len(); i++ {
 						dp := dps.At(i)
 						dataPointsCounter.updateTimestamp(dp.Timestamp())
-						dCtx := ottldatapoint.NewTransformContextPtr(dp, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dp)
 						multiError = errors.Join(multiError, dataPointsCounter.update(ctx, dp.Attributes(), scopeAttrs, resourceAttrs, dCtx))
 						dCtx.Close()
 					}

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -88,7 +88,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		case "metric":
 			pmetricutil.MoveMetricsWithContextIf(md, matched,
 				func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) bool {
-					mtx := ottlmetric.NewTransformContextPtr(m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
+					mtx := ottlmetric.NewTransformContextPtr(rm, sm, m)
 					_, isMatch, err := route.metricStatement.Execute(ctx, mtx)
 					mtx.Close()
 					// If error during statement evaluation consider it as not a match.
@@ -102,7 +102,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		case "datapoint":
 			pmetricutil.MoveDataPointsWithContextIf(md, matched,
 				func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dp any) bool {
-					dptx := ottldatapoint.NewTransformContextPtr(dp, m, sm.Metrics(), sm.Scope(), rm.Resource(), sm, rm)
+					dptx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
 					_, isMatch, err := route.dataPointStatement.Execute(ctx, dptx)
 					dptx.Close()
 					// If error during statement evaluation consider it as not a match.

--- a/connector/signaltometricsconnector/connector.go
+++ b/connector/signaltometricsconnector/connector.go
@@ -116,15 +116,14 @@ func (sm *signalToMetrics) ConsumeMetrics(ctx context.Context, m pmetric.Metrics
 					aggregate := func(dp any, dpAttrs pcommon.Map) error {
 						// The transform context is created from original attributes so that the
 						// OTTL expressions are also applied on the original attributes.
-						tCtx := ottldatapoint.NewTransformContextPtr(dp, metric, metrics, scopeMetric.Scope(), resourceMetric.Resource(), scopeMetric, resourceMetric)
+						tCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetric, metric, dp)
+						defer tCtx.Close()
 						if md.Conditions != nil {
 							match, err := md.Conditions.Eval(ctx, tCtx)
 							if err != nil {
-								tCtx.Close()
 								return fmt.Errorf("failed to evaluate conditions: %w", err)
 							}
 							if !match {
-								tCtx.Close()
 								sm.logger.Debug("condition not matched, skipping", zap.String("name", md.Key.Name))
 								return nil
 							}

--- a/connector/sumconnector/connector.go
+++ b/connector/sumconnector/connector.go
@@ -100,7 +100,7 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+				mCtx := ottlmetric.NewTransformContextPtr(resourceMetric, scopeMetrics, metric)
 				multiError = errors.Join(multiError, metricsSummer.update(ctx, pcommon.NewMap(), mCtx))
 				mCtx.Close()
 
@@ -111,35 +111,35 @@ func (c *sum) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 				case pmetric.MetricTypeGauge:
 					dps := metric.Gauge().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeSum:
 					dps := metric.Sum().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeSummary:
 					dps := metric.Summary().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeHistogram:
 					dps := metric.Histogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					dps := metric.ExponentialHistogram().DataPoints()
 					for i := 0; i < dps.Len(); i++ {
-						dCtx := ottldatapoint.NewTransformContextPtr(dps.At(i), metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource(), scopeMetrics, resourceMetric)
+						dCtx := ottldatapoint.NewTransformContextPtr(resourceMetric, scopeMetrics, metric, dps.At(i))
 						multiError = errors.Join(multiError, dataPointsSummer.update(ctx, dps.At(i).Attributes(), dCtx))
 						dCtx.Close()
 					}

--- a/internal/filter/filtermetric/filtermetric_test.go
+++ b/internal/filter/filtermetric/filtermetric_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
@@ -82,7 +81,7 @@ func TestMatcherMatches(t *testing.T) {
 			assert.NotNil(t, matcher)
 			assert.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(test.metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), test.metric)
 			matches, err := matcher.Eval(t.Context(), tCtx)
 			tCtx.Close()
 			assert.NoError(t, err)
@@ -185,11 +184,7 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			metric.SetName("metricA")
 
-			resource := pcommon.NewResource()
-
-			scope := pcommon.NewInstrumentationScope()
-
-			tCtx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), scope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer tCtx.Close()
 
 			boolExpr, err := NewSkipExpr(tt.include, tt.exclude)

--- a/internal/filter/filterottl/functions_test.go
+++ b/internal/filter/filterottl/functions_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
@@ -125,7 +124,7 @@ func Test_HasAttrKeyOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeKeyOnDatapoint(tt.key)
 			assert.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
 			defer tCtx.Close()
 			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)
@@ -352,7 +351,7 @@ func Test_HasAttrOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeOnDatapoint(tt.key, tt.expectedVal)
 			assert.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input())
 			defer tCtx.Close()
 			result, err := exprFunc(t.Context(), tCtx)
 			assert.NoError(t, err)

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -81,12 +81,12 @@ func NewTransformContext(metric pmetric.Metric, metrics pmetric.MetricSlice, ins
 
 // NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
 // Caller must call TransformContext.Close on the returned TransformContext.
-func NewTransformContextPtr(metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics, options ...TransformContextOption) *TransformContext {
+func NewTransformContextPtr(resourceMetrics pmetric.ResourceMetrics, scopeMetrics pmetric.ScopeMetrics, metric pmetric.Metric, options ...TransformContextOption) *TransformContext {
 	tCtx := tcPool.Get().(*TransformContext)
 	tCtx.metric = metric
-	tCtx.metrics = metrics
-	tCtx.instrumentationScope = instrumentationScope
-	tCtx.resource = resource
+	tCtx.metrics = scopeMetrics.Metrics()
+	tCtx.instrumentationScope = scopeMetrics.Scope()
+	tCtx.resource = resourceMetrics.Resource()
 	tCtx.scopeMetrics = scopeMetrics
 	tCtx.resourceMetrics = resourceMetrics
 	for _, opt := range options {

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -195,7 +195,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			metric := createTelemetry()
 
-			ctx := NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			got, err := accessor.Get(t.Context(), ctx)
@@ -216,13 +216,13 @@ func Test_newPathGetSetter(t *testing.T) {
 }
 
 func Test_newPathGetSetter_higherContextPath(t *testing.T) {
-	resource := pcommon.NewResource()
-	resource.Attributes().PutStr("foo", "bar")
+	rm := pmetric.NewResourceMetrics()
+	rm.Resource().Attributes().PutStr("foo", "bar")
 
-	instrumentationScope := pcommon.NewInstrumentationScope()
+	instrumentationScope := rm.ScopeMetrics().AppendEmpty().Scope()
 	instrumentationScope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContextPtr(pmetric.NewMetric(), pmetric.NewMetricSlice(), instrumentationScope, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	ctx := NewTransformContextPtr(rm, rm.ScopeMetrics().At(0), pmetric.NewMetric())
 	defer ctx.Close()
 
 	tests := []struct {

--- a/pkg/ottl/performance_bench_test.go
+++ b/pkg/ottl/performance_bench_test.go
@@ -422,7 +422,7 @@ func newBenchmarkMetricContext(attributeCount int) *ottlmetric.TransformContext 
 		dp.Attributes().PutStr(fmt.Sprintf("label_%d", i), fmt.Sprintf("value_%d", i))
 	}
 
-	return ottlmetric.NewTransformContextPtr(metric, scopeMetrics.Metrics(), scope, resource, scopeMetrics, resourceMetrics)
+	return ottlmetric.NewTransformContextPtr(resourceMetrics, scopeMetrics, metric)
 }
 
 func buildLogStatements(count int) []string {

--- a/processor/attributesprocessor/attributes_metric.go
+++ b/processor/attributesprocessor/attributes_metric.go
@@ -35,16 +35,14 @@ func (a *metricAttributesProcessor) processMetrics(ctx context.Context, md pmetr
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rs := rms.At(i)
-		resource := rs.Resource()
 		ilms := rs.ScopeMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ils := ilms.At(j)
-			scope := ils.Scope()
 			metrics := ils.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
 				if a.skipExpr != nil {
-					tCtx := ottlmetric.NewTransformContextPtr(m, metrics, scope, resource, ils, rs)
+					tCtx := ottlmetric.NewTransformContextPtr(rs, ils, m)
 					skip, err := a.skipExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/processor"
@@ -128,9 +127,8 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 
 	var errors error
 	md.ResourceMetrics().RemoveIf(func(rm pmetric.ResourceMetrics) bool {
-		resource := rm.Resource()
 		if fmp.skipResourceExpr != nil {
-			skip, err := fmp.skipResourceExpr.Eval(ctx, ottlresource.NewTransformContext(resource, rm))
+			skip, err := fmp.skipResourceExpr.Eval(ctx, ottlresource.NewTransformContext(rm.Resource(), rm))
 			if err != nil {
 				errors = multierr.Append(errors, err)
 				return false
@@ -143,10 +141,9 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 			return rm.ScopeMetrics().Len() == 0
 		}
 		rm.ScopeMetrics().RemoveIf(func(smetrics pmetric.ScopeMetrics) bool {
-			scope := smetrics.Scope()
 			smetrics.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 				if fmp.skipMetricExpr != nil {
-					tCtx := ottlmetric.NewTransformContextPtr(metric, smetrics.Metrics(), scope, resource, smetrics, rm)
+					tCtx := ottlmetric.NewTransformContextPtr(rm, smetrics, metric)
 					skip, err := fmp.skipMetricExpr.Eval(ctx, tCtx)
 					tCtx.Close()
 					if err != nil {
@@ -161,19 +158,19 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 					//exhaustive:enforce
 					switch metric.Type() {
 					case pmetric.MetricTypeSum:
-						errors = multierr.Append(errors, fmp.handleNumberDataPoints(ctx, metric.Sum().DataPoints(), metric, smetrics.Metrics(), scope, resource))
+						errors = multierr.Append(errors, fmp.handleNumberDataPoints(ctx, rm, smetrics, metric, metric.Sum().DataPoints()))
 						return metric.Sum().DataPoints().Len() == 0
 					case pmetric.MetricTypeGauge:
-						errors = multierr.Append(errors, fmp.handleNumberDataPoints(ctx, metric.Gauge().DataPoints(), metric, smetrics.Metrics(), scope, resource))
+						errors = multierr.Append(errors, fmp.handleNumberDataPoints(ctx, rm, smetrics, metric, metric.Gauge().DataPoints()))
 						return metric.Gauge().DataPoints().Len() == 0
 					case pmetric.MetricTypeHistogram:
-						errors = multierr.Append(errors, fmp.handleHistogramDataPoints(ctx, metric.Histogram().DataPoints(), metric, smetrics.Metrics(), scope, resource))
+						errors = multierr.Append(errors, fmp.handleHistogramDataPoints(ctx, rm, smetrics, metric, metric.Histogram().DataPoints()))
 						return metric.Histogram().DataPoints().Len() == 0
 					case pmetric.MetricTypeExponentialHistogram:
-						errors = multierr.Append(errors, fmp.handleExponentialHistogramDataPoints(ctx, metric.ExponentialHistogram().DataPoints(), metric, smetrics.Metrics(), scope, resource))
+						errors = multierr.Append(errors, fmp.handleExponentialHistogramDataPoints(ctx, rm, smetrics, metric, metric.ExponentialHistogram().DataPoints()))
 						return metric.ExponentialHistogram().DataPoints().Len() == 0
 					case pmetric.MetricTypeSummary:
-						errors = multierr.Append(errors, fmp.handleSummaryDataPoints(ctx, metric.Summary().DataPoints(), metric, smetrics.Metrics(), scope, resource))
+						errors = multierr.Append(errors, fmp.handleSummaryDataPoints(ctx, rm, smetrics, metric, metric.Summary().DataPoints()))
 						return metric.Summary().DataPoints().Len() == 0
 					default:
 						return false
@@ -270,12 +267,12 @@ func newResExpr(mp *filterconfig.MetricMatchProperties) (expr.BoolExpr[ottlresou
 	return resExpr(attributeMatcher), nil
 }
 
-func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, dps pmetric.NumberDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.NumberDataPointSlice) error {
 	var errors error
-	dps.RemoveIf(func(datapoint pmetric.NumberDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	dps.RemoveIf(func(dp pmetric.NumberDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
-		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -285,12 +282,12 @@ func (fmp *filterMetricProcessor) handleNumberDataPoints(ctx context.Context, dp
 	return errors
 }
 
-func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context, dps pmetric.HistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.HistogramDataPointSlice) error {
 	var errors error
-	dps.RemoveIf(func(datapoint pmetric.HistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	dps.RemoveIf(func(dp pmetric.HistogramDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
-		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -300,12 +297,12 @@ func (fmp *filterMetricProcessor) handleHistogramDataPoints(ctx context.Context,
 	return errors
 }
 
-func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx context.Context, dps pmetric.ExponentialHistogramDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.ExponentialHistogramDataPointSlice) error {
 	var errors error
-	dps.RemoveIf(func(datapoint pmetric.ExponentialHistogramDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	dps.RemoveIf(func(dp pmetric.ExponentialHistogramDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
-		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false
@@ -315,12 +312,12 @@ func (fmp *filterMetricProcessor) handleExponentialHistogramDataPoints(ctx conte
 	return errors
 }
 
-func (fmp *filterMetricProcessor) handleSummaryDataPoints(ctx context.Context, dps pmetric.SummaryDataPointSlice, metric pmetric.Metric, metrics pmetric.MetricSlice, is pcommon.InstrumentationScope, resource pcommon.Resource) error {
+func (fmp *filterMetricProcessor) handleSummaryDataPoints(ctx context.Context, rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dps pmetric.SummaryDataPointSlice) error {
 	var errors error
-	dps.RemoveIf(func(datapoint pmetric.SummaryDataPoint) bool {
-		tCtx := ottldatapoint.NewTransformContextPtr(datapoint, metric, metrics, is, resource, pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	dps.RemoveIf(func(dp pmetric.SummaryDataPoint) bool {
+		tCtx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
+		defer tCtx.Close()
 		skip, err := fmp.skipDataPointExpr.Eval(ctx, tCtx)
-		tCtx.Close()
 		if err != nil {
 			errors = multierr.Append(errors, err)
 			return false

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
@@ -318,7 +317,7 @@ func Test_aggregateOnAttributes(t *testing.T) {
 			evaluate, err := AggregateOnAttributes(tt.t, tt.attributes)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
 			_, err = evaluate(nil, tCtx)
 			tCtx.Close()
 			assert.Equal(t, tt.wantErr, err)

--- a/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_agregate_on_attribute_value_metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
@@ -487,7 +486,7 @@ func Test_aggregateOnAttributeValues(t *testing.T) {
 			evaluate, err := AggregateOnAttributeValue(tt.t, tt.attribute, tt.values, tt.newValue)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.input)
 			_, err = evaluate(t.Context(), tCtx)
 			tCtx.Close()
 			require.NoError(t, err)

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -252,7 +252,7 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -435,7 +435,7 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -565,7 +565,7 @@ func TestUniform_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)
@@ -695,7 +695,7 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input().CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, err := convertExponentialHistToExplicitHist(tt.distribution, tt.arg)

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
@@ -116,7 +115,7 @@ func Test_convertGaugeToSum(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
@@ -84,7 +83,7 @@ func Test_convertSumToGauge(t *testing.T) {
 			metric := pmetric.NewMetric()
 			tt.input.CopyTo(metric)
 
-			ctx := ottlmetric.NewTransformContextPtr(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			ctx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric)
 			defer ctx.Close()
 
 			exprFunc, _ := convertSumToGauge()

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -115,20 +114,20 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetrics := pmetric.NewMetricSlice()
-			tt.input.CopyTo(actualMetrics.AppendEmpty())
+			smetrics := pmetric.NewScopeMetrics()
+			tt.input.CopyTo(smetrics.Metrics().AppendEmpty())
 
 			evaluate, err := convertSummaryCountValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), smetrics, smetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)
-			assert.Equal(t, expected, actualMetrics)
+			assert.Equal(t, expected, smetrics.Metrics())
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_quantile_val_to_gauge_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -124,13 +123,13 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetric := pmetric.NewMetricSlice()
-			tt.input.CopyTo(actualMetric.AppendEmpty())
+			sMetrics := pmetric.NewScopeMetrics()
+			tt.input.CopyTo(sMetrics.Metrics().AppendEmpty())
 
 			evaluate, err := convertSummaryQuantileValToGauge(tt.key, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetric, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0))
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
@@ -143,8 +142,7 @@ func Test_ConvertSummaryQuantileValToGauge(t *testing.T) {
 			expected.CopyTo(sl)
 
 			actualMetrics := pmetric.NewMetrics()
-			sl2 := actualMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
-			actualMetric.CopyTo(sl2)
+			sMetrics.MoveTo(actualMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty())
 
 			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics))
 		})

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -125,20 +124,20 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetrics := pmetric.NewMetricSlice()
-			tt.input.CopyTo(actualMetrics.AppendEmpty())
+			sMetrics := pmetric.NewScopeMetrics()
+			tt.input.CopyTo(sMetrics.Metrics().AppendEmpty())
 
 			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, sMetrics.Metrics().At(0), pmetric.NewNumberDataPoint())
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			require.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)
-			assert.Equal(t, expected, actualMetrics)
+			assert.Equal(t, expected, sMetrics.Metrics())
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -112,8 +111,8 @@ func Test_copyMetric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			ms := pmetric.NewMetricSlice()
-			input := ms.AppendEmpty()
+			ms := pmetric.NewScopeMetrics()
+			input := ms.Metrics().AppendEmpty()
 			input.SetName("test")
 			input.SetDescription("test")
 			input.SetUnit("test")
@@ -121,24 +120,18 @@ func Test_copyMetric(t *testing.T) {
 			d := input.Sum().DataPoints().AppendEmpty()
 			d.SetIntValue(1)
 
-			expected := pmetric.NewMetricSlice()
-			ms.CopyTo(expected)
-			tt.want(expected)
+			expected := pmetric.NewScopeMetrics()
+			ms.Metrics().CopyTo(expected.Metrics())
+			tt.want(expected.Metrics())
 
 			exprFunc, err := copyMetric(tt.name, tt.desc, tt.unit)
 			require.NoError(t, err)
-			tCtx := ottlmetric.NewTransformContextPtr(input, ms, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), ms, input)
 			defer tCtx.Close()
 			_, err = exprFunc(t.Context(), tCtx)
 			require.NoError(t, err)
 
-			x := pmetric.NewScopeMetrics()
-			y := pmetric.NewScopeMetrics()
-
-			expected.CopyTo(x.Metrics())
-			ms.CopyTo(y.Metrics())
-
-			require.NoError(t, pmetrictest.CompareScopeMetrics(x, y))
+			require.NoError(t, pmetrictest.CompareScopeMetrics(expected, ms))
 		})
 	}
 }

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -175,13 +174,13 @@ func Test_extractCountMetric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetrics := pmetric.NewMetricSlice()
-			tt.input.CopyTo(actualMetrics.AppendEmpty())
+			sMetrics := pmetric.NewScopeMetrics()
+			tt.input.CopyTo(sMetrics.Metrics().AppendEmpty())
 
 			evaluate, err := extractCountMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, tt.input)
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)
@@ -189,7 +188,7 @@ func Test_extractCountMetric(t *testing.T) {
 			if tt.want != nil {
 				expected := pmetric.NewMetricSlice()
 				tt.want(expected)
-				assert.Equal(t, expected, actualMetrics)
+				assert.Equal(t, expected, sMetrics.Metrics())
 			}
 		})
 	}

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
@@ -302,13 +302,13 @@ func Test_extractSumMetric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetrics := pmetric.NewMetricSlice()
-			tt.input.CopyTo(actualMetrics.AppendEmpty())
+			sMetrics := pmetric.NewScopeMetrics()
+			tt.input.CopyTo(sMetrics.Metrics().AppendEmpty())
 
 			evaluate, err := extractSumMetric(tt.monotonicity, tt.suffix)
 			require.NoError(t, err)
 
-			tCtx := ottlmetric.NewTransformContextPtr(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+			tCtx := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), sMetrics, tt.input)
 			defer tCtx.Close()
 			_, err = evaluate(t.Context(), tCtx)
 			assert.Equal(t, tt.wantErr, err)
@@ -316,7 +316,7 @@ func Test_extractSumMetric(t *testing.T) {
 			if tt.want != nil {
 				expected := pmetric.NewMetricSlice()
 				tt.want(expected)
-				assert.Equal(t, expected, actualMetrics)
+				assert.Equal(t, expected, sMetrics.Metrics())
 			}
 		})
 	}

--- a/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
+++ b/processor/transformprocessor/internal/metrics/func_merge_histogram_buckets_test.go
@@ -150,15 +150,7 @@ func TestMergeHistogramBuckets(t *testing.T) {
 			dp.BucketCounts().FromRaw(tt.inputCounts)
 			dp.ExplicitBounds().FromRaw(tt.inputBounds)
 
-			ctx := ottldatapoint.NewTransformContextPtr(
-				dp,
-				metric,
-				pmetric.NewMetricSlice(),
-				pcommon.NewInstrumentationScope(),
-				pcommon.NewResource(),
-				pmetric.NewScopeMetrics(),
-				pmetric.NewResourceMetrics(),
-			)
+			ctx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
 			defer ctx.Close()
 
 			result, err := exprFunc(t.Context(), ctx)
@@ -209,7 +201,7 @@ func TestMergeHistogramBucketsNonHistogramDataPoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, exprFunc)
 
-	ctx := ottldatapoint.NewTransformContextPtr(dp, metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics())
+	ctx := ottldatapoint.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), metric, dp)
 	defer ctx.Close()
 	result, err := exprFunc(t.Context(), ctx)
 

--- a/processor/transformprocessor/internal/metrics/func_scale_test.go
+++ b/processor/transformprocessor/internal/metrics/func_scale_test.go
@@ -161,14 +161,7 @@ func TestScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := ottlmetric.NewTransformContextPtr(
-				tt.valueFunc(),
-				pmetric.NewMetricSlice(),
-				pcommon.NewInstrumentationScope(),
-				pcommon.NewResource(),
-				pmetric.NewScopeMetrics(),
-				pmetric.NewResourceMetrics(),
-			)
+			target := ottlmetric.NewTransformContextPtr(pmetric.NewResourceMetrics(), pmetric.NewScopeMetrics(), tt.valueFunc())
 			defer target.Close()
 
 			expressionFunc, _ := Scale(tt.args)


### PR DESCRIPTION
This PR changes how the newly added `NewTransformContextPtr` accept arguments to simplify what is sent and avoid mistakes. This is not a breaking change because the `NewTransformContextPtr` are not yet released.