### PR TITLE
[chore][receiver/awscloudwatch] Fix linting

### DIFF
--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -363,12 +364,7 @@ func TestAutodiscoverAccountIdentifiers(t *testing.T) {
 			if input.IncludeLinkedAccounts == nil || !*input.IncludeLinkedAccounts {
 				return false
 			}
-			for _, accountID := range input.AccountIdentifiers {
-				if accountID == testAccountID {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(input.AccountIdentifiers, testAccountID)
 		}),
 		mock.Anything,
 	).Return(


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix the linting issue introduced by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44468

```sh
Error: receiver/awscloudwatchreceiver/logs_test.go:366:4: slicescontains: Loop can be simplified using slices.Contains (modernize)
			for _, accountID := range input.AccountIdentifiers {
			^
```
