### PR TITLE
[processor/tailsampling] Drop large traces

### DIFF
--- a/.chloggen/drop-large-traces.yaml
+++ b/.chloggen/drop-large-traces.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Provide option to limit maximum trace size kept in memory by the tail sampling processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45286]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Traces that exceed the size limit will be immediately dropped, not have a decision made for them.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -65,6 +65,7 @@ The following configuration options can also be modified:
 - `sample_on_first_match`: Make decision as soon as a policy matches
 - `drop_pending_traces_on_shutdown`: Drop pending traces on shutdown instead of making a decision with the partial data
   already ingested.
+- `maximum_trace_size_bytes`: The maximum size a trace can reach in bytes, traces larger than this size will be immediately dropped from the tail sampling processor in order to protect the system.
 
 
 Each policy will result in a decision, and the processor will evaluate them to make a final decision:

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -312,4 +312,8 @@ type Config struct {
 	// DropPendingTracesOnShutdown will drop all traces that are part of batches that have not yet reached the decision
 	// wait when the processor is shutdown.
 	DropPendingTracesOnShutdown bool `mapstructure:"drop_pending_traces_on_shutdown"`
+	// MaximumTraceSizeBytes is the largest size of a trace a decision will be made for.
+	// If the trace size exceeds this it will be dropped before the decision period to keep memory more predictable.
+	// A 0 value disables dropping large traces early.
+	MaximumTraceSizeBytes uint64 `mapstructure:"maximum_trace_size_bytes"`
 }

--- a/processor/tailsamplingprocessor/documentation.md
+++ b/processor/tailsamplingprocessor/documentation.md
@@ -150,3 +150,11 @@ Tracks the number of traces current on memory [Development]
 | Unit | Metric Type | Value Type | Stability |
 | ---- | ----------- | ---------- | --------- |
 | {traces} | Gauge | Int | Development |
