### PR TITLE
[receiver/fluentforward] Ensure all established connections are properly closed on shutdown

### DIFF
--- a/.chloggen/feature_fluentforward-connection-close-on-shutdown-44433.yaml
+++ b/.chloggen/feature_fluentforward-connection-close-on-shutdown-44433.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/fluentforward
+
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:	Ensure all established connections are properly closed on shutdown in the fluentforward receiver. The shutdown process now reliably closes all active connections.
+
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44433]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Fixes shutdown behavior so that all existing connections are closed cleanly.
+  - Adds tests to verify proper connection closure.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/fluentforwardreceiver/receiver.go
+++ b/receiver/fluentforwardreceiver/receiver.go
@@ -97,7 +97,9 @@ func (r *fluentReceiver) Shutdown(context.Context) error {
 	if r.listener == nil {
 		return nil
 	}
-	r.listener.Close()
+	// Close the listener to stop accepting new connections
+	_ = r.listener.Close()
+	r.server.closeAllConns()
 	r.cancel()
 	return nil
 }

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -28,7 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver/internal/metadata"
 )
 
-func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observer.ObservedLogs, context.CancelFunc) {
+func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observer.ObservedLogs, context.CancelFunc, receiver.Logs) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	next := new(consumertest.LogsSink)
@@ -57,7 +58,7 @@ func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observ
 		assert.NoError(t, receiver.Shutdown(ctx))
 	}()
 
-	return connect, next, logObserver, cancel
+	return connect, next, logObserver, cancel, receiver
 }
 
 func waitForConnectionClose(t *testing.T, conn net.Conn) {
@@ -71,7 +72,7 @@ func waitForConnectionClose(t *testing.T, conn net.Conn) {
 
 // Make sure malformed events don't cause panics.
 func TestMessageEventConversionMalformed(t *testing.T) {
-	connect, _, observedLogs, cancel := setupServer(t)
+	connect, _, observedLogs, cancel, _ := setupServer(t)
 	defer cancel()
 
 	eventBytes := parseHexDump("testdata/message-event")
@@ -94,7 +95,7 @@ func TestMessageEventConversionMalformed(t *testing.T) {
 }
 
 func TestMessageEvent(t *testing.T) {
-	connect, next, _, cancel := setupServer(t)
+	connect, next, _, cancel, _ := setupServer(t)
 	defer cancel()
 
 	eventBytes := parseHexDump("testdata/message-event")
@@ -124,7 +125,7 @@ func TestMessageEvent(t *testing.T) {
 }
 
 func TestForwardEvent(t *testing.T) {
-	connect, next, _, cancel := setupServer(t)
+	connect, next, _, cancel, _ := setupServer(t)
 	defer cancel()
 
 	eventBytes := parseHexDump("testdata/forward-event")
@@ -172,7 +173,7 @@ func TestForwardEvent(t *testing.T) {
 }
 
 func TestEventAcknowledgment(t *testing.T) {
-	connect, _, logs, cancel := setupServer(t)
+	connect, _, logs, cancel, _ := setupServer(t)
 	defer func() { fmt.Printf("%v\n", logs.All()) }()
 	defer cancel()
 
@@ -203,7 +204,7 @@ func TestEventAcknowledgment(t *testing.T) {
 }
 
 func TestForwardPackedEvent(t *testing.T) {
-	connect, next, _, cancel := setupServer(t)
+	connect, next, _, cancel, _ := setupServer(t)
 	defer cancel()
 
 	eventBytes := parseHexDump("testdata/forward-packed")
@@ -265,7 +266,7 @@ func TestForwardPackedEvent(t *testing.T) {
 }
 
 func TestForwardPackedCompressedEvent(t *testing.T) {
-	connect, next, _, cancel := setupServer(t)
+	connect, next, _, cancel, _ := setupServer(t)
 	defer cancel()
 
 	eventBytes := parseHexDump("testdata/forward-packed-compressed")
@@ -370,7 +371,7 @@ func makeSampleEvent(tag string) []byte {
 }
 
 func TestHighVolume(t *testing.T) {
-	connect, next, _, cancel := setupServer(t)
+	connect, next, _, cancel, _ := setupServer(t)
 	defer cancel()
 
 	const totalRoutines = 8
@@ -405,4 +406,59 @@ func TestHighVolume(t *testing.T) {
 
 		return total == totalRoutines*totalMessagesPerRoutine
 	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// TestReceiverShutdownRefusesNewConnections verifies the graceful shutdown of a receiver, ensuring no new connections can be established afterward.
+func TestReceiverShutdownRefusesNewConnections(t *testing.T) {
+	connect, next, _, cancel, receiver := setupServer(t)
+	defer cancel()
+
+	eventBytes := parseHexDump("testdata/message-event")
+
+	conn := connect()
+	n, err := conn.Write(eventBytes)
+	require.NoError(t, err)
+	require.Equal(t, len(eventBytes), n)
+	require.NoError(t, conn.Close())
+
+	var converted []plog.Logs
+	require.Eventually(t, func() bool {
+		converted = next.AllLogs()
+		return len(converted) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// shutdown the receiver
+	require.NoError(t, receiver.Shutdown(t.Context()))
+
+	// New connection will be refused
+	_, err = net.Dial("tcp", receiver.(*fluentReceiver).listener.Addr().String())
+	require.Error(t, err)
+}
+
+// TestReceiverShutdownClosesExistingConnections verifies the graceful shutdown of a receiver, ensuring existing connections will be closed.
+func TestReceiverShutdownClosesExistingConnections(t *testing.T) {
+	connect, next, _, cancel, receiver := setupServer(t)
+	defer cancel()
+
+	eventBytes := parseHexDump("testdata/message-event")
+
+	conn := connect()
+	n, err := conn.Write(eventBytes)
+	require.NoError(t, err)
+	require.Equal(t, len(eventBytes), n)
+
+	var converted []plog.Logs
+	require.Eventually(t, func() bool {
+		converted = next.AllLogs()
+		return len(converted) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// shutdown the receiver
+	require.NoError(t, receiver.Shutdown(t.Context()))
+
+	// Existing connection will be refused
+	require.Eventually(t, func() bool {
+		_, err := conn.Write(eventBytes)
+		return err != nil
+	}, 5*time.Second, 1*time.Second)
 }


### PR DESCRIPTION
Fixes shutdown behavior so that all existing connections are closed cleanly. Adds tests to verify proper connection closure.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

#44433

#### Link to tracking issue

Fixes #44433

#### Testing

Add the test case to check the connection closed.

#### Documentation

-
