### PR TITLE
[chore] prevent import of semconv packages in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,6 +125,15 @@ linters:
             - go.opentelemetry.io/otel/semconv/v1.27.0
             - go.opentelemetry.io/otel/semconv/v1.37.0
             - go.opentelemetry.io/otel/semconv/v1.38.0
+        
+        semconv-in-test:
+          list-mode: lax
+          deny:
+            - pkg: go.opentelemetry.io/otel/semconv
+              desc: Don't import semconv packages in test files, use strings directly instead.
+              
+          files:
+            - '**/*_test.go'
 
         # Add a different guard rule so that we can ignore tests.
         ignore-in-test:


### PR DESCRIPTION
This ensures that future test files use expanded string values for semantic conventions instead of importing them. The following error is shown when running linters:

```
receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go:11:2: import 'go.opentelemetry.io/otel/semconv/v1.21.0' is not allowed from list 'semconv-in-test': Don't import semconv packages in test files, use strings directly instead. (depguard)
        conventions "go.opentelemetry.io/otel/semconv/v1.21.0"
```