### PR TITLE
[chore] update schemaurl tests to avoid breaking on every update

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -242,7 +242,7 @@ func TestDetectFromIMDS(t *testing.T) {
 			} else {
 				assert.Equal(t, 0, res.Attributes().Len())
 			}
-			assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schema)
+			assert.Contains(t, schema, "https://opentelemetry.io/schemas/")
 		})
 	}
 }
@@ -335,7 +335,7 @@ func TestDetectFromAPI(t *testing.T) {
 				}),
 			}
 			res, schema, err := d.detectFromAPI(t.Context())
-			assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schema)
+			assert.Contains(t, schema, "https://opentelemetry.io/schemas/")
 			if tt.expectedError {
 				assert.Error(t, err)
 			}
@@ -450,7 +450,7 @@ func TestDetect(t *testing.T) {
 			}
 			res, schema, err := det.Detect(t.Context())
 			assert.NoError(t, err)
-			assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schema)
+			assert.Contains(t, schema, "https://opentelemetry.io/schemas/")
 			assert.Equal(t, tt.expectedOutput, res.Attributes().AsRaw())
 		})
 	}

--- a/processor/resourcedetectionprocessor/internal/consul/consul_test.go
+++ b/processor/resourcedetectionprocessor/internal/consul/consul_test.go
@@ -46,7 +46,7 @@ func TestDetect(t *testing.T) {
 	}
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/digitalocean/digitalocean_test.go
+++ b/processor/resourcedetectionprocessor/internal/digitalocean/digitalocean_test.go
@@ -83,7 +83,7 @@ func TestDigitalOceanDetector_Detect_OK_JSON(t *testing.T) {
 
 	res, schemaURL, err := det.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	attrs := res.Attributes().AsRaw()
 	want := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/docker/docker_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker_test.go
@@ -41,7 +41,7 @@ func TestDetect(t *testing.T) {
 	detector.(*Detector).provider = md
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
@@ -24,7 +24,7 @@ func TestDetectTrue(t *testing.T) {
 	detector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())
 	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(t.Context())
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"heroku.app.id":                     "appid",
@@ -47,7 +47,7 @@ func TestDetectTruePartial(t *testing.T) {
 	detector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())
 	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(t.Context())
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"heroku.app.id":       "appid",
@@ -67,7 +67,7 @@ func TestDetectTruePartialMissingDynoId(t *testing.T) {
 	detector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())
 	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(t.Context())
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]any{
 		"heroku.app.id":   "appid",
@@ -83,6 +83,6 @@ func TestDetectFalse(t *testing.T) {
 	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	assert.True(t, internal.IsEmptyResource(res))
 }

--- a/processor/resourcedetectionprocessor/internal/hetzner/hetzner_test.go
+++ b/processor/resourcedetectionprocessor/internal/hetzner/hetzner_test.go
@@ -49,7 +49,7 @@ func TestHetznerDetector_Detect_OK(t *testing.T) {
 
 	res, schemaURL, err := d.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	want := map[string]any{
 		"cloud.provider":          TypeStr,

--- a/processor/resourcedetectionprocessor/internal/k8snode/k8snode_test.go
+++ b/processor/resourcedetectionprocessor/internal/k8snode/k8snode_test.go
@@ -48,7 +48,7 @@ func TestDetect(t *testing.T) {
 	k8sDetector.(*detector).provider = md
 	res, schemaURL, err := k8sDetector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{
@@ -75,7 +75,7 @@ func TestDetectDisabledResourceAttributes(t *testing.T) {
 	k8sDetector.(*detector).provider = md
 	res, schemaURL, err := k8sDetector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{}

--- a/processor/resourcedetectionprocessor/internal/kubeadm/kubeadm_test.go
+++ b/processor/resourcedetectionprocessor/internal/kubeadm/kubeadm_test.go
@@ -47,7 +47,7 @@ func TestDetect(t *testing.T) {
 	k8sDetector.(*detector).provider = md
 	res, schemaURL, err := k8sDetector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{
@@ -73,7 +73,7 @@ func TestDetectDisabledResourceAttributes(t *testing.T) {
 	k8sDetector.(*detector).provider = md
 	res, schemaURL, err := k8sDetector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{}

--- a/processor/resourcedetectionprocessor/internal/oraclecloud/oraclecloud_test.go
+++ b/processor/resourcedetectionprocessor/internal/oraclecloud/oraclecloud_test.go
@@ -60,7 +60,7 @@ func TestDetect(t *testing.T) {
 
 		res, schemaURL, err := det.Detect(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+		assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 		// Per Otel semantic conventions, these are the attribute keys for K8s clusters:
 		// https://opentelemetry.io/docs/specs/semconv/resource/k8s/#cluster
@@ -139,7 +139,7 @@ func TestDetectDisabledResourceAttributes(t *testing.T) {
 
 		res, schemaURL, err := det.Detect(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+		assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 		expected := map[string]any{
 			"cloud.provider":          "oracle_cloud",

--- a/processor/resourcedetectionprocessor/internal/scaleway/scaleway_test.go
+++ b/processor/resourcedetectionprocessor/internal/scaleway/scaleway_test.go
@@ -177,7 +177,7 @@ func TestScalewayDetector_Detect_OK(t *testing.T) {
 
 	res, schemaURL, err := det.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	attrs := res.Attributes().AsRaw()
 	// Region is derived from zone by trimming the trailing segment: "nl-ams-1" -> "nl-ams"

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -207,7 +207,7 @@ func TestDetectFQDNAvailable(t *testing.T) {
 	detector := newTestDetector(md, []string{"dns"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 	md.AssertNotCalled(t, "CPUInfo")
 
@@ -238,7 +238,7 @@ func TestFallbackHostname(t *testing.T) {
 	detector := newTestDetector(mdHostname, []string{"dns", "os"}, metadata.DefaultResourceAttributesConfig())
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	mdHostname.AssertExpectations(t)
 	mdHostname.AssertNotCalled(t, "HostID")
 	mdHostname.AssertNotCalled(t, "HostIPs")
@@ -267,7 +267,7 @@ func TestEnableHostID(t *testing.T) {
 	detector := newTestDetector(mdHostname, []string{"dns", "os"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	mdHostname.AssertExpectations(t)
 
 	expected := map[string]any{
@@ -300,7 +300,7 @@ func TestUseHostname(t *testing.T) {
 	detector := newTestDetector(mdHostname, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	mdHostname.AssertExpectations(t)
 
 	expected := map[string]any{
@@ -405,7 +405,7 @@ func TestDetectError(t *testing.T) {
 	detector = newTestDetector(mdHostID, []string{"os"}, allEnabledConfig())
 	res, schemaURL, err = detector.Detect(t.Context())
 	assert.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	assert.Equal(t, map[string]any{
 		"host.name":      "hostname",
 		"os.description": "Ubuntu 22.04.2 LTS (Jammy Jellyfish)",
@@ -436,7 +436,7 @@ func TestDetectCPUInfo(t *testing.T) {
 	detector := newTestDetector(md, []string{"dns"}, cfg)
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	md.AssertExpectations(t)
 
 	expected := map[string]any{
@@ -493,7 +493,7 @@ func TestHostInterfaces(t *testing.T) {
 	detector := newTestDetector(mdInterfaces, []string{"os"}, cfg)
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	mdInterfaces.AssertExpectations(t)
 
 	fmt.Println("res.Attributes().AsRaw()", res.Attributes().AsRaw())

--- a/processor/resourcedetectionprocessor/internal/upcloud/upcloud_test.go
+++ b/processor/resourcedetectionprocessor/internal/upcloud/upcloud_test.go
@@ -76,7 +76,7 @@ func TestUpcloudDetector_Detect_OK(t *testing.T) {
 
 	res, schemaURL, err := d.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	got := res.Attributes().AsRaw()
 	want := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/vultr/vultr_test.go
+++ b/processor/resourcedetectionprocessor/internal/vultr/vultr_test.go
@@ -76,7 +76,7 @@ func TestVultrDetector_Detect_OK(t *testing.T) {
 
 	res, schemaURL, err := d.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.37.0", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	got := res.Attributes().AsRaw()
 	want := map[string]any{


### PR DESCRIPTION
The schema URL changes with every update to semconv imports, these tests don't need to check a specific version as it is working as intended
