### PR TITLE
[chore][receiver/azuremonitor] Add more logs and rationalize methods wording

### DIFF
--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -335,7 +335,7 @@ func TestAzureScraperGetResources(t *testing.T) {
 	s.resources["subscriptionId1"] = map[string]*azureResource{}
 	s.subscriptions["subscriptionId1"] = &azureSubscription{}
 	s.cfg.CacheResources = 0
-	s.getResources(t.Context(), "subscriptionId1")
+	s.loadResources(t.Context(), "subscriptionId1")
 	assert.Contains(t, s.resources, "subscriptionId1")
 	assert.Len(t, s.resources["subscriptionId1"], 3)
 
@@ -353,7 +353,7 @@ func TestAzureScraperGetResources(t *testing.T) {
 		getMetricsValuesMockData(),
 		nil,
 	)
-	s.getResources(t.Context(), "subscriptionId1")
+	s.loadResources(t.Context(), "subscriptionId1")
 	assert.Contains(t, s.resources, "subscriptionId1")
 	assert.Empty(t, s.resources["subscriptionId1"])
 }

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -138,6 +138,7 @@ func TestAzureScraperScrape(t *testing.T) {
 			)
 
 			s := &azureScraper{
+				settings:                     settings.TelemetrySettings,
 				cfg:                          tt.fields.cfg,
 				mb:                           metadata.NewMetricsBuilder(tt.fields.cfg.MetricsBuilderConfig, settings),
 				mutex:                        &sync.Mutex{},
@@ -258,6 +259,7 @@ func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
 
 		settings := receivertest.NewNopSettings(metadata.Type)
 		s := &azureScraper{
+			settings:                     settings.TelemetrySettings,
 			cfg:                          cfgLimitedMertics,
 			mb:                           metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),
 			mutex:                        &sync.Mutex{},

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -138,7 +138,6 @@ func TestAzureScraperScrape(t *testing.T) {
 			)
 
 			s := &azureScraper{
-				settings:                     settings.TelemetrySettings,
 				cfg:                          tt.fields.cfg,
 				mb:                           metadata.NewMetricsBuilder(tt.fields.cfg.MetricsBuilderConfig, settings),
 				mutex:                        &sync.Mutex{},
@@ -259,7 +258,6 @@ func TestAzureScraperScrapeFilterMetrics(t *testing.T) {
 
 		settings := receivertest.NewNopSettings(metadata.Type)
 		s := &azureScraper{
-			settings:                     settings.TelemetrySettings,
 			cfg:                          cfgLimitedMertics,
 			mb:                           metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),
 			mutex:                        &sync.Mutex{},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The idea here is to go a step further in the observability of the azure monitor receiver. 
Starting here with the classic scraper (no batch one), it adds logs everywhere. It might be a bit too much and need to be reviewed to find the right balance. 
I push it there if it can help anyone.

I take it as an opportunity to go a bit deeper in the naming of the method. I would like to name loadXX everything that fill stuff into the struct fields. ``loadSubscriptions`` fill the ``s.subscriptions``, ``loadResources`` fill the ``s.resources`` etc...

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates #44940

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
