### PR TITLE
[processor/resourcedetection] add container.image.name and container.name resource attributes

### DIFF
--- a/.chloggen/example_docker.yaml
+++ b/.chloggen/example_docker.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional docker attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44898]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Add `container.image.name` and `container.name` optional resource attributes with the docker detector.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.279.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/digitalocean/go-metadata v0.0.0-20250129100319-e3650a3df44b
+	github.com/docker/docker v28.5.2+incompatible
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/consul/api v1.32.1
 	github.com/hetznercloud/hcloud-go/v2 v2.33.0
@@ -68,7 +69,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect

--- a/processor/resourcedetectionprocessor/internal/docker/docker.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker.go
@@ -57,8 +57,15 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		return pcommon.NewResource(), "", fmt.Errorf("failed getting OS hostname: %w", err)
 	}
 
+	info, err := d.provider.ContainerInfo(ctx)
+	if err != nil {
+		return pcommon.NewResource(), "", fmt.Errorf("failed getting container info: %w", err)
+	}
+
 	d.rb.SetHostName(hostname)
 	d.rb.SetOsType(osType)
+	d.rb.SetContainerName(info.Name)
+	d.rb.SetContainerImageName(info.Image)
 
 	return d.rb.Emit(), conventions.SchemaURL, nil
 }

--- a/processor/resourcedetectionprocessor/internal/docker/documentation.md
+++ b/processor/resourcedetectionprocessor/internal/docker/documentation.md
@@ -8,5 +8,7 @@
 
 | Name | Description | Values | Enabled |
 | ---- | ----------- | ------ | ------- |
+| container.image.name | The container image name | Any Str | false |
+| container.name | The container name | Any Str | false |
 | host.name | The host.name | Any Str | true |
 | os.type | The os.type | Any Str | true |

--- a/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_config.go
+++ b/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_config.go
@@ -27,12 +27,20 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 
 // ResourceAttributesConfig provides config for resourcedetectionprocessor/docker resource attributes.
 type ResourceAttributesConfig struct {
-	HostName ResourceAttributeConfig `mapstructure:"host.name"`
-	OsType   ResourceAttributeConfig `mapstructure:"os.type"`
+	ContainerImageName ResourceAttributeConfig `mapstructure:"container.image.name"`
+	ContainerName      ResourceAttributeConfig `mapstructure:"container.name"`
+	HostName           ResourceAttributeConfig `mapstructure:"host.name"`
+	OsType             ResourceAttributeConfig `mapstructure:"os.type"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
+		ContainerImageName: ResourceAttributeConfig{
+			Enabled: false,
+		},
+		ContainerName: ResourceAttributeConfig{
+			Enabled: false,
+		},
 		HostName: ResourceAttributeConfig{
 			Enabled: true,
 		},

--- a/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_config_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_config_test.go
@@ -24,15 +24,19 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: ResourceAttributesConfig{
-				HostName: ResourceAttributeConfig{Enabled: true},
-				OsType:   ResourceAttributeConfig{Enabled: true},
+				ContainerImageName: ResourceAttributeConfig{Enabled: true},
+				ContainerName:      ResourceAttributeConfig{Enabled: true},
+				HostName:           ResourceAttributeConfig{Enabled: true},
+				OsType:             ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
-				HostName: ResourceAttributeConfig{Enabled: false},
-				OsType:   ResourceAttributeConfig{Enabled: false},
+				ContainerImageName: ResourceAttributeConfig{Enabled: false},
+				ContainerName:      ResourceAttributeConfig{Enabled: false},
+				HostName:           ResourceAttributeConfig{Enabled: false},
+				OsType:             ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_resource.go
+++ b/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_resource.go
@@ -21,6 +21,20 @@ func NewResourceBuilder(rac ResourceAttributesConfig) *ResourceBuilder {
 	}
 }
 
+// SetContainerImageName sets provided value as "container.image.name" attribute.
+func (rb *ResourceBuilder) SetContainerImageName(val string) {
+	if rb.config.ContainerImageName.Enabled {
+		rb.res.Attributes().PutStr("container.image.name", val)
+	}
+}
+
+// SetContainerName sets provided value as "container.name" attribute.
+func (rb *ResourceBuilder) SetContainerName(val string) {
+	if rb.config.ContainerName.Enabled {
+		rb.res.Attributes().PutStr("container.name", val)
+	}
+}
+
 // SetHostName sets provided value as "host.name" attribute.
 func (rb *ResourceBuilder) SetHostName(val string) {
 	if rb.config.HostName.Enabled {

--- a/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_resource_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/internal/metadata/generated_resource_test.go
@@ -13,6 +13,8 @@ func TestResourceBuilder(t *testing.T) {
 		t.Run(tt, func(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, tt)
 			rb := NewResourceBuilder(cfg)
+			rb.SetContainerImageName("container.image.name-val")
+			rb.SetContainerName("container.name-val")
 			rb.SetHostName("host.name-val")
 			rb.SetOsType("os.type-val")
 
@@ -23,7 +25,7 @@ func TestResourceBuilder(t *testing.T) {
 			case "default":
 				assert.Equal(t, 2, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -31,7 +33,17 @@ func TestResourceBuilder(t *testing.T) {
 				assert.Failf(t, "unexpected test case: %s", tt)
 			}
 
-			val, ok := res.Attributes().Get("host.name")
+			val, ok := res.Attributes().Get("container.image.name")
+			assert.Equal(t, tt == "all_set", ok)
+			if ok {
+				assert.Equal(t, "container.image.name-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("container.name")
+			assert.Equal(t, tt == "all_set", ok)
+			if ok {
+				assert.Equal(t, "container.name-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("host.name")
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "host.name-val", val.Str())

--- a/processor/resourcedetectionprocessor/internal/docker/internal/metadata/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/internal/docker/internal/metadata/testdata/config.yaml
@@ -1,12 +1,20 @@
 default:
 all_set:
   resource_attributes:
+    container.image.name:
+      enabled: true
+    container.name:
+      enabled: true
     host.name:
       enabled: true
     os.type:
       enabled: true
 none_set:
   resource_attributes:
+    container.image.name:
+      enabled: false
+    container.name:
+      enabled: false
     host.name:
       enabled: false
     os.type:

--- a/processor/resourcedetectionprocessor/internal/docker/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/docker/metadata.yaml
@@ -3,6 +3,14 @@ type: resourcedetectionprocessor/docker
 parent: resourcedetection
 
 resource_attributes:
+  container.image.name:
+    description: The container image name
+    type: string
+    enabled: false
+  container.name:
+    description: The container name
+    type: string
+    enabled: false
   host.name:
     description: The host.name
     type: string


### PR DESCRIPTION
~Example of implementation of additional resource attributes to discuss #44476~

This adds 2 new optional attributes to the docker detector for the resourcedetection processor.