### PR TITLE
[exporter/kafka] franz-go: Exclude non-produce metrics from kafka_exporter_write_latency and kafka_exporter_latency

### DIFF
--- a/.chloggen/kafkaexporter-franzgo-fix-produce-metrics-pollution.yaml
+++ b/.chloggen/kafkaexporter-franzgo-fix-produce-metrics-pollution.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/kafka
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "franz-go: Exclude non-produce metrics from kafka_exporter_write_latency and kafka_exporter_latency"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45258]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/twmb/franz-go v1.20.6
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20251021233722-4ca18825d8c0
+	github.com/twmb/franz-go/pkg/kmsg v1.12.0
 	go.opentelemetry.io/collector/client v1.49.0
 	go.opentelemetry.io/collector/component v1.49.0
 	go.opentelemetry.io/collector/component/componenttest v0.143.0
@@ -98,7 +99,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/twmb/franz-go/pkg/kadm v1.17.1 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	github.com/twmb/franz-go/pkg/sasl/kerberos v1.1.0 // indirect
 	github.com/twmb/franz-go/plugin/kzap v1.1.2 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
@@ -81,7 +82,12 @@ func (fpm FranzProducerMetrics) OnBrokerThrottle(meta kgo.BrokerMetadata, thrott
 
 var _ kgo.HookBrokerE2E = FranzProducerMetrics{}
 
-func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, _ int16, e2e kgo.BrokerE2E) {
+func (fpm FranzProducerMetrics) OnBrokerE2E(meta kgo.BrokerMetadata, key int16, e2e kgo.BrokerE2E) {
+	// Do not pollute producer metrics with non-produce requests
+	if kmsg.Key(key) != kmsg.Produce {
+		return
+	}
+
 	outcome := "success"
 	if e2e.Err() != nil {
 		outcome = "failure"

--- a/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics_test.go
+++ b/exporter/kafkaexporter/internal/kafkaclient/franzgo_metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
@@ -90,7 +91,7 @@ func TestFranzProducerMetrics(t *testing.T) {
 		require.NoError(t, err)
 		defer tb.Shutdown()
 		fpm := NewFranzProducerMetrics(tb)
-		fpm.OnBrokerE2E(kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}, 0, kgo.BrokerE2E{
+		fpm.OnBrokerE2E(kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}, int16(kmsg.Produce), kgo.BrokerE2E{
 			WriteWait:   time.Second / 4,
 			TimeToWrite: time.Second / 4,
 			ReadWait:    time.Second / 4,
@@ -98,12 +99,20 @@ func TestFranzProducerMetrics(t *testing.T) {
 			WriteErr:    nil,
 			ReadErr:     nil,
 		})
-		fpm.OnBrokerE2E(kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}, 0, kgo.BrokerE2E{
+		fpm.OnBrokerE2E(kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}, int16(kmsg.Produce), kgo.BrokerE2E{
 			WriteWait:   time.Second * 25,
 			TimeToWrite: time.Second * 25,
 			ReadWait:    time.Second * 25,
 			TimeToRead:  time.Second * 25,
 			WriteErr:    errors.New(""),
+			ReadErr:     nil,
+		})
+		fpm.OnBrokerE2E(kgo.BrokerMetadata{NodeID: 1, Host: "broker1"}, int16(kmsg.Metadata), kgo.BrokerE2E{
+			WriteWait:   time.Second * 100,
+			TimeToWrite: time.Second * 100,
+			ReadWait:    time.Second * 100,
+			TimeToRead:  time.Second * 100,
+			WriteErr:    nil,
 			ReadErr:     nil,
 		})
 		var rm metricdata.ResourceMetrics


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

franz-go: In OnBrokerE2E hook, exclude metrics from non-Produce requests, to avoid polluting produce metrics. This will make it consistent with Sarama implementation.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
