### PR TITLE
[receiver/awss3receiver] Fix data loss on partial SQS message processing failure

### DIFF
--- a/.chloggen/awss3receiver-fix-sqs-partial-failure.yaml
+++ b/.chloggen/awss3receiver-fix-sqs-partial-failure.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awss3
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data loss when SQS messages contain multiple S3 object notifications and some fail to process
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45153]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The SQS notification reader was unconditionally deleting messages after processing,
+  even when some S3 object retrievals or callback processing failed. This caused data
+  loss when a message contained multiple S3 notification records and any of them failed.
+  Messages are now only deleted when all records are successfully processed, allowing
+  failed records to be retried after the visibility timeout.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
## Summary
- Fix data loss when SQS messages contain multiple S3 object notifications and some fail to process
- The SQS notification reader was unconditionally deleting messages after processing, even when some S3 object retrievals or callback processing failed
- Messages are now only deleted when ALL records are successfully processed

## Background
When S3 sends notifications to SQS, each message can contain multiple S3 object notification records. The existing code would:
1. Process all records in a message
2. Log errors for any failures
3. Delete the message regardless of failures

This caused permanent data loss because failed records could never be retried - the message was already deleted from the queue.

## Changes
- Track success/failure for all records in a message using `allRecordsSucceeded` flag
- Only call `DeleteMessage` if all records processed successfully
- Add warning log when message is left for retry due to failures
- Failed messages remain in queue and become visible after visibility timeout for retry

## Test plan
- [x] Added test `does_not_delete_message_on_S3_retrieval_error` - verifies message not deleted when S3 GetObject fails
- [x] Added test `does_not_delete_message_on_partial_failure` - verifies message not deleted when multi-record message has mixed success/failure
- [x] Added test `does_not_delete_message_on_callback_error` - verifies message not deleted when callback processing fails
- [x] Existing tests continue to pass

## Trade-off
With this fix, if any record fails, the entire message stays in the queue - meaning successful records will be reprocessed on retry. This is acceptable because:
- SQS provides at-least-once delivery, so consumers should be idempotent anyway
- Data loss is worse than duplicate processing
- Partial acknowledgment would require external state tracking, adding significant complexity