### PR TITLE
fix(deps): update module github.com/coreos/go-oidc/v3 to v3.17.0

### DIFF
--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -269,7 +269,7 @@ func TestOIDCAuthenticationSucceededSingleIssuerMismatch(t *testing.T) {
 	p := newTestExtension(t, config)
 
 	err = p.Start(t.Context(), componenttest.NewNopHost())
-	require.ErrorContains(t, err, "issuer did not match")
+	require.ErrorContains(t, err, "did not match")
 
 	srvAuth, ok := p.(extensionauth.Server)
 	require.True(t, ok)

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidca
 go 1.24.0
 
 require (
-	github.com/coreos/go-oidc/v3 v3.16.0
+	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/client v1.48.1-0.20251223191316-a9aaa99a1214

--- a/extension/oidcauthextension/go.sum
+++ b/extension/oidcauthextension/go.sum
@@ -1,7 +1,7 @@
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/coreos/go-oidc/v3 v3.16.0 h1:qRQUCFstKpXwmEjDQTIbyY/5jF00+asXzSkmkoa/mow=
-github.com/coreos/go-oidc/v3 v3.16.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
+github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
+github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Bumps go-oidc from v3.16.0 to v3.17.0. The only thing in the changelog was [this commit](https://github.com/coreos/go-oidc/commit/35b8e031bcac7fed73b96b09d42e6e233a6e6562) that changed some error text we happen to rely on for a test. `NewProvider()` [uses](https://github.com/coreos/go-oidc/blob/35b8e031bcac7fed73b96b09d42e6e233a6e6562/oidc/oidc.go#L238) `fmt.Errorf()` for all the errors it returns, so we have to check the error text to see what actually happened. This particular test case is important enough to warrant the brittle test, IMO. I opened [an issue](https://github.com/coreos/go-oidc/issues/471) with go-oidc to add sentinel errors for this use case.

Related to #44517.