### PR TITLE
Add kafka.topic and kafka.partition to resource so we can use it in otel

### DIFF
--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -413,6 +413,14 @@ func processMessage[T plog.Logs | pmetric.Metrics | ptrace.Traces | pprofile.Pro
 		}
 	}
 
+	// Add Kafka topic, partition, and offset as resource attributes
+	// This makes the topic available for downstream processors and exporters
+	for resource := range handler.getResources(data) {
+		resource.Attributes().PutStr("kafka.topic", message.topic())
+		resource.Attributes().PutInt("kafka.partition", int64(message.partition()))
+		resource.Attributes().PutInt("kafka.offset", message.offset())
+	}
+
 	err = handler.consumeData(ctx, data)
 	handler.endObsReport(obsCtx, n, err)
 	return err

--- a/receiver/kafkareceiver/metadata.yaml
+++ b/receiver/kafkareceiver/metadata.yaml
@@ -34,6 +34,20 @@ attributes:
     description: The Kafka topic.
     type: string
 
+resource_attributes:
+  kafka.topic:
+    description: The Kafka topic from which the message was received.
+    enabled: true
+    type: string
+  kafka.partition:
+    description: The Kafka partition from which the message was received.
+    enabled: true
+    type: int
+  kafka.offset:
+    description: The Kafka offset of the message.
+    enabled: true
+    type: int
+
 telemetry:
   metrics:
     kafka_broker_closed:


### PR DESCRIPTION
We're trying to add the kafka topic as an attribute in our logs, but are unable to. I believe this should allow us to do so. 

We currently pull from 60 kafka topics (so one receiver per topic isn't very tenable) but we still want to be able to get the topic detail on each log message. 

#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
