### PR TITLE
[exporter/cassandra] fix error handling for insert failures

### DIFF
--- a/.chloggen/fix-cassandra-error-handling.yaml
+++ b/.chloggen/fix-cassandra-error-handling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/cassandra
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix silent data loss by returning errors when span or log inserts fail
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-cassandra-error-handling.yaml
+++ b/.chloggen/fix-cassandra-error-handling.yaml
@@ -10,7 +10,7 @@ component: exporter/cassandra
 note: fix silent data loss by returning errors when span or log inserts fail
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [45205]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/cassandraexporter/exporter_logs.go
+++ b/exporter/cassandraexporter/exporter_logs.go
@@ -139,6 +139,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 
 				if insertLogError != nil {
 					e.logger.Error("insert log error", zap.Error(insertLogError))
+					return insertLogError
 				}
 			}
 		}

--- a/exporter/cassandraexporter/exporter_traces.go
+++ b/exporter/cassandraexporter/exporter_traces.go
@@ -137,6 +137,7 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 
 				if insertSpanError != nil {
 					e.logger.Error("insert span error", zap.Error(insertSpanError))
+					return insertSpanError
 				}
 			}
 		}

--- a/exporter/cassandraexporter/exporter_traces_test.go
+++ b/exporter/cassandraexporter/exporter_traces_test.go
@@ -12,36 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
-// TestPushTraceData_ErrorPropagation verifies the error handling :
-// when cassandra operations fail, errors must be returned for the retry logic
-func TestPushTraceData_ErrorPropagation(t *testing.T) {
-	t.Run("returns error type", func(t *testing.T) {
-		// verify pushTraceData signature returns the error
-		exporter := &tracesExporter{
-			logger: zap.NewNop(),
-			cfg:    createDefaultConfig().(*Config),
-		}
-
-		traces := ptrace.NewTraces()
-
-		// calling with nil client will fail, but were verifying the error
-		// this would panic in the old code (no error handling), but now should handle it?
-		_ = exporter.pushTraceData(context.Background(), traces)
-
-		// the key fix: errors now returned
-		// see exporter_traces.go:140 -insertSpanError is returned
-	})
-}
-
 // TestPushTraceData_EmptyTraces verifies behavior with valid but empty traces
 func TestPushTraceData_EmptyTraces(t *testing.T) {
 	exporter := &tracesExporter{
 		logger: zap.NewNop(),
 		cfg:    createDefaultConfig().(*Config),
-		client: nil, //no client needed for empty traces
+		client: nil, // no client needed for empty traces
 	}
 
-	// empty traces should succeed without trying to insert.
+	// empty traces should succeed without trying to insert
 	traces := ptrace.NewTraces()
 	err := exporter.pushTraceData(context.Background(), traces)
 

--- a/exporter/cassandraexporter/exporter_traces_test.go
+++ b/exporter/cassandraexporter/exporter_traces_test.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cassandraexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
+)
+
+// TestPushTraceData_ErrorPropagation verifies the error handling :
+// when cassandra operations fail, errors must be returned for the retry logic
+func TestPushTraceData_ErrorPropagation(t *testing.T) {
+	t.Run("returns error type", func(t *testing.T) {
+		// verify pushTraceData signature returns the error
+		exporter := &tracesExporter{
+			logger: zap.NewNop(),
+			cfg:    createDefaultConfig().(*Config),
+		}
+
+		traces := ptrace.NewTraces()
+
+		// calling with nil client will fail, but were verifying the error
+		// this would panic in the old code (no error handling), but now should handle it?
+		_ = exporter.pushTraceData(context.Background(), traces)
+
+		// the key fix: errors now returned
+		// see exporter_traces.go:140 -insertSpanError is returned
+	})
+}
+
+// TestPushTraceData_EmptyTraces verifies behavior with valid but empty traces
+func TestPushTraceData_EmptyTraces(t *testing.T) {
+	exporter := &tracesExporter{
+		logger: zap.NewNop(),
+		cfg:    createDefaultConfig().(*Config),
+		client: nil, //no client needed for empty traces
+	}
+
+	// empty traces should succeed without trying to insert.
+	traces := ptrace.NewTraces()
+	err := exporter.pushTraceData(context.Background(), traces)
+
+	assert.NoError(t, err, "empty traces should not cause errors")
+}


### PR DESCRIPTION
  #### Description

  currently if a span or log insert fails in the cassandra exporter, we log the error but return nil to the collector. this causes silent data loss since the collector thinks the export succeeded and moves on.

  this PR fixes the bug by returning the error immediately when an insert fails, which allows the collector's retry process to handle it properly.

  **changes:**
  - `exporter_traces.go`: return error on span insert failure instead of just logging
  - `exporter_logs.go`: return error on log insert failure instead of just logging

  #### Link to tracking issue
  N/A - found during code review

  #### Testing

  ran the existing test suite:
  ```bash
  cd exporter/cassandraexporter && go test -v ./...
```

  all tests pass. verified with go fmt and go vet.

  note: the component doesn't currently have integration tests that mock cassandra insert failures, so I verified the fix by reviewing the control flow and error paths manually.

  #### Documentation

  no documentation changes needed - this is a bug fix that makes the actual behavior match expected behavior (exporters should return errors on failure, not silently succeed).