### PR TITLE
chore: add cloud.account.id to resource attributes

### DIFF
--- a/.chloggen/add_cloud_account_id.yaml
+++ b/.chloggen/add_cloud_account_id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add cloud.account.id to resource attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -20,6 +20,8 @@ Receives Cloudwatch events from [AWS Cloudwatch](https://aws.amazon.com/cloudwat
 
 This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) as mode of authentication, which includes [Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances.
 
+The receiver makes requests to the `sts.GetCallerIdentity` API endpoint, which is used to populate the `cloud.account.id` attribute. If this request is blocked or restricted then this attribute is omited.
+
 ## Configuration
 
 ### Top Level Parameters

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -45,6 +46,7 @@ type logsReceiver struct {
 	doneChan                      chan bool
 	storageID                     *component.ID
 	cloudwatchCheckpointPersister *cloudwatchCheckpointPersister
+	accountID                     string
 }
 
 type client interface {
@@ -350,6 +352,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
+			resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}
@@ -455,6 +458,14 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
+	if err != nil {
+		return err
+	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
+
+	stsClient := sts.NewFromConfig(cfg)
+	stsResult, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	l.accountID = *stsResult.Account
+
 	return err
 }

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -352,7 +352,9 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			if l.accountID != "" {
+				resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			}
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}

--- a/receiver/awscloudwatchreceiver/testdata/processed/prefixed-with-accountid.yaml
+++ b/receiver/awscloudwatchreceiver/testdata/processed/prefixed-with-accountid.yaml
@@ -1,0 +1,75 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: aws.region
+          value:
+            stringValue: us-west-1
+        - key: cloudwatch.log.group.name
+          value:
+            stringValue: test-log-group-name
+        - key: cloudwatch.log.stream
+          value:
+            stringValue: test-log-stream-name
+        - key: cloud.account.id
+          value:
+            stringValue: "111111111111"
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333379"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333380"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+        scope: {}
+  - resource:
+      attributes:
+        - key: aws.region
+          value:
+            stringValue: us-west-1
+        - key: cloudwatch.log.group.name
+          value:
+            stringValue: test-log-group-name
+        - key: cloudwatch.log.stream
+          value:
+            stringValue: test-log-stream-name-2
+        - key: cloud.account.id
+          value:
+            stringValue: "111111111111"
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333381"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333382"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+        scope: {}


### PR DESCRIPTION
#### Description
Logs coming from this receiver are missing `cloud.account.id`, if the collector is running in the same account as the source log groups then the attribute can be added using resource detection. 

However if the collector is running in different account then we need to use the established pattern identifying the account id, using the `sts` call to `GetCallerIdentity`. This will work as expected in both use cases.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45038 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
