### PR TITLE
[exporter/sapm] deprecate the code of the exporter, ahead of its removal

### DIFF
--- a/.chloggen/deprecate_sapmexporter.yaml
+++ b/.chloggen/deprecate_sapmexporter.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/sapm
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the SAPM exporter code ahead of its removal.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45062]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This exporter has been deprecated since 2024-12-19.
+  Please use the OTLP exporter instead.
+  With this change, the Go module is declared deprecated.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/sapmexporter/doc.go
+++ b/exporter/sapmexporter/doc.go
@@ -4,4 +4,6 @@
 //go:generate mdatagen metadata.yaml
 
 // Package sapmexporter sends traces to a SAPM endpoint.
+//
+// Deprecated: [v0.143.0] Use OTLP exporter instead
 package sapmexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: [v0.143.0] Use OTLP exporter instead
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
 
 go 1.24.0


### PR DESCRIPTION
This PR deprecates the code of the SAPM exporter ahead of its removal. The exporter has been deprecated for a year.