### PR TITLE
Add feature gate for the removal of 'report_extra_scrape_metrics' config

### DIFF
--- a/.chloggen/prometheus-remove-extra-scrape-metrics-config.yaml
+++ b/.chloggen/prometheus-remove-extra-scrape-metrics-config.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig` feature gate to disable the `report_extra_scrape_metrics` config option."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44181]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When enabled, the `report_extra_scrape_metrics` configuration option is ignored, and extra scrape metrics are
+  controlled solely by the `receiver.prometheusreceiver.EnableReportExtraScrapeMetrics` feature gate.
+  This mimics Prometheus behavior where extra scrape metrics are controlled by a feature flag.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -257,6 +257,15 @@ More info about querying `/api/v1/` and the data format that is returned can be 
 "--feature-gates=receiver.prometheusreceiver.EnableReportExtraScrapeMetrics"
 ```
 
+- `receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig`: When enabled, the
+  `report_extra_scrape_metrics` configuration option is ignored, and extra scrape metrics are
+  controlled solely by the `EnableReportExtraScrapeMetrics` feature gate. This mimics 
+  Prometheus behavior where extra scrape metrics are controlled by a feature flag:
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig"
+```
+
 - `receiver.prometheusreceiver.UseCreatedMetric`: Start time for Summary, Histogram 
   and Sum metrics can be retrieved from `_created` metrics. Currently, this behaviour
   is disabled by default. To enable it, use the following feature gate option:

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -259,8 +259,8 @@ More info about querying `/api/v1/` and the data format that is returned can be 
 
 - `receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig`: When enabled, the
   `report_extra_scrape_metrics` configuration option is ignored, and extra scrape metrics are
-  controlled solely by the `EnableReportExtraScrapeMetrics` feature gate. This mimics 
-  Prometheus behavior where extra scrape metrics are controlled by a feature flag:
+  controlled solely by the `EnableReportExtraScrapeMetrics` feature gate. The intention is
+  to have extra scrape metrics all the time in the future:
 
 ```shell
 "--feature-gates=receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig"

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -50,6 +50,12 @@ var enableReportExtraScrapeMetricsGate = featuregate.GlobalRegistry().MustRegist
 		" Extra scrape metrics are metrics that are not scraped by Prometheus but are reported by the Prometheus server."),
 )
 
+var removeReportExtraScrapeMetricsConfigGate = featuregate.GlobalRegistry().MustRegister(
+	"receiver.prometheusreceiver.RemoveReportExtraScrapeMetricsConfig",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Removes the report_extra_scrape_metrics configuration option."),
+)
+
 // NewFactory creates a new Prometheus receiver factory.
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -223,7 +223,8 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, logger *slog.L
 func (r *pReceiver) initScrapeOptions() *scrape.Options {
 	opts := &scrape.Options{
 		PassMetadataInContext: true,
-		ExtraMetrics:          enableReportExtraScrapeMetricsGate.IsEnabled() || r.cfg.ReportExtraScrapeMetrics,
+		// We're slowly switching to the feature gate, so we need to check both the feature gate and the config option for a few releases.
+		ExtraMetrics: enableReportExtraScrapeMetricsGate.IsEnabled() || (r.cfg.ReportExtraScrapeMetrics && !removeReportExtraScrapeMetricsConfigGate.IsEnabled()),
 		HTTPClientOptions: []commonconfig.HTTPClientOption{
 			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
 		},


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds a feature gate that will be used to control the removal of the config option `report_extra_scrape_metrics`.  When enabled, the feature gate ensures that the config option has no effect.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to #44181 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
