### PR TITLE
[exporter/elasticsearch] Deduplicate attribute keys from non-compliant SDKs in otel mapping mode

### DIFF
--- a/.chloggen/elasticsearchexporter_otel-dedup-attr.yaml
+++ b/.chloggen/elasticsearchexporter_otel-dedup-attr.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deduplicate attribute keys from non-compliant SDKs in otel mapping mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The serializer in otel mapping mode now explicitly deduplicates attribute keys when writing to Elasticsearch,
+  keeping only the first occurrence. This prevents invalid JSON from being produced when
+  non-compliant SDKs send duplicate keys.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/common.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/common.go
@@ -57,7 +57,18 @@ func writeAttributes(v *json.Visitor, attributes pcommon.Map, stringifyMapValues
 
 	_ = v.OnKey("attributes")
 	_ = v.OnObjectStart(-1, structform.AnyType)
+
+	// Deduplicate keys to workaround non-compliant SDKs.
+	// It is better to drop duplicate keys than to produce invalid JSON which may cause the entire document to be rejected.
+	seenKeys := make(map[string]struct{})
+
 	for k, val := range attributes.All() {
+		// Skip duplicate keys
+		if _, exists := seenKeys[k]; exists {
+			continue
+		}
+		seenKeys[k] = struct{}{}
+
 		// Exclude well-known, Elastic-specific attributes
 		// from the document. These are handled elsewhere.
 		switch k {

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelserializer
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/elastic/go-structform"
+	esjson "github.com/elastic/go-structform/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestWriteAttributes_Deduplication(t *testing.T) {
+	// Test that writeAttributes deduplicates keys by keeping the first occurrence.
+	// Parse OTLP JSON with duplicate attribute keys to create a pcommon.Map with duplicates.
+	otlpJSON := `{
+		"resourceLogs": [{
+			"scopeLogs": [{
+				"logRecords": [{
+					"attributes": [
+						{"key": "duplicateKey", "value": {"stringValue": "first"}},
+						{"key": "normalKey", "value": {"stringValue": "normal"}},
+						{"key": "duplicateKey", "value": {"stringValue": "second"}}
+					]
+				}]
+			}]
+		}]
+	}`
+	
+	unmarshaler := &plog.JSONUnmarshaler{}
+	logs, err := unmarshaler.UnmarshalLogs([]byte(otlpJSON))
+	require.NoError(t, err)
+	
+	attributes := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes()
+	
+	// Verify the parsed attributes contain duplicates (3 entries including duplicate)
+	require.Equal(t, 3, attributes.Len())
+	
+	// Serialize using writeAttributes
+	var buf bytes.Buffer
+	visitor := esjson.NewVisitor(&buf)
+	require.NoError(t, visitor.OnObjectStart(-1, structform.AnyType))
+	writeAttributes(visitor, attributes, false)
+	require.NoError(t, visitor.OnObjectFinished())
+
+	// Parse and verify the output
+	var result map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&result))
+	
+	// Verify deduplication: only 2 keys, and duplicateKey has the first value
+	expected := map[string]any{
+		"attributes": map[string]any{
+			"duplicateKey": "first",
+			"normalKey":    "normal",
+		},
+	}
+	assert.Equal(t, expected, result)
+}

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/elastic/go-structform"
-	esjson "github.com/elastic/go-structform/json"
+	structformjson "github.com/elastic/go-structform/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -31,19 +31,19 @@ func TestWriteAttributes_Deduplication(t *testing.T) {
 			}]
 		}]
 	}`
-	
+
 	unmarshaler := &plog.JSONUnmarshaler{}
 	logs, err := unmarshaler.UnmarshalLogs([]byte(otlpJSON))
 	require.NoError(t, err)
 	
 	attributes := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes()
-	
+
 	// Verify the parsed attributes contain duplicates (3 entries including duplicate)
 	require.Equal(t, 3, attributes.Len())
-	
+
 	// Serialize using writeAttributes
 	var buf bytes.Buffer
-	visitor := esjson.NewVisitor(&buf)
+	visitor := structformjson.NewVisitor(&buf)
 	require.NoError(t, visitor.OnObjectStart(-1, structform.AnyType))
 	writeAttributes(visitor, attributes, false)
 	require.NoError(t, visitor.OnObjectFinished())
@@ -53,7 +53,7 @@ func TestWriteAttributes_Deduplication(t *testing.T) {
 	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
 	decoder.UseNumber()
 	require.NoError(t, decoder.Decode(&result))
-	
+
 	// Verify deduplication: only 2 keys, and duplicateKey has the first value
 	expected := map[string]any{
 		"attributes": map[string]any{

--- a/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
+++ b/exporter/elasticsearchexporter/internal/serializer/otelserializer/common_test.go
@@ -35,7 +35,7 @@ func TestWriteAttributes_Deduplication(t *testing.T) {
 	unmarshaler := &plog.JSONUnmarshaler{}
 	logs, err := unmarshaler.UnmarshalLogs([]byte(otlpJSON))
 	require.NoError(t, err)
-	
+
 	attributes := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes()
 
 	// Verify the parsed attributes contain duplicates (3 entries including duplicate)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The serializer in otel mapping mode now explicitly deduplicates attribute keys when writing to Elasticsearch,
keeping only the first occurrence. This prevents invalid JSON from being produced when
non-compliant SDKs send duplicate keys.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #39304

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
