### PR TITLE
[chore][pkg/kafka/configkafka] resolve_canonical_bootstrap_servers_only is ignored for franz-go

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -32,7 +32,7 @@ The following settings can be optionally configured:
 
 - `brokers` (default = localhost:9092): The list of kafka brokers.
 - `protocol_version` (default = 2.1.0): Kafka protocol version.
-- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. Ignored for franz-go.
+- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. ignored by franz-go.
 - `client_id` (default = "otel-collector"): The client ID to configure the Kafka client with. The client ID will be used for all produce requests.
 - `logs`
   - `topic` (default = otlp\_logs): The name of the Kafka topic to which logs will be exported.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -32,7 +32,7 @@ The following settings can be optionally configured:
 
 - `brokers` (default = localhost:9092): The list of kafka brokers.
 - `protocol_version` (default = 2.1.0): Kafka protocol version.
-- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup.
+- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. Ignored for franz-go.
 - `client_id` (default = "otel-collector"): The client ID to configure the Kafka client with. The client ID will be used for all produce requests.
 - `logs`
   - `topic` (default = otlp\_logs): The name of the Kafka topic to which logs will be exported.

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -41,7 +41,7 @@ type ClientConfig struct {
 	// a DNS lookup on each of the provided brokers, and then perform a reverse
 	// lookup on the resulting IPs to obtain the canonical hostnames to use as the
 	// bootstrap servers. This can be required in SASL environments.
-	// Ignored for franz-go.
+	// ignored by franz-go.
 	ResolveCanonicalBootstrapServersOnly bool `mapstructure:"resolve_canonical_bootstrap_servers_only"`
 
 	// ProtocolVersion defines the Kafka protocol version that the client will

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -41,6 +41,7 @@ type ClientConfig struct {
 	// a DNS lookup on each of the provided brokers, and then perform a reverse
 	// lookup on the resulting IPs to obtain the canonical hostnames to use as the
 	// bootstrap servers. This can be required in SASL environments.
+	// Ignored for franz-go.
 	ResolveCanonicalBootstrapServersOnly bool `mapstructure:"resolve_canonical_bootstrap_servers_only"`
 
 	// ProtocolVersion defines the Kafka protocol version that the client will

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -39,7 +39,7 @@ The following settings can be optionally configured:
 
 - `brokers` (default = localhost:9092): The list of kafka brokers.
 - `protocol_version` (default = 2.1.0): Kafka protocol version.
-- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. Ignored for franz-go.
+- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. ignored by franz-go.
 - `logs`
   - `topic` (Deprecated [v0.142.0]: use `topics`) 
      (default = otlp\logs): If this is set, it will take precedence over default value of `topics`

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -39,7 +39,7 @@ The following settings can be optionally configured:
 
 - `brokers` (default = localhost:9092): The list of kafka brokers.
 - `protocol_version` (default = 2.1.0): Kafka protocol version.
-- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup
+- `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup. Ignored for franz-go.
 - `logs`
   - `topic` (Deprecated [v0.142.0]: use `topics`) 
      (default = otlp\logs): If this is set, it will take precedence over default value of `topics`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Update docs and comment to state that franz-go does not support `resolve_canonical_bootstrap_servers_only`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
