### PR TITLE
[receiver/dockerstats] Upgrade default Docker API version to 1.44

### DIFF
--- a/.chloggen/fix-version-dockerstats.yaml
+++ b/.chloggen/fix-version-dockerstats.yaml
@@ -1,5 +1,5 @@
 change_type: breaking
-component: receiver/dockerstats
+component: receiver/docker_stats
 note: "Upgrades default Docker API version to 1.44 to be compatible with recent Docker Engine versions."
 issues: [44279]
 subtext: "Users requiring an older Docker API version can set the `api_version` in the docker stats receiver config. The minimum supported API level is not changed, only default."

--- a/.chloggen/fix-version-dockerstats.yaml
+++ b/.chloggen/fix-version-dockerstats.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: receiver/dockerstats
+note: "Upgrades default Docker API version to 1.44 to be compatible with recent Docker Engine versions."
+issues: [44279]
+subtext: "Users requiring an older Docker API version can set the `api_version` in the docker stats receiver config. The minimum supported API level is not changed, only default."
+change_logs: [user]

--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -20,7 +20,7 @@ all desired running containers on a configured interval.  These stats are for co
 resource usage of cpu, memory, network, and the
 [blkio controller](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt).
 
-> :information_source: Requires Docker API version 1.22+
+> :information_source: Requires Docker API version 1.25+
 
 ## Configuration
 
@@ -42,7 +42,7 @@ only unmatched container image names should be excluded.
     - Globs are non-regex items (e.g. `/items/`) containing any of the following: `*[]{}?`.  Negations are supported:
     `!my*container` will exclude all containers whose image name doesn't match the blob `my*container`.
 - `timeout` (default = `5s`): The request timeout for any docker daemon query.
-- `api_version` (default = `"1.25"`): The Docker client API version (must be 1.25+). Must be input as a string, not a float (e.g. `"1.40"` instead of `1.40`). [Docker API versions](https://docs.docker.com/engine/api/).
+- `api_version` (default = `"1.44"`): The Docker client API version (must be 1.25+). Must be input as a string, not a float (e.g. `"1.40"` instead of `1.40`). [Docker API versions](https://docs.docker.com/engine/api/).
 - `metrics` (defaults at [./documentation.md](./documentation.md)): Enables/disables individual metrics. See [./documentation.md](./documentation.md) for full detail.
 
 Example:
@@ -53,7 +53,7 @@ receivers:
     endpoint: http://example.com/
     collection_interval: 2s
     timeout: 20s
-    api_version: "1.24"
+    api_version: "1.25"
     container_labels_to_metric_labels:
       my.container.label: my-metric-label
       my.other.container.label: my-other-metric-label

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -25,8 +25,8 @@ import (
 )
 
 var (
-	defaultDockerAPIVersion         = "1.25"
-	minimumRequiredDockerAPIVersion = docker.MustNewAPIVersion(defaultDockerAPIVersion)
+	defaultDockerAPIVersion         = docker.MustNewAPIVersion("1.44")
+	minimumRequiredDockerAPIVersion = docker.MustNewAPIVersion("1.25")
 )
 
 type resultV2 struct {


### PR DESCRIPTION
#### Description

Latest version of the docker engine requires  1.44 as the minimum API version. The effect meaning that default configuration is incompatible with latest docker versions.

The minimum supported version does not change.

Previously I thought this PR would update this, but it was missed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44411 

#### Link to tracking issue
Fixes #44279 

#### Testing

I added coverage for testing with both minimum and default API versions (before the version was hardcoded). This is mainly to ensure the docker client operates the same in both scenarios.


#### Documentation

Updated README and made some slight corrections to minimum supported version (it incorreectly said 1.22, where it is actually 1.25)