### PR TITLE
Add a virtual_node_enabled config argument

### DIFF
--- a/.chloggen/servicegraph-virtual-node-enabled-config.yaml
+++ b/.chloggen/servicegraph-virtual-node-enabled-config.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: connector/servicegraph
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `virtual_node_enabled` config option to explicitly enable or disable virtual node creation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 41086 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `virtual_node_enabled` config option allows users to explicitly enable or disable
+  virtual node creation without relying on the feature gate. When set to true, virtual
+  nodes are enabled regardless of the feature gate. When set to false, virtual nodes
+  are disabled regardless of the feature gate. When not set, the connector falls back
+  to the `connector.servicegraph.virtualNode` feature gate for backwards compatibility.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -140,6 +140,8 @@ The following settings can be optionally configured:
   - Default: `[peer.service, db.name, db.system]`
 - `virtual_node_extra_label`: adds an extra label `virtual_node` with an optional value of `client` or `server`, indicating which node is the uninstrumented one.
   - Default: `false`
+- `virtual_node_enabled`: explicitly enables or disables virtual node creation. When set to `true`, virtual nodes are enabled regardless of the feature gate. When set to `false`, virtual nodes are disabled regardless of the feature gate. When not set, falls back to the `connector.servicegraph.virtualNode` feature gate for backwards compatibility.
+  - Default: not set (uses feature gate)
 - `metrics_flush_interval`: the interval at which metrics are flushed to the exporter.
   - Default: `60s`
 - `metrics_timestamp_offset`: the offset to subtract from metric timestamps. If set to a positive duration, metric timestamps will be set to (current time - offset), effectively shifting metrics to appear as if they were generated in the past.

--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -41,6 +41,12 @@ type Config struct {
 	// CacheLoop is the time to expire old entries from the store periodically.
 	StoreExpirationLoop time.Duration `mapstructure:"store_expiration_loop"`
 
+	// VirtualNodeEnabled explicitly enables or disables virtual node creation.
+	// When set to true: virtual nodes are enabled regardless of the feature gate.
+	// When set to false: virtual nodes are disabled regardless of the feature gate.
+	// When not set (nil): falls back to the connector.servicegraph.virtualNode feature gate for backwards compatibility.
+	VirtualNodeEnabled *bool `mapstructure:"virtual_node_enabled"`
+
 	// VirtualNodePeerAttributes the list of attributes need to match, the higher the front, the higher the priority.
 	VirtualNodePeerAttributes []string `mapstructure:"virtual_node_peer_attributes"`
 
@@ -84,4 +90,14 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// IsVirtualNodeEnabled returns whether virtual node creation is enabled.
+// It checks the explicit config setting first, then falls back to the feature gate.
+func (c *Config) IsVirtualNodeEnabled() bool {
+	if c.VirtualNodeEnabled != nil {
+		return *c.VirtualNodeEnabled
+	}
+	// Fall back to feature gate for backwards compatibility
+	return virtualNodeFeatureGate.IsEnabled()
 }

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -275,7 +275,7 @@ func (p *serviceGraphConnector) aggregateMetrics(ctx context.Context, td ptrace.
 						e.Failed = e.Failed || span.Status().Code() == ptrace.StatusCodeError
 						p.upsertDimensions(clientKind, e.Dimensions, rAttributes, span.Attributes())
 
-						if virtualNodeFeatureGate.IsEnabled() {
+						if p.config.IsVirtualNodeEnabled() {
 							p.upsertPeerAttributes(p.config.VirtualNodePeerAttributes, e.Peer, span.Attributes())
 						}
 
@@ -366,7 +366,7 @@ func (p *serviceGraphConnector) onExpire(e *store.Edge) {
 
 	p.telemetryBuilder.ConnectorServicegraphExpiredEdges.Add(context.Background(), 1)
 
-	if virtualNodeFeatureGate.IsEnabled() && len(p.config.VirtualNodePeerAttributes) > 0 {
+	if p.config.IsVirtualNodeEnabled() && len(p.config.VirtualNodePeerAttributes) > 0 {
 		e.ConnectionType = store.VirtualNode
 		if e.ClientService == "" && e.Key.SpanIDIsEmpty() {
 			e.ClientService = "user"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Having a config option for virtual nodes would make it easier to enable or disable this feature on a per component basis.

I have a few open questions:
* Should I add information about the feature gate deprecation?
* Should I add tests?

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #41086

<!--Please delete paragraphs that you did not use before submitting.-->
