### PR TITLE
Implement initial_delay in receivers/sqlquery logs collection

### DIFF
--- a/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
+++ b/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/sqlquery
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add support for `initial_delay` in sqlquery receiver logs collection."
+note: "Add support for `initial_delay` in logs collection."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [29671]

--- a/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
+++ b/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/sqlqueryreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for `initial_delay` in sqlquery receiver logs collection."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29671]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
+++ b/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/sqlqueryreceiver
+component: receiver/sqlquery
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Add support for `initial_delay` in sqlquery receiver logs collection."

--- a/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
+++ b/.chloggen/sqlqueryreceiver-logs-initial-delay.yaml
@@ -15,7 +15,10 @@ issues: [29671]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: >
+  Log collection now applies `initial_delay` (previously ignored). If `initial_delay`
+  is not set, the first log collection now occurs at 1 second, instead of occurring
+  after `collection_interval` time has passed.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -56,6 +56,7 @@ The SQL Query Receiver uses custom SQL queries to generate logs and/or metrics f
   HANA), _oracle_ (Oracle DB), _tds_ (SapASE/Sybase).
 - `queries` (required): A list of queries, where a query is a sql statement and one or more `logs` and/or `metrics` sections (details below).
 - `collection_interval`(optional): The time interval between query executions. Defaults to _10s_.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `storage` (optional, default `""`): The ID of a [storage][storage_extension] extension to be used to [track processed results](#tracking-processed-results).
 - `telemetry` (optional) Defines settings for the component's own telemetry - logs, metrics or traces.
   - `telemetry.logs` (optional) Defines settings for the component's own logs.

--- a/receiver/sqlqueryreceiver/config_test.go
+++ b/receiver/sqlqueryreceiver/config_test.go
@@ -189,6 +189,33 @@ func TestLoadConfig(t *testing.T) {
 			errorMessage: "'database' or 'datasource' must be specified",
 		},
 		{
+			fname: "config-logs-initial-delay.yaml",
+			id:    component.NewIDWithName(metadata.Type, ""),
+			expected: &Config{
+				Config: sqlquery.Config{
+					ControllerConfig: scraperhelper.ControllerConfig{
+						CollectionInterval: 10 * time.Second,
+						InitialDelay:       5 * time.Second,
+					},
+					Driver:     "postgres",
+					DataSource: "host=localhost port=5432 user=me password=s3cr3t sslmode=disable",
+					Queries: []sqlquery.Query{
+						{
+							SQL:                "select * from test_logs where log_id > ?",
+							TrackingColumn:     "log_id",
+							TrackingStartValue: "10",
+							Logs: []sqlquery.LogsCfg{
+								{
+									BodyColumn:       "log_body",
+									AttributeColumns: []string{"log_attribute_1", "log_attribute_2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			fname: "config-logs.yaml",
 			id:    component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{

--- a/receiver/sqlqueryreceiver/logs_receiver_test.go
+++ b/receiver/sqlqueryreceiver/logs_receiver_test.go
@@ -195,7 +195,7 @@ func TestLogsReceiver_InitialDelay(t *testing.T) {
 				}},
 			},
 		},
-		consumertest.NewNop(),
+		&consumertest.LogsSink{},
 	)
 	require.NoError(t, err)
 
@@ -205,13 +205,14 @@ func TestLogsReceiver_InitialDelay(t *testing.T) {
 	}()
 
 	time.Sleep(initialDelay / 2)
-	assert.Equal(t, 0, fakeClient.RequestCounter, "should not collect before initial delay")
+	sink := receiver.(*logsReceiver).nextConsumer.(*consumertest.LogsSink)
+	assert.Equal(t, 0, sink.LogRecordCount(), "should not collect before initial delay")
 
 	require.Eventually(t, func() bool {
-		return fakeClient.RequestCounter >= 1
+		return sink.LogRecordCount() >= 1
 	}, initialDelay+50*time.Millisecond, 5*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		return fakeClient.RequestCounter >= 2
+		return sink.LogRecordCount() >= 2
 	}, initialDelay+collectionInterval+50*time.Millisecond, 5*time.Millisecond)
 }

--- a/receiver/sqlqueryreceiver/logs_receiver_test.go
+++ b/receiver/sqlqueryreceiver/logs_receiver_test.go
@@ -159,3 +159,59 @@ func TestLogsQueryReceiver_NullValue(t *testing.T) {
 	require.Equal(t, "problems encountered getting log rows", entry.Message)
 	require.Equal(t, sqlquery.ErrNullValueWarning.Error(), entry.ContextMap()["error"])
 }
+
+func TestLogsReceiver_InitialDelay(t *testing.T) {
+	fakeClient := &sqlquery.FakeDBClient{
+		StringMaps: [][]sqlquery.StringMap{
+			{{"col1": "42"}},
+			{{"col1": "63"}},
+		},
+	}
+
+	createReceiver := createLogsReceiverFunc(fakeDBConnect, func(sqlquery.Db, string, *zap.Logger, sqlquery.TelemetryConfig) sqlquery.DbClient {
+		return fakeClient
+	})
+
+	ctx := t.Context()
+	initialDelay := 50 * time.Millisecond
+	collectionInterval := 100 * time.Millisecond
+
+	receiver, err := createReceiver(
+		ctx,
+		receivertest.NewNopSettings(metadata.Type),
+		&Config{
+			Config: sqlquery.Config{
+				ControllerConfig: scraperhelper.ControllerConfig{
+					CollectionInterval: collectionInterval,
+					InitialDelay:       initialDelay,
+				},
+				Driver:     "postgres",
+				DataSource: "my-datasource",
+				Queries: []sqlquery.Query{{
+					SQL: "select * from foo",
+					Logs: []sqlquery.LogsCfg{{
+						BodyColumn: "col1",
+					}},
+				}},
+			},
+		},
+		consumertest.NewNop(),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+	defer func() {
+		_ = receiver.Shutdown(ctx)
+	}()
+
+	time.Sleep(initialDelay / 2)
+	assert.Equal(t, 0, fakeClient.RequestCounter, "should not collect before initial delay")
+
+	require.Eventually(t, func() bool {
+		return fakeClient.RequestCounter >= 1
+	}, initialDelay+50*time.Millisecond, 5*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return fakeClient.RequestCounter >= 2
+	}, initialDelay+collectionInterval+50*time.Millisecond, 5*time.Millisecond)
+}

--- a/receiver/sqlqueryreceiver/logs_receiver_test.go
+++ b/receiver/sqlqueryreceiver/logs_receiver_test.go
@@ -211,8 +211,4 @@ func TestLogsReceiver_InitialDelay(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return sink.LogRecordCount() >= 1
 	}, initialDelay+50*time.Millisecond, 5*time.Millisecond)
-
-	require.Eventually(t, func() bool {
-		return sink.LogRecordCount() >= 2
-	}, initialDelay+collectionInterval+50*time.Millisecond, 5*time.Millisecond)
 }

--- a/receiver/sqlqueryreceiver/testdata/config-logs-initial-delay.yaml
+++ b/receiver/sqlqueryreceiver/testdata/config-logs-initial-delay.yaml
@@ -1,0 +1,12 @@
+sqlquery:
+  collection_interval: 10s
+  initial_delay: 5s
+  driver: postgres
+  datasource: "host=localhost port=5432 user=me password=s3cr3t sslmode=disable"
+  queries:
+    - sql: "select * from test_logs where log_id > ?"
+      tracking_start_value: "10"
+      tracking_column: log_id
+      logs:
+        - body_column: log_body
+          attribute_columns: ["log_attribute_1", "log_attribute_2"]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds support for initial_delay in receivers/sqlquery logs collection

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #29671

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added tests to:
- receiver/sqlqueryreceiver/config_test.go
- receiver/sqlqueryreceiver/logs_receiver_test.go

Manually tested a build with:
- initial_delay undefined (default 1s)
- initial_delay less than collection_interval
- initial_delay greater thancollection_interval

<!--Describe the documentation added.-->
#### Documentation

receiver/sqlqueryreceiver/README.md
```
- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
```

Matching other receivers' documentation:

```
cd ./receiver/ && rg initial_delay | grep "defines how long this receiver waits before starting." | wc -l
      30
```

<!--Please delete paragraphs that you did not use before submitting.-->
