### PR TITLE
Use pointer when passing TransformContext around or calling into for Resource/Scope

### DIFF
--- a/.chloggen/use-pointer-for-context.yaml
+++ b/.chloggen/use-pointer-for-context.yaml
@@ -24,6 +24,7 @@ subtext: |
   - `ottlmetric.NewTransformContext` in favor of `ottlmetric.NewTransformContextPtr`;
   - `ottlspan.NewTransformContext` in favor of `ottlspan.NewTransformContextPtr`;
   - `ottlspanevent.NewTransformContext` in favor of `ottlspanevent.NewTransformContextPtr`;
+  - `filterprocessor.WithResourceFunctions` in favor of `filterprocessor.WithResourceFunctionsNew`
   - `filterprocessor.DefaultDataPointFunctions` in favor of `filtermprocessor.DefaultDataPointFunctionsNew`
   - `filterprocessor.WithDataPointFunctions` in favor of `filterprocessor.WithDataPointFunctionsNew`
   - `filterprocessor.DefaultLogFunctions` in favor of `filterprocessor.DefaultLogFunctionsNew`

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -74,7 +74,8 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		case "", "resource":
 			plogutil.MoveResourcesIf(ld, matched,
 				func(rl plog.ResourceLogs) bool {
-					rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
+					rtx := ottlresource.NewTransformContextPtr(rl.Resource(), rl)
+					defer rtx.Close()
 					_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -75,7 +75,8 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		case "", "resource":
 			pmetricutil.MoveResourcesIf(md, matched,
 				func(rs pmetric.ResourceMetrics) bool {
-					rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
+					rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+					defer rtx.Close()
 					_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -453,9 +453,9 @@ func TestMetricsConnectorDetailed(t *testing.T) {
 
 	// IsMap and IsString are just candidate for Standard Converter Function to prevent any unknown regressions for this component
 	isResourceString := `IsString(attributes["resourceName"]) == true`
-	require.Contains(t, standardFunctions[ottlresource.TransformContext](), "IsString")
+	require.Contains(t, standardFunctions[*ottlresource.TransformContext](), "IsString")
 	isAttributesMap := `IsMap(attributes) == true`
-	require.Contains(t, standardFunctions[ottlresource.TransformContext](), "IsMap")
+	require.Contains(t, standardFunctions[*ottlresource.TransformContext](), "IsMap")
 
 	isMetricE := `name == "metricE"`
 	isMetricF := `name == "metricF"`

--- a/connector/routingconnector/router.go
+++ b/connector/routingconnector/router.go
@@ -31,7 +31,7 @@ type consumerProvider[C any] func(...pipeline.ID) (C, error)
 // parameter C is expected to be one of: consumer.Traces, consumer.Metrics, or
 // consumer.Logs.
 type router[C any] struct {
-	resourceParser   ottl.Parser[ottlresource.TransformContext]
+	resourceParser   ottl.Parser[*ottlresource.TransformContext]
 	spanParser       ottl.Parser[*ottlspan.TransformContext]
 	metricParser     ottl.Parser[*ottlmetric.TransformContext]
 	dataPointParser  ottl.Parser[*ottldatapoint.TransformContext]
@@ -73,7 +73,7 @@ func newRouter[C any](
 type routingItem[C any] struct {
 	consumer           C
 	requestCondition   *requestCondition
-	resourceStatement  *ottl.Statement[ottlresource.TransformContext]
+	resourceStatement  *ottl.Statement[*ottlresource.TransformContext]
 	spanStatement      *ottl.Statement[*ottlspan.TransformContext]
 	metricStatement    *ottl.Statement[*ottlmetric.TransformContext]
 	dataPointStatement *ottl.Statement[*ottldatapoint.TransformContext]
@@ -101,7 +101,7 @@ func (r *router[C]) buildParsers(table []RoutingTableItem, settings component.Te
 	var errs error
 	if buildResource {
 		parser, err := ottlresource.NewParser(
-			standardFunctions[ottlresource.TransformContext](),
+			standardFunctions[*ottlresource.TransformContext](),
 			settings,
 		)
 		if err == nil {

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -74,7 +74,8 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 		case "", "resource":
 			ptraceutil.MoveResourcesIf(td, matched,
 				func(rs ptrace.ResourceSpans) bool {
-					rtx := ottlresource.NewTransformContext(rs.Resource(), rs)
+					rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
+					defer rtx.Close()
 					_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 					// If error during statement evaluation consider it as not a match.
 					if err != nil {

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -86,7 +86,7 @@ func NewLogSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[*ottllog.
 	return NewBoolExprForLog(statements, StandardLogFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
 }
 
-func NewResourceSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottlresource.TransformContext], error) {
+func NewResourceSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[*ottlresource.TransformContext], error) {
 	statements := make([]string, 0, 2)
 	if mc.Include != nil {
 		// OTTL treats resource attributes as attributes for the resource context.

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -143,15 +143,15 @@ func NewBoolExprForProfileWithOptions(conditions []string, functions map[string]
 	return &c, nil
 }
 
-// NewBoolExprForResource creates a BoolExpr[ottlresource.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForResource creates a BoolExpr[*ottlresource.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlresource.TransformContext], error) {
+func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[*ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlresource.TransformContext], error) {
 	return NewBoolExprForResourceWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForResourceWithOptions is like NewBoolExprForResource, but with additional options.
-func NewBoolExprForResourceWithOptions(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottlresource.TransformContext]) (*ottl.ConditionSequence[ottlresource.TransformContext], error) {
+func NewBoolExprForResourceWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlresource.TransformContext]) (*ottl.ConditionSequence[*ottlresource.TransformContext], error) {
 	parser, err := ottlresource.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
@@ -164,15 +164,15 @@ func NewBoolExprForResourceWithOptions(conditions []string, functions map[string
 	return &c, nil
 }
 
-// NewBoolExprForScope creates a BoolExpr[ottlscope.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
+// NewBoolExprForScope creates a BoolExpr[*ottlscope.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
-func NewBoolExprForScope(conditions []string, functions map[string]ottl.Factory[ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlscope.TransformContext], error) {
+func NewBoolExprForScope(conditions []string, functions map[string]ottl.Factory[*ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[*ottlscope.TransformContext], error) {
 	return NewBoolExprForScopeWithOptions(conditions, functions, errorMode, set, nil)
 }
 
 // NewBoolExprForScopeWithOptions is like NewBoolExprForScope, but with additional options.
-func NewBoolExprForScopeWithOptions(conditions []string, functions map[string]ottl.Factory[ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[ottlscope.TransformContext]) (*ottl.ConditionSequence[ottlscope.TransformContext], error) {
+func NewBoolExprForScopeWithOptions(conditions []string, functions map[string]ottl.Factory[*ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottl.Option[*ottlscope.TransformContext]) (*ottl.ConditionSequence[*ottlscope.TransformContext], error) {
 	parser, err := ottlscope.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err

--- a/internal/filter/filterottl/filter_test.go
+++ b/internal/filter/filterottl/filter_test.go
@@ -373,7 +373,7 @@ func Test_NewBoolExprForResource(t *testing.T) {
 			resBoolExpr, err := NewBoolExprForResource(tt.conditions, StandardResourceFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, resBoolExpr)
-			result, err := resBoolExpr.Eval(t.Context(), ottlresource.TransformContext{})
+			result, err := resBoolExpr.Eval(t.Context(), &ottlresource.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -386,7 +386,7 @@ func Test_NewBoolExprForResourceWithOptions(t *testing.T) {
 		StandardResourceFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottlresource.TransformContext]{ottlresource.EnablePathContextNames()},
+		[]ottl.Option[*ottlresource.TransformContext]{ottlresource.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }
@@ -434,7 +434,7 @@ func Test_NewBoolExprForScope(t *testing.T) {
 			resBoolExpr, err := NewBoolExprForScope(tt.conditions, StandardScopeFuncs(), ottl.PropagateError, componenttest.NewNopTelemetrySettings())
 			assert.NoError(t, err)
 			assert.NotNil(t, resBoolExpr)
-			result, err := resBoolExpr.Eval(t.Context(), ottlscope.TransformContext{})
+			result, err := resBoolExpr.Eval(t.Context(), &ottlscope.TransformContext{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedResult, result)
 		})
@@ -447,7 +447,7 @@ func Test_NewBoolExprForScopeWithOptions(t *testing.T) {
 		StandardScopeFuncs(),
 		ottl.PropagateError,
 		componenttest.NewNopTelemetrySettings(),
-		[]ottl.Option[ottlscope.TransformContext]{ottlscope.EnablePathContextNames()},
+		[]ottl.Option[*ottlscope.TransformContext]{ottlscope.EnablePathContextNames()},
 	)
 	assert.NoError(t, err)
 }

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -45,8 +45,8 @@ func StandardDataPointFuncs() map[string]ottl.Factory[*ottldatapoint.TransformCo
 	return ottlfuncs.StandardConverters[*ottldatapoint.TransformContext]()
 }
 
-func StandardScopeFuncs() map[string]ottl.Factory[ottlscope.TransformContext] {
-	return ottlfuncs.StandardConverters[ottlscope.TransformContext]()
+func StandardScopeFuncs() map[string]ottl.Factory[*ottlscope.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottlscope.TransformContext]()
 }
 
 func StandardLogFuncs() map[string]ottl.Factory[*ottllog.TransformContext] {
@@ -57,8 +57,8 @@ func StandardProfileFuncs() map[string]ottl.Factory[ottlprofile.TransformContext
 	return ottlfuncs.StandardConverters[ottlprofile.TransformContext]()
 }
 
-func StandardResourceFuncs() map[string]ottl.Factory[ottlresource.TransformContext] {
-	return ottlfuncs.StandardConverters[ottlresource.TransformContext]()
+func StandardResourceFuncs() map[string]ottl.Factory[*ottlresource.TransformContext] {
+	return ottlfuncs.StandardConverters[*ottlresource.TransformContext]()
 }
 
 type hasAttributeOnDatapointArguments struct {

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -5,6 +5,7 @@ package ottlresource // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"errors"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -16,6 +17,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxresource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
 
 // ContextName is the name of the context for resources.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
@@ -34,7 +41,7 @@ type TransformContext struct {
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("cache", logging.Map(tCtx.cache)))
 	return err
@@ -43,7 +50,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		resource:      resource,
@@ -56,13 +63,34 @@ func NewTransformContext(resource pcommon.Resource, schemaURLItem ctxcommon.Sche
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.resource = resource
+	tCtx.schemaURLItem = schemaURLItem
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.schemaURLItem = nil
+	tcPool.Put(tCtx)
+}
+
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetResourceSchemaURLItem returns the schema URL item for the resource from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 
@@ -71,24 +99,24 @@ func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem 
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{ContextName})(p)
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{ContextName})(p)
 	}
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -97,17 +125,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -117,10 +145,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new resource parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -134,16 +162,16 @@ func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("resource context does not provide Enum support")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxresource.Name,
 		ctxresource.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name: ctxresource.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name: ctxresource.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -37,14 +37,14 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -55,10 +55,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -71,7 +71,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refResource.Attributes(),
@@ -82,10 +82,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -98,10 +98,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -114,10 +114,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -130,10 +130,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -146,10 +146,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -162,10 +162,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -181,10 +181,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -200,10 +200,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -219,10 +219,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -238,10 +238,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -257,10 +257,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -278,10 +278,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes mpa[string]interface",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -299,16 +299,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -325,16 +325,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -352,7 +352,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -367,14 +367,14 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range slices.Clone(tests) {
 		testWithContext := tt
 		testWithContext.name = "with_path_context:" + tt.name
-		pathWithContext := *tt.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *tt.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = ContextName
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		tests = append(tests, testWithContext)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cacheGetter := func(tCtx TransformContext) pcommon.Map {
+			cacheGetter := func(tCtx *TransformContext) pcommon.Map {
 				return tCtx.cache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -382,7 +382,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			resource := createTelemetry()
 
-			tCtx := NewTransformContext(resource, pmetric.NewResourceMetrics())
+			tCtx := NewTransformContextPtr(resource, pmetric.NewResourceMetrics())
+			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -5,6 +5,7 @@ package ottlscope // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	"errors"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -17,6 +18,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxscope"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/logging"
 )
+
+var tcPool = sync.Pool{
+	New: func() any {
+		return &TransformContext{cache: pcommon.NewMap()}
+	},
+}
 
 // ContextName is the name of the context for instrumentation scopes.
 // Experimental: *NOTE* this constant is subject to change or removal in the future.
@@ -37,7 +44,7 @@ type TransformContext struct {
 }
 
 // MarshalLogObject serializes the TransformContext into a zapcore.ObjectEncoder for logging.
-func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
+func (tCtx *TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) error {
 	err := encoder.AddObject("resource", logging.Resource(tCtx.resource))
 	err = errors.Join(err, encoder.AddObject("scope", logging.InstrumentationScope(tCtx.instrumentationScope)))
 	err = errors.Join(err, encoder.AddObject("cache", logging.Map(tCtx.cache)))
@@ -47,7 +54,7 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 // TransformContextOption represents an option for configuring a TransformContext.
 type TransformContextOption func(*TransformContext)
 
-// NewTransformContext creates a new TransformContext with the provided parameters.
+// Deprecated: [v0.142.0] Use NewTransformContextPtr.
 func NewTransformContext(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) TransformContext {
 	tc := TransformContext{
 		instrumentationScope: instrumentationScope,
@@ -61,23 +68,46 @@ func NewTransformContext(instrumentationScope pcommon.InstrumentationScope, reso
 	return tc
 }
 
+// NewTransformContextPtr returns a new TransformContext with the provided parameters from a pool of contexts.
+// Caller must call TransformContext.Close on the returned TransformContext.
+func NewTransformContextPtr(instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, schemaURLItem ctxcommon.SchemaURLItem, options ...TransformContextOption) *TransformContext {
+	tCtx := tcPool.Get().(*TransformContext)
+	tCtx.instrumentationScope = instrumentationScope
+	tCtx.resource = resource
+	tCtx.schemaURLItem = schemaURLItem
+	for _, opt := range options {
+		opt(tCtx)
+	}
+	return tCtx
+}
+
+// Close the current TransformContext.
+// After this function returns this instance cannot be used.
+func (tCtx *TransformContext) Close() {
+	tCtx.instrumentationScope = pcommon.InstrumentationScope{}
+	tCtx.resource = pcommon.Resource{}
+	tCtx.cache.Clear()
+	tCtx.schemaURLItem = nil
+	tcPool.Put(tCtx)
+}
+
 // GetInstrumentationScope returns the instrumentation scope from the TransformContext.
-func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
+func (tCtx *TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {
 	return tCtx.instrumentationScope
 }
 
 // GetResource returns the resource from the TransformContext.
-func (tCtx TransformContext) GetResource() pcommon.Resource {
+func (tCtx *TransformContext) GetResource() pcommon.Resource {
 	return tCtx.resource
 }
 
 // GetScopeSchemaURLItem returns the schema URL item for the scope from the TransformContext.
-func (tCtx TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetScopeSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 
 // GetResourceSchemaURLItem returns the schema URL item for the resource from the TransformContext.
-func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
+func (tCtx *TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem {
 	return tCtx.schemaURLItem
 }
 
@@ -86,9 +116,9 @@ func (tCtx TransformContext) GetResourceSchemaURLItem() ctxcommon.SchemaURLItem 
 // otherwise an error is reported.
 //
 // Experimental: *NOTE* this option is subject to change or removal in the future.
-func EnablePathContextNames() ottl.Option[TransformContext] {
-	return func(p *ottl.Parser[TransformContext]) {
-		ottl.WithPathContextNames[TransformContext]([]string{
+func EnablePathContextNames() ottl.Option[*TransformContext] {
+	return func(p *ottl.Parser[*TransformContext]) {
+		ottl.WithPathContextNames[*TransformContext]([]string{
 			ContextName,
 			ctxresource.Name,
 		})(p)
@@ -96,17 +126,17 @@ func EnablePathContextNames() ottl.Option[TransformContext] {
 }
 
 // StatementSequenceOption represents an option for configuring a statement sequence.
-type StatementSequenceOption func(*ottl.StatementSequence[TransformContext])
+type StatementSequenceOption func(*ottl.StatementSequence[*TransformContext])
 
 // WithStatementSequenceErrorMode sets the error mode for a statement sequence.
 func WithStatementSequenceErrorMode(errorMode ottl.ErrorMode) StatementSequenceOption {
-	return func(s *ottl.StatementSequence[TransformContext]) {
-		ottl.WithStatementSequenceErrorMode[TransformContext](errorMode)(s)
+	return func(s *ottl.StatementSequence[*TransformContext]) {
+		ottl.WithStatementSequenceErrorMode[*TransformContext](errorMode)(s)
 	}
 }
 
 // NewStatementSequence creates a new statement sequence with the provided statements and options.
-func NewStatementSequence(statements []*ottl.Statement[TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[TransformContext] {
+func NewStatementSequence(statements []*ottl.Statement[*TransformContext], telemetrySettings component.TelemetrySettings, options ...StatementSequenceOption) ottl.StatementSequence[*TransformContext] {
 	s := ottl.NewStatementSequence(statements, telemetrySettings)
 	for _, op := range options {
 		op(&s)
@@ -115,17 +145,17 @@ func NewStatementSequence(statements []*ottl.Statement[TransformContext], teleme
 }
 
 // ConditionSequenceOption represents an option for configuring a condition sequence.
-type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+type ConditionSequenceOption func(*ottl.ConditionSequence[*TransformContext])
 
 // WithConditionSequenceErrorMode sets the error mode for a condition sequence.
 func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
-	return func(c *ottl.ConditionSequence[TransformContext]) {
-		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	return func(c *ottl.ConditionSequence[*TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[*TransformContext](errorMode)(c)
 	}
 }
 
 // NewConditionSequence creates a new condition sequence with the provided conditions and options.
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+func NewConditionSequence(conditions []*ottl.Condition[*TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[*TransformContext] {
 	c := ottl.NewConditionSequence(conditions, telemetrySettings)
 	for _, op := range options {
 		op(&c)
@@ -135,10 +165,10 @@ func NewConditionSequence(conditions []*ottl.Condition[TransformContext], teleme
 
 // NewParser creates a new scope parser with the provided functions and options.
 func NewParser(
-	functions map[string]ottl.Factory[TransformContext],
+	functions map[string]ottl.Factory[*TransformContext],
 	telemetrySettings component.TelemetrySettings,
-	options ...ottl.Option[TransformContext],
-) (ottl.Parser[TransformContext], error) {
+	options ...ottl.Option[*TransformContext],
+) (ottl.Parser[*TransformContext], error) {
 	return ctxcommon.NewParser(
 		functions,
 		telemetrySettings,
@@ -152,18 +182,18 @@ func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, errors.New("instrumentation scope context does not provide Enum support")
 }
 
-func getCache(tCtx TransformContext) pcommon.Map {
+func getCache(tCtx *TransformContext) pcommon.Map {
 	return tCtx.cache
 }
 
-func pathExpressionParser(cacheGetter ctxcache.Getter[TransformContext]) ottl.PathExpressionParser[TransformContext] {
+func pathExpressionParser(cacheGetter ctxcache.Getter[*TransformContext]) ottl.PathExpressionParser[*TransformContext] {
 	return ctxcommon.PathExpressionParser(
 		ctxscope.Name,
 		ctxscope.DocRef,
 		cacheGetter,
-		map[string]ottl.PathExpressionParser[TransformContext]{
-			ctxresource.Name:    ctxresource.PathGetSetter[TransformContext],
-			ctxscope.Name:       ctxscope.PathGetSetter[TransformContext],
-			ctxscope.LegacyName: ctxscope.PathGetSetter[TransformContext],
+		map[string]ottl.PathExpressionParser[*TransformContext]{
+			ctxresource.Name:    ctxresource.PathGetSetter[*TransformContext],
+			ctxscope.Name:       ctxscope.PathGetSetter[*TransformContext],
+			ctxscope.LegacyName: ctxscope.PathGetSetter[*TransformContext],
 		})
 }

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -38,7 +38,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	type testCase struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		orig     any
 		newVal   any
 		modified func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
@@ -47,7 +47,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	tests := []testCase{
 		{
 			name: "cache",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
@@ -58,10 +58,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "cache",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("temp"),
 					},
 				},
@@ -74,7 +74,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
 			},
 			orig:   refIS.Attributes(),
@@ -85,10 +85,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("str"),
 					},
 				},
@@ -101,10 +101,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bool"),
 					},
 				},
@@ -117,10 +117,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("int"),
 					},
 				},
@@ -133,10 +133,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("double"),
 					},
 				},
@@ -149,10 +149,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("bytes"),
 					},
 				},
@@ -165,10 +165,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_str"),
 					},
 				},
@@ -184,10 +184,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bool"),
 					},
 				},
@@ -203,10 +203,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_int"),
 					},
 				},
@@ -222,10 +222,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_float"),
 					},
 				},
@@ -241,10 +241,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("arr_bytes"),
 					},
 				},
@@ -260,10 +260,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("pMap"),
 					},
 				},
@@ -281,10 +281,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -302,16 +302,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("slice"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("map"),
 					},
 				},
@@ -328,16 +328,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("new"),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(2),
 					},
-					&pathtest.Key[TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						I: ottltest.Intp(0),
 					},
 				},
@@ -355,7 +355,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
@@ -366,7 +366,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "name",
 			},
 			orig:   refIS.Name(),
@@ -377,7 +377,7 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "version",
-			path: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{
 				N: "version",
 			},
 			orig:   refIS.Version(),
@@ -392,9 +392,9 @@ func Test_newPathGetSetter(t *testing.T) {
 	copyTestCase := func(test testCase, prefix, contextName string) testCase {
 		testWithContext := test
 		testWithContext.name = prefix + test.name
-		pathWithContext := *test.path.(*pathtest.Path[TransformContext])
+		pathWithContext := *test.path.(*pathtest.Path[*TransformContext])
 		pathWithContext.C = contextName
-		testWithContext.path = ottl.Path[TransformContext](&pathWithContext)
+		testWithContext.path = ottl.Path[*TransformContext](&pathWithContext)
 		return testWithContext
 	}
 
@@ -408,7 +408,7 @@ func Test_newPathGetSetter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testCache := pcommon.NewMap()
-			cacheGetter := func(_ TransformContext) pcommon.Map {
+			cacheGetter := func(*TransformContext) pcommon.Map {
 				return testCache
 			}
 			accessor, err := pathExpressionParser(cacheGetter)(tt.path)
@@ -416,7 +416,8 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			is, res := createTelemetry()
 
-			tCtx := NewTransformContext(is, res, pmetric.NewResourceMetrics())
+			tCtx := NewTransformContextPtr(is, res, pmetric.NewResourceMetrics())
+			defer tCtx.Close()
 			got, err := accessor.Get(t.Context(), tCtx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
@@ -442,19 +443,20 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 	scope := pcommon.NewInstrumentationScope()
 	scope.SetName("instrumentation_scope")
 
-	ctx := NewTransformContext(scope, resource, pmetric.NewResourceMetrics())
+	ctx := NewTransformContextPtr(scope, resource, pmetric.NewResourceMetrics())
+	defer ctx.Close()
 
 	tests := []struct {
 		name     string
-		path     ottl.Path[TransformContext]
+		path     ottl.Path[*TransformContext]
 		expected any
 	}{
 		{
 			name: "resource",
-			path: &pathtest.Path[TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "", N: "resource", NextPath: &pathtest.Path[*TransformContext]{
 				N: "attributes",
-				KeySlice: []ottl.Key[TransformContext]{
-					&pathtest.Key[TransformContext]{
+				KeySlice: []ottl.Key[*TransformContext]{
+					&pathtest.Key[*TransformContext]{
 						S: ottltest.Strp("foo"),
 					},
 				},
@@ -463,8 +465,8 @@ func Test_newPathGetSetter_higherContextPath(t *testing.T) {
 		},
 		{
 			name: "resource with context",
-			path: &pathtest.Path[TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[TransformContext]{
-				&pathtest.Key[TransformContext]{
+			path: &pathtest.Path[*TransformContext]{C: "resource", N: "attributes", KeySlice: []ottl.Key[*TransformContext]{
+				&pathtest.Key[*TransformContext]{
 					S: ottltest.Strp("foo"),
 				},
 			}},

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -46,7 +46,7 @@ type Config struct {
 
 	Profiles ProfileFilters `mapstructure:"profiles"`
 
-	resourceFunctions  map[string]ottl.Factory[ottlresource.TransformContext]
+	resourceFunctions  map[string]ottl.Factory[*ottlresource.TransformContext]
 	dataPointFunctions map[string]ottl.Factory[*ottldatapoint.TransformContext]
 	logFunctions       map[string]ottl.Factory[*ottllog.TransformContext]
 	metricFunctions    map[string]ottl.Factory[*ottlmetric.TransformContext]

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -156,8 +156,8 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -169,7 +169,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -192,7 +192,7 @@ func Test_FactoryWithFunctions_CreateTraces(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -329,8 +329,8 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -342,7 +342,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -365,7 +365,7 @@ func Test_FactoryWithFunctions_CreateLogs(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -452,8 +452,8 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -465,7 +465,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -476,7 +476,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -488,7 +488,7 @@ func Test_FactoryWithFunctions_CreateMetrics(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -625,8 +625,8 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -638,7 +638,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "TestResourceFunc"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions(DefaultResourceFunctions()),
+				WithResourceFunctionsNew(DefaultResourceFunctions()),
 			},
 		},
 		{
@@ -649,7 +649,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 				},
 			},
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{
@@ -661,7 +661,7 @@ func Test_FactoryWithFunctions_CreateProfiles(t *testing.T) {
 			},
 			wantErrorWith: `undefined function "IsBool"`,
 			factoryOptions: []FactoryOption{
-				WithResourceFunctions([]ottl.Factory[ottlresource.TransformContext]{createTestFuncFactory[ottlresource.TransformContext]("TestResourceFunc")}),
+				WithResourceFunctionsNew([]ottl.Factory[*ottlresource.TransformContext]{createTestFuncFactory[*ottlresource.TransformContext]("TestResourceFunc")}),
 			},
 		},
 		{

--- a/processor/filterprocessor/functions.go
+++ b/processor/filterprocessor/functions.go
@@ -19,7 +19,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func DefaultResourceFunctions() []ottl.Factory[ottlresource.TransformContext] {
+func DefaultResourceFunctions() []ottl.Factory[*ottlresource.TransformContext] {
 	return slices.Collect(maps.Values(defaultResourceFunctionsMap()))
 }
 
@@ -80,7 +80,7 @@ func DefaultProfileFunctions() []ottl.Factory[ottlprofile.TransformContext] {
 	return slices.Collect(maps.Values(defaultProfileFunctionsMap()))
 }
 
-func defaultResourceFunctionsMap() map[string]ottl.Factory[ottlresource.TransformContext] {
+func defaultResourceFunctionsMap() map[string]ottl.Factory[*ottlresource.TransformContext] {
 	return filterottl.StandardResourceFuncs()
 }
 

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -1076,7 +1076,8 @@ func Test_ResourceSkipExpr_With_Bridge(t *testing.T) {
 			resource := pcommon.NewResource()
 			resource.Attributes().PutStr("test", "test")
 
-			tCtx := ottlresource.NewTransformContext(resource, pmetric.NewResourceMetrics())
+			tCtx := ottlresource.NewTransformContextPtr(resource, pmetric.NewResourceMetrics())
+			defer tCtx.Close()
 
 			includeMatchProperties, err := filterconfig.CreateMetricMatchPropertiesFromDefault(tt.condition.Include)
 			assert.NoError(t, err)

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -10,10 +10,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-func ResourceFunctions() map[string]ottl.Factory[ottlresource.TransformContext] {
-	return ottlfuncs.StandardFuncs[ottlresource.TransformContext]()
+func ResourceFunctions() map[string]ottl.Factory[*ottlresource.TransformContext] {
+	return ottlfuncs.StandardFuncs[*ottlresource.TransformContext]()
 }
 
-func ScopeFunctions() map[string]ottl.Factory[ottlscope.TransformContext] {
-	return ottlfuncs.StandardFuncs[ottlscope.TransformContext]()
+func ScopeFunctions() map[string]ottl.Factory[*ottlscope.TransformContext] {
+	return ottlfuncs.StandardFuncs[*ottlscope.TransformContext]()
 }

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -22,8 +22,8 @@ import (
 var _ baseContext = &resourceStatements{}
 
 type resourceStatements struct {
-	ottl.StatementSequence[ottlresource.TransformContext]
-	expr.BoolExpr[ottlresource.TransformContext]
+	ottl.StatementSequence[*ottlresource.TransformContext]
+	expr.BoolExpr[*ottlresource.TransformContext]
 }
 
 func (resourceStatements) Context() ContextID {
@@ -32,14 +32,16 @@ func (resourceStatements) Context() ContextID {
 
 func (r resourceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	for _, rspans := range td.ResourceSpans().All() {
-		tCtx := ottlresource.NewTransformContext(rspans.Resource(), rspans)
+		tCtx := ottlresource.NewTransformContextPtr(rspans.Resource(), rspans)
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
+			tCtx.Close()
 			return err
 		}
 		if condition {
-			err := r.Execute(ctx, tCtx)
+			err = r.Execute(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 		}
@@ -49,51 +51,60 @@ func (r resourceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces)
 
 func (r resourceStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	for _, rmetrics := range md.ResourceMetrics().All() {
-		tCtx := ottlresource.NewTransformContext(rmetrics.Resource(), rmetrics)
+		tCtx := ottlresource.NewTransformContextPtr(rmetrics.Resource(), rmetrics)
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
+			tCtx.Close()
 			return err
 		}
 		if condition {
-			err := r.Execute(ctx, tCtx)
+			err = r.Execute(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
 
 func (r resourceStatements) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	for _, rlogs := range ld.ResourceLogs().All() {
-		tCtx := ottlresource.NewTransformContext(rlogs.Resource(), rlogs)
+		tCtx := ottlresource.NewTransformContextPtr(rlogs.Resource(), rlogs)
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
+			tCtx.Close()
 			return err
 		}
 		if condition {
-			err := r.Execute(ctx, tCtx)
+			err = r.Execute(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
 
 func (r resourceStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error {
 	for _, rprofiles := range ld.ResourceProfiles().All() {
-		tCtx := ottlresource.NewTransformContext(rprofiles.Resource(), rprofiles)
+		tCtx := ottlresource.NewTransformContextPtr(rprofiles.Resource(), rprofiles)
 		condition, err := r.Eval(ctx, tCtx)
 		if err != nil {
+			tCtx.Close()
 			return err
 		}
 		if condition {
-			err := r.Execute(ctx, tCtx)
+			err = r.Execute(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
@@ -101,8 +112,8 @@ func (r resourceStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Pro
 var _ baseContext = &scopeStatements{}
 
 type scopeStatements struct {
-	ottl.StatementSequence[ottlscope.TransformContext]
-	expr.BoolExpr[ottlscope.TransformContext]
+	ottl.StatementSequence[*ottlscope.TransformContext]
+	expr.BoolExpr[*ottlscope.TransformContext]
 }
 
 func (scopeStatements) Context() ContextID {
@@ -112,17 +123,20 @@ func (scopeStatements) Context() ContextID {
 func (s scopeStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	for _, rspans := range td.ResourceSpans().All() {
 		for _, sspans := range rspans.ScopeSpans().All() {
-			tCtx := ottlscope.NewTransformContext(sspans.Scope(), rspans.Resource(), sspans)
+			tCtx := ottlscope.NewTransformContextPtr(sspans.Scope(), rspans.Resource(), sspans)
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 			if condition {
-				err := s.Execute(ctx, tCtx)
+				err = s.Execute(ctx, tCtx)
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 			}
+			tCtx.Close()
 		}
 	}
 	return nil
@@ -131,17 +145,20 @@ func (s scopeStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 func (s scopeStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	for _, rmetrics := range md.ResourceMetrics().All() {
 		for _, smetrics := range rmetrics.ScopeMetrics().All() {
-			tCtx := ottlscope.NewTransformContext(smetrics.Scope(), rmetrics.Resource(), smetrics)
+			tCtx := ottlscope.NewTransformContextPtr(smetrics.Scope(), rmetrics.Resource(), smetrics)
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 			if condition {
-				err := s.Execute(ctx, tCtx)
+				err = s.Execute(ctx, tCtx)
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 			}
+			tCtx.Close()
 		}
 	}
 	return nil
@@ -150,17 +167,20 @@ func (s scopeStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics)
 func (s scopeStatements) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	for _, rlogs := range ld.ResourceLogs().All() {
 		for _, slogs := range rlogs.ScopeLogs().All() {
-			tCtx := ottlscope.NewTransformContext(slogs.Scope(), rlogs.Resource(), slogs)
+			tCtx := ottlscope.NewTransformContextPtr(slogs.Scope(), rlogs.Resource(), slogs)
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 			if condition {
 				err := s.Execute(ctx, tCtx)
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 			}
+			tCtx.Close()
 		}
 	}
 	return nil
@@ -169,17 +189,20 @@ func (s scopeStatements) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 func (s scopeStatements) ConsumeProfiles(ctx context.Context, ld pprofile.Profiles) error {
 	for _, rprofiles := range ld.ResourceProfiles().All() {
 		for _, sprofiles := range rprofiles.ScopeProfiles().All() {
-			tCtx := ottlscope.NewTransformContext(sprofiles.Scope(), rprofiles.Resource(), sprofiles)
+			tCtx := ottlscope.NewTransformContextPtr(sprofiles.Scope(), rprofiles.Resource(), sprofiles)
 			condition, err := s.Eval(ctx, tCtx)
 			if err != nil {
+				tCtx.Close()
 				return err
 			}
 			if condition {
-				err := s.Execute(ctx, tCtx)
+				err = s.Execute(ctx, tCtx)
 				if err != nil {
+					tCtx.Close()
 					return err
 				}
 			}
+			tCtx.Close()
 		}
 	}
 	return nil
@@ -203,12 +226,12 @@ func withCommonContextParsers[R any]() ottl.ParserCollectionOption[R] {
 			return err
 		}
 
-		err = ottl.WithParserCollectionContext(ottlresource.ContextName, &rp, ottl.WithStatementConverter[ottlresource.TransformContext, R](parseResourceContextStatements))(pc)
+		err = ottl.WithParserCollectionContext(ottlresource.ContextName, &rp, ottl.WithStatementConverter[*ottlresource.TransformContext, R](parseResourceContextStatements))(pc)
 		if err != nil {
 			return err
 		}
 
-		err = ottl.WithParserCollectionContext(ottlscope.ContextName, &sp, ottl.WithStatementConverter[ottlscope.TransformContext, R](parseScopeContextStatements))(pc)
+		err = ottl.WithParserCollectionContext(ottlscope.ContextName, &sp, ottl.WithStatementConverter[*ottlscope.TransformContext, R](parseScopeContextStatements))(pc)
 		if err != nil {
 			return err
 		}
@@ -220,7 +243,7 @@ func withCommonContextParsers[R any]() ottl.ParserCollectionOption[R] {
 func parseResourceContextStatements[R any](
 	pc *ottl.ParserCollection[R],
 	statements ottl.StatementsGetter,
-	parsedStatements []*ottl.Statement[ottlresource.TransformContext],
+	parsedStatements []*ottl.Statement[*ottlresource.TransformContext],
 ) (R, error) {
 	contextStatements, err := toContextStatements(statements)
 	if err != nil {
@@ -230,7 +253,7 @@ func parseResourceContextStatements[R any](
 	if contextStatements.ErrorMode != "" {
 		errorMode = contextStatements.ErrorMode
 	}
-	var parserOptions []ottl.Option[ottlresource.TransformContext]
+	var parserOptions []ottl.Option[*ottlresource.TransformContext]
 	if contextStatements.Context == "" {
 		parserOptions = append(parserOptions, ottlresource.EnablePathContextNames())
 	}
@@ -246,7 +269,7 @@ func parseResourceContextStatements[R any](
 func parseScopeContextStatements[R any](
 	pc *ottl.ParserCollection[R],
 	statements ottl.StatementsGetter,
-	parsedStatements []*ottl.Statement[ottlscope.TransformContext],
+	parsedStatements []*ottl.Statement[*ottlscope.TransformContext],
 ) (R, error) {
 	contextStatements, err := toContextStatements(statements)
 	if err != nil {
@@ -256,7 +279,7 @@ func parseScopeContextStatements[R any](
 	if contextStatements.ErrorMode != "" {
 		errorMode = contextStatements.ErrorMode
 	}
-	var parserOptions []ottl.Option[ottlscope.TransformContext]
+	var parserOptions []ottl.Option[*ottlscope.TransformContext]
 	if contextStatements.Context == "" {
 		parserOptions = append(parserOptions, ottlscope.EnablePathContextNames())
 	}


### PR DESCRIPTION
No changelog since continuation of another effort.