+
+### otelcol_processor_tail_sampling_traces_dropped_too_large
+
+Count of traces that were dropped because they were too large [Development]
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {traces} | Sum | Int | true | Development |

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -38,6 +38,7 @@ type TelemetryBuilder struct {
 	ProcessorTailSamplingSamplingTraceDroppedTooEarly   metric.Int64Counter
 	ProcessorTailSamplingSamplingTraceRemovalAge        metric.Int64Histogram
 	ProcessorTailSamplingSamplingTracesOnMemory         metric.Int64Gauge
+	ProcessorTailSamplingTracesDroppedTooLarge          metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -145,6 +146,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ProcessorTailSamplingSamplingTracesOnMemory, err = builder.meter.Int64Gauge(
 		"otelcol_processor_tail_sampling_sampling_traces_on_memory",
 		metric.WithDescription("Tracks the number of traces current on memory [Development]"),
+		metric.WithUnit("{traces}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorTailSamplingTracesDroppedTooLarge, err = builder.meter.Int64Counter(
+		"otelcol_processor_tail_sampling_traces_dropped_too_large",
+		metric.WithDescription("Count of traces that were dropped because they were too large [Development]"),
 		metric.WithUnit("{traces}"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
+++ b/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest.go
@@ -223,3 +223,19 @@ func AssertEqualProcessorTailSamplingSamplingTracesOnMemory(t *testing.T, tt *co
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
+
+func AssertEqualProcessorTailSamplingTracesDroppedTooLarge(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_processor_tail_sampling_traces_dropped_too_large",
+		Description: "Count of traces that were dropped because they were too large [Development]",
+		Unit:        "{traces}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_processor_tail_sampling_traces_dropped_too_large")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}

--- a/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
+++ b/processor/tailsamplingprocessor/internal/metadatatest/generated_telemetrytest_test.go
@@ -32,6 +32,7 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.ProcessorTailSamplingSamplingTraceDroppedTooEarly.Add(context.Background(), 1)
 	tb.ProcessorTailSamplingSamplingTraceRemovalAge.Record(context.Background(), 1)
 	tb.ProcessorTailSamplingSamplingTracesOnMemory.Record(context.Background(), 1)
+	tb.ProcessorTailSamplingTracesDroppedTooLarge.Add(context.Background(), 1)
 	AssertEqualProcessorTailSamplingCountSpansSampled(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
@@ -69,6 +70,9 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualProcessorTailSamplingSamplingTracesOnMemory(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualProcessorTailSamplingTracesDroppedTooLarge(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -161,3 +161,13 @@ telemetry:
       enabled: true
       gauge:
         value_type: int
+
+    processor_tail_sampling_traces_dropped_too_large:
+      description: Count of traces that were dropped because they were too large
+      stability:
+        level: development
+      unit: "{traces}"
+      enabled: true
+      sum:
+        value_type: int
+        monotonic: true

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -75,13 +75,15 @@ type tailSamplingSpanProcessor struct {
 	recordPolicy        bool
 	sampleOnFirstMatch  bool
 	blockOnOverflow     bool
+	maxTraceSizeBytes   uint64
 
 	cfg  Config
 	host component.Host
 
-	newPolicyChan chan newPolicyCmd
-	workChan      chan []traceBatch
-	doneChan      chan struct{}
+	newPolicyChan    chan newPolicyCmd
+	newTraceSizeChan chan uint64
+	workChan         chan []traceBatch
+	doneChan         chan struct{}
 
 	// tickChan triggers ticks and responds on the provided channel when the tick is complete.
 	// this is used in tests to produce deterministic ticks.
@@ -123,11 +125,13 @@ func newTracesProcessor(ctx context.Context, set processor.Settings, nextConsume
 		deleteTraceQueue:   list.New(),
 		sampleOnFirstMatch: cfg.SampleOnFirstMatch,
 		blockOnOverflow:    cfg.BlockOnOverflow,
+		maxTraceSizeBytes:  cfg.MaximumTraceSizeBytes,
 		// Similar to the id batcher, allow a batch per CPU to be buffered before blocking ConsumeTraces.
 		workChan: make(chan []traceBatch, runtime.NumCPU()),
-		// We need to buffer one new policy command so that external callers can
+		// We need to buffer one new policy command/size update so that external callers can
 		// queue up new policies without blocking on the ticker.
-		newPolicyChan: make(chan newPolicyCmd, 1),
+		newPolicyChan:    make(chan newPolicyCmd, 1),
+		newTraceSizeChan: make(chan uint64, 1),
 	}
 
 	for _, opt := range cfg.Options {
@@ -263,6 +267,10 @@ func (tsp *tailSamplingSpanProcessor) loadSamplingPolicies(host component.Host, 
 	}
 	// Dropped decision takes precedence over all others, therefore we evaluate them first.
 	return slices.Concat(dropPolicies, policies), nil
+}
+
+func (tsp *tailSamplingSpanProcessor) SetMaximumTraceSizeBytes(size uint64) {
+	tsp.newTraceSizeChan <- size
 }
 
 // traceBatch contains all spans from a single batch for a single trace.
@@ -492,6 +500,9 @@ func (tsp *tailSamplingSpanProcessor) iter(tickChan <-chan time.Time, workChan <
 	case cmd := <-tsp.newPolicyChan:
 		tsp.policies = cmd.policies
 		tsp.logger.Debug("New policies loaded", zap.Int("policies.len", len(tsp.policies)))
+	case maxTraceSize := <-tsp.newTraceSizeChan:
+		tsp.maxTraceSizeBytes = maxTraceSize
+		tsp.logger.Debug("New maximum trace size loaded", zap.Uint64("size", maxTraceSize))
 	case <-tickChan:
 		tsp.samplingPolicyOnTick()
 	case tickChan := <-tsp.tickChan:
@@ -798,8 +809,8 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 	actualData.bytes += uint64(marshaler.ResourceSpansSize(rss))
 
 	if finalDecision == samplingpolicy.Unspecified &&
-		tsp.cfg.MaximumTraceSizeBytes > 0 &&
-		actualData.bytes > tsp.cfg.MaximumTraceSizeBytes {
+		tsp.maxTraceSizeBytes > 0 &&
+		actualData.bytes > tsp.maxTraceSizeBytes {
 		tsp.telemetry.ProcessorTailSamplingTracesDroppedTooLarge.Add(tsp.ctx, 1)
 		actualData.finalDecision = samplingpolicy.NotSampled
 		tsp.releaseNotSampledTrace(id, "")

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1092,6 +1093,56 @@ func TestNumericAttributeCases(t *testing.T) {
 	}
 }
 
+func TestDropLargeTraces(t *testing.T) {
+	controller := newTestTSPController()
+
+	traces := ptrace.NewTraces()
+	// Create a large trace (clearly more than 1024 bytes).
+	largeTrace := traces.ResourceSpans().AppendEmpty()
+	ss := largeTrace.ScopeSpans().AppendEmpty()
+	largeValue := strings.Repeat("bar", 1024)
+	sp := ss.Spans().AppendEmpty()
+	sp.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 4}))
+	sp.Attributes().PutStr("foo", largeValue)
+
+	// Small trace with just one attribute.
+	smallTrace := traces.ResourceSpans().AppendEmpty()
+	ss = smallTrace.ScopeSpans().AppendEmpty()
+	sp = ss.Spans().AppendEmpty()
+	sp.SetTraceID(pcommon.TraceID([16]byte{1, 2, 3, 5}))
+	sp.Attributes().PutStr("foo", "short")
+
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(4),
+		ExpectedNewTracesPerSec: 64,
+		MaximumTraceSizeBytes:   1024,
+		PolicyCfgs:              testPolicy,
+		Options: []Option{
+			withTestController(controller),
+		},
+	}
+	telem := setupTestTelemetry()
+	telemetrySettings := telem.newSettings()
+	nextConsumer := new(consumertest.TracesSink)
+	processor, err := newTracesProcessor(t.Context(), telemetrySettings, nextConsumer, cfg)
+	require.NoError(t, err)
+
+	err = processor.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		err = processor.Shutdown(t.Context())
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, processor.ConsumeTraces(t.Context(), traces))
+	controller.waitForTick()
+	controller.waitForTick()
+
+	allSampledTraces := nextConsumer.AllTraces()
+	assert.Len(t, allSampledTraces, 1)
+}
+
 // TestDeleteQueueCleared verifies that all in memory traces are removed from
 // both the idToTrace map as well as the deleteTraceQueue.
 func TestDeleteQueueCleared(t *testing.T) {
@@ -1131,7 +1182,6 @@ func TestDeleteQueueCleared(t *testing.T) {
 	controller.waitForTick()
 	controller.waitForTick()
 
-	// Make sure about half of traces are sampled before a tick is called.
 	allSampledTraces := nextConsumer.AllTraces()
 	assert.Len(t, allSampledTraces, 128)
 	// All traces should be flushed from the map.


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change adds a new config option, `maximum_trace_size_bytes` which will immediately drop any trace that exceeds the configured size. It allows operators to protect their system as otherwise occasional large traces cause spiky memory usage, and could even cause unbounded memory usage.

Here is an example of the memory usage before and after of configuring a maximum trace size.
<img width="879" height="384" alt="image" src="https://github.com/user-attachments/assets/2b5cc36d-d4cb-443a-b96f-ce110440d598" />

<!--Describe what testing was performed and which tests were added.-->
#### Testing

An automated test was added and this has been successfully running in multiple internal instances for a few weeks now.

<!--Describe the documentation added.-->
#### Documentation

New parameter added to the TSP readme.