### PR TITLE
[pkg/stanza/trim] Improve performance of Trailing and Leading

### DIFF
--- a/pkg/stanza/trim/benchmark_test.go
+++ b/pkg/stanza/trim/benchmark_test.go
@@ -7,8 +7,6 @@ import (
 	"bufio"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // BenchmarkTrimFuncs tests the core trimming logic (Leading, Trailing, Whitespace, Nop)
@@ -96,8 +94,7 @@ func BenchmarkWithFunc(b *testing.B) {
 			split := tc.fn
 
 			for b.Loop() {
-				_, _, err := split(data, false)
-				require.NoError(b, err)
+				_, _, _ = split(data, false)
 			}
 		})
 	}
@@ -131,8 +128,7 @@ func BenchmarkToLength(b *testing.B) {
 			data := tc.data
 
 			for b.Loop() {
-				_, _, err := split(data, false)
-				require.NoError(b, err)
+				_, _, _ = split(data, false)
 			}
 		})
 	}

--- a/pkg/stanza/trim/benchmark_test.go
+++ b/pkg/stanza/trim/benchmark_test.go
@@ -1,0 +1,139 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trim
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkTrimFuncs tests the core trimming logic (Leading, Trailing, Whitespace, Nop)
+func BenchmarkTrimFuncs(b *testing.B) {
+	inputs := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "small clean",
+			data: []byte("simple_log_line"),
+		},
+		{
+			name: "small dirty",
+			data: []byte("   \t\r\n simple_log_line \t\r\n   "),
+		},
+		{
+			name: "all space",
+			data: []byte("   \t\r\n   "),
+		},
+		{
+			name: "large dirty",
+			data: []byte(strings.Repeat("   \t content \r\n ", 100)),
+		},
+	}
+
+	funcs := []struct {
+		name string
+		fn   Func
+	}{
+		{
+			name: "leading",
+			fn:   Leading,
+		},
+		{
+			name: "trailing",
+			fn:   Trailing,
+		},
+		{
+			name: "whitespace",
+			fn:   Whitespace,
+		},
+		{
+			name: "nop",
+			fn:   Nop,
+		},
+	}
+
+	for _, f := range funcs {
+		for _, input := range inputs {
+			b.Run(f.name+"/"+input.name, func(b *testing.B) {
+				b.ReportAllocs()
+				data := input.data
+
+				for b.Loop() {
+					_ = f.fn(data)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkWithFunc tests the overhead of wrapping a SplitFunc
+func BenchmarkWithFunc(b *testing.B) {
+	data := []byte("line1\nline2\nline3\n")
+
+	tests := []struct {
+		name string
+		fn   bufio.SplitFunc
+	}{
+		{
+			name: "baseline scanlines",
+			fn:   bufio.ScanLines,
+		},
+		{
+			name: "with whitespace",
+			fn:   WithFunc(bufio.ScanLines, Whitespace),
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			split := tc.fn
+
+			for b.Loop() {
+				_, _, err := split(data, false)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+// BenchmarkToLength tests the truncation logic
+func BenchmarkToLength(b *testing.B) {
+	tests := []struct {
+		name  string
+		data  []byte
+		limit int
+	}{
+		{
+			name:  "under limit",
+			data:  []byte("short"),
+			limit: 10,
+		},
+		{
+			name:  "over limit",
+			data:  []byte(strings.Repeat("long", 100)),
+			limit: 10,
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			// Initialize the split function with the specific limit
+			split := ToLength(bufio.ScanLines, tc.limit)
+			data := tc.data
+
+			for b.Loop() {
+				_, _, err := split(data, false)
+				require.NoError(b, err)
+			}
+		})
+	}
+}

--- a/pkg/stanza/trim/trim.go
+++ b/pkg/stanza/trim/trim.go
@@ -5,7 +5,6 @@ package trim // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"bufio"
-	"bytes"
 )
 
 type Func func([]byte) []byte
@@ -45,18 +44,22 @@ func Nop(token []byte) []byte {
 	return token
 }
 
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n'
+}
+
 func Leading(data []byte) []byte {
-	token := bytes.TrimLeft(data, "\r\n\t ")
-	if token == nil {
-		// TrimLeft sometimes overwrites something with nothing.
-		// We need to override this behavior in order to preserve empty tokens.
-		return data
+	for len(data) > 0 && isSpace(data[0]) {
+		data = data[1:]
 	}
-	return token
+	return data
 }
 
 func Trailing(data []byte) []byte {
-	return bytes.TrimRight(data, "\r\n\t ")
+	for len(data) > 0 && isSpace(data[len(data)-1]) {
+		data = data[:len(data)-1]
+	}
+	return data
 }
 
 func Whitespace(data []byte) []byte {

--- a/pkg/stanza/trim/trim_test.go
+++ b/pkg/stanza/trim/trim_test.go
@@ -7,8 +7,9 @@ import (
 	"bufio"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 )
 
 func TestTrim(t *testing.T) {

--- a/pkg/stanza/trim/trim_test.go
+++ b/pkg/stanza/trim/trim_test.go
@@ -7,9 +7,8 @@ import (
 	"bufio"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTrim(t *testing.T) {
@@ -57,21 +56,91 @@ func TestTrim(t *testing.T) {
 			expect:           nil,
 		},
 		{
+			name:             "trim trailing returns nil when given nil",
+			preserveLeading:  true,
+			preserveTrailing: false,
+			input:            nil,
+			expect:           nil,
+		},
+		{
 			name:             "trim leading returns []byte when given []byte",
 			preserveLeading:  false,
 			preserveTrailing: true,
 			input:            []byte{},
 			expect:           []byte{},
 		},
+		{
+			name:             "all whitespace becomes empty",
+			preserveLeading:  false,
+			preserveTrailing: false,
+			input:            []byte("   \t\r\n   "),
+			expect:           []byte{},
+		},
+		{
+			name:             "no whitespace remains unchanged",
+			preserveLeading:  false,
+			preserveTrailing: false,
+			input:            []byte("content"),
+			expect:           []byte("content"),
+		},
+		{
+			name:             "mixed whitespace types",
+			preserveLeading:  false,
+			preserveTrailing: false,
+			input:            []byte(" \t\r\ncontent \t\r\n"),
+			expect:           []byte("content"),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			trimFunc := Config{
 				PreserveLeading:  tc.preserveLeading,
 				PreserveTrailing: tc.preserveTrailing,
 			}.Func()
 			assert.Equal(t, tc.expect, trimFunc(tc.input))
+		})
+	}
+}
+
+func TestIsSpace(t *testing.T) {
+	testCases := []struct {
+		name    string
+		b       byte
+		isSpace bool
+	}{
+		{
+			name:    "space",
+			b:       ' ',
+			isSpace: true,
+		},
+		{
+			name:    "newline",
+			b:       '\n',
+			isSpace: true,
+		},
+		{
+			name:    "tab",
+			b:       '\t',
+			isSpace: true,
+		},
+		{
+			name:    "carriage return",
+			b:       '\r',
+			isSpace: true,
+		},
+		{
+			name:    "not a space",
+			b:       '1',
+			isSpace: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.isSpace, isSpace(tc.b))
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Improves the performance of `Trailing` and `Leading` functions. You can see it in the benchmarks results here:

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                    │ Previous code │               This PR                │
                                    │    sec/op     │    sec/op     vs base                │
TrimFuncs/leading/small_clean-16      20.345n ± 23%   2.924n ± 18%  -85.63% (p=0.000 n=10)
TrimFuncs/leading/small_dirty-16       24.65n ± 30%   12.77n ± 10%  -48.22% (p=0.000 n=10)
TrimFuncs/leading/all_space-16         25.91n ± 13%   13.38n ±  8%  -48.35% (p=0.000 n=10)
TrimFuncs/leading/large_dirty-16      21.440n ± 15%   8.457n ±  7%  -60.56% (p=0.000 n=10)
TrimFuncs/trailing/small_clean-16     16.400n ±  8%   2.737n ±  3%  -83.31% (p=0.000 n=10)
TrimFuncs/trailing/small_dirty-16      18.88n ± 14%   10.37n ±  8%  -45.10% (p=0.000 n=10)
TrimFuncs/trailing/all_space-16        22.61n ±  5%   12.10n ±  7%  -46.50% (p=0.000 n=10)
TrimFuncs/trailing/large_dirty-16     19.085n ± 10%   7.271n ± 22%  -61.90% (p=0.000 n=10)
TrimFuncs/whitespace/small_clean-16   29.895n ±  4%   3.788n ±  3%  -87.33% (p=0.000 n=10)
TrimFuncs/whitespace/small_dirty-16    41.10n ± 11%   17.20n ±  3%  -58.16% (p=0.000 n=10)
TrimFuncs/whitespace/all_space-16      24.47n ±  7%   13.22n ± 17%  -45.97% (p=0.000 n=10)
TrimFuncs/whitespace/large_dirty-16    36.59n ± 15%   12.82n ± 15%  -64.95% (p=0.000 n=10)
TrimFuncs/nop/small_clean-16           2.071n ±  8%   1.937n ±  7%        ~ (p=0.052 n=10)
TrimFuncs/nop/small_dirty-16           2.048n ±  7%   1.939n ±  4%        ~ (p=0.063 n=10)
TrimFuncs/nop/all_space-16             2.346n ± 10%   2.022n ±  4%  -13.83% (p=0.000 n=10)
TrimFuncs/nop/large_dirty-16           2.355n ±  9%   2.175n ± 12%   -7.62% (p=0.023 n=10)
WithFunc/baseline_scanlines-16         215.8n ± 11%   219.5n ±  3%        ~ (p=0.755 n=10)
WithFunc/with_whitespace-16            237.3n ± 12%   237.9n ± 13%        ~ (p=0.912 n=10)
ToLength/under_limit-16                241.7n ± 12%   267.3n ± 17%  +10.57% (p=0.002 n=10)
ToLength/over_limit-16                 266.9n ± 12%   247.1n ± 20%        ~ (p=0.393 n=10)
geomean                                23.72n         12.33n        -48.00%

                                    │ Previous code │               This PR               │
                                    │     B/op      │    B/op     vs base                 │
TrimFuncs/leading/small_clean-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/small_dirty-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/all_space-16         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/large_dirty-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/small_clean-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/small_dirty-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/all_space-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/large_dirty-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/small_clean-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/small_dirty-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/all_space-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/large_dirty-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/small_clean-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/small_dirty-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/all_space-16             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/large_dirty-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithFunc/baseline_scanlines-16         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithFunc/with_whitespace-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ToLength/under_limit-16                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ToLength/over_limit-16                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                    │ Previous code │               This PR               │
                                    │   allocs/op   │ allocs/op   vs base                 │
TrimFuncs/leading/small_clean-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/small_dirty-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/all_space-16         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/leading/large_dirty-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/small_clean-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/small_dirty-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/all_space-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/trailing/large_dirty-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/small_clean-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/small_dirty-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/all_space-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/whitespace/large_dirty-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/small_clean-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/small_dirty-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/all_space-16             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
TrimFuncs/nop/large_dirty-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithFunc/baseline_scanlines-16         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithFunc/with_whitespace-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ToLength/under_limit-16                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ToLength/over_limit-16                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```