### PR TITLE
githubreceiver: deterministic IDs from job.check_run_id (job + simplified step mode)

### DIFF
--- a/.chloggen/jun_span-id-v2.yaml
+++ b/.chloggen/jun_span-id-v2.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/github
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add simplified id_generation mode to generate deterministic ID from job.check_run_id and step names.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44856,45157]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  Adds `id_generation` config parameter. The default is backwards compatible `legacy`, and the new `simplified` 
+  mode makes it easier to compute parent Job span IDs directly inside a running GitHub Actions job 
+  using ${{ job.check_run_id }} (no GitHub API calls), and parent Step span span IDs just using the step name 
+  (deduplicated) and not step.Number to simplify attachement to a step.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/githubreceiver/README.md
+++ b/receiver/githubreceiver/README.md
@@ -186,7 +186,7 @@ receivers:
             service_name: github-actions  # single logical CI service (See Configuring Service Name section below)
             required_headers:
                 WAF-Header: "value"
-            id_generation: legacy  # or "check_run_id"
+            id_generation: legacy  # or "simplified"
         scrapers: # The validation expects at least a dummy scraper config
             scraper:
                 github_org: open-telemetry

--- a/receiver/githubreceiver/config.go
+++ b/receiver/githubreceiver/config.go
@@ -64,7 +64,7 @@ var (
 	_ component.Config    = (*Config)(nil)
 	_ confmap.Unmarshaler = (*Config)(nil)
 
-	errMissingEndpointFromConfig = errors.New("missing receiver server endpoint from config")
+	errMissingEndpointFromConfig   = errors.New("missing receiver server endpoint from config")
 	errReadTimeoutExceedsMaxValue  = errors.New("the duration specified for read_timeout exceeds the maximum allowed value of 10s")
 	errWriteTimeoutExceedsMaxValue = errors.New("the duration specified for write_timeout exceeds the maximum allowed value of 10s")
 	errRequiredHeader              = errors.New("both key and value are required to assign a required_header")

--- a/receiver/githubreceiver/config.go
+++ b/receiver/githubreceiver/config.go
@@ -56,8 +56,8 @@ type GitHubHeaders struct {
 }
 
 const (
-	idGenerationLegacy      = "legacy"
-	idGenerationCheckRunID  = "check_run_id"
+	idGenerationLegacy     = "legacy"
+	idGenerationSimplified = "simplified"
 )
 
 var (
@@ -70,7 +70,7 @@ var (
 	errRequiredHeader              = errors.New("both key and value are required to assign a required_header")
 	errRequireOneScraper           = errors.New("must specify at least one scraper")
 	errGitHubHeader                = errors.New("github default headers [X-GitHub-Event, X-GitHub-Delivery, X-GitHub-Hook-ID, X-Hub-Signature-256] cannot be configured")
-	errInvalidIDGeneration         = errors.New("id_generation must be 'legacy' or 'check_run_id'")
+	errInvalidIDGeneration         = errors.New("id_generation must be 'legacy' or 'simplified'")
 )
 
 // Validate the configuration passed through the OTEL config.yaml
@@ -108,7 +108,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	// Validate id_generation is one of the allowed values
-	if cfg.WebHook.IDGeneration != "" && cfg.WebHook.IDGeneration != idGenerationLegacy && cfg.WebHook.IDGeneration != idGenerationCheckRunID {
+	if cfg.WebHook.IDGeneration != "" && cfg.WebHook.IDGeneration != idGenerationLegacy && cfg.WebHook.IDGeneration != idGenerationSimplified {
 		errs = multierr.Append(errs, errInvalidIDGeneration)
 	}
 

--- a/receiver/githubreceiver/config.go
+++ b/receiver/githubreceiver/config.go
@@ -47,7 +47,7 @@ type WebHook struct {
 	Secret                  string                         `mapstructure:"secret"`           // secret for webhook
 	ServiceName             string                         `mapstructure:"service_name"`
 	IncludeSpanEvents       bool                           `mapstructure:"include_span_events"` // attach raw webhook event JSON as span events
-	IDGeneration            string                         `mapstructure:"id_generation"`       // ID generation mode: "legacy" (default) or "check_run_id"
+	IDGeneration            string                         `mapstructure:"id_generation"`       // ID generation mode: "legacy" (default) or "simplified"
 }
 
 type GitHubHeaders struct {

--- a/receiver/githubreceiver/config_test.go
+++ b/receiver/githubreceiver/config_test.go
@@ -64,6 +64,7 @@ func TestLoadConfig(t *testing.T) {
 				"X-Hub-Signature-256": "",
 			},
 		},
+		IDGeneration: "legacy",
 	}
 
 	assert.Equal(t, defaultConfigGitHubReceiver, r0)
@@ -99,6 +100,7 @@ func TestLoadConfig(t *testing.T) {
 					"X-Hub-Signature-256": "",
 				},
 			},
+			IDGeneration: "legacy",
 		},
 	}
 

