### PR TITLE
[chore][processor/k8sattributesprocessor] Improve Logging for Missing Pod Metadata in k8sattributesprocessor to Aid Debugging

### DIFF
--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -155,16 +155,16 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	}
 
 	var pod *kube.Pod
-	if podIdentifierValue.IsNotEmpty() {
-		var podFound bool
-		if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
-			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
+	var podFound bool
+	if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
+		kp.logger.Debug("getting the pod", zap.Any("pod", pod))
 
-			for key, val := range pod.Attributes {
-				setResourceAttribute(resource.Attributes(), key, val)
-			}
-			kp.addContainerAttributes(resource.Attributes(), pod)
+		for key, val := range pod.Attributes {
+			setResourceAttribute(resource.Attributes(), key, val)
 		}
+		kp.addContainerAttributes(resource.Attributes(), pod)
+	} else {
+		kp.logger.Debug("unable to find pod based on identifier", zap.Any("value", podIdentifierValue))
 	}
 
 	namespace := getNamespace(pod, resource.Attributes())

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -155,16 +155,18 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	}
 
 	var pod *kube.Pod
-	var podFound bool
-	if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
-		kp.logger.Debug("getting the pod", zap.Any("pod", pod))
+	if podIdentifierValue.IsNotEmpty() {
+		var podFound bool
+		if pod, podFound = kp.kc.GetPod(podIdentifierValue); podFound {
+			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
 
-		for key, val := range pod.Attributes {
-			setResourceAttribute(resource.Attributes(), key, val)
+			for key, val := range pod.Attributes {
+				setResourceAttribute(resource.Attributes(), key, val)
+			}
+			kp.addContainerAttributes(resource.Attributes(), pod)
+		} else {
+			kp.logger.Debug("unable to find pod based on identifier", zap.Any("value", podIdentifierValue))
 		}
-		kp.addContainerAttributes(resource.Attributes(), pod)
-	} else {
-		kp.logger.Debug("unable to find pod based on identifier", zap.Any("value", podIdentifierValue))
 	}
 
 	namespace := getNamespace(pod, resource.Attributes())


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In our Kubernetes environment, we have observed that some tracing spans were missing Kubernetes metadata enrichment, particularly resource attributes required for compliance with our software taxonomy.
Currently, when the k8sattributesprocessor fails to find a pod based on the provided identifier, there is no explicit log message indicating this failure. This makes it difficult to debug issues related to missing metadata and to ensure that all observability signals are properly enriched and compliant with our taxonomy.

Justification for the Change:

- Improved Debuggability: By explicitly logging when a pod cannot be found based on the identifier, operators can more easily diagnose and resolve issues related to missing Kubernetes metadata enrichment.
- Operational Clarity: The lack of explicit logging for missing pods can lead to silent failures, false alarms in monitoring, and increased operational overhead.

Proposed Code Change: Update the processResource function in k8sattributesprocessor to add a debug log when a pod cannot be found for the given identifier.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45099
