### PR TITLE
[receiver/kafka] Validate that `exclude_topics` entries in config are non-empty

### DIFF
--- a/.chloggen/feat_44920.yaml
+++ b/.chloggen/feat_44920.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/feat_44920.yaml
+++ b/.chloggen/feat_44920.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "receiver/kafka"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Validate that `exclude_topics` entries in kafkareceiver config are non-empty."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44920]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -213,6 +213,13 @@ func validateExcludeTopic(signalType string, topics, excludeTopics []string) err
 	}
 
 	for _, excludeTopic := range excludeTopics {
+		// Validate that exclude_topic is not empty
+		if excludeTopic == "" {
+			return fmt.Errorf(
+				"%s.exclude_topics contains empty string, which would match all topics",
+				signalType,
+			)
+		}
 		// Validate that exclude_topic is a valid regex pattern
 		if _, err := regexp.Compile(excludeTopic); err != nil {
 			return fmt.Errorf(

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -397,6 +397,50 @@ func TestConfigValidate(t *testing.T) {
 			},
 			expectedErr: "logs.exclude_topic contains invalid regex pattern",
 		},
+		{
+			name: "invalid config with empty string in exclude_topics for logs",
+			config: &Config{
+				Logs: TopicEncodingConfig{
+					Topics:        []string{"^logs-.*"},
+					ExcludeTopics: []string{""},
+					Encoding:      "otlp_proto",
+				},
+			},
+			expectedErr: "logs.exclude_topics contains empty string",
+		},
+		{
+			name: "invalid config with empty string in exclude_topics for metrics",
+			config: &Config{
+				Metrics: TopicEncodingConfig{
+					Topics:        []string{"^metrics-.*"},
+					ExcludeTopics: []string{"", "^metrics-test$"},
+					Encoding:      "otlp_proto",
+				},
+			},
+			expectedErr: "metrics.exclude_topics contains empty string",
+		},
+		{
+			name: "invalid config with empty string in exclude_topics for traces",
+			config: &Config{
+				Traces: TopicEncodingConfig{
+					Topics:        []string{"^traces-.*"},
+					ExcludeTopics: []string{"^traces-test$", ""},
+					Encoding:      "otlp_proto",
+				},
+			},
+			expectedErr: "traces.exclude_topics contains empty string",
+		},
+		{
+			name: "invalid config with empty string in exclude_topics for profiles",
+			config: &Config{
+				Profiles: TopicEncodingConfig{
+					Topics:        []string{"^profiles-.*"},
+					ExcludeTopics: []string{""},
+					Encoding:      "otlp_proto",
+				},
+			},
+			expectedErr: "profiles.exclude_topics contains empty string",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

If a user supplies an empty string on the `exclude_topics` array, it will exclude all the topics. This change ensure if that happens, the collector returns an error.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44920

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated tests to validate that the error is returned for all the signals.