### PR TITLE
[pkg/stanza/fileconsumer] fix error message

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -244,7 +244,7 @@ func (c Config) validate() error {
 	}
 
 	if runtime.GOOS == "windows" && (c.IncludeFileOwnerName || c.IncludeFileOwnerGroupName) {
-		return fmt.Errorf("'include_file_owner_name' or 'include_file_owner_group_name' it's not supported for windows: %w", err)
+		return errors.New("'include_file_owner_name' or 'include_file_owner_group_name' it's not supported on Windows")
 	}
 
 	return nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `err` on the validation if it is the Windows OS and the user is trying to enable `include_file_owner_name` or `include_file_owner_group_name`  will always be `nil`.
