### PR TITLE
[chore][receiver/sqlquery]: Fix the flaky integration test

### DIFF
--- a/receiver/sqlserverreceiver/integration_test.go
+++ b/receiver/sqlserverreceiver/integration_test.go
@@ -158,7 +158,7 @@ func TestEventsScraper(t *testing.T) {
 					assert.NotNil(tt, actualLog)
 					assert.NoError(tt, err)
 					assert.Positive(tt, actualLog.LogRecordCount())
-				}, 10*time.Second, 100*time.Millisecond)
+				}, 20*time.Second, 100*time.Millisecond)
 				found := false
 				logRecords := actualLog.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 				for i := 0; i < logRecords.Len(); i++ {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes the flaky `TestEventsScraper` test. It seems like a time related problem and by increasing the `waitFor` time the test passes consistently on my local mac.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45070
