### PR TITLE
[receiver/systemd] Add metric for service restarts

### DIFF
--- a/.chloggen/systemd-restart-count.yaml
+++ b/.chloggen/systemd-restart-count.yaml
@@ -10,7 +10,7 @@ component: receiver/systemd
 note: Add metric for number of times a service has restarted.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0]
+issues: [45071]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/systemd-restart-count.yaml
+++ b/.chloggen/systemd-restart-count.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/systemd
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add metric for number of times a service has restarted.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [0]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/systemdreceiver/documentation.md
+++ b/receiver/systemdreceiver/documentation.md
@@ -40,6 +40,29 @@ Total CPU time spent by this service.
 | ---- | ----------- | ------ | -------- |
 | systemd.unit.active_state | The active state of the unit (https://www.freedesktop.org/software/systemd/man/latest/systemd.html#Units) | Str: ``active``, ``reloading``, ``inactive``, ``failed``, ``activating``, ``deactivating``, ``maintenance``, ``refreshing`` | Recommended |
 
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
+### systemd.service.restarts
+
+Number of automatic restarts for the service.
+
+This exposes services' `NRestarts` property as a metric. This only tracks
+automatic service restarts (restarts when the process exits), and does
+not include manual restarts (e.g. from `systemctl restart`).
+
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
+| ---- | ----------- | ---------- | ----------------------- | --------- | --------- |
+| {restarts} | Sum | Int | Cumulative | true | Development |
+
 ## Resource Attributes
 
 | Name | Description | Values | Enabled |

--- a/receiver/systemdreceiver/internal/metadata/generated_config.go
+++ b/receiver/systemdreceiver/internal/metadata/generated_config.go
@@ -28,14 +28,18 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for systemd metrics.
 type MetricsConfig struct {
-	SystemdServiceCPUTime MetricConfig `mapstructure:"systemd.service.cpu.time"`
-	SystemdUnitState      MetricConfig `mapstructure:"systemd.unit.state"`
+	SystemdServiceCPUTime  MetricConfig `mapstructure:"systemd.service.cpu.time"`
+	SystemdServiceRestarts MetricConfig `mapstructure:"systemd.service.restarts"`
+	SystemdUnitState       MetricConfig `mapstructure:"systemd.unit.state"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		SystemdServiceCPUTime: MetricConfig{
 			Enabled: true,
+		},
+		SystemdServiceRestarts: MetricConfig{
+			Enabled: false,
 		},
 		SystemdUnitState: MetricConfig{
 			Enabled: true,

--- a/receiver/systemdreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/systemdreceiver/internal/metadata/generated_config_test.go
@@ -26,8 +26,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemdServiceCPUTime: MetricConfig{Enabled: true},
-					SystemdUnitState:      MetricConfig{Enabled: true},
+					SystemdServiceCPUTime:  MetricConfig{Enabled: true},
+					SystemdServiceRestarts: MetricConfig{Enabled: true},
+					SystemdUnitState:       MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					SystemdUnitName: ResourceAttributeConfig{Enabled: true},
@@ -38,8 +39,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemdServiceCPUTime: MetricConfig{Enabled: false},
-					SystemdUnitState:      MetricConfig{Enabled: false},
+					SystemdServiceCPUTime:  MetricConfig{Enabled: false},
+					SystemdServiceRestarts: MetricConfig{Enabled: false},
+					SystemdUnitState:       MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					SystemdUnitName: ResourceAttributeConfig{Enabled: false},

--- a/receiver/systemdreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/systemdreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,8 @@ all_set:
   metrics:
     systemd.service.cpu.time:
       enabled: true
+    systemd.service.restarts:
+      enabled: true
     systemd.unit.state:
       enabled: true
   resource_attributes:
@@ -11,6 +13,8 @@ all_set:
 none_set:
   metrics:
     systemd.service.cpu.time:
+      enabled: false
+    systemd.service.restarts:
       enabled: false
     systemd.unit.state:
       enabled: false

--- a/receiver/systemdreceiver/metadata.yaml
+++ b/receiver/systemdreceiver/metadata.yaml
@@ -48,6 +48,21 @@ metrics:
     unit: us
     attributes: [cpu.mode]
 
+  systemd.service.restarts:
+    description: Number of automatic restarts for the service.
+    extended_documentation: |
+      This exposes services' `NRestarts` property as a metric. This only tracks
+      automatic service restarts (restarts when the process exits), and does
+      not include manual restarts (e.g. from `systemctl restart`).
+    enabled: false
+    stability:
+      level: development
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: true
+    unit: "{restarts}"
+
   systemd.unit.state:
     description: 1 if the check resulted in active_state matching the current state, otherwise 0.
     enabled: true

--- a/receiver/systemdreceiver/testdata/expected_metrics/restarts.yaml
+++ b/receiver/systemdreceiver/testdata/expected_metrics/restarts.yaml
@@ -1,0 +1,21 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: systemd.unit.name
+          value:
+            stringValue: nginx.service
+    scopeMetrics:
+      - metrics:
+          - description: Number of automatic restarts for the service.
+            name: systemd.service.restarts
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{restarts}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
+          version: latest


### PR DESCRIPTION
#### Description
This adds a metric for the number of times a systemd service has exited and been automatically restarted. This is *not* enabled by default — I think there's enough overlap with other metrics I'd like to expose (e.g. service uptime), that it's not worth it.

#### Testing
There is a unit for this, and I did some manual testing with a transient unit started with `systemd-run --user -u test -p Restart=always -p StartLimitBurst=50 -- bash -c "sleep 1; exit 1"`.

#### Documentation
Description (and some extended docs) in the `metadata.yaml` as expected, but nothing else.