### PR TITLE
Add a deprecation warning to es exporter mapping::mode before ignoring it

### DIFF
--- a/.chloggen/elasticsearch-deprecate-mapping-mode-config.yaml
+++ b/.chloggen/elasticsearch-deprecate-mapping-mode-config.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate `mapping::mode` config option"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45246]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `mapping::mode` config option is now deprecated and will soonbe ignored. Instead, use
+  the `X-Elastic-Mapping-Mode` client metadata key (via headers_setter extension) or the
+  `elastic.mapping.mode` scope attribute to control the mapping mode per-request.
+  See the README for migration instructions.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/.chloggen/elasticsearch-deprecate-mapping-mode-config.yaml
+++ b/.chloggen/elasticsearch-deprecate-mapping-mode-config.yaml
@@ -16,7 +16,7 @@ issues: [45246]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The `mapping::mode` config option is now deprecated and will soonbe ignored. Instead, use
+  The `mapping::mode` config option is now deprecated and will soon be ignored. Instead, use
   the `X-Elastic-Mapping-Mode` client metadata key (via headers_setter extension) or the
   `elastic.mapping.mode` scope attribute to control the mapping mode per-request.
   See the README for migration instructions.

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -167,26 +167,69 @@ The Elasticsearch exporter supports several document schemas and preprocessing
 behaviours, which may be configured through the following settings:
 
 - `mapping`:
-  - `mode` (default=otel): The default mapping mode. Valid modes are:
-    - `none`
-    - `ecs`
-    - `otel`
-    - `raw`
-    - `bodymap`
+  - `mode` (DEPRECATED) The mapping mode if supplied via config file is deprecated and will soon be ignored. Use the `X-Elastic-Mapping-Mode` client metadata key or the `elastic.mapping.mode` scope attribute instead. If not specified via these methods, the default mapping mode is `otel`.
+
   - `allowed_modes` (defaults to all mapping modes): A list of allowed mapping modes.
 
-The mapping mode can also be controlled via the client metadata key `X-Elastic-Mapping-Mode`,
-e.g. via HTTP headers, gRPC metadata. This will override the configured `mapping::mode`.
+The mapping mode can be controlled via the client metadata key `X-Elastic-Mapping-Mode`,
+e.g. via HTTP headers, gRPC metadata.
+
+
 It is possible to restrict which mapping modes may be requested by configuring
 `mapping::allowed_modes`, which defaults to all mapping modes. Keep in mind that not all
 processors or exporter configurations will maintain client metadata.
 
-Finally, the mapping mode can be controlled via the scope attribute `elastic.mapping.mode`.
+The mapping mode can also be controlled via the scope attribute `elastic.mapping.mode`.
 If specified, this takes precedence over the `X-Elastic-Mapping-Mode` client metadata.
 If any scope has an invalid mapping mode, the exporter will reject the entire batch.
 The attribute will be excluded from the final document.
 
+Valid mapping modes are:
+- `none`
+- `ecs`
+- `otel`
+- `raw`
+- `bodymap`
+
 See below for a description of each mapping mode.
+
+#### Migration: Setting mapping mode via scope attribute
+
+Since the `mapping::mode` config option is deprecated, use the following method to set the mapping mode:
+
+**Use scope attribute via transform processor**
+
+This approach sets the `elastic.mapping.mode` scope attribute on the telemetry data.
+
+```yaml
+processors:
+  transform:
+    log_statements:
+      - context: scope
+        statements:
+          - set(attributes["elastic.mapping.mode"], "otel")
+    trace_statements:
+      - context: scope
+        statements:
+          - set(attributes["elastic.mapping.mode"], "otel")
+    metric_statements:
+      - context: scope
+        statements:
+          - set(attributes["elastic.mapping.mode"], "otel")
+exporters:
+  elasticsearch:
+    endpoint: https://elasticsearch:9200
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [transform]
+      exporters: [elasticsearch]
+```
+
+> [!NOTE]
+> The scope attribute `elastic.mapping.mode` takes precedence over the `X-Elastic-Mapping-Mode` client metadata.
+> The attribute will be excluded from the final document sent to Elasticsearch.
 
 #### OTel mapping mode
 

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -498,6 +498,9 @@ func handleDeprecatedConfig(cfg *Config, logger *zap.Logger) {
 		// Do not set cfg.Retry.Enabled = false if cfg.Retry.MaxRequest = 1 to avoid breaking change on behavior
 		logger.Warn("retry::max_requests has been deprecated, and will be removed in a future version. Use retry::max_retries instead.")
 	}
+	if canonicalMappingModeName(cfg.Mapping.Mode) != MappingOTel.String() {
+		logger.Warn("mapping::mode config option is now deprecated and will soon beignored. Use the `elastic.mapping.mode` scope attribute instead. See the README for migration instructions.")
+	}
 	if cfg.LogsDynamicIndex.Enabled {
 		logger.Warn("logs_dynamic_index::enabled has been deprecated, and will be removed in a future version. It is now a no-op. Dynamic document routing is now the default. See Elasticsearch Exporter README.")
 	}

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -499,7 +499,7 @@ func handleDeprecatedConfig(cfg *Config, logger *zap.Logger) {
 		logger.Warn("retry::max_requests has been deprecated, and will be removed in a future version. Use retry::max_retries instead.")
 	}
 	if canonicalMappingModeName(cfg.Mapping.Mode) != MappingOTel.String() {
-		logger.Warn("mapping::mode config option is now deprecated and will soon beignored. Use the `elastic.mapping.mode` scope attribute instead. See the README for migration instructions.")
+		logger.Warn("mapping::mode config option is now deprecated and will soon be ignored. Use the `elastic.mapping.mode` scope attribute instead. See the README for migration instructions.")
 	}
 	if cfg.LogsDynamicIndex.Enabled {
 		logger.Warn("logs_dynamic_index::enabled has been deprecated, and will be removed in a future version. It is now a no-op. Dynamic document routing is now the default. See Elasticsearch Exporter README.")

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -629,6 +629,9 @@ func (e *elasticsearchExporter) getRequestMappingMode(ctx context.Context) (Mapp
 	values := client.FromContext(ctx).Metadata.Get(metadataKey)
 	switch n := len(values); n {
 	case 0:
+		if e.defaultMappingMode != MappingOTel {
+			e.set.Logger.Warn("mapping mode being supplied via config file is now a deprecated feature. Use the `X-Elastic-Mapping-Mode` client metadata key or the `elastic.mapping.mode` scope attribute instead.")
+		}
 		return e.defaultMappingMode, nil
 	case 1:
 		mode, err := e.parseMappingMode(values[0])

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -629,9 +629,6 @@ func (e *elasticsearchExporter) getRequestMappingMode(ctx context.Context) (Mapp
 	values := client.FromContext(ctx).Metadata.Get(metadataKey)
 	switch n := len(values); n {
 	case 0:
-		if e.defaultMappingMode != MappingOTel {
-			e.set.Logger.Warn("mapping mode being supplied via config file is now a deprecated feature. Use the `X-Elastic-Mapping-Mode` client metadata key or the `elastic.mapping.mode` scope attribute instead.")
-		}
 		return e.defaultMappingMode, nil
 	case 1:
 		mode, err := e.parseMappingMode(values[0])


### PR DESCRIPTION
#### Description
Add a deprecation warning to es exporter when mapping::mode config is provided, this is the first step before ignoring this config entirely.

#### Link to tracking issue
Relates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45246

#### Documentation
Added readme instructions.

