### PR TITLE
[processor/tailsampling] Fix memory leak

### DIFF
--- a/.chloggen/fix-tsp-memory-leak.yaml
+++ b/.chloggen/fix-tsp-memory-leak.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a memory leak introduced in 0.141.0 of the tail sampling processor when not blocking on overflow.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44884]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
When the TSP is configured to drop samples on overflow we add each trace id to a queue to drop, but if we never actually overflow the trace ids are not removed from the queue causing a memory leak. Whenever a trace is removed from the map we also need to drop it from the queue.

This was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43671 which was released in v0.141.0 but that is all so far.