### PR TITLE
[chore][exporter/awsxrayexporter] improve linting

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -576,6 +577,11 @@ func convertToAmazonTraceID(traceID pcommon.TraceID, skipTimestampValidation boo
 
 	binary.BigEndian.PutUint32(b[0:4], uint32(epoch))
 
+	// Build the X-Ray trace ID format: 1-{hex(epoch)}-{identifier}
+	// Ensure we have enough space in the content array
+	if len(content) < traceIDLength {
+		return "", errors.New("content array too small")
+	}
 	content[0] = '1'
 	content[1] = '-'
 	hex.Encode(content[2:10], b[0:4])


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This is part of the process to enable the [modernize](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44199) linter in CI and upgrade `golanglint` to the latest version.

There are no changes in the component behaviour.

```sh
Error: exporter/awsxrayexporter/internal/translator/segment.go:579:9: G602: slice index out of range (gosec)
	content[0] = '1'
	       ^
Error: exporter/awsxrayexporter/internal/translator/segment.go:580:9: G602: slice index out of range (gosec)
	content[1] = '-'
	       ^
Error: exporter/awsxrayexporter/internal/translator/segment.go:582:9: G602: slice index out of range (gosec)
	content[10] = '-'
	       ^
```
