### PR TITLE
[pkg/fileconsumer] Retain original file attributes over rotated file attributes

### DIFF
--- a/.chloggen/fix_38454.yaml
+++ b/.chloggen/fix_38454.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "breaking"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "pkg/fileconsumer"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Retain original file attributes over rotated file attributes to ensure consistent metadata"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/fileconsumer/internal/reader/factory_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory_test.go
@@ -4,6 +4,8 @@
 package reader
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -155,4 +157,91 @@ func TestStartAt(t *testing.T) {
 	r, err = f.NewReader(temp, fp)
 	require.NoError(t, err)
 	assert.Equal(t, int64(len(content)), r.Offset)
+}
+
+func TestOriginalPathPreservation(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create initial file with a specific name
+	originalPath := filepath.Join(tempDir, "app.log")
+	originalFile, err := os.Create(originalPath)
+	require.NoError(t, err)
+	content := "test log line\n"
+	_, err = originalFile.WriteString(content)
+	require.NoError(t, err)
+
+	// Create factory with file path attribute enabled
+	f, _ := testFactory(t, func(c *testFactoryCfg) {
+		c.attributes = attrs.Resolver{
+			IncludeFileName: true,
+			IncludeFilePath: true,
+		}
+	})
+
+	// Create reader for original file
+	fp, err := f.NewFingerprint(originalFile)
+	require.NoError(t, err)
+	r, err := f.NewReader(originalFile, fp)
+	require.NoError(t, err)
+
+	// Verify OriginalPath is captured
+	require.Equal(t, originalPath, r.OriginalPath)
+	require.Equal(t, originalPath, r.FileAttributes[attrs.LogFilePath])
+
+	// Get metadata to simulate file rotation
+	metadata := r.Close()
+	require.Equal(t, originalPath, metadata.OriginalPath)
+
+	// Simulate file rotation - create a "rotated" file that looks like a rotation
+	// (original filename with a suffix added)
+	rotatedPath := originalPath + ".1"
+	rotatedFile, err := os.Create(rotatedPath)
+	require.NoError(t, err)
+	defer rotatedFile.Close()
+	_, err = rotatedFile.WriteString(content)
+	require.NoError(t, err)
+
+	// Reuse metadata with rotated file (simulates rotation scenario)
+	r2, err := f.NewReaderFromMetadata(rotatedFile, metadata)
+	require.NoError(t, err)
+
+	// Verify OriginalPath is preserved even though file name changed
+	require.Equal(t, originalPath, r2.OriginalPath, "OriginalPath should be preserved through rotation")
+	require.Equal(t, originalPath, r2.FileAttributes[attrs.LogFilePath], "File path attribute should use original path")
+	require.NotEqual(t, rotatedPath, r2.FileAttributes[attrs.LogFilePath], "File path attribute should not use rotated path")
+}
+
+func TestOriginalPathBackwardCompatibility(t *testing.T) {
+	tempDir := t.TempDir()
+	file := filetest.OpenTemp(t, tempDir)
+	filePath := file.Name()
+	content := "test log line\n"
+	_, err := file.WriteString(content)
+	require.NoError(t, err)
+
+	// Create factory with file path attribute enabled
+	f, _ := testFactory(t, func(c *testFactoryCfg) {
+		c.attributes = attrs.Resolver{
+			IncludeFileName: true,
+			IncludeFilePath: true,
+		}
+	})
+
+	fp, err := f.NewFingerprint(file)
+	require.NoError(t, err)
+
+	// Create metadata without OriginalPath (simulates old checkpoint)
+	oldMetadata := &Metadata{
+		Fingerprint:    fp,
+		FileAttributes: make(map[string]any),
+		OriginalPath:   "", // Empty to simulate old checkpoint
+	}
+
+	// NewReaderFromMetadata should handle missing OriginalPath
+	r, err := f.NewReaderFromMetadata(file, oldMetadata)
+	require.NoError(t, err)
+
+	// OriginalPath should be set from current file name
+	require.Equal(t, filePath, r.OriginalPath, "OriginalPath should be set from file when missing")
+	require.Equal(t, filePath, r.FileAttributes[attrs.LogFilePath])
 }

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -32,6 +32,7 @@ type Metadata struct {
 	Offset          int64
 	RecordNum       int64
 	FileAttributes  map[string]any
+	OriginalPath    string
 	HeaderFinalized bool
 	FlushState      flush.State
 	TokenLenState   tokenlen.State


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR addresses an issue where log files lose their original filename attributes after rotation, resulting in timing-dependent behavior where the `container` parser accepts or rejects logs based on whether the file was read before or after rotation.

- Added `OriginalPath` field to reader metadata
- Modified reader factory to preserve original path through rotation
- Added rotation detection logic to distinguish rotation from archive recovery

I'm not sure if this should start living behind a feature gate, but please let me know if it should, as I can add it 🙏 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #38454

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests to ensure the behaviour is respected.
