### PR TITLE
fix: use url decoded key for S3 reads

### DIFF
--- a/.chloggen/fix_aws-lambdareciever-s3-key-usage.yaml
+++ b/.chloggen/fix_aws-lambdareciever-s3-key-usage.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awslambda
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix S3 key usage in AWS Lambda Receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45364]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awslambdareceiver/handler.go
+++ b/receiver/awslambdareceiver/handler.go
@@ -117,17 +117,17 @@ func (s *s3Handler[T]) handle(ctx context.Context, event json.RawMessage) error 
 	}
 
 	s.logger.Debug("Processing S3 event notification.",
-		zap.String("File", parsedEvent.S3.Object.Key),
+		zap.String("File", parsedEvent.S3.Object.URLDecodedKey),
 		zap.String("S3Bucket", parsedEvent.S3.Bucket.Arn),
 	)
 
 	// Skip processing zero length objects. This includes events from folder creation and empty object.
 	if parsedEvent.S3.Object.Size == 0 {
-		s.logger.Info("Empty object, skipping download", zap.String("File", parsedEvent.S3.Object.Key))
+		s.logger.Info("Empty object, skipping download", zap.String("File", parsedEvent.S3.Object.URLDecodedKey))
 		return nil
 	}
 
-	body, err := s.s3Service.ReadObject(ctx, parsedEvent.S3.Bucket.Name, parsedEvent.S3.Object.Key)
+	body, err := s.s3Service.ReadObject(ctx, parsedEvent.S3.Bucket.Name, parsedEvent.S3.Object.URLDecodedKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Description

This PR fixes AWS Lambda receiver's S3 event handling by using URL decoded S3 key to fetch content of the S3 object.

Prior to this fix, implementation use `S3Object.Key`. This can be URL encoded when S3 key contains non ASCII characters.

This fix uses `URLDecodedKey`, which is already URL decoded.

For more details, see `S3Object` implementation - https://github.com/aws/aws-lambda-go/blob/d4fbc0b070f2d682054a6f932528162e431a9de5/events/s3.go#L50-L71

#### Testing

Validated with deployment & end-to-end testing. 

#### Documentation

N/A - Non user facing fix
