### PR TITLE
[extension/datadog] Remove extension check error when getting active components

### DIFF
--- a/.chloggen/stanley.liu_fix-extension-check.yaml
+++ b/.chloggen/stanley.liu_fix-extension-check.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Datadog extension no longer throws an error for missing extensions when getting a list of active components.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45358]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -141,7 +141,7 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 	}
 
 	// Populate the list of components that are active in a pipeline
-	activeComponents, err := componentchecker.PopulateActiveComponents(e.configs.collector, moduleInfoJSON)
+	activeComponents, err := componentchecker.PopulateActiveComponents(e.logger, e.configs.collector, moduleInfoJSON)
 	if err != nil {
 		e.logger.Warn("Failed to populate active components list", zap.Error(err))
 	} else if activeComponents != nil {

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -60,7 +60,7 @@ func TestPopulateActiveComponentsIntegration(t *testing.T) {
 	moduleInfoJSON := createModuleInfoFromSampleConfig()
 
 	// Test PopulateActiveComponents with the loaded configuration
-	activeComponents, err := componentchecker.PopulateActiveComponents(confMap, moduleInfoJSON)
+	activeComponents, err := componentchecker.PopulateActiveComponents(zap.NewNop(), confMap, moduleInfoJSON)
 	require.NoError(t, err, "PopulateActiveComponents should not return error")
 	require.NotNil(t, activeComponents, "activeComponents should not be nil")
 
@@ -331,7 +331,7 @@ func createTestOtelCollectorPayload() *payload.OtelCollectorPayload {
 
 	// Create module info and populate active components
 	moduleInfoJSON := createModuleInfoFromSampleConfig()
-	activeComponents, _ := componentchecker.PopulateActiveComponents(confMap, moduleInfoJSON)
+	activeComponents, _ := componentchecker.PopulateActiveComponents(zap.NewNop(), confMap, moduleInfoJSON)
 
 	// Create build info
 	buildInfo := payload.CustomBuildInfo{
@@ -548,7 +548,7 @@ func TestHTTPServerIntegration(t *testing.T) {
 
 	// Create module info and populate active components for realistic test data
 	moduleInfoJSON := createModuleInfoFromSampleConfig()
-	activeComponents, err := componentchecker.PopulateActiveComponents(confMap, moduleInfoJSON)
+	activeComponents, err := componentchecker.PopulateActiveComponents(zap.NewNop(), confMap, moduleInfoJSON)
 	require.NoError(t, err)
 
 	// Create OtelCollector metadata

--- a/extension/datadogextension/internal/componentchecker/componentchecker.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker.go
@@ -6,7 +6,6 @@ package componentchecker // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"go.opentelemetry.io/collector/component"
@@ -112,7 +111,8 @@ func PopulateActiveComponents(c *confmap.Conf, moduleInfoJSON *payload.ModuleInf
 			extension.Gomod = module.Gomod
 			extension.Version = module.Version
 		} else {
-			return nil, fmt.Errorf("extension not found in Module Info, something has gone wrong with status parsing for extension ID: %s", extensionID.String())
+			// This extension may be a custom component from the datadog-agent repository (i.e. ddflareextension)
+			continue
 		}
 		// TODO: Add component status parsing, potentially via pkg/status
 		serviceComponents = append(serviceComponents, extension)

--- a/extension/datadogextension/internal/componentchecker/componentchecker.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/service"
 	"go.opentelemetry.io/collector/service/pipelines"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
 )
@@ -92,7 +93,7 @@ func PopulateFullComponentsJSON(moduleInfo service.ModuleInfos, c *confmap.Conf)
 
 // PopulateActiveComponents gets a list of active components in the collector service
 // configuration and returns a list of ServiceComponent structs for inclusion in a fleet payload
-func PopulateActiveComponents(c *confmap.Conf, moduleInfoJSON *payload.ModuleInfoJSON) (*[]payload.ServiceComponent, error) {
+func PopulateActiveComponents(logger *zap.Logger, c *confmap.Conf, moduleInfoJSON *payload.ModuleInfoJSON) (*[]payload.ServiceComponent, error) {
 	oc := otelcol.Config{}
 	var serviceComponents []payload.ServiceComponent
 	if err := c.Unmarshal(&oc); err != nil {
@@ -112,6 +113,7 @@ func PopulateActiveComponents(c *confmap.Conf, moduleInfoJSON *payload.ModuleInf
 			extension.Version = module.Version
 		} else {
 			// This extension may be a custom component from the datadog-agent repository (i.e. ddflareextension)
+			logger.Warn("extension not found in Module Info, something has gone wrong with status parsing for extension ID", zap.String("extensionID", extensionID.String()))
 			continue
 		}
 		// TODO: Add component status parsing, potentially via pkg/status

--- a/extension/datadogextension/internal/componentchecker/componentchecker_test.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/service"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
 )
@@ -513,7 +514,7 @@ func TestPopulateActiveComponents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			confMap := confmap.NewFromStringMap(tt.collectorConfigStringMap)
-			activeComponents, err := PopulateActiveComponents(confMap, tt.moduleInfoJSON)
+			activeComponents, err := PopulateActiveComponents(zap.NewNop(), confMap, tt.moduleInfoJSON)
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tt.expectedError)
@@ -646,7 +647,7 @@ func TestPopulateActiveComponentsAdditionalErrorPaths(t *testing.T) {
 
 		// This should panic when trying to call GetComponent on nil moduleInfoJSON
 		assert.Panics(t, func() {
-			_, err := PopulateActiveComponents(confMap, nil)
+			_, err := PopulateActiveComponents(zap.NewNop(), confMap, nil)
 			require.Error(t, err)
 		})
 	})
@@ -657,7 +658,7 @@ func TestPopulateActiveComponentsAdditionalErrorPaths(t *testing.T) {
 		})
 
 		moduleInfoJSON := payload.NewModuleInfoJSON()
-		_, err := PopulateActiveComponents(confMap, moduleInfoJSON)
+		_, err := PopulateActiveComponents(zap.NewNop(), confMap, moduleInfoJSON)
 		require.Error(t, err) // Should error on unmarshal
 	})
 }

