### PR TITLE
[exporter/coralogix] Allow the exporter to set grpc-accept-encoding

### DIFF
--- a/.chloggen/45191.yaml
+++ b/.chloggen/45191.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/coralogix
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exposed a new field to set `grpc-accept-encoding`. `gzip` will be used by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"google.golang.org/grpc/encoding/gzip"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter/internal/metadata"
 )
@@ -51,6 +52,7 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: configgrpc.ClientConfig{
 						Compression: configcompression.TypeGzip,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Metrics: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
@@ -58,12 +60,14 @@ func TestLoadConfig(t *testing.T) {
 						Compression:     configcompression.TypeGzip,
 						WriteBufferSize: 512 * 1024,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Logs: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
 						Endpoint:    "https://",
 						Compression: configcompression.TypeGzip,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Traces: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
@@ -80,6 +84,7 @@ func TestLoadConfig(t *testing.T) {
 						WaitForReady:    false,
 						BalancerName:    "",
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   true,
@@ -103,6 +108,7 @@ func TestLoadConfig(t *testing.T) {
 					ClientConfig: configgrpc.ClientConfig{
 						Compression: configcompression.TypeGzip,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Metrics: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
@@ -110,12 +116,14 @@ func TestLoadConfig(t *testing.T) {
 						Compression:     configcompression.TypeGzip,
 						WriteBufferSize: 512 * 1024,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Logs: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
 						Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:4317",
 						Compression: configcompression.TypeGzip,
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				Traces: TransportConfig{
 					ClientConfig: configgrpc.ClientConfig{
@@ -132,6 +140,7 @@ func TestLoadConfig(t *testing.T) {
 						WaitForReady:    false,
 						BalancerName:    "",
 					},
+					AcceptEncoding: gzip.Name,
 				},
 				AppNameAttributes:   []string{"service.namespace", "k8s.namespace.name"},
 				SubSystemAttributes: []string{"service.name", "k8s.deployment.name", "k8s.statefulset.name", "k8s.daemonset.name", "k8s.cronjob.name", "k8s.job.name", "k8s.container.name"},
@@ -440,6 +449,41 @@ func TestCreateExportersWithBatcher(t *testing.T) {
 	})
 }
 
+func TestGetAcceptEncoding(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		acceptEncoding   string
+		expectedEncoding string
+	}{
+		{
+			name:             "empty_returns_empty",
+			acceptEncoding:   "",
+			expectedEncoding: "",
+		},
+		{
+			name:             "explicit_gzip",
+			acceptEncoding:   gzip.Name,
+			expectedEncoding: gzip.Name,
+		},
+		{
+			name:             "custom_encoding",
+			acceptEncoding:   "snappy",
+			expectedEncoding: "snappy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &TransportConfig{
+				AcceptEncoding: tt.acceptEncoding,
+			}
+			assert.Equal(t, tt.expectedEncoding, cfg.GetAcceptEncoding())
+		})
+	}
+}
+
 func TestConfigValidation(t *testing.T) {
 	t.Parallel()
 
@@ -503,6 +547,45 @@ func TestConfigValidation(t *testing.T) {
 				Domain:     "coralogix.com",
 				PrivateKey: "test-key",
 				AppName:    "test-app",
+			},
+			expectedErr: "",
+		},
+		{
+			name: "valid_gzip_accept_encoding",
+			config: &Config{
+				Protocol:   "grpc",
+				Domain:     "coralogix.com",
+				PrivateKey: "test-key",
+				AppName:    "test-app",
+				Traces: TransportConfig{
+					AcceptEncoding: gzip.Name,
+				},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid_accept_encoding",
+			config: &Config{
+				Protocol:   "grpc",
+				Domain:     "coralogix.com",
+				PrivateKey: "test-key",
+				AppName:    "test-app",
+				Traces: TransportConfig{
+					AcceptEncoding: "invalid-encoding",
+				},
+			},
+			expectedErr: "traces.accept_encoding: unsupported compression encoding",
+		},
+		{
+			name: "empty_accept_encoding_is_valid",
+			config: &Config{
+				Protocol:   "grpc",
+				Domain:     "coralogix.com",
+				PrivateKey: "test-key",
+				AppName:    "test-app",
+				Traces: TransportConfig{
+					AcceptEncoding: "",
+				},
 			},
 			expectedErr: "",
 		},

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
 	"go.opentelemetry.io/collector/exporter/xexporter"
+	"google.golang.org/grpc/encoding/gzip"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter/internal/metadata"
 )
@@ -45,6 +46,7 @@ func createDefaultConfig() component.Config {
 			ClientConfig: configgrpc.ClientConfig{
 				Compression: configcompression.TypeGzip,
 			},
+			AcceptEncoding: gzip.Name,
 		},
 		// Traces GRPC client
 		Traces: TransportConfig{
@@ -52,6 +54,7 @@ func createDefaultConfig() component.Config {
 				Endpoint:    "https://",
 				Compression: configcompression.TypeGzip,
 			},
+			AcceptEncoding: gzip.Name,
 		},
 		Metrics: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
@@ -60,12 +63,14 @@ func createDefaultConfig() component.Config {
 				Compression:     configcompression.TypeGzip,
 				WriteBufferSize: 512 * 1024,
 			},
+			AcceptEncoding: gzip.Name,
 		},
 		Logs: TransportConfig{
 			ClientConfig: configgrpc.ClientConfig{
 				Endpoint:    "https://",
 				Compression: configcompression.TypeGzip,
 			},
+			AcceptEncoding: gzip.Name,
 		},
 		PrivateKey: "",
 		AppName:    "",

--- a/exporter/coralogixexporter/grpc_accept_encoding_test.go
+++ b/exporter/coralogixexporter/grpc_accept_encoding_test.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package coralogixexporter
+
+import (
+	"strings"
+	"testing"
+
+	grpcgzip "google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/metadata"
+)
+
+func assertAcceptEncodingGzip(tb testing.TB, md metadata.MD) {
+	tb.Helper()
+
+	values := md.Get("grpc-accept-encoding")
+	if len(values) == 0 {
+		tb.Fatalf("expected grpc-accept-encoding metadata")
+	}
+
+	// The grpc-accept-encoding header contains a comma-separated list of all
+	// compressors the client is willing to accept. We just need to verify that
+	// gzip is in the list.
+	acceptEncoding := values[0]
+	encodings := strings.Split(acceptEncoding, ",")
+	found := false
+	for _, enc := range encodings {
+		if strings.TrimSpace(enc) == grpcgzip.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		tb.Fatalf("expected grpc-accept-encoding to contain %q, got %q", grpcgzip.Name, acceptEncoding)
+	}
+}

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -229,6 +229,8 @@ func (m *mockLogsServer) Export(ctx context.Context, req plogotlp.ExportRequest)
 		return plogotlp.NewExportResponse(), errors.New("invalid authorization header")
 	}
 
