### PR TITLE
[processor/resourcedetection] Fix nil pointer panic when HTTP client creation fails in Start method

### DIFF
--- a/.chloggen/fix_fix_resourcedetection_errorhandle.yaml
+++ b/.chloggen/fix_fix_resourcedetection_errorhandle.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "processor/resourcedetection"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix nil pointer panic when HTTP client creation fails in Start method"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45220]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/resourcedetection_processor.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor.go
@@ -27,11 +27,14 @@ type resourceDetectionProcessor struct {
 
 // Start is invoked during service startup.
 func (rdp *resourceDetectionProcessor) Start(ctx context.Context, host component.Host) error {
-	client, _ := rdp.httpClientSettings.ToClient(ctx, host.GetExtensions(), rdp.telemetrySettings)
+	client, err := rdp.httpClientSettings.ToClient(ctx, host.GetExtensions(), rdp.telemetrySettings)
+	if err != nil {
+		return err
+	}
 	ctx = internal.ContextWithClient(ctx, client)
 
 	// Perform initial resource detection
-	err := rdp.provider.Refresh(ctx, client)
+	err = rdp.provider.Refresh(ctx, client)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes a bug in the `resourcedetection` processor where errors from HTTP client creation in the `Start()` method are silently ignored, causing the collector to panic with a nil pointer dereference when `ToClient()` fails.

This change properly checks and returns the error before attempting to use the client, allowing the collector to fail gracefully at startup with a meaningful error message instead of crashing.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45220

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a unit test to validate the behaviour.

Output before the fix:

```sh
=== Failed
=== FAIL: . TestStartFailsGracefullyOnInvalidHTTPClientConfig/traces_processor (0.00s)

=== FAIL: . TestStartFailsGracefullyOnInvalidHTTPClientConfig (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1037f7840]

goroutine 405 [running]:
testing.tRunner.func1.2({0x107425ae0, 0x1093d8050})
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1872 +0x2b4
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1875 +0x460
panic({0x107425ae0?, 0x1093d8050?})
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/runtime/panic.go:783 +0x120
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal.(*ResourceProvider).Refresh(0xc000344b60, {0x1079ac210, 0xc000625d10}, 0x0)
	~/repos/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/resourcedetection.go:135 +0x40
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor.(*resourceDetectionProcessor).Start(0xc0005cc008, {0x1079ac248, 0xc000500f50}, {0x107966660, 0x10a3b4140})
	~/repos/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/resourcedetection_processor.go:34 +0x128
go.opentelemetry.io/collector/component.StartFunc.Start(...)
	/Users/paudia1/go/pkg/mod/go.opentelemetry.io/collector/component@v1.48.1-0.20251231114627-ad49dc64648d/component.go:66
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor.TestStartFailsGracefullyOnInvalidHTTPClientConfig.func1(0xc0004e1c00)
	~/repos/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/resourcedetection_processor_test.go:832 +0x2c4
testing.tRunner(0xc0004e1c00, 0xc000500ff0)
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1934 +0x168
created by testing.(*T).Run in goroutine 404
	/opt/homebrew/Cellar/go/1.25.4/libexec/src/testing/testing.go:1997 +0x6e4

=== FAIL: . TestLoadConfig (unknown)

DONE 494 tests, 3 failures in 3.898s
ERROR rerun aborted because previous run had a suspected panic and some test may not have run
make: *** [test] Error 3
```