### PR TITLE
[receiver/mongodb] Add support for auth_mechanism, auth_mechanism_properties and auth_source configuration

### DIFF
--- a/.chloggen/receiver_mongodb_add-auth-mechanism-source.yaml
+++ b/.chloggen/receiver_mongodb_add-auth-mechanism-source.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mongodb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for auth_mechanism, auth_source, and auth_mechanism_properties configuration options
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [40686]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users can now specify the authentication mechanism (e.g., SCRAM-SHA-256, GSSAPI, MONGODB-AWS), auth source database,
+  and auth mechanism properties when connecting to MongoDB instances. This is particularly useful for MongoDB servers
+  that require specific authentication mechanisms. For example, GSSAPI (Kerberos) may require SERVICE_NAME, and
+  MONGODB-AWS may require AWS_SESSION_TOKEN when using temporary AWS credentials.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -42,8 +42,9 @@ The following settings are optional:
   - For a sharded MongoDB deployment, please specify a list of the `mongos` hosts.
 - `username`: If authentication is required, the user can with `clusterMonitor` permissions can be provided here.
 - `password`: If authentication is required, the password can be provided here.
-- `auth_mechanism`: (optional) The authentication mechanism to use. Common values include `SCRAM-SHA-1`, `SCRAM-SHA-256`, `MONGODB-X509`, etc. If not specified, MongoDB will use the default mechanism.
+- `auth_mechanism`: (optional) The authentication mechanism to use. Common values include `SCRAM-SHA-1`, `SCRAM-SHA-256`, `MONGODB-X509`, `GSSAPI`, `MONGODB-AWS`, etc. If not specified, MongoDB will use the default mechanism.
 - `auth_source`: (optional) The database name to use for authentication. If not specified, MongoDB will use the default authentication database (usually `admin`).
