### PR TITLE
exporter/elasticsearch: fix host.hostname and host.name mapping

### DIFF
--- a/.chloggen/esexporter-fix-hostname.yaml
+++ b/.chloggen/esexporter-fix-hostname.yaml
@@ -16,8 +16,7 @@ issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issue
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  - The exporter now correctly maps `host.name` and `host.hostname` attributes to their respective ECS fields.
-  - This ensures backwards compatibility with Elasticsearch ECS handling.
+  - The exporter now supports to map an otel field to an ecs field only if the ecs field is not already present. This is applied to `host.hostname` mapping. 
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/esexporter-fix-hostname.yaml
+++ b/.chloggen/esexporter-fix-hostname.yaml
@@ -10,7 +10,7 @@ component: exporter/elasticsearch
 note: "Fix hostname mapping in Elasticsearch exporter"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44874]
+issues: [44874]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/esexporter-fix-hostname.yaml
+++ b/.chloggen/esexporter-fix-hostname.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix hostname mapping in Elasticsearch exporter"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44874]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - The exporter now correctly maps `host.name` and `host.hostname` attributes to their respective ECS fields.
+  - This ensures backwards compatibility with Elasticsearch ECS handling.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -430,47 +430,46 @@ The value of the last-mapped attribute will take precedence.
 
 ### Resource attribute mapping
 
-| Semantic Convention Name    | ECS Name                    | Preserve |
-|-----------------------------|-----------------------------|----------|
-| client.address              | client.ip                   | false    |
-| cloud.platform              | cloud.service.name          | false    |
-| container.image.tags        | container.image.tag         | false    |
-| deployment.environment      | service.environment         | false    |
-| deployment.environment.name | service.environment         | false    |
-| faas.instance               | faas.id                     | false    |
-| faas.trigger                | faas.trigger.type           | false    |
-| host.arch                   | host.architecture           | false    |
-| host.name                   | host.name                   | true     |
-| host.hostname               | host.hostname               | true     |
-| k8s.cluster.name            | orchestrator.cluster.name   | false    |
-| k8s.container.name          | kubernetes.container.name   | false    |
-| k8s.cronjob.name            | kubernetes.cronjob.name     | false    |
-| k8s.daemonset.name          | kubernetes.daemonset.name   | false    |
-| k8s.deployment.name         | kubernetes.deployment.name  | false    |
-| k8s.job.name                | kubernetes.job.name         | false    |
-| k8s.namespace.name          | kubernetes.namespace        | false    |
-| k8s.node.name               | kubernetes.node.name        | false    |
-| k8s.pod.name                | kubernetes.pod.name         | false    |
-| k8s.pod.uid                 | kubernetes.pod.uid          | false    |
-| k8s.replicaset.name         | kubernetes.replicaset.name  | false    |
-| k8s.statefulset.name        | kubernetes.statefulset.name | false    |
-| os.description              | host.os.full                | false    |
-| os.name                     | host.os.name                | false    |
-| os.type                     | host.os.platform            | false    |
-| os.version                  | host.os.version             | false    |
-| process.command_line        | process.args                 | false    |
-| process.executable.name     | process.title                | false    |
-| process.executable.path     | process.executable          | false    |
-| process.parent.pid          | process.parent.pid          | false    |
-| process.runtime.name        | service.runtime.name        | false    |
-| process.runtime.version     | service.runtime.version     | false    |
-| service.instance.id         | service.node.name           | false    |
-| source.address              | source.ip                   | false    |
-| telemetry.distro.name       | ""                          | false    |
-| telemetry.distro.version    | ""                          | false    |
-| telemetry.sdk.language      | ""                          | false    |
-| telemetry.sdk.name          | ""                          | false    |
-| telemetry.sdk.version       | ""                          | false    |
+| Semantic Convention Name    | ECS Name                    | Preserve | Skip if exists |
+|-----------------------------|-----------------------------|----------|----------------|
+| client.address              | client.ip                   | false    | false          |
+| cloud.platform              | cloud.service.name          | false    | false          |
+| container.image.tags        | container.image.tag         | false    | false          |
+| deployment.environment      | service.environment         | false    | false          |
+| deployment.environment.name | service.environment         | false    | false          |
+| faas.instance               | faas.id                     | false    | false          |
+| faas.trigger                | faas.trigger.type           | false    | false          |
+| host.arch                   | host.architecture           | false    | false          |
+| host.hostname               | host.hostname               | true     | true           |
+| k8s.cluster.name            | orchestrator.cluster.name   | false    | false          |
+| k8s.container.name          | kubernetes.container.name   | false    | false          |
+| k8s.cronjob.name            | kubernetes.cronjob.name     | false    | false          |
+| k8s.daemonset.name          | kubernetes.daemonset.name   | false    | false          |
+| k8s.deployment.name         | kubernetes.deployment.name  | false    | false          |
+| k8s.job.name                | kubernetes.job.name         | false    | false          |
+| k8s.namespace.name          | kubernetes.namespace        | false    | false          |
+| k8s.node.name               | kubernetes.node.name        | false    | false          |
+| k8s.pod.name                | kubernetes.pod.name         | false    | false          |
+| k8s.pod.uid                 | kubernetes.pod.uid          | false    | false          |
+| k8s.replicaset.name         | kubernetes.replicaset.name  | false    | false          |
+| k8s.statefulset.name        | kubernetes.statefulset.name | false    | false          |
+| os.description              | host.os.full                | false    | false          |
+| os.name                     | host.os.name                | false    | false          |
+| os.type                     | host.os.platform            | false    | false          |
+| os.version                  | host.os.version             | false    | false          |
+| process.command_line        | process.args                | false    | false          |
+| process.executable.name     | process.title               | false    | false          |
+| process.executable.path     | process.executable          | false    | false          |
+| process.parent.pid          | process.parent.pid          | false    | false          |
+| process.runtime.name        | service.runtime.name        | false    | false          |
+| process.runtime.version     | service.runtime.version     | false    | false          |
+| service.instance.id         | service.node.name           | false    | false          |
+| source.address              | source.ip                   | false    | false          |
+| telemetry.distro.name       | ""                          | false    | false          |
+| telemetry.distro.version    | ""                          | false    | false          |
+| telemetry.sdk.language      | ""                          | false    | false          |
+| telemetry.sdk.name          | ""                          | false    | false          |
+| telemetry.sdk.version       | ""                          | false    | false          |
 
 ### Log record attribute mapping
 
