### PR TITLE
Avoid panic when detector returns zero-valued pdata resource

### DIFF
--- a/.chloggen/41934.yaml
+++ b/.chloggen/41934.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent the resource detection processor from panicking when detectors return a zero-valued pdata resource.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41934]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -279,6 +279,9 @@ func MergeResource(to, from pcommon.Resource, overrideTo bool) {
 }
 
 func IsEmptyResource(res pcommon.Resource) bool {
+	if res == (pcommon.Resource{}) {
+		return true
+	}
 	return res.Attributes().Len() == 0
 }
 

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -200,6 +200,24 @@ func TestMergeResource(t *testing.T) {
 	}
 }
 
+func TestMergeResourceZeroValueFrom(t *testing.T) {
+	t.Parallel()
+
+	to := pcommon.NewResource()
+	require.NoError(t, to.Attributes().FromRaw(map[string]any{"keep": "me"}))
+
+	assert.NotPanics(t, func() {
+		MergeResource(to, pcommon.Resource{}, false)
+	})
+	assert.Equal(t, map[string]any{"keep": "me"}, to.Attributes().AsRaw())
+}
+
+func TestIsEmptyResourceZeroValue(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsEmptyResource(pcommon.Resource{}))
+}
+
 type mockParallelDetector struct {
 	mock.Mock
 	ch chan struct{}


### PR DESCRIPTION
#### Link to tracking issue
Fixes #41934
