### PR TITLE
[tailsamplingprocessor] Cache the sampled policy

### DIFF
--- a/.chloggen/logiraptor_cache-sampled-policy.yaml
+++ b/.chloggen/logiraptor_cache-sampled-policy.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: processor/tail_sampling
@@ -24,4 +24,4 @@ subtext: This change allows the `tailsampling.policy` attribute to be set on the
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user, api]

--- a/.chloggen/logiraptor_cache-sampled-policy.yaml
+++ b/.chloggen/logiraptor_cache-sampled-policy.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: processor/tailsamplingprocessor
+component: processor/tail_sampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add support for caching the policy name involved in a sampling decision.

--- a/.chloggen/logiraptor_cache-sampled-policy.yaml
+++ b/.chloggen/logiraptor_cache-sampled-policy.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for caching the policy name involved in a sampling decision.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45040]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This change allows the `tailsampling.policy` attribute to be set on the spans in a trace when a sampling decision is cached.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/tailsamplingprocessor/cache/nop_cache.go
+++ b/processor/tailsamplingprocessor/cache/nop_cache.go
@@ -5,20 +5,17 @@ package cache // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import "go.opentelemetry.io/collector/pdata/pcommon"
 
-type nopDecisionCache[V any] struct{}
+type nopDecisionCache struct{}
 
-var _ Cache[any] = (*nopDecisionCache[any])(nil)
+var _ Cache = (*nopDecisionCache)(nil)
 