--- a/extension/datadogextension/internal/componentchecker/componentchecker_test.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker_test.go
@@ -494,6 +494,20 @@ func TestPopulateActiveComponents(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name: "Extension not found in module info",
+			collectorConfigStringMap: map[string]any{
+				"extensions": map[string]any{
+					"missing_extension": map[string]any{},
+				},
+				"service": map[string]any{
+					"extensions": []any{"missing_extension"},
+				},
+			},
+			moduleInfoJSON:     payload.NewModuleInfoJSON(),
+			expectedComponents: []payload.ServiceComponent{},
+			expectedError:      "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -645,24 +659,6 @@ func TestPopulateActiveComponentsAdditionalErrorPaths(t *testing.T) {
 		moduleInfoJSON := payload.NewModuleInfoJSON()
 		_, err := PopulateActiveComponents(confMap, moduleInfoJSON)
 		require.Error(t, err) // Should error on unmarshal
-	})
-
-	t.Run("extension not found in module info", func(t *testing.T) {
-		confMap := confmap.NewFromStringMap(map[string]any{
-			"extensions": map[string]any{
-				"missing_extension": map[string]any{},
-			},
-			"service": map[string]any{
-				"extensions": []any{"missing_extension"},
-			},
-		})
-
-		moduleInfoJSON := payload.NewModuleInfoJSON()
-		// Don't add the extension to moduleInfoJSON
-
-		_, err := PopulateActiveComponents(confMap, moduleInfoJSON)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "extension not found in Module Info")
 	})
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Skips adding extension to list of active components instead of throwing an error when the extension is not found in the module info. This error occurs for custom components in the datadog-agent repo such as the ddflareextension, but this behavior of throwing an error is inconsistent with how we handle pipelines in the same function: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/datadogextension/internal/componentchecker/componentchecker.go#L171-L177.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit test

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
