### PR TITLE
[extension/text_encoding] Pass separators from config to codec

### DIFF
--- a/.chloggen/text_encoding_separator_config.yaml
+++ b/.chloggen/text_encoding_separator_config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/text_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix an issue where marshalling/unmarshalling separators were ignored
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42797]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/textencodingextension/extension.go
+++ b/extension/encoding/textencodingextension/extension.go
@@ -5,6 +5,7 @@ package textencodingextension // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"regexp"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -36,8 +37,22 @@ func (e *textExtension) Start(_ context.Context, _ component.Host) error {
 	if err != nil {
 		return err
 	}
+
+	var unmarshallingSeparator *regexp.Regexp
+
+	if e.config.UnmarshalingSeparator != "" {
+		unmarshallingSeparator, err = regexp.Compile(e.config.UnmarshalingSeparator)
+		if err != nil {
+			return err
+		}
+	} else {
+		unmarshallingSeparator = nil
+	}
+
 	e.textEncoder = &textLogCodec{
-		decoder: enc.NewDecoder(),
+		decoder:               enc.NewDecoder(),
+		marshalingSeparator:   e.config.MarshalingSeparator,
+		unmarshalingSeparator: unmarshallingSeparator,
 	}
 
 	return err

--- a/extension/encoding/textencodingextension/extension_test.go
+++ b/extension/encoding/textencodingextension/extension_test.go
@@ -82,3 +82,14 @@ func Test_MarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, plogtest.CompareLogs(logs, result, plogtest.IgnoreTimestamp(), plogtest.IgnoreObservedTimestamp()))
 }
+
+func Test_StartSeparatorConfig(t *testing.T) {
+	factory := NewFactory()
+	ext, err := factory.Create(t.Context(), extensiontest.NewNopSettings(factory.Type()), factory.CreateDefaultConfig())
+	require.NoError(t, err)
+	err = ext.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	e := ext.(*textExtension)
+	require.Equal(t, e.config.MarshalingSeparator, e.textEncoder.marshalingSeparator)
+	require.Equal(t, e.config.UnmarshalingSeparator, e.textEncoder.unmarshalingSeparator.String())
+}


### PR DESCRIPTION
This (partially) fixes #42797 by passing marshalling/unmarshalling separators from the text_encoding extension configuration to the `textLogCodec`. After this change, configured separators should work as expected. This change includes a new unit test to show that separators configuration is propagated as expected.

This pull request does _not_ address the second part of of #42797 related to spurious line breaks because I think there's room for reasonable minds to disagree on a solution there. I'll open a separate pull request for that with the expectation that it may warrant more discussion.