### PR TITLE
[receiver/libhoney] Handle wider variety of encoding

### DIFF
--- a/.chloggen/libhoney-improve-msgpack.yaml
+++ b/.chloggen/libhoney-improve-msgpack.yaml
@@ -1,0 +1,5 @@
+change_type: "bug_fix"
+component: "receiver/libhoney"
+issues: [45273]
+note: "Improve msgpack decoding to handle ints or uints"
+change_logs: [user]

--- a/receiver/libhoneyreceiver/internal/codec/codec.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec.go
@@ -254,6 +254,8 @@ func buildLibhoneyEventFromMap(rawEvent map[string]any) libhoneyevent.LibhoneyEv
 			event.Samplerate = v
 		case int64:
 			event.Samplerate = int(v)
+		case uint64:
+			event.Samplerate = int(v)
 		case float64:
 			event.Samplerate = int(v)
 		}

--- a/receiver/libhoneyreceiver/internal/codec/codec_test.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec_test.go
@@ -561,6 +561,61 @@ func TestGetEncoder(t *testing.T) {
 	}
 }
 
+func TestBuildLibhoneyEventFromMap_SamplerateTypes(t *testing.T) {
+	tests := []struct {
+		name             string
+		rawEvent         map[string]any
+		expectedSampleRate int
+	}{
+		{
+			name: "samplerate as int",
+			rawEvent: map[string]any{
+				"data":       map[string]any{"field1": "value1"},
+				"samplerate": int(10),
+			},
+			expectedSampleRate: 10,
+		},
+		{
+			name: "samplerate as int64",
+			rawEvent: map[string]any{
+				"data":       map[string]any{"field1": "value1"},
+				"samplerate": int64(10),
+			},
+			expectedSampleRate: 10,
+		},
+		{
+			name: "samplerate as uint64",
+			rawEvent: map[string]any{
+				"data":       map[string]any{"field1": "value1"},
+				"samplerate": uint64(10),
+			},
+			expectedSampleRate: 10,
+		},
+		{
+			name: "samplerate as float64",
+			rawEvent: map[string]any{
+				"data":       map[string]any{"field1": "value1"},
+				"samplerate": float64(10.0),
+			},
+			expectedSampleRate: 10,
+		},
+		{
+			name: "no samplerate defaults to 1",
+			rawEvent: map[string]any{
+				"data": map[string]any{"field1": "value1"},
+			},
+			expectedSampleRate: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := buildLibhoneyEventFromMap(tt.rawEvent)
+			assert.Equal(t, tt.expectedSampleRate, event.Samplerate)
+		})
+	}
+}
+
 func TestEncoder_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/receiver/libhoneyreceiver/internal/codec/codec_test.go
+++ b/receiver/libhoneyreceiver/internal/codec/codec_test.go
@@ -563,8 +563,8 @@ func TestGetEncoder(t *testing.T) {
 
 func TestBuildLibhoneyEventFromMap_SamplerateTypes(t *testing.T) {
 	tests := []struct {
-		name             string
-		rawEvent         map[string]any
+		name               string
+		rawEvent           map[string]any
 		expectedSampleRate int
 	}{
 		{

--- a/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
+++ b/receiver/libhoneyreceiver/internal/libhoneyevent/libhoneyevent.go
@@ -290,7 +290,13 @@ func (l *LibhoneyEvent) ToPLogRecord(newLog *plog.LogRecord, alreadyUsedFields *
 	newLog.SetTimestamp(pcommon.Timestamp(timeNs))
 
 	if logSevCode, ok := l.Data["severity_code"]; ok {
-		logSevInt := int32(logSevCode.(int64))
+		var logSevInt int32
+		switch v := logSevCode.(type) {
+		case int64:
+			logSevInt = int32(v)
+		case uint64:
+			logSevInt = int32(v)
+		}
 		newLog.SetSeverityNumber(plog.SeverityNumber(logSevInt))
 	}
 
@@ -299,7 +305,13 @@ func (l *LibhoneyEvent) ToPLogRecord(newLog *plog.LogRecord, alreadyUsedFields *
 	}
 
 	if logFlags, ok := l.Data["flags"]; ok {
-		logFlagsUint := uint32(logFlags.(uint64))
+		var logFlagsUint uint32
+		switch v := logFlags.(type) {
+		case int64:
+			logFlagsUint = uint32(v)
+		case uint64:
+			logFlagsUint = uint32(v)
+		}
 		newLog.SetFlags(plog.LogRecordFlags(logFlagsUint))
 	}
 
@@ -326,6 +338,8 @@ func (l *LibhoneyEvent) ToPLogRecord(newLog *plog.LogRecord, alreadyUsedFields *
 		case int64, int16, int32:
 			intv := v.(int64)
 			newLog.Attributes().PutInt(k, intv)
+		case uint64:
+			newLog.Attributes().PutInt(k, int64(v))
 		case float64:
 			newLog.Attributes().PutDouble(k, v)
 		case bool:
@@ -473,6 +487,8 @@ func (l *LibhoneyEvent) ToPTraceSpan(newSpan *ptrace.Span, alreadyUsedFields *[]
 		case int64, int16, int32:
 			intv := v.(int64)
 			newSpan.Attributes().PutInt(k, intv)
+		case uint64:
+			newSpan.Attributes().PutInt(k, int64(v))
 		case float64:
 			newSpan.Attributes().PutDouble(k, v)
 		case bool:

--- a/receiver/libhoneyreceiver/internal/parser/parser.go
+++ b/receiver/libhoneyreceiver/internal/parser/parser.go
@@ -197,6 +197,8 @@ func addSpanEventsToSpan(sp ptrace.Span, events []libhoneyevent.LibhoneyEvent, a
 			case int64, int16, int32:
 				intv := lval.(int64)
 				newEvent.Attributes().PutInt(lkey, intv)
+			case uint64:
+				newEvent.Attributes().PutInt(lkey, int64(lval))
 			case float64:
 				newEvent.Attributes().PutDouble(lkey, lval)
 			case bool:
@@ -283,6 +285,8 @@ func addSpanLinksToSpan(sp ptrace.Span, links []libhoneyevent.LibhoneyEvent, alr
 			case int64, int16, int32:
 				intv := lval.(int64)
 				newLink.Attributes().PutInt(lkey, intv)
+			case uint64:
+				newLink.Attributes().PutInt(lkey, int64(lval))
 			case float64:
 				newLink.Attributes().PutDouble(lkey, lval)
 			case bool:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Newer software sending msgpack data in Libhoney format is sending integers with signs now when they were unsigned in the past. This allows the receiver to accept either type of integer. 



<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added test cases that fail with the old code and pass with the new code 

<!--Describe the documentation added.-->
#### Documentation

This change allows the receiver to meet the current expectations so no additional documentation is needed.

<!--Please delete paragraphs that you did not use before submitting.-->
