### PR TITLE
[httpcheck] fix incorrect stale value in httpcheck.status when status_code changes

### DIFF
--- a/.chloggen/39683-fix-httpcheck-receiver-stale-metrics.yaml
+++ b/.chloggen/39683-fix-httpcheck-receiver-stale-metrics.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent wrong stale value with prometheus exporter when status_code changes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39683, 44917]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When the status code changes, the series for the previous status stops being exported.
+  This is problematic with prometheus exporter's metric_expiration, as
+  the stale value will continue to be reported for some time.
+
+  To counter this, the new code will once export value 0 after the change to
+  move the stale value to the correct value.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -22,11 +22,12 @@ configured `method`. This scraper generates a metric with a label for each HTTP 
 class. For example, the following metrics will be generated if the endpoint returned a `200`:
 
 ```
-httpcheck.status{http.status_class:1xx, http.status_code:200,...} = 0
+httpcheck.status{http.status_class:1xx,...} = 0
+httpcheck.status{http.status_class:2xx,...} = 1
 httpcheck.status{http.status_class:2xx, http.status_code:200,...} = 1
-httpcheck.status{http.status_class:3xx, http.status_code:200,...} = 0
-httpcheck.status{http.status_class:4xx, http.status_code:200,...} = 0
-httpcheck.status{http.status_class:5xx, http.status_code:200,...} = 0
+httpcheck.status{http.status_class:3xx,...} = 0
+httpcheck.status{http.status_class:4xx,...} = 0
+httpcheck.status{http.status_class:5xx,...} = 0
 ```
 
 For HTTPS endpoints, the receiver can collect TLS certificate metrics including the time remaining until certificate expiry. This allows monitoring of certificate expiration alongside HTTP availability. Note that TLS certificate metrics are disabled by default and must be explicitly enabled in the metrics configuration.

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptrace"
@@ -447,24 +448,19 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 			// We also want a metric without status_code for each class:
 			// httpcheck.status{http.status_class:2xx, ...} = 1
 
-			// Was there a ever a successful scrape?
-			if h.lastStatusCode[targetIndex] != 0 {
-				// did the status change since last successful scrape? (even in the same class, e.g 200 -> 201)
-				// then export the old status_code once with value 0 to avoid stale value 1
-				if h.lastStatusCode[targetIndex] != statusCode {
-					for class, intVal := range httpResponseClasses {
-						if h.lastStatusCode[targetIndex]/100 == intVal {
-							h.mb.RecordHttpcheckStatusDataPoint(
-								now,
-								int64(0),
-								endpoint,
-								int64(h.lastStatusCode[targetIndex]),
-								req.Method,
-								class,
-							)
-						}
-					}
-				}
+			// did the status change since last successful scrape? (even in the same class, e.g 200 -> 201)
+			// then export the old status_code once with value 0 to avoid stale value 1
+			// and was there a ever a successful scrape?
+			if h.lastStatusCode[targetIndex] != statusCode && h.lastStatusCode[targetIndex] != 0 {
+				class := fmt.Sprintf("%dxx", h.lastStatusCode[targetIndex]/100)
+				h.mb.RecordHttpcheckStatusDataPoint(
+					now,
+					int64(0),
+					endpoint,
+					int64(h.lastStatusCode[targetIndex]),
+					req.Method,
+					class,
+				)
 			}
 
 			for class, intVal := range httpResponseClasses {

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -84,10 +84,11 @@ func (t *timingInfo) getDurations() (dnsNs, tcpNs, tlsNs, requestNs, responseNs 
 }
 
 type httpcheckScraper struct {
-	clients  []*http.Client
-	cfg      *Config
-	settings component.TelemetrySettings
-	mb       *metadata.MetricsBuilder
+	clients        []*http.Client
+	cfg            *Config
+	settings       component.TelemetrySettings
+	mb             *metadata.MetricsBuilder
+	lastStatusCode []int // per target, 0 signifies not present
 }
 
 // extractTLSInfo extracts TLS certificate information from the connection state
@@ -233,7 +234,7 @@ func (h *httpcheckScraper) start(ctx context.Context, host component.Host) (err 
 			expandedTargets = append(expandedTargets, &targetClone) // Add the cloned target to expanded targets
 		}
 	}
-
+	h.lastStatusCode = make([]int, len(expandedTargets))
 	h.cfg.Targets = expandedTargets // Replace targets with expanded targets
 	return err
 }
@@ -429,8 +430,47 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 			}
 
 			// Record HTTP status class metrics
