### PR TITLE
[extension/text_encoding] Avoid spurious marshalling separators at end of lines

### DIFF
--- a/.chloggen/text_encoding_repeated_marshalling_separator.yaml
+++ b/.chloggen/text_encoding_repeated_marshalling_separator.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/text_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid spurious marshalling separators at end of lines
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42797]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, text_encoding would append the marshalling separator to the end of
+  each log record, potentially resulting in double-newlines between blocks of
+  records.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/textencodingextension/text.go
+++ b/extension/encoding/textencodingextension/text.go
@@ -63,14 +63,19 @@ func (r *textLogCodec) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 
 func (r *textLogCodec) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	var b []byte
+	appendedLogRecord := false
+
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
 		for j := 0; j < rl.ScopeLogs().Len(); j++ {
 			sl := rl.ScopeLogs().At(j)
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				lr := sl.LogRecords().At(k)
+				if appendedLogRecord {
+					b = append(b, []byte(r.marshalingSeparator)...)
+				}
 				b = append(b, []byte(lr.Body().AsString())...)
-				b = append(b, []byte(r.marshalingSeparator)...)
+				appendedLogRecord = true
 			}
 		}
 	}

--- a/extension/encoding/textencodingextension/text_test.go
+++ b/extension/encoding/textencodingextension/text_test.go
@@ -24,7 +24,7 @@ func TestTextRoundtrip(t *testing.T) {
 	assert.Equal(t, 2, ld.LogRecordCount())
 	b, err := codec.MarshalLogs(ld)
 	require.NoError(t, err)
-	require.Equal(t, "foo\nbar\n", string(b))
+	require.Equal(t, "foo\nbar", string(b))
 }
 
 func TestTextRoundtripMissingNewline(t *testing.T) {
@@ -38,7 +38,7 @@ func TestTextRoundtripMissingNewline(t *testing.T) {
 	assert.Equal(t, 2, ld.LogRecordCount())
 	b, err := codec.MarshalLogs(ld)
 	require.NoError(t, err)
-	require.Equal(t, "foo\nbar\n", string(b))
+	require.Equal(t, "foo\nbar", string(b))
 }
 
 func TestNoSeparator(t *testing.T) {


### PR DESCRIPTION
As a companion to #45272, this partially fixes #42797 by avoiding spurious newlines between blocks of log records. This change modifies existing unit tests to demonstrate the new behavior.

Since tests already existed for this behavior, I recognize that the existing behavior may already be working as intended. Even so, I offer this in the spirit of fully addressing the concerns raise in #42797.