### PR TITLE
[chore][internal/aws/containerinsight] improve linting

### DIFF
--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -33,12 +33,13 @@ func SumFields(fields []map[string]any) map[string]float64 {
 		return result
 	}
 
-	for i := 1; i < len(fields); i++ {
+	for _, currentField := range fields[1:] {
 		for k, v := range result {
-			if fields[i][k] == nil {
+			fieldValue, exists := currentField[k]
+			if !exists || fieldValue == nil {
 				continue
 			}
-			if fv, ok := fields[i][k].(float64); ok {
+			if fv, ok := fieldValue.(float64); ok {
 				result[k] = v + fv
 			}
 		}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
Error: internal/aws/containerinsight/utils.go:38:13: G602: slice index out of range (gosec)
			if fields[i][k] == nil {
			         ^
Error: internal/aws/containerinsight/utils.go:41:23: G602: slice index out of range (gosec)
			if fv, ok := fields[i][k].(float64); ok {
```