+	assertAcceptEncodingGzip(m.t, md)
+
 	m.recvCount += req.Logs().LogRecordCount()
 	resp := plogotlp.NewExportResponse()
 	if m.partialSuccess != nil {

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -242,6 +242,8 @@ func (m *mockMetricsServer) Export(ctx context.Context, req pmetricotlp.ExportRe
 		return pmetricotlp.NewExportResponse(), errors.New("invalid authorization header")
 	}
 
+	assertAcceptEncodingGzip(m.t, md)
+
 	m.recvCount += req.Metrics().DataPointCount()
 	resp := pmetricotlp.NewExportResponse()
 	if m.partialSuccess != nil {

--- a/exporter/coralogixexporter/profiles_client_test.go
+++ b/exporter/coralogixexporter/profiles_client_test.go
@@ -227,6 +227,8 @@ func (m *mockProfilesServer) Export(ctx context.Context, req pprofileotlp.Export
 		return pprofileotlp.NewExportResponse(), errors.New("invalid authorization header")
 	}
 
+	assertAcceptEncodingGzip(m.t, md)
+
 	// Count individual profiles instead of resource profiles
 	for _, rp := range req.Profiles().ResourceProfiles().All() {
 		for _, sp := range rp.ScopeProfiles().All() {

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -230,6 +230,8 @@ func (m *mockTracesServer) Export(ctx context.Context, req ptraceotlp.ExportRequ
 		return ptraceotlp.NewExportResponse(), errors.New("invalid authorization header")
 	}
 
+	assertAcceptEncodingGzip(m.t, md)
+
 	m.recvCount += req.Traces().SpanCount()
 	resp := ptraceotlp.NewExportResponse()
 	if m.partialSuccess != nil {


### PR DESCRIPTION
#### Description
Allow the exporter to set `grpc-accept-encoding` header

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45191

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Manual test with this config:
```yaml
receivers:
  otlp:
    protocols:
      grpc:

processors:
  batch:
    timeout: 1s
    send_batch_size: 2048

exporters:
  coralogix:
    domain: eu2.coralogix.com
    private_key: "${env:CORALOGIX_KEY}"
    application_name: otel-benchmark
    subsystem_name: memory-test
    traces:
      accept_encoding: gzip

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [coralogix]
```