### PR TITLE
[receiver/otelarrowreceiver] Fix admission control bypass for metadata-only requests

### DIFF
--- a/.chloggen/otelarrowreceiver-fix-admission-bypass.yaml
+++ b/.chloggen/otelarrowreceiver-fix-admission-bypass.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/otelarrow
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix admission control bypass for requests with metadata but no data points
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45152]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The receiver was bypassing admission control for requests with zero data points
+  (spans/logs/metrics), even when such requests contained significant metadata.
+  This allowed potential memory exhaustion by sending large volumes of resource
+  and scope metadata without actual telemetry data.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/otelarrowreceiver/internal/logs/otlp.go
+++ b/receiver/otelarrowreceiver/internal/logs/otlp.go
@@ -43,14 +43,18 @@ func New(logger *zap.Logger, nextConsumer consumer.Logs, obsrecv *receiverhelper
 func (r *Receiver) Export(ctx context.Context, req plogotlp.ExportRequest) (plogotlp.ExportResponse, error) {
 	ld := req.Logs()
 	numRecords := ld.LogRecordCount()
-	if numRecords == 0 {
+	sizeBytes := uint64(r.sizer.LogsSize(ld))
+
+	// Early return for truly empty requests (no data at all).
+	// We check size rather than record count to ensure requests with
+	// metadata but no log records still go through admission control.
+	if sizeBytes == 0 {
 		return plogotlp.NewExportResponse(), nil
 	}
 
 	ctx = r.obsrecv.StartLogsOp(ctx)
 
 	var err error
-	sizeBytes := uint64(r.sizer.LogsSize(req.Logs()))
 	if releaser, acqErr := r.boundedQueue.Acquire(ctx, sizeBytes); acqErr == nil {
 		err = r.nextConsumer.ConsumeLogs(ctx, ld)
 		releaser() // immediate release

--- a/receiver/otelarrowreceiver/internal/logs/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/logs/otlp_test.go
@@ -131,19 +131,56 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 }
 
 func TestExport_AdmissionRequestTooLarge(t *testing.T) {
-	ld := testdata.GenerateLogs(10)
-	logSink := newTestSink()
-	req := plogotlp.NewExportRequestFromLogs(ld)
-	logsClient, selfExp, selfProv := makeTraceServiceClient(t, logSink)
+	t.Run("with data points", func(t *testing.T) {
+		ld := testdata.GenerateLogs(10)
+		logSink := newTestSink()
+		req := plogotlp.NewExportRequestFromLogs(ld)
+		logsClient, selfExp, selfProv := makeTraceServiceClient(t, logSink)
 
-	go logSink.unblock()
-	resp, err := logsClient.Export(t.Context(), req)
-	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
-	assert.Equal(t, plogotlp.ExportResponse{}, resp)
+		go logSink.unblock()
+		resp, err := logsClient.Export(t.Context(), req)
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
+		assert.Equal(t, plogotlp.ExportResponse{}, resp)
 
-	// One self-tracing spans is issued.
-	require.NoError(t, selfProv.ForceFlush(t.Context()))
-	require.Len(t, selfExp.GetSpans(), 1)
+		// One self-tracing spans is issued.
+		require.NoError(t, selfProv.ForceFlush(t.Context()))
+		require.Len(t, selfExp.GetSpans(), 1)
+	})
+
+	t.Run("with metadata only", func(t *testing.T) {
+		// Create logs with metadata but no actual log records.
+		// This should still go through admission control based on size.
+		ld := plog.NewLogs()
+		for range 100 {
+			rl := ld.ResourceLogs().AppendEmpty()
+			// Add large attributes to the resource.
+			for range 10 {
+				rl.Resource().Attributes().PutStr(
+					"large.attribute.key.that.takes.space",
+					"This is a large attribute value that demonstrates metadata can be significant even without log records",
+				)
+			}
+			// Add scope but no log records.
+			sl := rl.ScopeLogs().AppendEmpty()
+			sl.Scope().SetName("test-scope")
+		}
+
+		require.Equal(t, 0, ld.LogRecordCount(), "Test setup: should have no log records")
+
+		sizer := &plog.ProtoMarshaler{}
+		sizeBytes := sizer.LogsSize(ld)
+		require.Greater(t, sizeBytes, maxBytes, "Test setup: metadata size should exceed admission limit")
+
+		req := plogotlp.NewExportRequestFromLogs(ld)
+		logSink := newTestSink()
+		logsClient, _, _ := makeTraceServiceClient(t, logSink)
+
+		// No need to call unblock() - request is rejected by admission control
+		// before ConsumeLogs is ever called.
+		_, err := logsClient.Export(t.Context(), req)
+		// Should be rejected by admission control due to size, not accepted with early return.
+		assert.ErrorContains(t, err, "rejecting request", "Should be rejected by admission control")
+	})
 }
 
 func TestExport_AdmissionLimitExceeded(t *testing.T) {

--- a/receiver/otelarrowreceiver/internal/metrics/otlp.go
+++ b/receiver/otelarrowreceiver/internal/metrics/otlp.go
@@ -43,14 +43,18 @@ func New(logger *zap.Logger, nextConsumer consumer.Metrics, obsrecv *receiverhel
 func (r *Receiver) Export(ctx context.Context, req pmetricotlp.ExportRequest) (pmetricotlp.ExportResponse, error) {
 	md := req.Metrics()
 	dataPointCount := md.DataPointCount()
-	if dataPointCount == 0 {
+	sizeBytes := uint64(r.sizer.MetricsSize(md))
+
+	// Early return for truly empty requests (no data at all).
+	// We check size rather than data point count to ensure requests with
+	// metadata but no data points still go through admission control.
+	if sizeBytes == 0 {
 		return pmetricotlp.NewExportResponse(), nil
 	}
 
 	ctx = r.obsrecv.StartMetricsOp(ctx)
 
 	var err error
-	sizeBytes := uint64(r.sizer.MetricsSize(req.Metrics()))
 	if releaser, acqErr := r.boundedQueue.Acquire(ctx, sizeBytes); acqErr == nil {
 		err = r.nextConsumer.ConsumeMetrics(ctx, md)
 		releaser() // immediate release

--- a/receiver/otelarrowreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/metrics/otlp_test.go
@@ -131,19 +131,56 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 }
 
 func TestExport_AdmissionRequestTooLarge(t *testing.T) {
-	md := testdata.GenerateMetrics(10)
-	metricsSink := newTestSink()
-	req := pmetricotlp.NewExportRequestFromMetrics(md)
-	metricsClient, selfExp, selfProv := makeMetricsServiceClient(t, metricsSink)
+	t.Run("with data points", func(t *testing.T) {
+		md := testdata.GenerateMetrics(10)
+		metricsSink := newTestSink()
+		req := pmetricotlp.NewExportRequestFromMetrics(md)
+		metricsClient, selfExp, selfProv := makeMetricsServiceClient(t, metricsSink)
 
-	go metricsSink.unblock()
-	resp, err := metricsClient.Export(t.Context(), req)
-	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
-	assert.Equal(t, pmetricotlp.ExportResponse{}, resp)
+		go metricsSink.unblock()
+		resp, err := metricsClient.Export(t.Context(), req)
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
+		assert.Equal(t, pmetricotlp.ExportResponse{}, resp)
 
-	// One self-tracing spans is issued.
-	require.NoError(t, selfProv.ForceFlush(t.Context()))
-	require.Len(t, selfExp.GetSpans(), 1)
+		// One self-tracing spans is issued.
+		require.NoError(t, selfProv.ForceFlush(t.Context()))
+		require.Len(t, selfExp.GetSpans(), 1)
+	})
+
+	t.Run("with metadata only", func(t *testing.T) {
+		// Create metrics with metadata but no actual data points.
+		// This should still go through admission control based on size.
+		md := pmetric.NewMetrics()
+		for range 100 {
+			rm := md.ResourceMetrics().AppendEmpty()
+			// Add large attributes to the resource.
+			for range 10 {
+				rm.Resource().Attributes().PutStr(
+					"large.attribute.key.that.takes.space",
+					"This is a large attribute value that demonstrates metadata can be significant even without data points",
+				)
+			}
+			// Add scope but no metrics.
+			sm := rm.ScopeMetrics().AppendEmpty()
+			sm.Scope().SetName("test-scope")
+		}
+
+		require.Equal(t, 0, md.DataPointCount(), "Test setup: should have no data points")
+
+		sizer := &pmetric.ProtoMarshaler{}
+		sizeBytes := sizer.MetricsSize(md)
+		require.Greater(t, sizeBytes, maxBytes, "Test setup: metadata size should exceed admission limit")
+
+		req := pmetricotlp.NewExportRequestFromMetrics(md)
+		metricsSink := newTestSink()
+		metricsClient, _, _ := makeMetricsServiceClient(t, metricsSink)
+
+		// No need to call unblock() - request is rejected by admission control
+		// before ConsumeMetrics is ever called.
+		_, err := metricsClient.Export(t.Context(), req)
+		// Should be rejected by admission control due to size, not accepted with early return.
+		assert.ErrorContains(t, err, "rejecting request", "Should be rejected by admission control")
+	})
 }
 
 func TestExport_AdmissionLimitExceeded(t *testing.T) {

--- a/receiver/otelarrowreceiver/internal/trace/otlp.go
+++ b/receiver/otelarrowreceiver/internal/trace/otlp.go
@@ -43,14 +43,18 @@ func New(logger *zap.Logger, nextConsumer consumer.Traces, obsrecv *receiverhelp
 func (r *Receiver) Export(ctx context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
 	td := req.Traces()
 	numSpans := td.SpanCount()
-	if numSpans == 0 {
+	sizeBytes := uint64(r.sizer.TracesSize(td))
+
+	// Early return for truly empty requests (no data at all).
+	// We check size rather than span count to ensure requests with
+	// metadata but no spans still go through admission control.
+	if sizeBytes == 0 {
 		return ptraceotlp.NewExportResponse(), nil
 	}
 
 	ctx = r.obsrecv.StartTracesOp(ctx)
 
 	var err error
-	sizeBytes := uint64(r.sizer.TracesSize(req.Traces()))
 	if releaser, acqErr := r.boundedQueue.Acquire(ctx, sizeBytes); acqErr == nil {
 		err = r.nextConsumer.ConsumeTraces(ctx, td)
 		releaser() // immediate release

--- a/receiver/otelarrowreceiver/internal/trace/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/trace/otlp_test.go
@@ -131,19 +131,56 @@ func TestExport_PermanentErrorConsumer(t *testing.T) {
 }
 
 func TestExport_AdmissionRequestTooLarge(t *testing.T) {
-	td := testdata.GenerateTraces(10)
-	traceSink := newTestSink()
-	req := ptraceotlp.NewExportRequestFromTraces(td)
-	traceClient, selfExp, selfProv := makeTraceServiceClient(t, traceSink)
+	t.Run("with data points", func(t *testing.T) {
+		td := testdata.GenerateTraces(10)
+		traceSink := newTestSink()
+		req := ptraceotlp.NewExportRequestFromTraces(td)
+		traceClient, selfExp, selfProv := makeTraceServiceClient(t, traceSink)
 
-	go traceSink.unblock()
-	resp, err := traceClient.Export(t.Context(), req)
-	assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
-	assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
+		go traceSink.unblock()
+		resp, err := traceClient.Export(t.Context(), req)
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = rejecting request, request is too large")
+		assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
 
-	// One self-tracing spans is issued.
-	require.NoError(t, selfProv.ForceFlush(t.Context()))
-	require.Len(t, selfExp.GetSpans(), 1)
+		// One self-tracing spans is issued.
+		require.NoError(t, selfProv.ForceFlush(t.Context()))
+		require.Len(t, selfExp.GetSpans(), 1)
+	})
+
+	t.Run("with metadata only", func(t *testing.T) {
+		// Create traces with metadata but no actual spans.
+		// This should still go through admission control based on size.
+		td := ptrace.NewTraces()
+		for range 100 {
+			rs := td.ResourceSpans().AppendEmpty()
+			// Add large attributes to the resource.
+			for range 10 {
+				rs.Resource().Attributes().PutStr(
+					"large.attribute.key.that.takes.space",
+					"This is a large attribute value that demonstrates metadata can be significant even without spans",
+				)
+			}
+			// Add scope but no spans.
+			ss := rs.ScopeSpans().AppendEmpty()
+			ss.Scope().SetName("test-scope")
+		}
+
+		require.Equal(t, 0, td.SpanCount(), "Test setup: should have no spans")
+
+		sizer := &ptrace.ProtoMarshaler{}
+		sizeBytes := sizer.TracesSize(td)
+		require.Greater(t, sizeBytes, maxBytes, "Test setup: metadata size should exceed admission limit")
+
+		req := ptraceotlp.NewExportRequestFromTraces(td)
+		traceSink := newTestSink()
+		traceClient, _, _ := makeTraceServiceClient(t, traceSink)
+
+		// No need to call unblock() - request is rejected by admission control
+		// before ConsumeTraces is ever called.
+		_, err := traceClient.Export(t.Context(), req)
+		// Should be rejected by admission control due to size, not accepted with early return.
+		assert.ErrorContains(t, err, "rejecting request", "Should be rejected by admission control")
+	})
 }
 
 func TestExport_AdmissionLimitExceeded(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix admission control bypass for requests with zero data points but significant metadata
- The receiver was checking data point count (`numSpans == 0`, `numRecords == 0`, `dataPointCount == 0`) for early return, allowing requests with large metadata but no data points to bypass admission control entirely
- Changed to check `sizeBytes == 0` instead, ensuring all non-empty requests go through admission control

## Background
Admission control was added in PR #35021 to prevent memory exhaustion. However, the implementation included an early return optimization that checked data point count before the admission control check, creating a bypass vulnerability.

## Changes
- `internal/trace/otlp.go`: Check `sizeBytes == 0` instead of `numSpans == 0`
- `internal/logs/otlp.go`: Check `sizeBytes == 0` instead of `numRecords == 0`
- `internal/metrics/otlp.go`: Check `sizeBytes == 0` instead of `dataPointCount == 0`
- Added tests verifying metadata-only requests go through admission control

## Test plan
- [x] Added `TestExport_AdmissionRequestTooLarge/with_metadata_only` subtest for all three signal types
- [x] Existing tests continue to pass
- [x] `TestExport_EmptyRequest` still passes (truly empty requests bypass admission control as expected)