### PR TITLE
Make service discoveries removable through Go build tags

### DIFF
--- a/.chloggen/prometheusreceiver-removable-sd.yaml
+++ b/.chloggen/prometheusreceiver-removable-sd.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support removable Prometheus service discoveries via Go build tags.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44406]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Prometheus service discoveries can now be removed at build time when building the collector with OCB (OpenTelemetry Collector Builder).
+  Use the `build_tags` option in the builder configuration to pass Go build tags such as `remove_all_sd` to exclude optional service discoveries.
+  See the Prometheus documentation for available build tags to customize which service discoveries are included.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/prometheusreceiver-removable-sd.yaml
+++ b/.chloggen/prometheusreceiver-removable-sd.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/prometheusreceiver
+component: receiver/prometheus
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support removable Prometheus service discoveries via Go build tags.

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	promconfig "github.com/prometheus/prometheus/config"
-	_ "github.com/prometheus/prometheus/discovery/install" // init() of this package registers service discovery impl.
+	_ "github.com/prometheus/prometheus/plugins" // init() of this package registers service discovery impl.
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR is built on top of https://github.com/prometheus/prometheus/pull/17736. There are a lot of go mod changes, and that also inherits fixes to interface changes that were made since Prometheus 3.8

The only change that is really about making SDs removable is this change in imports in `factory.go`:
```diff
-	_ "github.com/prometheus/prometheus/discovery/install" // init() of this package registers service discovery impl.
+	_ "github.com/prometheus/prometheus/plugins" // init() of this package registers service discovery impl.
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44406

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Used two builder configs and measured the binary size difference:

Without build tags(120MB):
```yaml
dist:
  module: github.com/open-telemetry/otelcontribcol
  name: otelcontribcol
  version: 0.143.0
  output_path: ./cmd/otelcontribcol/sd-test/full

receivers:
  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.143.0
    path: ./receiver/prometheusreceiver

exporters:
  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.143.0
```

With build tags(63MG):
```yaml
dist:
  module: github.com/open-telemetry/otelcontribcol
  name: otelcontribcol
  version: 0.143.0
  output_path: ./cmd/otelcontribcol/sd-test/no-sd
  build_tags: "remove_all_sd"

receivers:
  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.143.0
    path: ./receiver/prometheusreceiver

exporters:
  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.143.0
```