### PR TITLE
[prometheusreceiver] Prevent GC goroutine accumulation in JobsMap

### DIFF
--- a/.chloggen/fix-prometheusreceiver-gc-goroutine-accumulation.yaml
+++ b/.chloggen/fix-prometheusreceiver-gc-goroutine-accumulation.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent GC goroutine accumulation in metrics adjuster under high concurrency
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44922]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Under high concurrency, multiple calls to JobsMap.get() could each spawn
+  a gc() goroutine when lastGC was stale, causing unnecessary goroutine
+  accumulation. Now uses atomic compare-and-swap to ensure only one gc
+  goroutine runs at a time.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Under high concurrency, multiple calls to `JobsMap.get()` could each spawn a `gc()` goroutine if `lastGC` was stale, causing unnecessary goroutine accumulation while they wait for the lock.

Add an atomic `gcRunning` flag with compare-and-swap to ensure only one gc goroutine runs at a time. The flag is reset after `gc()` completes.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