@@ -521,8 +520,7 @@ Takes the value of `telemetry.distro.version` or `telemetry.sdk.version`. If bot
 
 #### `host.name` and `host.hostname`
 
-Maintains the SemConv Value `host.name` as ECS value `host.name`.
-Keeps `host.hostname` in ECS, despite not being a valid SemConv Value for backwards compatibility. 
+Maintains the SemConv Value `host.name` as ECS Value `host.name` and maps it to ECS Value `host.hostname`, if this does not already exist.
 
 #### `host.os.type`
 

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -440,7 +440,8 @@ The value of the last-mapped attribute will take precedence.
 | faas.instance               | faas.id                     | false    |
 | faas.trigger                | faas.trigger.type           | false    |
 | host.arch                   | host.architecture           | false    |
-| host.name                   | host.hostname               | true     |
+| host.name                   | host.name                   | true     |
+| host.hostname               | host.hostname               | true     |
 | k8s.cluster.name            | orchestrator.cluster.name   | false    |
 | k8s.container.name          | kubernetes.container.name   | false    |
 | k8s.cronjob.name            | kubernetes.cronjob.name     | false    |
@@ -517,6 +518,11 @@ These values are all valid:
 #### `agent.version`
 
 Takes the value of `telemetry.distro.version` or `telemetry.sdk.version`. If both telemetry.distro.version and telemetry.sdk.version are present, telemetry.distro.version takes precedence.