--- a/receiver/githubreceiver/factory.go
+++ b/receiver/githubreceiver/factory.go
@@ -83,6 +83,7 @@ func createDefaultConfig() component.Config {
 			Path:              defaultPath,
 			HealthPath:        defaultHealthPath,
 			IncludeSpanEvents: defaultIncludeSpanEvents,
+			IDGeneration:      idGenerationLegacy,
 		},
 	}
 }

--- a/receiver/githubreceiver/testdata/workflow-job-expected-check-run-id.yaml
+++ b/receiver/githubreceiver/testdata/workflow-job-expected-check-run-id.yaml
@@ -1,0 +1,238 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: otel-collector
+        - key: github.repository.custom_properties.team_name
+          value:
+            stringValue: open-telemetry
+        - key: vcs.repository.name
+          value:
+            stringValue: open-telemetry-otel-collector
+        - key: vcs.provider.name
+          value:
+            stringValue: github
+        - key: vcs.ref.head
+          value:
+            stringValue: renovate/major-tool-deps
+        - key: vcs.ref.type
+          value:
+            stringValue: branch
+        - key: vcs.ref.head.revision
+          value:
+            stringValue: 6077d805b0fc49f65e6dbaefc2d1fc9b4f92aa4e
+        - key: cicd.pipeline.worker.id
+          value:
+            intValue: "346"
+        - key: cicd.pipeline.worker.group.id
+          value:
+            intValue: "2"
+        - key: cicd.pipeline.worker.name
+          value:
+            stringValue: GitHub Actions 320
+        - key: cicd.pipeline.worker.group.name
+          value:
+            stringValue: GitHub Actions
+        - key: cicd.pipeline.worker.node.id
+          value:
+            stringValue: CR_kwDOJKXdfM8AAAAJeQ3FOg
+        - key: cicd.pipeline.worker.labels
+          value:
+            arrayValue:
+              values:
+                - stringValue: ubuntu-latest
+        - key: cicd.pipeline.name
+          value:
+            stringValue: test (1.23)
+        - key: cicd.pipeline.task.run.sender.login
+          value:
+            stringValue: renovate[bot]
+        - key: cicd.pipeline.task.run.url.full
+          value:
+            stringValue: https://github.com/open-telemetry/open-telemetry-otel-collector/actions/runs/14460881260/job/40685651258
+        - key: cicd.pipeline.task.run.id
+          value:
+            intValue: "40685651258"
+        - key: cicd.pipeline.run.task.status
+          value:
+            stringValue: success
+    scopeSpans:
+      - scope: {}
+        spans:
+          - endTimeUnixNano: "1744837825000000000"
+            kind: 1
+            name: test (1.23)
+            parentSpanId: aba151af7cfbcf0f
+            spanId: 30a453e6cffaf8d7
+            startTimeUnixNano: "1744837738000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.run.queue.duration
+                value:
+                  doubleValue: 5e+09
+            endTimeUnixNano: "1744837743000000000"
+            kind: 1
+            name: queue-test (1.23)
+            parentSpanId: 30a453e6cffaf8d7
+            spanId: d328504edfc4f5dc
+            startTimeUnixNano: "1744837738000000000"
+            status: {}
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Set up job
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837744000000000"
+            kind: 1
+            name: Set up job
+            parentSpanId: d328504edfc4f5dc
+            spanId: 103b52e85d34ae1c
+            startTimeUnixNano: "1744837742000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Run actions/checkout@v4
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837745000000000"
+            kind: 1
+            name: Run actions/checkout@v4
+            parentSpanId: d328504edfc4f5dc
+            spanId: b0a2cdd89199b9a5
+            startTimeUnixNano: "1744837744000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Set up Go
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837745000000000"
+            kind: 1
+            name: Set up Go
+            parentSpanId: d328504edfc4f5dc
+            spanId: c04460ffd6bf3917
+            startTimeUnixNano: "1744837745000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Make test-all
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837820000000000"
+            kind: 1
+            name: Make test-all
+            parentSpanId: d328504edfc4f5dc
+            spanId: 1684627ec86a096c
+            startTimeUnixNano: "1744837746000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Upload coverage to Codecov
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837823000000000"
+            kind: 1
+            name: Upload coverage to Codecov
+            parentSpanId: d328504edfc4f5dc
+            spanId: 25aeeca484f9f7e5
+            startTimeUnixNano: "1744837820000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Post Set up Go
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837823000000000"
+            kind: 1
+            name: Post Set up Go
+            parentSpanId: d328504edfc4f5dc
+            spanId: 0715a13bb338e46e
+            startTimeUnixNano: "1744837823000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Post Run actions/checkout@v4
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837825000000000"
+            kind: 1
+            name: Post Run actions/checkout@v4
+            parentSpanId: d328504edfc4f5dc
+            spanId: e231dce10420723b
+            startTimeUnixNano: "1744837825000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0
+      - scope: {}
+        spans:
+          - attributes:
+              - key: cicd.pipeline.task.name
+                value:
+                  stringValue: Complete job
+              - key: cicd.pipeline.run.task.status
+                value:
+                  stringValue: success
+            endTimeUnixNano: "1744837823000000000"
+            kind: 1
+            name: Complete job
+            parentSpanId: d328504edfc4f5dc
+            spanId: bb94c07ba3717632
+            startTimeUnixNano: "1744837823000000000"
+            status:
+              code: 1
+              message: success
+            traceId: 731ec8a47fd7450f753a812a4a8aa5a0