-func NewNopDecisionCache[V any]() Cache[V] {
-	return &nopDecisionCache[V]{}
+func NewNopDecisionCache() Cache {
+	return &nopDecisionCache{}
 }
 
-func (*nopDecisionCache[V]) Get(pcommon.TraceID) (V, bool) {
-	var v V
-	return v, false
+func (*nopDecisionCache) Get(pcommon.TraceID) (DecisionMetadata, bool) {
+	return DecisionMetadata{}, false
 }
 
-func (*nopDecisionCache[V]) Put(_ pcommon.TraceID, _ V) {
+func (*nopDecisionCache) Put(_ pcommon.TraceID, _ DecisionMetadata) {
 }
-
-func (*nopDecisionCache[V]) Delete(_ pcommon.TraceID) {}

--- a/processor/tailsamplingprocessor/cache/nop_cache_test.go
+++ b/processor/tailsamplingprocessor/cache/nop_cache_test.go
@@ -11,11 +11,12 @@ import (
 )
 
 func TestNopCache(t *testing.T) {
-	c := NewNopDecisionCache[bool]()
+	c := NewNopDecisionCache()
 	id, err := traceIDFromHex("12341234123412341234123412341234")
 	require.NoError(t, err)
-	c.Put(id, true)
-	v, ok := c.Get(id)
-	assert.False(t, v)
+	c.Put(id, DecisionMetadata{
+		PolicyName: "mock-policy",
+	})
+	_, ok := c.Get(id)
 	assert.False(t, ok)
 }

--- a/processor/tailsamplingprocessor/cache/types.go
+++ b/processor/tailsamplingprocessor/cache/types.go
@@ -3,15 +3,20 @@
 
 package cache // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/cache"
 
-import "go.opentelemetry.io/collector/pdata/pcommon"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
-// Cache is a cache using a pcommon.TraceID as the key and any generic type as the value.
-type Cache[V any] interface {
-	// Get returns the value for the given id, and a boolean to indicate whether the key was found.
-	// If the key is not present, the zero value is returned.
-	Get(id pcommon.TraceID) (V, bool)
-	// Put sets the value for a given id
-	Put(id pcommon.TraceID, v V)
-	// Delete deletes the value for the given id
-	Delete(id pcommon.TraceID)
+// Cache is a cache implementation for the tailsamplingprocessor's decision cache.
+type Cache interface {
+	// Get returns the decision for the given id, and a boolean to indicate whether the key was found.
+	// Returning a zero value for DecisionMetadata is valid for caches that do not store metadata.
+	// Callers should check the boolean return value to determine if the key was found.
+	Get(id pcommon.TraceID) (DecisionMetadata, bool)
+	// Put sets the decision for a given id. If the key is already present, the decision is overwritten.
+	Put(id pcommon.TraceID, metadata DecisionMetadata)
+}
+
+type DecisionMetadata struct {
+	PolicyName string
 }

--- a/processor/tailsamplingprocessor/internal/sampling/composite.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite.go
@@ -119,7 +119,7 @@ func (c *Composite) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace
 
 				// Let the sampling happen
 				if c.recordSubPolicy {
-					SetAttrOnScopeSpans(trace, "tailsampling.composite_policy", sub.name)
+					SetAttrOnScopeSpans(trace.ReceivedBatches, "tailsampling.composite_policy", sub.name)
 				}
 				return samplingpolicy.Sampled, nil
 			}

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -93,8 +93,8 @@ func hasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlice, che
 	return invert
 }
 
-func SetAttrOnScopeSpans(data *samplingpolicy.TraceData, attrName, attrKey string) {
-	rs := data.ReceivedBatches.ResourceSpans()
+func SetAttrOnScopeSpans(data ptrace.Traces, attrName, attrKey string) {
+	rs := data.ResourceSpans()
 	for i := 0; i < rs.Len(); i++ {
 		rss := rs.At(i)
 		for j := 0; j < rss.ScopeSpans().Len(); j++ {

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -9,17 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/pkg/samplingpolicy"
 )
 
 func TestSetAttrOnScopeSpans_Empty(_ *testing.T) {
 	traces := ptrace.NewTraces()
-	traceData := &samplingpolicy.TraceData{
-		ReceivedBatches: traces,
-	}
 
-	SetAttrOnScopeSpans(traceData, "test.attr", "value")
+	SetAttrOnScopeSpans(traces, "test.attr", "value")
 }
 
 func TestSetAttrOnScopeSpans_Many(t *testing.T) {
@@ -41,11 +36,7 @@ func TestSetAttrOnScopeSpans_Many(t *testing.T) {
 	ss3 := rs2.ScopeSpans().AppendEmpty()
 	span4 := ss3.Spans().AppendEmpty()
 
-	traceData := &samplingpolicy.TraceData{
-		ReceivedBatches: traces,
-	}
-
-	SetAttrOnScopeSpans(traceData, "test.attr", "value")
+	SetAttrOnScopeSpans(traces, "test.attr", "value")
 
 	assertAttrExists(t, ss1.Scope().Attributes(), "test.attr", "value")
 	assertAttrExists(t, ss2.Scope().Attributes(), "test.attr", "value")
@@ -81,11 +72,7 @@ func BenchmarkSetAttrOnScopeSpans(b *testing.B) {
 			ss3.Spans().AppendEmpty()
 		}
 
-		traceData := &samplingpolicy.TraceData{
-			ReceivedBatches: traces,
-		}
-
 		b.StartTimer()
-		SetAttrOnScopeSpans(traceData, "test.attr", "value")
+		SetAttrOnScopeSpans(traces, "test.attr", "value")
 	}
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -492,9 +492,8 @@ func (tsp *tailSamplingSpanProcessor) processCachedTrace(traceID pcommon.TraceID
 		if tsp.recordPolicy {
 			if metadata.PolicyName != "" {
 				sampling.SetAttrOnScopeSpans(traceTd, "tailsampling.policy", metadata.PolicyName)
-			} else {
-				sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
 			}
+			sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
 		}
 		tsp.forwardSpans(tsp.ctx, traceTd)
 		tsp.telemetry.ProcessorTailSamplingEarlyReleasesFromCacheDecision.

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -50,6 +50,7 @@ type traceData struct {
 	arrivalTime   time.Time
 	decisionTime  time.Time
 	finalDecision samplingpolicy.Decision
+	policyName    string
 	deleteElement *list.Element
 }
 
@@ -66,8 +67,8 @@ type tailSamplingSpanProcessor struct {
 	idToTrace          map[pcommon.TraceID]*traceData
 	tickerFrequency    time.Duration
 	decisionBatcher    idbatcher.Batcher
-	sampledIDCache     cache.Cache[bool]
-	nonSampledIDCache  cache.Cache[bool]
+	sampledIDCache     cache.Cache
+	nonSampledIDCache  cache.Cache
 	recordPolicy       bool
 	sampleOnFirstMatch bool
 	blockOnOverflow    bool
@@ -90,17 +91,17 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 	if err != nil {
 		return nil, err
 	}
-	nopCache := cache.NewNopDecisionCache[bool]()
+	nopCache := cache.NewNopDecisionCache()
 	sampledDecisions := nopCache
 	nonSampledDecisions := nopCache
 	if cfg.DecisionCache.SampledCacheSize > 0 {
-		sampledDecisions, err = cache.NewLRUDecisionCache[bool](cfg.DecisionCache.SampledCacheSize)
+		sampledDecisions, err = cache.NewLRUDecisionCache(cfg.DecisionCache.SampledCacheSize)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if cfg.DecisionCache.NonSampledCacheSize > 0 {
-		nonSampledDecisions, err = cache.NewLRUDecisionCache[bool](cfg.DecisionCache.NonSampledCacheSize)
+		nonSampledDecisions, err = cache.NewLRUDecisionCache(cfg.DecisionCache.NonSampledCacheSize)
 		if err != nil {
 			return nil, err
 		}
@@ -288,14 +289,14 @@ var (
 type Option func(*tailSamplingSpanProcessor)
 
 // WithSampledDecisionCache sets the cache which the processor uses to store recently sampled trace IDs.
-func WithSampledDecisionCache(c cache.Cache[bool]) Option {
+func WithSampledDecisionCache(c cache.Cache) Option {
 	return func(tsp *tailSamplingSpanProcessor) {
 		tsp.sampledIDCache = c
 	}
 }
 
 // WithNonSampledDecisionCache sets the cache which the processor uses to store recently non-sampled trace IDs.
-func WithNonSampledDecisionCache(c cache.Cache[bool]) Option {
+func WithNonSampledDecisionCache(c cache.Cache) Option {
 	return func(tsp *tailSamplingSpanProcessor) {
 		tsp.nonSampledIDCache = c
 	}
@@ -484,12 +485,16 @@ func (tsp *tailSamplingSpanProcessor) iter(tickChan <-chan time.Time, workChan <
 // dropped) and forwards the span appropriately. It returns true if the trace
 // was cached and false if regular processing must be done.
 func (tsp *tailSamplingSpanProcessor) processCachedTrace(traceID pcommon.TraceID, rss ptrace.ResourceSpans, spanCount int64) bool {
-	if _, ok := tsp.sampledIDCache.Get(traceID); ok {
+	if metadata, ok := tsp.sampledIDCache.Get(traceID); ok {
 		tsp.logger.Debug("Trace ID is in the sampled cache", zap.Stringer("id", traceID))
 		traceTd := ptrace.NewTraces()
 		appendToTraces(traceTd, rss)
 		if tsp.recordPolicy {
-			sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
+			if metadata.PolicyName != "" {
+				sampling.SetAttrOnScopeSpans(traceTd, "tailsampling.policy", metadata.PolicyName)
+			} else {
+				sampling.SetBoolAttrOnScopeSpans(traceTd, "tailsampling.cached_decision", true)
+			}
 		}
 		tsp.forwardSpans(tsp.ctx, traceTd)
 		tsp.telemetry.ProcessorTailSamplingEarlyReleasesFromCacheDecision.
@@ -553,18 +558,19 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() bool {
 		}
 		trace.decisionTime = time.Now()
 
-		decision := tsp.makeDecision(id, &trace.TraceData, metrics)
+		decision, policyName := tsp.makeDecision(id, &trace.TraceData, metrics)
 		globalTracesSampledByDecision[decision]++
 
 		// Sampled or not, remove the batches
 		allSpans := trace.ReceivedBatches
 		trace.finalDecision = decision
+		trace.policyName = policyName
 		trace.ReceivedBatches = ptrace.NewTraces()
 
 		if decision == samplingpolicy.Sampled {
-			tsp.releaseSampledTrace(ctx, id, allSpans)
+			tsp.releaseSampledTrace(ctx, id, allSpans, policyName)
 		} else {
-			tsp.releaseNotSampledTrace(id)
+			tsp.releaseNotSampledTrace(id, policyName)
 		}
 	}
 
@@ -599,7 +605,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() bool {
 	return hasMore
 }
 
-func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *samplingpolicy.TraceData, metrics *policyTickMetrics) samplingpolicy.Decision {
+func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *samplingpolicy.TraceData, metrics *policyTickMetrics) (samplingpolicy.Decision, string) {
 	finalDecision := samplingpolicy.NotSampled
 	samplingDecisions := map[samplingpolicy.Decision]*policy{
 		samplingpolicy.Error:            nil,
@@ -649,6 +655,7 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sa
 	switch {
 	case samplingDecisions[samplingpolicy.Dropped] != nil: // Dropped takes precedence
 		finalDecision = samplingpolicy.Dropped
+		sampledPolicy = samplingDecisions[samplingpolicy.Dropped]
 	case samplingDecisions[samplingpolicy.InvertNotSampled] != nil: // Then InvertNotSampled
 		finalDecision = samplingpolicy.NotSampled
 	case samplingDecisions[samplingpolicy.Sampled] != nil:
@@ -659,8 +666,8 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sa
 		sampledPolicy = samplingDecisions[samplingpolicy.InvertSampled]
 	}
 
-	if tsp.recordPolicy && sampledPolicy != nil {
-		sampling.SetAttrOnScopeSpans(trace, "tailsampling.policy", sampledPolicy.name)
+	if tsp.recordPolicy && sampledPolicy != nil && finalDecision == samplingpolicy.Sampled {
+		sampling.SetAttrOnScopeSpans(trace.ReceivedBatches, "tailsampling.policy", sampledPolicy.name)
 	}
 
 	switch finalDecision {
@@ -672,7 +679,7 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sa
 		metrics.decisionDropped++
 	}
 
-	return finalDecision
+	return finalDecision, getPolicyName(sampledPolicy)
 }
 
 func groupSpansByTraceKey(resourceSpans ptrace.ResourceSpans) map[pcommon.TraceID][]spanAndScope {
@@ -741,7 +748,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 		appendToTraces(traceTd, rss)
 		tsp.forwardSpans(tsp.ctx, traceTd)
 	case samplingpolicy.NotSampled:
-		tsp.releaseNotSampledTrace(id)
+		tsp.releaseNotSampledTrace(id, actualData.policyName)
 	default:
 		tsp.logger.Warn("Unexpected sampling decision", zap.Int("decision", int(finalDecision)))
 	}
@@ -806,8 +813,8 @@ func (tsp *tailSamplingSpanProcessor) forwardSpans(ctx context.Context, td ptrac
 // releaseSampledTrace sends the trace data to the next consumer. It
 // additionally adds the trace ID to the cache of sampled trace IDs. If the
 // trace ID is cached, it deletes the spans from the internal map.
-func (tsp *tailSamplingSpanProcessor) releaseSampledTrace(ctx context.Context, id pcommon.TraceID, td ptrace.Traces) {
-	tsp.sampledIDCache.Put(id, true)
+func (tsp *tailSamplingSpanProcessor) releaseSampledTrace(ctx context.Context, id pcommon.TraceID, td ptrace.Traces, policyName string) {
+	tsp.sampledIDCache.Put(id, cache.DecisionMetadata{PolicyName: policyName})
 	tsp.forwardSpans(ctx, td)
 	_, ok := tsp.sampledIDCache.Get(id)
 	if ok {
@@ -817,12 +824,19 @@ func (tsp *tailSamplingSpanProcessor) releaseSampledTrace(ctx context.Context, i
 
 // releaseNotSampledTrace adds the trace ID to the cache of not sampled trace
 // IDs. If the trace ID is cached, it deletes the spans from the internal map.
-func (tsp *tailSamplingSpanProcessor) releaseNotSampledTrace(id pcommon.TraceID) {
-	tsp.nonSampledIDCache.Put(id, true)
+func (tsp *tailSamplingSpanProcessor) releaseNotSampledTrace(id pcommon.TraceID, policyName string) {
+	tsp.nonSampledIDCache.Put(id, cache.DecisionMetadata{PolicyName: policyName})
 	_, ok := tsp.nonSampledIDCache.Get(id)
 	if ok {
 		tsp.dropTrace(id, time.Now())
 	}
+}
+
+func getPolicyName(policy *policy) string {
+	if policy == nil {
+		return ""
+	}
+	return policy.name
 }
 
 func appendToTraces(dest ptrace.Traces, rss ptrace.ResourceSpans) {

--- a/processor/tailsamplingprocessor/processor_benchmarks_test.go
+++ b/processor/tailsamplingprocessor/processor_benchmarks_test.go
@@ -46,7 +46,7 @@ func BenchmarkSampling(b *testing.B) {
 
 	for b.Loop() {
 		for i, id := range traceIDs {
-			_ = tsp.makeDecision(id, sampleBatches[i], metrics)
+			_, _ = tsp.makeDecision(id, sampleBatches[i], metrics)
 		}
 	}
 }

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -645,7 +645,7 @@ func TestLateArrivingSpanUsesDecisionCacheWhenDropped(t *testing.T) {
 	require.Equal(t, 1, mpe.EvaluationCount)
 	require.Equal(t, 0, nextConsumer.SpanCount(), "original final decision not honored")
 	allTraces := nextConsumer.AllTraces()
-	require.Len(t, allTraces, 0)
+	require.Empty(t, allTraces)
 
 	metadata, ok := c.Get(traceID)
 	if !ok {

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -476,7 +476,7 @@ func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
 	}
 
 	// Use this instead of the default no-op cache
-	c, err := cache.NewLRUDecisionCache[bool](200)
+	c, err := cache.NewLRUDecisionCache(200)
 	require.NoError(t, err)
 
 	cfg := Config{
@@ -551,11 +551,83 @@ func TestLateArrivingSpanUsesDecisionCache(t *testing.T) {
 	require.Len(t, allTraces, 2)
 
 	// Second trace should have the cached decision attribute
-	cachedAttr, ok := allTraces[1].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.cached_decision")
+	policyAttr, ok := allTraces[1].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.policy")
 	if !ok {
 		assert.FailNow(t, "Did not find expected attribute")
 	}
-	require.True(t, cachedAttr.Bool())
+	require.Equal(t, "mock-policy-1", policyAttr.AsString())
+}
+
+func TestLateArrivingSpanWithoutCacheMetadata(t *testing.T) {
+	nextConsumer := new(consumertest.TracesSink)
+	controller := newTestTSPController()
+
+	mpe := &mockPolicyEvaluator{}
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+	}
+
+	// Use this instead of the default no-op cache
+	c, err := cache.NewLRUDecisionCache(200)
+	require.NoError(t, err)
+
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait * 10,
+		NumTraces:    defaultNumTraces,
+		Options: []Option{
+			withTestController(controller),
+			withPolicies(policies),
+			WithSampledDecisionCache(c),
+			withRecordPolicy(),
+		},
+	}
+
+	// We are going to create 2 spans belonging to the same trace
+	traceID := uInt64ToTraceID(1)
+
+	// The first span will be sampled, this will later be set to not sampled, but the sampling decision will be cached
+	mpe.NextDecision = samplingpolicy.Sampled
+
+	// A function that return a ptrace.Traces containing a single span for the single trace we are using.
+	spanIndexToTraces := func(spanIndex uint64) ptrace.Traces {
+		traces := ptrace.NewTraces()
+		span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetTraceID(traceID)
+		span.SetSpanID(uInt64ToSpanID(spanIndex))
+		return traces
+	}
+
+	// Simulate a decision cached without any metadata.
+	c.Put(traceID, cache.DecisionMetadata{})
+
+	// Now we create a brand new tailsampling span processor with the same decision cache
+	p, err := newTracesProcessor(t.Context(), processortest.NewNopSettings(metadata.Type), nextConsumer, cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func(p processor.Traces) {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}(p)
+
+	// Set next decision to not sampled, ensuring the next decision is determined by the decision cache, not the policy
+	mpe.NextDecision = samplingpolicy.NotSampled
+
+	// Generate and deliver final span for the trace which SHOULD get the same sampling decision as the first span.
+	// The policies should NOT be evaluated again.
+	require.NoError(t, p.ConsumeTraces(t.Context(), spanIndexToTraces(2)))
+	controller.waitForTick()
+
+	// Policy should never have been evaluated
+	require.Equal(t, 0, mpe.EvaluationCount)
+	require.Equal(t, 1, nextConsumer.SpanCount(), "original final decision not honored")
+	allTraces := nextConsumer.AllTraces()
+	require.Len(t, allTraces, 1)
+
+	// Second trace should have the cached decision attribute
+	cacheAttr, ok := allTraces[0].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.cached_decision")
+	if !ok {
+		assert.FailNow(t, "Did not find expected attribute")
+	}
+	require.True(t, cacheAttr.Bool())
 }
 
 func TestLateSpanUsesNonSampledDecisionCache(t *testing.T) {
@@ -568,7 +640,7 @@ func TestLateSpanUsesNonSampledDecisionCache(t *testing.T) {
 	}
 
 	// Use this instead of the default no-op cache
-	c, err := cache.NewLRUDecisionCache[bool](200)
+	c, err := cache.NewLRUDecisionCache(200)
 	require.NoError(t, err)
 
 	cfg := Config{

--- a/processor/tailsamplingprocessor/processor_telemetry_test.go
+++ b/processor/tailsamplingprocessor/processor_telemetry_test.go
@@ -927,7 +927,7 @@ func TestProcessorTailSamplingEarlyReleasesFromCacheDecision(t *testing.T) {
 	controller := newTestTSPController()
 
 	// Use this instead of the default no-op cache
-	c, err := cache.NewLRUDecisionCache[bool](200)
+	c, err := cache.NewLRUDecisionCache(200)
 	require.NoError(t, err)
 
 	cfg := Config{


### PR DESCRIPTION
#### Description
This PR adds the policy name to the decision cache. This allows us to properly track the `tailsampling.policy` attribute, even for cached decisions.

For non-sampled traces, we track either an empty policy name (if no policy matched), or the name of a specific drop policy.

Since I'm already modifying the Cache interface, I went ahead and cleaned up some unnecessary design features:

* Removed `Delete` which was unused
* Removed generic type parameter which was always instantiated as `bool`
