### PR TITLE
[chore] remove import of semconv 1.6.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,7 +113,6 @@ linters:
             # TODO: Remove older semconv versions after v1.38.0 migration is complete.
             # If for any reason an individual package needs to use an older semconv version,
             # add a nolint directive on the import line.
-            - go.opentelemetry.io/otel/semconv/v1.6.1
             - go.opentelemetry.io/otel/semconv/v1.9.0
             - go.opentelemetry.io/otel/semconv/v1.12.0
             - go.opentelemetry.io/otel/semconv/v1.15.0
@@ -123,6 +122,8 @@ linters:
             - go.opentelemetry.io/otel/semconv/v1.22.0
             - go.opentelemetry.io/otel/semconv/v1.25.0
             - go.opentelemetry.io/otel/semconv/v1.27.0
+            # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45030
+            - go.opentelemetry.io/otel/semconv/v1.34.0
             - go.opentelemetry.io/otel/semconv/v1.38.0
         
         semconv-in-test:

--- a/pkg/translator/zipkin/zipkinv1/json.go
+++ b/pkg/translator/zipkin/zipkinv1/json.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jaegertracing/jaeger-idl/thrift-gen/zipkincore"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/internal/zipkin"
 )

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -15,8 +15,8 @@ import (
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions112 "go.opentelemetry.io/otel/semconv/v1.12.0"
 	conventions "go.opentelemetry.io/otel/semconv/v1.15.0"
-	conventions161 "go.opentelemetry.io/otel/semconv/v1.6.1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
@@ -324,9 +324,9 @@ func zipkinEndpointFromTags(
 
 	var ipKey, portKey string
 	if remoteEndpoint {
-		ipKey, portKey = string(conventions161.NetPeerIPKey), string(conventions.NetPeerPortKey)
+		ipKey, portKey = string(conventions112.NetPeerIPKey), string(conventions.NetPeerPortKey)
 	} else {
-		ipKey, portKey = string(conventions161.NetHostIPKey), string(conventions.NetHostPortKey)
+		ipKey, portKey = string(conventions112.NetHostIPKey), string(conventions.NetHostPortKey)
 	}
 
 	var ip net.IP

--- a/processor/resourcedetectionprocessor/internal/akamai/akamai.go
+++ b/processor/resourcedetectionprocessor/internal/akamai/akamai.go
@@ -10,7 +10,7 @@ import (
 	linodemeta "github.com/linode/go-metadata"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"

--- a/processor/resourcedetectionprocessor/internal/akamai/akamai_test.go
+++ b/processor/resourcedetectionprocessor/internal/akamai/akamai_test.go
@@ -85,7 +85,7 @@ func TestAkamaiDetector_Detect_OK(t *testing.T) {
 
 	res, schemaURL, err := det.Detect(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "https://opentelemetry.io/schemas/1.6.1", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 
 	got := res.Attributes().AsRaw()
 	want := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
@@ -10,7 +10,8 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions134 "go.opentelemetry.io/otel/semconv/v1.34.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/azure"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
@@ -54,7 +55,7 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		attrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAzure.Value.AsString())
 	}
 	if d.resourceAttributes.CloudPlatform.Enabled {
-		attrs.PutStr(string(conventions.CloudPlatformKey), conventions.CloudPlatformAzureAKS.Value.AsString())
+		attrs.PutStr(string(conventions.CloudPlatformKey), conventions134.CloudPlatformAzureAKS.Value.AsString())
 	}
 	if d.resourceAttributes.K8sClusterName.Enabled {
 		attrs.PutStr(string(conventions.K8SClusterNameKey), parseClusterName(m.ResourceGroupName))

--- a/processor/resourcedetectionprocessor/internal/azure/aks/aks_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/aks_test.go
@@ -28,7 +28,7 @@ func TestDetector_Detect_K8s_Azure(t *testing.T) {
 	detector := &Detector{provider: mockProvider(), resourceAttributes: resourceAttributes}
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.6.1", schemaURL)
+	assert.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	assert.Equal(t, map[string]any{
 		"cloud.provider": "azure",
 		"cloud.platform": "azure_aks",

--- a/processor/resourcedetectionprocessor/internal/azure/azure.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure.go
@@ -9,7 +9,8 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions134 "go.opentelemetry.io/otel/semconv/v1.34.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/azure"
@@ -60,7 +61,7 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 	}
 
 	d.rb.SetCloudProvider(conventions.CloudProviderAzure.Value.AsString())
-	d.rb.SetCloudPlatform(conventions.CloudPlatformAzureVM.Value.AsString())
+	d.rb.SetCloudPlatform(conventions134.CloudPlatformAzureVM.Value.AsString())
 	d.rb.SetHostName(compute.OSProfile.ComputerName)
 	d.rb.SetCloudRegion(compute.Location)
 	d.rb.SetHostID(compute.VMID)

--- a/processor/resourcedetectionprocessor/internal/azure/azure_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure_test.go
@@ -60,7 +60,7 @@ func TestDetectAzureAvailable(t *testing.T) {
 	}
 	res, schemaURL, err := detector.Detect(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, "https://opentelemetry.io/schemas/1.6.1", schemaURL)
+	require.Contains(t, schemaURL, "https://opentelemetry.io/schemas/")
 	mp.AssertExpectations(t)
 
 	expected := map[string]any{

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -439,7 +439,7 @@ func TestDetect(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, "https://opentelemetry.io/schemas/1.6.1", schema)
+			assert.Contains(t, schema, "https://opentelemetry.io/schemas/")
 			assert.Equal(t, tc.expectedResource, res.Attributes().AsRaw(), "Resource object returned is incorrect")
 		})
 	}

--- a/processor/sumologicprocessor/cloud_namespace_processor.go
+++ b/processor/sumologicprocessor/cloud_namespace_processor.go
@@ -8,7 +8,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 )
 
 // cloudNamespaceProcessor adds the `cloud.namespace` resource attribute to logs, metrics and traces.

--- a/receiver/k8sclusterreceiver/internal/container/containers.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/otel/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 


### PR DESCRIPTION
Updated dependencies to latest where possible. Added 1.34.0 along with an issue to track the changes needed to remove it.