--- a/receiver/githubreceiver/testdata/workflow-job-expected-simplified.yaml
+++ b/receiver/githubreceiver/testdata/workflow-job-expected-simplified.yaml
@@ -80,7 +80,7 @@ resourceSpans:
             kind: 1
             name: queue-test (1.23)
             parentSpanId: 30a453e6cffaf8d7
-            spanId: d328504edfc4f5dc
+            spanId: d06cc99ed1b10e50
             startTimeUnixNano: "1744837738000000000"
             status: {}
             traceId: 731ec8a47fd7450f753a812a4a8aa5a0
@@ -96,8 +96,8 @@ resourceSpans:
             endTimeUnixNano: "1744837744000000000"
             kind: 1
             name: Set up job
-            parentSpanId: d328504edfc4f5dc
-            spanId: 103b52e85d34ae1c
+            parentSpanId: d06cc99ed1b10e50
+            spanId: 0b773706a3aadafd
             startTimeUnixNano: "1744837742000000000"
             status:
               code: 1
@@ -115,8 +115,8 @@ resourceSpans:
             endTimeUnixNano: "1744837745000000000"
             kind: 1
             name: Run actions/checkout@v4
-            parentSpanId: d328504edfc4f5dc
-            spanId: b0a2cdd89199b9a5
+            parentSpanId: d06cc99ed1b10e50
+            spanId: ecc2c4ced370102d
             startTimeUnixNano: "1744837744000000000"
             status:
               code: 1
@@ -134,8 +134,8 @@ resourceSpans:
             endTimeUnixNano: "1744837745000000000"
             kind: 1
             name: Set up Go
-            parentSpanId: d328504edfc4f5dc
-            spanId: c04460ffd6bf3917
+            parentSpanId: d06cc99ed1b10e50
+            spanId: 08aa8ada616c29af
             startTimeUnixNano: "1744837745000000000"
             status:
               code: 1
@@ -153,8 +153,8 @@ resourceSpans:
             endTimeUnixNano: "1744837820000000000"
             kind: 1
             name: Make test-all
-            parentSpanId: d328504edfc4f5dc
-            spanId: 1684627ec86a096c
+            parentSpanId: d06cc99ed1b10e50
+            spanId: 99015d43fdacbf32
             startTimeUnixNano: "1744837746000000000"
             status:
               code: 1
@@ -172,8 +172,8 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Upload coverage to Codecov
-            parentSpanId: d328504edfc4f5dc
-            spanId: 25aeeca484f9f7e5
+            parentSpanId: d06cc99ed1b10e50
+            spanId: aae89f99acbed864
             startTimeUnixNano: "1744837820000000000"
             status:
               code: 1
@@ -191,8 +191,8 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Post Set up Go
-            parentSpanId: d328504edfc4f5dc
-            spanId: 0715a13bb338e46e
+            parentSpanId: d06cc99ed1b10e50
+            spanId: 7ac5a2bcb9bdf35e
             startTimeUnixNano: "1744837823000000000"
             status:
               code: 1
@@ -210,8 +210,8 @@ resourceSpans:
             endTimeUnixNano: "1744837825000000000"
             kind: 1
             name: Post Run actions/checkout@v4