+			//
+			// we want for e.g. status_code=200
+			// httpcheck.status{http.status_class:2xx, http.status_code:200,...} = 1
+			// the other httpcheck.status DataPoints may be 0 or (preferably) not exported
+			//
+			// when the code changes, we want to reflect that immediately, e.g
+			// sart with status=200
+			// httpcheck.status{http.status_class:2xx, http.status_code:200,...} = 1
+			// change status=200 to status=500:
+			// httpcheck.status{http.status_class:2xx, http.status_code:200,...} = 0
+			// httpcheck.status{http.status_class:5xx, http.status_code:500,...} = 1
+			// after "stabilitzation" at status=500 we could omit the 200 series and only export
+			// httpcheck.status{http.status_class:5xx, http.status_code:500,...} = 1
+			//
+			// We also want a metric without status_code for each class:
+			// httpcheck.status{http.status_class:2xx, ...} = 1
+
+			// Was there a ever a successful scrape?
+			if h.lastStatusCode[targetIndex] != 0 {
+				// did the status change since last successful scrape? (even in the same class, e.g 200 -> 201)
+				// then export the old status_code once with value 0 to avoid stale value 1
+				if h.lastStatusCode[targetIndex] != statusCode {
+					for class, intVal := range httpResponseClasses {
+						if h.lastStatusCode[targetIndex]/100 == intVal {
+							h.mb.RecordHttpcheckStatusDataPoint(
+								now,
+								int64(0),
+								endpoint,
+								int64(h.lastStatusCode[targetIndex]),
+								req.Method,
+								class,
+							)
+						}
+					}
+				}
+			}
+
 			for class, intVal := range httpResponseClasses {
+				valueForStatusClass := 0
 				if statusCode/100 == intVal {
+					valueForStatusClass = 1
 					h.mb.RecordHttpcheckStatusDataPoint(
 						now,
 						int64(1),
@@ -439,16 +479,23 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 						req.Method,
 						class,
 					)
-				} else {
-					h.mb.RecordHttpcheckStatusDataPoint(
-						now,
-						int64(0),
-						h.cfg.Targets[targetIndex].Endpoint,
-						int64(0), // Use 0 as status code when the class doesn't match
-						req.Method,
-						class,
-					)
 				}
+				// status_code-less datapoint
+				h.mb.RecordHttpcheckStatusDataPoint(
+					now,
+					int64(valueForStatusClass),
+					h.cfg.Targets[targetIndex].Endpoint,
+					// mark status_code attribute for deletion in removeStatusCodeForZeroValues
+					// cannot omit this here as RecordHttpcheckStatusDataPoint is auto-generated
+					int64(0),
+					req.Method,
+					class,
+				)
+			}
+			// store current statusCode for next round only when it was recorded above (0 isn't)
+			// also prevents confusing lastStatusCode's initial 0 with reset to 0
+			if statusCode != 0 {
+				h.lastStatusCode[targetIndex] = statusCode
 			}
 			mux.Unlock()
 		}(client, idx)
@@ -456,15 +503,16 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 
 	wg.Wait()
 
-	// Emit metrics and post-process to remove http.status_code when value is 0
+	// Emit metrics and post-process to remove http.status_code attribute where not useful
 	metrics := h.mb.Emit()
-	removeStatusCodeForZeroValues(metrics)
+	removeStatusCodeIfZero(metrics)
 
 	return metrics, nil
 }
 
-// removeStatusCodeForZeroValues removes the http.status_code attribute from httpcheck.status metrics
-func removeStatusCodeForZeroValues(metrics pmetric.Metrics) {
+// removeStatusCodeIfZero removes the http.status_code attribute from httpcheck.status metrics
+// where http.status_code == 0
+func removeStatusCodeIfZero(metrics pmetric.Metrics) {
 	rms := metrics.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
@@ -480,8 +528,9 @@ func removeStatusCodeForZeroValues(metrics pmetric.Metrics) {
 						dps := m.Sum().DataPoints()
 						for l := 0; l < dps.Len(); l++ {
 							dp := dps.At(l)
-							// If the value is 0, remove the http.status_code attribute
-							if dp.IntValue() == 0 {
+							statusCode, ok := dp.Attributes().Get("http.status_code")
+							// remove the http.status_code attribute if its value is 0
+							if ok && statusCode.Int() == 0 {
 								dp.Attributes().Remove("http.status_code")
 							}
 						}

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/500_after_golden.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/500_after_golden.yaml
@@ -30,7 +30,7 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "1"
+                - asInt: "0" # report error on preexisting dataPoint
                   attributes:
                     - key: http.method
                       value:
@@ -46,7 +46,7 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "1"
+                - asInt: "0" # report error on preexisting dataPoint
                   attributes:
                     - key: http.method
                       value:
@@ -85,7 +85,7 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "0"
+                - asInt: "1"
                   attributes:
                     - key: http.method
                       value:
@@ -93,6 +93,22 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 5xx
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "500"
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
@@ -64,6 +64,19 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 4xx
+                    - key: http.url
+                      value:
+                        stringValue: http://invalid-endpoint
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
                     - key: http.status_code
                       value:
                         intValue: "404"

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
@@ -56,6 +56,19 @@ resourceMetrics:
                     - key: http.status_class
                       value:
                         stringValue: 2xx
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
                     - key: http.status_code
                       value:
                         intValue: "200"
@@ -104,6 +117,19 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
                   attributes:
                     - key: http.method
                       value:


### PR DESCRIPTION
#### Description

Currently, when the status_code of a target changes, e.g. 200 -> 500, its DataPoints stop being exported, while a new metric without attribute `status_code` and the same `status_class` is created. With the prometheus_exporter this means the metric is remaining stale at the old value 1. (5 minutes for the prometheus_exporter and another 5 minutes for the scraping prometheus instance in default configuration.)

See #39683  for more context. 

This PR changes the behavior such that:

1. the first scrape after the status changed will generate a value 0 for the old status_code metric
2. the metrics without status_code will be permanent, and switch between 0 and 1; i tried to preserve them for backwards compatibility but don't think they are strictly necessary. (This means I am open to removing the status_code less metrics altogether but that might break some users who explicitly filter for them.)

#### Link to tracking issue
Fixes #39683

#### Testing

An additional test case has been added that does not only check one scrape but two consecutive scrapes with the first return status_code=200 and the second status_code=500.

#### Documentation

Synced example with current behavior. Even without this change, the example would not match the current behavior.
