### PR TITLE
[chore][transformprocessor] prevent leaking data by closing resource

### DIFF
--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -112,6 +112,7 @@ func (d dataPointStatements) handleNumberDataPoints(ctx context.Context, resourc
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
@@ -131,6 +132,7 @@ func (d dataPointStatements) handleHistogramDataPoints(ctx context.Context, reso
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
@@ -150,6 +152,7 @@ func (d dataPointStatements) handleExponentialHistogramDataPoints(ctx context.Co
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }
@@ -169,6 +172,7 @@ func (d dataPointStatements) handleSummaryDataPoints(ctx context.Context, resour
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -45,6 +45,7 @@ func (r resourceStatements) ConsumeTraces(ctx context.Context, td ptrace.Traces)
 				return err
 			}
 		}
+		tCtx.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44541 introduces the use of `NewTransformContextPtr()`. When using `NewTransformContextPtr()` some places missed to close the resource after use.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