-            parentSpanId: d328504edfc4f5dc
-            spanId: e231dce10420723b
+            parentSpanId: d06cc99ed1b10e50
+            spanId: cda1542610aeaad7
             startTimeUnixNano: "1744837825000000000"
             status:
               code: 1
@@ -229,8 +229,8 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Complete job
-            parentSpanId: d328504edfc4f5dc
-            spanId: bb94c07ba3717632
+            parentSpanId: d06cc99ed1b10e50
+            spanId: 925ea3fafc92c93c
             startTimeUnixNano: "1744837823000000000"
             status:
               code: 1

--- a/receiver/githubreceiver/trace_event_handling_test.go
+++ b/receiver/githubreceiver/trace_event_handling_test.go
@@ -141,22 +141,22 @@ func TestWorkflowJobIDMatchesCheckRunID(t *testing.T) {
 
 func TestHandleWorkflowJobWithGoldenFileIDGeneration(t *testing.T) {
 	tests := []struct {
-		name              string
-		idGeneration      string
-		inputFile         string
-		expectedFile      string
+		name         string
+		idGeneration string
+		inputFile    string
+		expectedFile string
 	}{
 		{
-			name:          "legacy mode",
-			idGeneration:  "legacy",
-			inputFile:     "workflow-job-completed.json",
-			expectedFile:  "workflow-job-expected.yaml",
+			name:         "legacy mode",
+			idGeneration: "legacy",
+			inputFile:    "workflow-job-completed.json",
+			expectedFile: "workflow-job-expected.yaml",
 		},
 		{
-			name:          "simplified mode",
-			idGeneration:  "simplified",
-			inputFile:     "workflow-job-completed.json",
-			expectedFile:  "workflow-job-expected-simplified.yaml",
+			name:         "simplified mode",
+			idGeneration: "simplified",
+			inputFile:    "workflow-job-completed.json",
+			expectedFile: "workflow-job-expected-simplified.yaml",
 		},
 	}
 

--- a/receiver/githubreceiver/trace_event_handling_test.go
+++ b/receiver/githubreceiver/trace_event_handling_test.go
@@ -123,7 +123,7 @@ func TestWorkflowJobIDMatchesCheckRunID(t *testing.T) {
 
 	// Parse the numeric ID from the URL
 	parts := strings.Split(checkRunURL, "/")
-	require.Greater(t, len(parts), 0, "check_run_url should have path components")
+	require.NotEmpty(t, parts, "check_run_url should have path components")
 
 	checkRunIDFromURL := parts[len(parts)-1]
 	require.NotEmpty(t, checkRunIDFromURL, "check_run_id should be extractable from URL")


### PR DESCRIPTION
#### Description

This PR adds a configuration option to the GitHub receiver to control how deterministic span IDs are generated for traces emitted from GitHub Actions workflow webhooks. The goal is to make it possible to compute parent span IDs directly inside a running GitHub Actions job using ${{ job.check_run_id }} (no GitHub API calls), and to make step span IDs less brittle during workflow refactors.

NOTE that I designed the solution based on the 2 issues linked, but the coding was done with an AI agent.

This PR contains two commits; I can easily split the second commit into a follow-up PR if preferred. 

##### Commit 1: Deterministic job span IDs from check_run_id (opt-in)

Adds webhook.id_generation (default legacy) and an opt-in mode that derives job SpanIDs from the job’s check run ID (workflow_job.id, matching ${{ job.check_run_id }}) plus run attempt.

This enables correlating spans created inside the job with the receiver’s job span without API calls.

##### Commit 2: Simplified step span IDs (opt-in)

Introduces id_generation: simplified and extends the opt-in mode to step spans:
- step SpanID seed = check_run_id : run_attempt : deduped_step_name
- removes dependence on step.Number, improving stability across step reordering

Duplicate step names are handled via the receiver’s existing deduping behavior (Build, Build-1, …). Reordering duplicated steps can change suffix assignment; best practice is to use unique step names.

Since queue spans used the `newStepSpanID` as well, we have to pick a stepKey discriminator and just use the same `spanName` for it which is unique enough. Since we don't aim with this PR to also attach to queue spans, this is convenient and expedient, but we could pick for instance a "unique enough" reserved name such as `__queue` and also allow to attach custom spans to queue spans. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44856 #45157

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Legacy golden tests remain unchanged.
- Adds a simplified-mode golden fixture for workflow-job events.
- Adds unit tests proving simplified mode is stable across changes to step.Number and produces unique IDs for duplicate step names.

#### Documentation

Added README sections on ID generation and attaching custom spans to steps.

