### PR TITLE
[chore] update chloggen config

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -136,6 +136,7 @@ components:
     - internal/healthcheck
     - internal/k8sconfig
     - internal/k8sinventory
+    - internal/k8sleaderelectortest
     - internal/kafka
     - internal/kubelet
     - internal/metadataproviders


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add missing `internal/k8sleaderelectortest` to the chloggen config running `make generate-chloggen-components` command.

https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/20094969552/job/57651005585?pr=44863

This was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44761
