### PR TITLE
[receiver/kafka] Fix deprecated field migration logic for metrics, traces, and profiles topic configuration

### DIFF
--- a/.chloggen/kafka_receiver_validation_logic.yaml
+++ b/.chloggen/kafka_receiver_validation_logic.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "receiver/kafka"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix deprecated field migration logic for metrics, traces, and profiles topic configuration"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45213]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fixed bug where deprecated `topic` and `exclude_topic` fields for metrics, traces, and profiles
+  were incorrectly checking logs configuration instead of their respective signal type's configuration.
+  This prevented proper migration from deprecated fields unless logs.topics was empty.
+  Also fixed validation error message typo for traces.exclude_topic and corrected profiles validation
+  to check ExcludeTopic fields instead of Topic fields.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/kafka_receiver_validation_logic.yaml
+++ b/.chloggen/kafka_receiver_validation_logic.yaml
@@ -10,7 +10,7 @@ component: "receiver/kafka"
 note: "Fix deprecated field migration logic for metrics, traces, and profiles topic configuration"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [45213]
+issues: [45215]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -81,7 +81,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 
 	// handle deprecated topic and exclude_topic for metric signal
 	if zeroConfig.Metrics.Topic != "" {
-		if len(zeroConfig.Logs.Topics) == 0 {
+		if len(zeroConfig.Metrics.Topics) == 0 {
 			c.Metrics.Topics = []string{zeroConfig.Metrics.Topic}
 			c.Metrics.topicAlias = c.Metrics.Topic
 			c.Metrics.Topic = ""
@@ -89,7 +89,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	}
 
 	if zeroConfig.Metrics.ExcludeTopic != "" {
-		if len(zeroConfig.Logs.ExcludeTopics) == 0 {
+		if len(zeroConfig.Metrics.ExcludeTopics) == 0 {
 			c.Metrics.ExcludeTopics = []string{zeroConfig.Metrics.ExcludeTopic}
 			c.Metrics.excludeTopicAlias = c.Metrics.ExcludeTopic
 			c.Metrics.ExcludeTopic = ""
@@ -98,7 +98,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 
 	// handle deprecated topic and exclude_topic for trace signal
 	if zeroConfig.Traces.Topic != "" {
-		if len(zeroConfig.Logs.Topics) == 0 {
+		if len(zeroConfig.Traces.Topics) == 0 {
 			c.Traces.Topics = []string{zeroConfig.Traces.Topic}
 			c.Traces.topicAlias = c.Traces.Topic
 			c.Traces.Topic = ""
@@ -106,7 +106,7 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 	}
 
 	if zeroConfig.Traces.ExcludeTopic != "" {
-		if len(zeroConfig.Logs.ExcludeTopics) == 0 {
+		if len(zeroConfig.Traces.ExcludeTopics) == 0 {
 			c.Traces.ExcludeTopics = []string{zeroConfig.Traces.ExcludeTopic}
 			c.Traces.excludeTopicAlias = c.Traces.ExcludeTopic
 			c.Traces.ExcludeTopic = ""
@@ -115,14 +115,14 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 
 	// handle deprecated topic and exclude_topic for profile signal
 	if zeroConfig.Profiles.Topic != "" {
-		if len(zeroConfig.Logs.Topics) == 0 {
+		if len(zeroConfig.Profiles.Topics) == 0 {
 			c.Profiles.Topics = []string{zeroConfig.Profiles.Topic}
 			c.Profiles.topicAlias = c.Profiles.Topic
 			c.Profiles.Topic = ""
 		}
 	}
 	if zeroConfig.Profiles.ExcludeTopic != "" {
-		if len(zeroConfig.Logs.ExcludeTopics) == 0 {
+		if len(zeroConfig.Profiles.ExcludeTopics) == 0 {
 			c.Profiles.ExcludeTopics = []string{zeroConfig.Profiles.ExcludeTopic}
 			c.Profiles.excludeTopicAlias = c.Profiles.ExcludeTopic
 			c.Profiles.ExcludeTopic = ""
@@ -168,9 +168,9 @@ func (c *Config) Validate() error {
 		return errors.New("both metrics.exclude_topic and metrics.exclude_topics cannot be set")
 	}
 	if c.Traces.ExcludeTopic != "" && len(c.Traces.ExcludeTopics) != 0 {
-		return errors.New("both traces.exclude_topic and traces.exclude_topic cannot be set")
+		return errors.New("both traces.exclude_topic and traces.exclude_topics cannot be set")
 	}
-	if c.Profiles.Topic != "" && len(c.Profiles.Topics) != 0 {
+	if c.Profiles.ExcludeTopic != "" && len(c.Profiles.ExcludeTopics) != 0 {
 		return errors.New("both profiles.exclude_topic and profiles.exclude_topics cannot be set")
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixed bug where deprecated `topic` and `exclude_topic` fields for metrics, traces, and profiles were incorrectly checking the logs configuration instead of their respective signal type's configuration. This prevented proper migration from deprecated fields unless `logs.topics` was empty.

Also fixed validation error message typo for `traces.exclude_topic` and corrected profiles validation to check ExcludeTopic fields instead of Topic fields.