+- `auth_mechanism_properties`: (optional) A map of key-value pairs specifying additional properties for the authentication mechanism. For example, when using `GSSAPI` (Kerberos), you may need to set `SERVICE_NAME`. For `MONGODB-AWS`, you may need to set `AWS_SESSION_TOKEN` when using temporary AWS credentials.
 - `collection_interval`: (default = `1m`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `replica_set`: If the deployment of MongoDB is a replica set then this allows users to specify the replica set name which allows for autodiscovery of other nodes in the replica set.

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -42,6 +42,8 @@ The following settings are optional:
   - For a sharded MongoDB deployment, please specify a list of the `mongos` hosts.
 - `username`: If authentication is required, the user can with `clusterMonitor` permissions can be provided here.
 - `password`: If authentication is required, the password can be provided here.
+- `auth_mechanism`: (optional) The authentication mechanism to use. Common values include `SCRAM-SHA-1`, `SCRAM-SHA-256`, `MONGODB-X509`, etc. If not specified, MongoDB will use the default mechanism.
+- `auth_source`: (optional) The database name to use for authentication. If not specified, MongoDB will use the default authentication database (usually `admin`).
 - `collection_interval`: (default = `1m`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `replica_set`: If the deployment of MongoDB is a replica set then this allows users to specify the replica set name which allows for autodiscovery of other nodes in the replica set.

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -70,6 +70,137 @@ receivers:
 
 The full list of settings exposed for this receiver are documented in [config.go](./config.go) with detailed sample configurations in [testdata/config.yaml](./testdata/config.yaml).
 
+## Authentication
+
+The receiver supports several MongoDB [authentication mechanisms](https://www.mongodb.com/docs/drivers/go/current/fundamentals/auth/). The `auth_mechanism`, `auth_source`, and `auth_mechanism_properties` fields are passed directly to the MongoDB Go driver's [`options.Credential`](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo/options#Credential) struct.
+
+### SCRAM (Default)
+
+[SCRAM-SHA-256](https://www.mongodb.com/docs/drivers/go/current/security/authentication/scram/) is the default authentication mechanism for MongoDB 4.0+. If `auth_mechanism` is not specified and `username`/`password` are provided, the driver will negotiate the strongest SCRAM mechanism supported by the server (SCRAM-SHA-256, falling back to SCRAM-SHA-1).
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: localhost:27017
+    username: otel
+    password: ${env:MONGODB_PASSWORD}
+    collection_interval: 60s
+    initial_delay: 1s
+    tls:
+      insecure: true
+```
+
+To explicitly specify the mechanism:
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: localhost:27017
+    username: otel
+    password: ${env:MONGODB_PASSWORD}
+    auth_mechanism: SCRAM-SHA-256
+    auth_source: admin
+    collection_interval: 60s
+    initial_delay: 1s
+    tls:
+      insecure: true
+```
+
+### X.509 Certificate Authentication
+
+[X.509 authentication](https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo#example-Connect-X509) uses TLS client certificates instead of username and password. The certificate's subject DN is used as the identity.
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: localhost:27018
+    auth_mechanism: MONGODB-X509
+    auth_source: $external
+    collection_interval: 60s
+    initial_delay: 1s
+    tls:
+      ca_file: /path/to/ca.pem
+      cert_file: /path/to/client-cert.pem
+      key_file: /path/to/client-key.pem
+```
+
+The MongoDB Go driver typically uses a single combined PEM file (`tlsCertificateKeyFile`) containing both the certificate and private key. However, the receiver uses the OpenTelemetry Collector's standard [TLS configuration](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md), which requires separate `cert_file` and `key_file` entries.
+
+If you have a combined PEM file, split it into separate files:
+
+```bash
+# Extract the certificate
+openssl x509 -in client.pem -out client-cert.pem
+
+# Extract the private key
+openssl pkey -in client.pem -out client-key.pem
+```
+
+### MONGODB-AWS (IAM Authentication)
+
+[MONGODB-AWS](https://www.mongodb.com/docs/drivers/go/current/security/authentication/aws-iam/) authenticates using AWS IAM credentials. This mechanism is available in MongoDB 4.4+ and requires server-side support (e.g., [MongoDB Atlas](https://www.mongodb.com/docs/atlas/security/aws-iam-authentication/) or [Percona Server for MongoDB](https://docs.percona.com/percona-server-for-mongodb/7.0/aws-iam.html)). It is not supported by the MongoDB Community Edition.
+
+Using explicit IAM credentials:
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: mongodb-host:27017
+    username: ${env:AWS_ACCESS_KEY_ID}
+    password: ${env:AWS_SECRET_ACCESS_KEY}
+    auth_mechanism: MONGODB-AWS
+    auth_source: $external
+    auth_mechanism_properties:
+      AWS_SESSION_TOKEN: ${env:AWS_SESSION_TOKEN}
+    collection_interval: 60s
+    initial_delay: 1s
+    tls:
+      insecure: true
+```
+
+When running on AWS infrastructure (EC2, ECS, Lambda), the driver can automatically discover credentials from environment variables, the ECS task role endpoint, or the EC2 instance metadata endpoint. In that case, `username`, `password`, and `auth_mechanism_properties` can be omitted:
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: mongodb-host:27017
+    auth_mechanism: MONGODB-AWS
+    auth_source: $external
+    collection_interval: 60s
+    initial_delay: 1s
+```
+
+### GSSAPI (Kerberos)
+
+[GSSAPI/Kerberos](https://www.mongodb.com/docs/drivers/go/current/security/authentication/kerberos/) is available for [MongoDB Enterprise](https://www.mongodb.com/docs/manual/tutorial/control-access-to-mongodb-with-kerberos-authentication/) deployments only. It is not supported by MongoDB Community Edition.
+
+Using this mechanism requires:
+- The collector to be compiled with the `gssapi` build tag and cgo support (`CGO_ENABLED=1`).
+- On Linux, the `libkrb5` library must be installed.
+
+> **Note:** The default `otelcontribcol` binary is built without the `gssapi` build tag and with `CGO_ENABLED=0`, so GSSAPI authentication will not work out of the box. You will need to [build a custom collector](https://opentelemetry.io/docs/collector/custom-collector/) with `CGO_ENABLED=1` and the `gssapi` build tag to use this mechanism.
+
+```yaml
+receivers:
+  mongodb:
+    hosts:
+      - endpoint: mongodb-host:27017
+    username: user@KERBEROS.REALM.COM
+    auth_mechanism: GSSAPI
+    auth_source: $external
+    auth_mechanism_properties:
+      SERVICE_NAME: mongodb
+    collection_interval: 60s
+    initial_delay: 1s
+```
+
+The default Kerberos service name is `mongodb`. Users can authenticate with an explicit password or by storing authentication keys in keytab files initialized with the `kinit` utility.
+
 ## Metrics
 
 The following metric are available with versions:

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Hosts            []confignet.TCPAddrConfig `mapstructure:"hosts"`
 	Username         string                    `mapstructure:"username"`
 	Password         configopaque.String       `mapstructure:"password"`
+	AuthMechanism    string                    `mapstructure:"auth_mechanism,omitempty"`
+	AuthSource       string                    `mapstructure:"auth_source,omitempty"`
 	ReplicaSet       string                    `mapstructure:"replica_set,omitempty"`
 	Timeout          time.Duration             `mapstructure:"timeout"`
 	DirectConnection bool                      `mapstructure:"direct_connection"`
@@ -73,10 +75,17 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 		}
 
 		if c.Username != "" && c.Password != "" {
-			clientOptions.SetAuth(options.Credential{
+			credential := options.Credential{
 				Username: c.Username,
 				Password: string(c.Password),
-			})
+			}
+			if c.AuthMechanism != "" {
+				credential.AuthMechanism = c.AuthMechanism
+			}
+			if c.AuthSource != "" {
+				credential.AuthSource = c.AuthSource
+			}
+			clientOptions.SetAuth(credential)
 		}
 
 		return clientOptions
@@ -103,10 +112,17 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 	}
 
 	if c.Username != "" && c.Password != "" {
-		clientOptions.SetAuth(options.Credential{
+		credential := options.Credential{
 			Username: c.Username,
 			Password: string(c.Password),
-		})
+		}
+		if c.AuthMechanism != "" {
+			credential.AuthMechanism = c.AuthMechanism
+		}
+		if c.AuthSource != "" {
+			credential.AuthSource = c.AuthSource
+		}
+		clientOptions.SetAuth(credential)
 	}
 
 	return clientOptions

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -27,14 +27,15 @@ type Config struct {
 	// MetricsBuilderConfig defines which metrics/attributes to enable for the scraper
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Deprecated - Transport option will be removed in v0.102.0
-	Hosts            []confignet.TCPAddrConfig `mapstructure:"hosts"`
-	Username         string                    `mapstructure:"username"`
-	Password         configopaque.String       `mapstructure:"password"`
-	AuthMechanism    string                    `mapstructure:"auth_mechanism,omitempty"`
-	AuthSource       string                    `mapstructure:"auth_source,omitempty"`
-	ReplicaSet       string                    `mapstructure:"replica_set,omitempty"`
-	Timeout          time.Duration             `mapstructure:"timeout"`
-	DirectConnection bool                      `mapstructure:"direct_connection"`
+	Hosts                   []confignet.TCPAddrConfig `mapstructure:"hosts"`
+	Username                string                    `mapstructure:"username"`
+	Password                configopaque.String       `mapstructure:"password"`
+	AuthMechanism           string                    `mapstructure:"auth_mechanism,omitempty"`
+	AuthSource              string                    `mapstructure:"auth_source,omitempty"`
+	AuthMechanismProperties map[string]string         `mapstructure:"auth_mechanism_properties,omitempty"`
+	ReplicaSet              string                    `mapstructure:"replica_set,omitempty"`
+	Timeout                 time.Duration             `mapstructure:"timeout"`
+	DirectConnection        bool                      `mapstructure:"direct_connection"`
 }
 
 func (c *Config) Validate() error {
@@ -85,6 +86,9 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 			if c.AuthSource != "" {
 				credential.AuthSource = c.AuthSource
 			}
+			if len(c.AuthMechanismProperties) > 0 {
+				credential.AuthMechanismProperties = c.AuthMechanismProperties
+			}
 			clientOptions.SetAuth(credential)
 		}
 
@@ -121,6 +125,9 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 		}
 		if c.AuthSource != "" {
 			credential.AuthSource = c.AuthSource
+		}
+		if len(c.AuthMechanismProperties) > 0 {
+			credential.AuthMechanismProperties = c.AuthMechanismProperties
 		}
 		clientOptions.SetAuth(credential)
 	}

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -75,10 +75,15 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 			clientOptions.SetConnectTimeout(c.Timeout)
 		}
 
-		if c.Username != "" && c.Password != "" {
-			credential := options.Credential{
-				Username: c.Username,
-				Password: string(c.Password),
+		// Set up authentication if username/password are provided or if an auth mechanism is specified
+		// Some mechanisms (e.g., MONGODB-X509, MONGODB-AWS with IAM) don't require username/password
+		if c.Username != "" && c.Password != "" || c.AuthMechanism != "" {
+			credential := options.Credential{}
+			if c.Username != "" {
+				credential.Username = c.Username
+			}
+			if c.Password != "" {
+				credential.Password = string(c.Password)
 			}
 			if c.AuthMechanism != "" {
 				credential.AuthMechanism = c.AuthMechanism
@@ -115,10 +120,15 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 		clientOptions.SetDirect(c.DirectConnection)
 	}
 
-	if c.Username != "" && c.Password != "" {
-		credential := options.Credential{
-			Username: c.Username,
-			Password: string(c.Password),
+	// Set up authentication if username/password are provided or if an auth mechanism is specified
+	// Some mechanisms (e.g., MONGODB-X509, MONGODB-AWS with IAM) don't require username/password
+	if c.Username != "" && c.Password != "" || c.AuthMechanism != "" {
+		credential := options.Credential{}
+		if c.Username != "" {
+			credential.Username = c.Username
+		}
+		if c.Password != "" {
+			credential.Password = string(c.Password)
 		}
 		if c.AuthMechanism != "" {
 			credential.AuthMechanism = c.AuthMechanism

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -78,22 +78,7 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 		// Set up authentication if username/password are provided or if an auth mechanism is specified
 		// Some mechanisms (e.g., MONGODB-X509, MONGODB-AWS with IAM) don't require username/password
 		if c.Username != "" && c.Password != "" || c.AuthMechanism != "" {
-			credential := options.Credential{}
-			if c.Username != "" {
-				credential.Username = c.Username
-			}
-			if c.Password != "" {
-				credential.Password = string(c.Password)
-			}
-			if c.AuthMechanism != "" {
-				credential.AuthMechanism = c.AuthMechanism
-			}
-			if c.AuthSource != "" {
-				credential.AuthSource = c.AuthSource
-			}
-			if len(c.AuthMechanismProperties) > 0 {
-				credential.AuthMechanismProperties = c.AuthMechanismProperties
-			}
+			credential := c.buildCredential()
 			clientOptions.SetAuth(credential)
 		}
 
@@ -123,26 +108,34 @@ func (c *Config) ClientOptions(secondary bool) *options.ClientOptions {
 	// Set up authentication if username/password are provided or if an auth mechanism is specified
 	// Some mechanisms (e.g., MONGODB-X509, MONGODB-AWS with IAM) don't require username/password
 	if c.Username != "" && c.Password != "" || c.AuthMechanism != "" {
-		credential := options.Credential{}
-		if c.Username != "" {
-			credential.Username = c.Username
-		}
-		if c.Password != "" {
-			credential.Password = string(c.Password)
-		}
-		if c.AuthMechanism != "" {
-			credential.AuthMechanism = c.AuthMechanism
-		}
-		if c.AuthSource != "" {
-			credential.AuthSource = c.AuthSource
-		}
-		if len(c.AuthMechanismProperties) > 0 {
-			credential.AuthMechanismProperties = c.AuthMechanismProperties
-		}
+		credential := c.buildCredential()
 		clientOptions.SetAuth(credential)
 	}
 
 	return clientOptions
+}
+
+func (c *Config) buildCredential() options.Credential {
+	credential := options.Credential{}
+	if c.Username != "" {
+		credential.Username = c.Username
+	}
+	if c.Password != "" {
+		credential.Password = string(c.Password)
+		// PasswordSet is required for GSSAPI (Kerberos) when a password is explicitly provided.
+		// For other mechanisms, this field is ignored by the driver.
+		credential.PasswordSet = true
+	}
+	if c.AuthMechanism != "" {
+		credential.AuthMechanism = c.AuthMechanism
+	}
+	if c.AuthSource != "" {
+		credential.AuthSource = c.AuthSource
+	}
+	if len(c.AuthMechanismProperties) > 0 {
+		credential.AuthMechanismProperties = c.AuthMechanismProperties
+	}
+	return credential
 }
 
 func (c *Config) hostlist() []string {

--- a/receiver/mongodbreceiver/config.schema.yaml
+++ b/receiver/mongodbreceiver/config.schema.yaml
@@ -1,5 +1,13 @@
 type: object
 properties:
+  auth_mechanism:
+    type: string
+  auth_mechanism_properties:
+    type: object
+    additionalProperties:
+      type: string
+  auth_source:
+    type: string
   direct_connection:
     type: boolean
   hosts:

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -186,8 +186,11 @@ func TestOptionsWithAuthMechanismAndSource(t *testing.T) {
 		Password:      "password",
 		AuthMechanism: "SCRAM-SHA-256",
 		AuthSource:    "admin",
-		Timeout:       2 * time.Minute,
-		ReplicaSet:    "rs-1",
+		AuthMechanismProperties: map[string]string{
+			"SERVICE_NAME": "mongodb",
+		},
+		Timeout:    2 * time.Minute,
+		ReplicaSet: "rs-1",
 	}
 
 	// Test primary connection options
@@ -195,6 +198,7 @@ func TestOptionsWithAuthMechanismAndSource(t *testing.T) {
 	require.Equal(t, clientOptions.Auth.Username, cfg.Username)
 	require.Equal(t, clientOptions.Auth.AuthMechanism, cfg.AuthMechanism)
 	require.Equal(t, clientOptions.Auth.AuthSource, cfg.AuthSource)
+	require.Equal(t, clientOptions.Auth.AuthMechanismProperties, cfg.AuthMechanismProperties)
 	require.Equal(t,
 		clientOptions.ConnectTimeout.Milliseconds(),
 		(2 * time.Minute).Milliseconds(),
@@ -206,6 +210,7 @@ func TestOptionsWithAuthMechanismAndSource(t *testing.T) {
 	require.Equal(t, secondaryOptions.Auth.Username, cfg.Username)
 	require.Equal(t, secondaryOptions.Auth.AuthMechanism, cfg.AuthMechanism)
 	require.Equal(t, secondaryOptions.Auth.AuthSource, cfg.AuthSource)
+	require.Equal(t, secondaryOptions.Auth.AuthMechanismProperties, cfg.AuthMechanismProperties)
 }
 
 func TestOptionsTLS(t *testing.T) {
@@ -251,6 +256,9 @@ func TestLoadConfig(t *testing.T) {
 	expected.CollectionInterval = time.Minute
 	expected.AuthMechanism = "SCRAM-SHA-256"
 	expected.AuthSource = "admin"
+	expected.AuthMechanismProperties = map[string]string{
+		"SERVICE_NAME": "mongodb",
+	}
 
 	require.Equal(t, expected, cfg)
 }

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -213,6 +213,34 @@ func TestOptionsWithAuthMechanismAndSource(t *testing.T) {
 	require.Equal(t, secondaryOptions.Auth.AuthMechanismProperties, cfg.AuthMechanismProperties)
 }
 
+func TestOptionsWithAuthMechanismOnly(t *testing.T) {
+	// Test auth mechanisms that don't require username/password (e.g., MONGODB-X509, MONGODB-AWS with IAM)
+	cfg := &Config{
+		Hosts: []confignet.TCPAddrConfig{
+			{
+				Endpoint: defaultEndpoint,
+			},
+		},
+		AuthMechanism: "MONGODB-X509",
+		AuthSource:    "$external",
+		Timeout:       2 * time.Minute,
+	}
+
+	// Test primary connection options
+	clientOptions := cfg.ClientOptions(false)
+	require.Equal(t, "", clientOptions.Auth.Username)
+	require.Equal(t, "", clientOptions.Auth.Password)
+	require.Equal(t, "MONGODB-X509", clientOptions.Auth.AuthMechanism)
+	require.Equal(t, "$external", clientOptions.Auth.AuthSource)
+
+	// Test secondary connection options
+	secondaryOptions := cfg.ClientOptions(true)
+	require.Equal(t, "", secondaryOptions.Auth.Username)
+	require.Equal(t, "", secondaryOptions.Auth.Password)
+	require.Equal(t, "MONGODB-X509", secondaryOptions.Auth.AuthMechanism)
+	require.Equal(t, "$external", secondaryOptions.Auth.AuthSource)
+}
+
 func TestOptionsTLS(t *testing.T) {
 	// loading valid ca file
 	caFile := filepath.Join("testdata", "certs", "ca.crt")

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -228,15 +228,15 @@ func TestOptionsWithAuthMechanismOnly(t *testing.T) {
 
 	// Test primary connection options
 	clientOptions := cfg.ClientOptions(false)
-	require.Equal(t, "", clientOptions.Auth.Username)
-	require.Equal(t, "", clientOptions.Auth.Password)
+	require.Empty(t, clientOptions.Auth.Username)
+	require.Empty(t, clientOptions.Auth.Password)
 	require.Equal(t, "MONGODB-X509", clientOptions.Auth.AuthMechanism)
 	require.Equal(t, "$external", clientOptions.Auth.AuthSource)
 
 	// Test secondary connection options
 	secondaryOptions := cfg.ClientOptions(true)
-	require.Equal(t, "", secondaryOptions.Auth.Username)
-	require.Equal(t, "", secondaryOptions.Auth.Password)
+	require.Empty(t, secondaryOptions.Auth.Username)
+	require.Empty(t, secondaryOptions.Auth.Password)
 	require.Equal(t, "MONGODB-X509", secondaryOptions.Auth.AuthMechanism)
 	require.Equal(t, "$external", secondaryOptions.Auth.AuthSource)
 }

--- a/receiver/mongodbreceiver/testdata/config.yaml
+++ b/receiver/mongodbreceiver/testdata/config.yaml
@@ -3,4 +3,6 @@ mongodb:
     - endpoint: localhost:27017
   username: otel
   password: ${env:MONGO_PASSWORD}
+  auth_mechanism: SCRAM-SHA-256
+  auth_source: admin
   collection_interval: 60s

--- a/receiver/mongodbreceiver/testdata/config.yaml
+++ b/receiver/mongodbreceiver/testdata/config.yaml
@@ -5,4 +5,6 @@ mongodb:
   password: ${env:MONGO_PASSWORD}
   auth_mechanism: SCRAM-SHA-256
   auth_source: admin
+  auth_mechanism_properties:
+    SERVICE_NAME: mongodb
   collection_interval: 60s


### PR DESCRIPTION
#### Description
Adds configuration options for MongoDB authentication mechanism, source database, and mechanism properties to the MongoDB receiver. This allows users to specify authentication methods like SCRAM-SHA-256, GSSAPI (Kerberos), or MONGODB-AWS when connecting to MongoDB instances that require specific authentication mechanisms. The implementation adds three new optional configuration fields:
- `auth_mechanism`: The authentication mechanism to use (e.g., SCRAM-SHA-1, SCRAM-SHA-256, GSSAPI, MONGODB-AWS, MONGODB-X509)
- `auth_source`: The database name to use for authentication (defaults to admin if not specified)
- `auth_mechanism_properties`: A map of key-value pairs specifying additional properties for the authentication mechanism (e.g., SERVICE_NAME for GSSAPI, AWS_SESSION_TOKEN for MONGODB-AWS)

These fields are applied to both primary and secondary MongoDB connections when connecting to replica sets, ensuring consistent authentication configuration across all connections.

#### Link to tracking issue
Fixes #40686

#### Testing
- Added new test `TestOptionsWithAuthMechanismAndSource` to verify authentication configuration (including auth_mechanism, auth_source, and auth_mechanism_properties) is correctly applied to both primary and secondary connections
- Updated `TestLoadConfig` to verify configuration loading from YAML with the new fields
- All existing tests pass
- Verified linting (`make lint`) and formatting checks pass
- Tested that `auth_mechanism`, `auth_source`, and `auth_mechanism_properties` are properly set in MongoDB client options when provided

#### Documentation
- Updated `README.md` to document the new `auth_mechanism`, `auth_source`, and `auth_mechanism_properties` configuration options with usage examples
- Updated `testdata/config.yaml` to include example usage of the new configuration fields
- Added changelog entry describing the enhancement for users