### PR TITLE
[exporter/elasticsearch] Update the ecs mode span encoder to drop `transaction.root`

### DIFF
--- a/.chloggen/es-exporter-drop-tx-root.yaml
+++ b/.chloggen/es-exporter-drop-tx-root.yaml
@@ -10,7 +10,7 @@ component: exporter/elasticsearch
 note: Update the ecs mode span encoder to drop `transaction.root` since this field is not required for individual span documents.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [45060]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/es-exporter-drop-tx-root.yaml
+++ b/.chloggen/es-exporter-drop-tx-root.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the ecs mode span encoder to drop `transaction.root` since this field is not required for individual span documents.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The `transaction.root` is only needed for transaction metrics.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -492,6 +492,9 @@ The value of the last-mapped attribute will take precedence.
 | db.query.text              | span.db.statement                                         | false    |
 | http.response.body.size    | http.response.encoded_body_size                           | false    |
 
+#### transaction.root
+The `transaction.root` ECS attribute is removed during ECS mapping since it is not required for individual spans.
+This attribute is only needed for transaction metrics. 
 
 ### Compound Mapping
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -271,6 +271,8 @@ func (ecsModeEncoder) encodeSpan(
 		string(conventions.DBNamespaceKey):              {to: "span.db.instance"},
 		string(conventions.DBQueryTextKey):              {to: "span.db.statement"},
 		string(conventions.HTTPResponseBodySizeKey):     {to: "http.response.encoded_body_size"},
+		// Dropping since transaction.root is not needed for individual spans
+		"transaction.root": {to: "", skip: true},
 	}
 
 	// Handle special cases.

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -488,6 +488,7 @@ func TestEncodeSpanECSMode(t *testing.T) {
 		"db.namespace":               "users",
 		"db.query.text":              "SELECT * FROM users WHERE user_id=?",
 		"http.response.body.size":    "http.response.encoded_body_size",
+		"transaction.root":           true,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR removes `transaction.root` from the document when the mapping mode is `ecs`. The attribute is only needed for aggregated transaction [metrics](https://www.elastic.co/docs/solutions/observability/apm/metrics#_transaction_metrics) and does not need to be included in individual span documents. 

The legacy apm data flow does not include `transaction.root` for individual transactions. Based on my investigation the main reason `transaction.root` added is so that it is available for the [elasticapmconnector](https://github.com/elastic/opentelemetry-collector-components/blob/v0.24.0/connector/elasticapmconnector/config.go#L239-L252) which is responsible for generating transaction metrics.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Updated unit test

<!--Describe the documentation added.-->
#### Documentation
- Updated README
