### PR TITLE
redactionprocessor: clarify allowed_values and blocked_values precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1150,13 +1150,10 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `mysqlreceiver`: Fix for the conversion error on mysql.event_id. Setting an int (0) as default value in SQL. (#42040)
 - `windowseventlogreceiver`: Fixes issue for remote log collection where domain was not properly passed into EvtOpenSession syscall (#41950)
 
-
 <!-- previous-version -->
 
 
-
 ## v0.132.0
-
 ### 🛑 Breaking changes 🛑
 
 - `azuremonitorreceiver`: Updated `append_tags_as_attributes` configuration type from boolean to array. It controls which Azure resource tags are added as resource attributes to the metrics. The values can be a list of specific tag names or `["*"]` to include all tags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -957,6 +957,7 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `servicegraphconnector`: Fix exponential histogram doesn't clean when expire (#42019)
 - `awss3receiver`: Ensures default wait time is applied in SQS configuration when not explicitly set. (#42608)
 - `exporter/loadbalancing`: Drop resources if the service routing key does not exist (#41550)
+- processor/redaction: Support redaction of scope level attributes (#42659)
 - `faroexporter`: Fix success response handling in faroexporter so any HTTP 2xx status code indicates success instead of only 202 Accepted. (#42658)
 - `splunkenterprisereceiver`: Fix a typo from a previous PR implementing the search artifact size metrics, which has caused errors from parsing empty strings. (#42615)
 - `signalfxexporter`: Only validate the root_path of the collector if `sync_host_metadata` is enabled. (#42688)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1150,7 +1150,10 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `mysqlreceiver`: Fix for the conversion error on mysql.event_id. Setting an int (0) as default value in SQL. (#42040)
 - `windowseventlogreceiver`: Fixes issue for remote log collection where domain was not properly passed into EvtOpenSession syscall (#41950)
 
+- `processor/redaction`: Clarify precedence between `allowed_values` and `blocked_values` in configuration (#45390)
 <!-- previous-version -->
+
+
 
 ## v0.132.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -957,7 +957,7 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `servicegraphconnector`: Fix exponential histogram doesn't clean when expire (#42019)
 - `awss3receiver`: Ensures default wait time is applied in SQS configuration when not explicitly set. (#42608)
 - `exporter/loadbalancing`: Drop resources if the service routing key does not exist (#41550)
-- processor/redaction: Support redaction of scope level attributes (#42659)
+- `processor/redaction`: Support redaction of scope level atrributes (#42659)
 - `faroexporter`: Fix success response handling in faroexporter so any HTTP 2xx status code indicates success instead of only 202 Accepted. (#42658)
 - `splunkenterprisereceiver`: Fix a typo from a previous PR implementing the search artifact size metrics, which has caused errors from parsing empty strings. (#42615)
 - `signalfxexporter`: Only validate the root_path of the collector if `sync_host_metadata` is enabled. (#42688)
@@ -1152,8 +1152,8 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 
 <!-- previous-version -->
 
-
 ## v0.132.0
+
 ### 🛑 Breaking changes 🛑
 
 - `azuremonitorreceiver`: Updated `append_tags_as_attributes` configuration type from boolean to array. It controls which Azure resource tags are added as resource attributes to the metrics. The values can be a list of specific tag names or `["*"]` to include all tags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -957,7 +957,6 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `servicegraphconnector`: Fix exponential histogram doesn't clean when expire (#42019)
 - `awss3receiver`: Ensures default wait time is applied in SQS configuration when not explicitly set. (#42608)
 - `exporter/loadbalancing`: Drop resources if the service routing key does not exist (#41550)
-- `processor/redaction`: Support redaction of scope level atrributes (#42659)
 - `faroexporter`: Fix success response handling in faroexporter so any HTTP 2xx status code indicates success instead of only 202 Accepted. (#42658)
 - `splunkenterprisereceiver`: Fix a typo from a previous PR implementing the search artifact size metrics, which has caused errors from parsing empty strings. (#42615)
 - `signalfxexporter`: Only validate the root_path of the collector if `sync_host_metadata` is enabled. (#42688)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1149,7 +1149,7 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
 - `mysqlreceiver`: Fix for the conversion error on mysql.event_id. Setting an int (0) as default value in SQL. (#42040)
 - `windowseventlogreceiver`: Fixes issue for remote log collection where domain was not properly passed into EvtOpenSession syscall (#41950)
 
-- `processor/redaction`: Clarify precedence between `allowed_values` and `blocked_values` in configuration (#45390)
+
 <!-- previous-version -->
 
 

--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -128,6 +128,25 @@ part of the value is not masked even if it matches the regular expression for a 
 If the value matches the regular expression for a blocked value only, the matching
 part of the value is masked with a fixed length of asterisks.
 
+### Precedence between `allowed_values` and `blocked_values`
+
+When both `allowed_values` and `blocked_values` are configured, `allowed_values` takes precedence.
+
+This means that if a value matches an entry in `allowed_values`, it will not be masked even if it also matches `blocked_values`. This behavior is intentional and allows operators to explicitly whitelist known-safe values while still blocking broader patterns.
+
+#### Example
+
+```yaml
+processors:
+  redaction:
+    blocked_values:
+      - "mycompany.com"
+    allowed_values:
+      - "support.mycompany.com"
+
+```
+
+
 `blocked_key_patterns` applies to the values of the keys matching one of the patterns.
 The value is then masked according to the configuration.
 


### PR DESCRIPTION
This PR documents the precedence between allowed_values and blocked_values as discussed in #43826. Adds an explicit example to avoid operator confusion.
Refs: #43826