### PR TITLE
[processor/resourcedetection] Improve performance on MergeResource and detectedResource

### DIFF
--- a/processor/resourcedetectionprocessor/internal/benchmark_test.go
+++ b/processor/resourcedetectionprocessor/internal/benchmark_test.go
@@ -1,0 +1,174 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+// generateResource creates a resource with keys in range [start, end[
+func generateResource(b *testing.B, start, end int) pcommon.Resource {
+	b.Helper()
+	count := end - start
+	require.GreaterOrEqual(b, count, 0)
+	r := pcommon.NewResource()
+	r.Attributes().EnsureCapacity(count)
+	for i := start; i < end; i++ {
+		r.Attributes().PutStr(fmt.Sprintf("k%d", i), fmt.Sprintf("v%d", i))
+	}
+	return r
+}
+
+func BenchmarkMergeResource(b *testing.B) {
+	tests := map[string]struct {
+		countFrom  int
+		countTo    int
+		overlapPct int // how identical the two maps are
+	}{
+		// Scenario 1: Merge into empty map.
+		// Measures allocation and bulk insertion speed.
+		"From_1_Into_0": {
+			countFrom:  1,
+			countTo:    0,
+			overlapPct: 0,
+		},
+		"From_1000_Into_0": {
+			countFrom:  1000,
+			countTo:    0,
+			overlapPct: 0,
+		},
+
+		// Scenario 2: Merge into an identical map.
+		// Measures lookup speed (checking for existing keys).
+		"From_1_Into_1_Match": {
+			countFrom:  1,
+			countTo:    1,
+			overlapPct: 100,
+		},
+		"From_1000_Into_1000_Match": {
+			countFrom:  1000,
+			countTo:    1000,
+			overlapPct: 100,
+		},
+
+		// Scenario 3: partial overlap between the maps
+		"From_1000_Into_1000_50Pct": {
+			countFrom:  1000,
+			countTo:    1000,
+			overlapPct: 50,
+		},
+	}
+
+	for name, tc := range tests {
+		b.Run(name, func(b *testing.B) {
+			toBase := generateResource(b, 0, tc.countTo)
+
+			overlapCount := (tc.countFrom * tc.overlapPct) / 100
+			startFrom := max(tc.countTo-overlapCount, 0)
+			from := generateResource(b, startFrom, startFrom+tc.countFrom)
+
+			to := pcommon.NewResource()
+
+			// Do we need to reset 'to' every iteration?
+			// 1. If destination is empty, we just Clear() (fast).
+			// 2. If overlap is 100%, we don't mutate 'to', so NO reset needed.
+			// 3. Otherwise (Partial), we mutate, so we MUST reset.
+			isPartial := tc.countTo > 0 && tc.overlapPct < 100
+
+			// If we aren't resetting in the loop (Match case), fill it once now.
+			if tc.countTo > 0 && !isPartial {
+				toBase.CopyTo(to)
+			}
+
+			b.ReportAllocs()
+
+			for b.Loop() {
+				if tc.countTo == 0 {
+					// Fast path: just clear. No need to stop timer.
+					to.Attributes().Clear()
+				} else if isPartial {
+					// Slow path: strictly required for correctness in Partial tests.
+					b.StopTimer()
+					toBase.CopyTo(to)
+					b.StartTimer()
+				}
+
+				MergeResource(to, from, false)
+			}
+		})
+	}
+}
+
+func BenchmarkResourceProvider(b *testing.B) {
+	// Set up a provider with 3 detectors.
+	// This forces the 'detectResource' function to manage multiple goroutines and merge them.
+	d1 := &benchDetector{res: generateResource(b, 0, 10)}
+	d2 := &benchDetector{res: generateResource(b, 0, 10)}
+	d3 := &benchDetector{res: generateResource(b, 0, 10)}
+	provider := NewResourceProvider(zap.NewNop(), 0, d1, d2, d3)
+	ctx := b.Context()
+	client := &http.Client{}
+	_ = provider.Refresh(ctx, client)
+
+	// Each test: "1 in X operations is a Refresh"
+	// 0       = Read Only
+	// 100     = 1% Writes (99 Reads / 1 Refresh)
+	// 10      = 10% Writes (9 Reads / 1 Refresh)
+	tests := []struct {
+		name      string
+		refreshAt int
+	}{
+		{
+			"ReadOnly",
+			0,
+		},
+		{
+			"Mixed_1Pct_Write",
+			100,
+		},
+		{
+			"Mixed_10Pct_Write",
+			10,
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+
+			// RunParallel simulates concurrent access
+			// (Trace Processors reading + Background Refresher writing)
+			b.RunParallel(func(pb *testing.PB) {
+				for i := 1; pb.Next(); i++ {
+					// If refreshAt > 0 and we hit the interval, Write. Otherwise, Read.
+					if tc.refreshAt > 0 && i%tc.refreshAt == 0 {
+						_ = provider.Refresh(ctx, client)
+					} else {
+						_, _, _ = provider.Get(ctx, client)
+					}
+				}
+			})
+		})
+	}
+}
+
+type benchDetector struct {
+	// mockDetector uses mock.Mock which introduces overhead
+	// that we don't want to consider for the benchmarks,
+	// so we create the benchDetector to work around that.
+	res pcommon.Resource
+}
+
+func (d *benchDetector) Detect(_ context.Context) (pcommon.Resource, string, error) {
+	r := pcommon.NewResource()
+	d.res.CopyTo(r)
+	return r, "http://schema", nil
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR introduces a couple of changes, so the processor performs better. You can see the results here:

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                           │    old.txt     │                new.txt                │
                                           │     sec/op     │    sec/op      vs base                │
MergeResource/From_1_Into_0-16                 99.30n ± 13%    81.12n ±  8%  -18.31% (p=0.001 n=10)
MergeResource/From_1000_Into_0-16            4021.69µ ± 11%    44.97µ ±  5%  -98.88% (p=0.000 n=10)
MergeResource/From_1_Into_1_Match-16           10.76n ±  9%    14.80n ± 23%  +37.59% (p=0.000 n=10)
MergeResource/From_1000_Into_1000_Match-16     1.658m ± 14%    2.002m ±  5%  +20.74% (p=0.004 n=10)
MergeResource/From_1000_Into_1000_50Pct-16     3.354m ±  8%    2.357m ± 21%  -29.72% (p=0.000 n=10)
ResourceProvider/ReadOnly-16                 73.7850n ±  6%   0.5283n ±  6%  -99.28% (p=0.000 n=10)
ResourceProvider/Mixed_1Pct_Write-16          188.60n ± 10%    28.93n ±  9%  -84.66% (p=0.000 n=10)
ResourceProvider/Mixed_10Pct_Write-16          775.0n ±  5%    308.9n ±  5%  -60.14% (p=0.000 n=10)
geomean                                        4.747µ          1.023µ        -78.44%

                                           │    old.txt     │                new.txt                 │
                                           │      B/op      │     B/op      vs base                  │
MergeResource/From_1_Into_0-16                 48.00 ± 0%       48.00 ± 0%        ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_0-16            84.22Ki ± 0%     47.62Ki ± 0%  -43.45% (p=0.000 n=10)
MergeResource/From_1_Into_1_Match-16           0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_1000_Match-16     0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_1000_50Pct-16   7.935Ki ± 0%     7.912Ki ± 0%   -0.29% (p=0.011 n=10)
geomean                                                   ²                 -10.83%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                           │    old.txt    │               new.txt                │
                                           │   allocs/op   │  allocs/op   vs base                 │
MergeResource/From_1_Into_0-16                2.000 ± 0%      2.000 ± 0%       ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_0-16            1.011k ± 0%     1.001k ± 0%  -0.99% (p=0.000 n=10)
MergeResource/From_1_Into_1_Match-16          0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_1000_Match-16    0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=10) ¹
MergeResource/From_1000_Into_1000_50Pct-16    500.0 ± 0%      500.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                  ²                -0.20%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