+
+#### `host.name` and `host.hostname`
+
+Maintains the SemConv Value `host.name` as ECS value `host.name`.
+Keeps `host.hostname` in ECS, despite not being a valid SemConv Value for backwards compatibility. 
 
 #### `host.os.type`
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -42,7 +42,6 @@ var resourceAttrsConversionMap = map[string]string{
 	string(semconv.TelemetryDistroVersionKey):    "",
 	string(semconv.CloudPlatformKey):             "cloud.service.name",
 	string(semconv.ContainerImageTagsKey):        "container.image.tag",
-	string(semconv.HostNameKey):                  "host.hostname",
 	string(semconv.HostArchKey):                  "host.architecture",
 	string(semconv.ProcessParentPIDKey):          "process.parent.pid",
 	string(semconv.ProcessExecutableNameKey):     "process.title",
@@ -75,9 +74,7 @@ var resourceAttrsConversionMap = map[string]string{
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.
 // This can happen when an attribute needs to be mapped to an ECS equivalent but
 // at the same time be preserved to its original form.
-var resourceAttrsToPreserve = map[string]bool{
-	string(semconv.HostNameKey): true,
-}
+var resourceAttrsToPreserve = map[string]bool{}
 
 var ErrInvalidTypeForBodyMapMode = errors.New("invalid log record body type for 'bodymap' mapping mode")
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -40,22 +40,22 @@ const (
 	expectedLogBodyWithEmptyTimestamp = `{"@timestamp":"1970-01-01T00:00:00.000000000Z","Attributes.log-attr1":"value1","Body":"log-body","Resource.key1":"value1","Scope.name":"","Scope.version":"","SeverityNumber":0,"TraceFlags":0}`
 )
 
-const expectedMetricsEncoded = `{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"idle","system":{"cpu":{"time":440.23}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"interrupt","system":{"cpu":{"time":0.0}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"nice","system":{"cpu":{"time":0.14}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"softirq","system":{"cpu":{"time":0.77}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"steal","system":{"cpu":{"time":0.0}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"system","system":{"cpu":{"time":24.8}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"user","system":{"cpu":{"time":64.78}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"wait","system":{"cpu":{"time":1.65}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"idle","system":{"cpu":{"time":475.69}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"interrupt","system":{"cpu":{"time":0.0}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"nice","system":{"cpu":{"time":0.1}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"softirq","system":{"cpu":{"time":0.57}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"steal","system":{"cpu":{"time":0.0}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"system","system":{"cpu":{"time":15.88}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"user","system":{"cpu":{"time":50.09}}}
-{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"wait","system":{"cpu":{"time":0.95}}}`
+const expectedMetricsEncoded = `{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"idle","system":{"cpu":{"time":440.23}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"interrupt","system":{"cpu":{"time":0.0}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"nice","system":{"cpu":{"time":0.14}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"softirq","system":{"cpu":{"time":0.77}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"steal","system":{"cpu":{"time":0.0}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"system","system":{"cpu":{"time":24.8}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"user","system":{"cpu":{"time":64.78}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"wait","system":{"cpu":{"time":1.65}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"idle","system":{"cpu":{"time":475.69}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"interrupt","system":{"cpu":{"time":0.0}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"nice","system":{"cpu":{"time":0.1}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"softirq","system":{"cpu":{"time":0.57}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"steal","system":{"cpu":{"time":0.0}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"system","system":{"cpu":{"time":15.88}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"user","system":{"cpu":{"time":50.09}}}
+{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-hostname","name":"my-host","os":{"platform":"linux"}},"state":"wait","system":{"cpu":{"time":0.95}}}`
 
 func TestEncodeSpan(t *testing.T) {
 	t.Run("non data stream", func(t *testing.T) {
@@ -420,7 +420,7 @@ func TestEncodeLogECSModeDuplication(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	want := `{"@timestamp":"2024-03-12T20:00:41.123456789Z","agent":{"name":"otlp"},"container":{"image":{"tag":["v3.4.0"]}},"event":{"action":"user-password-change"},"host":{"hostname":"localhost","name":"localhost","os":{"full":"Mac OS Mojave","name":"Mac OS X","platform":"darwin","type":"macos","version":"10.14.1"}},"service":{"name":"foo.bar","version":"1.1.0"}}`
+	want := `{"@timestamp":"2024-03-12T20:00:41.123456789Z","agent":{"name":"otlp"},"container":{"image":{"tag":["v3.4.0"]}},"event":{"action":"user-password-change"},"host":{"name":"localhost","os":{"full":"Mac OS Mojave","name":"Mac OS X","platform":"darwin","type":"macos","version":"10.14.1"}},"service":{"name":"foo.bar","version":"1.1.0"}}`
 
 	resourceContainerImageTags := resource.Attributes().PutEmptySlice(string(semconv.ContainerImageTagsKey))
 	err = resourceContainerImageTags.FromRaw([]any{"v3.4.0"})
@@ -679,6 +679,7 @@ func TestEncodeLogECSMode(t *testing.T) {
 		string(semconv.ContainerImageNameKey):        "my-app",
 		string(semconv22.ContainerRuntimeKey):        "docker",
 		string(semconv.HostNameKey):                  "i-103de39e0a.gke.us-west-1b.cloud.google.com",
+		"host.hostname":                              "hostname.example.com",
 		string(semconv.HostIDKey):                    "i-103de39e0a",
 		string(semconv.HostTypeKey):                  "t2.medium",
 		string(semconv.HostArchKey):                  "x86_64",
@@ -763,7 +764,7 @@ func TestEncodeLogECSMode(t *testing.T) {
 		  "runtime": "docker"
 		},
 		"host": {
-		  "hostname": "i-103de39e0a.gke.us-west-1b.cloud.google.com",
+		  "hostname": "hostname.example.com",
 		  "name": "i-103de39e0a.gke.us-west-1b.cloud.google.com",
 		  "id": "i-103de39e0a",
 		  "type": "t2.medium",

--- a/exporter/elasticsearchexporter/testdata/metrics-cpu.json
+++ b/exporter/elasticsearchexporter/testdata/metrics-cpu.json
@@ -10,6 +10,12 @@
             }
           },
           {
+            "key": "host.hostname",
+            "value": {
+              "stringValue": "my-hostname"
+            }
+          },
+          {
             "key": "os.type",
             "value": {
               "stringValue": "linux"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Instead of always mapping `host.name` to `host.hostname` in ECS, preserve `host.hostname` original value if already set. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44874

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested with unit tests 
