### PR TITLE
[chore] Fix goleak in TestInputStart_RemoteSessionWithDomain

### DIFF
--- a/pkg/stanza/operator/input/windows/input_test.go
+++ b/pkg/stanza/operator/input/windows/input_test.go
@@ -183,6 +183,9 @@ func TestInputStart_RemoteSessionWithDomain(t *testing.T) {
 
 	err := input.Start(persister)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, input.Stop())
+	})
 
 	require.False(t, domainWasNil)
 	require.Equal(t, "remote-domain", capturedDomain)


### PR DESCRIPTION
Fix a failure identified by @MrAnno at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43195#issuecomment-3657964446