### PR TITLE
Add type safe Value definition for OTTL

### DIFF
--- a/pkg/ottl/ottlruntime/bool.go
+++ b/pkg/ottl/ottlruntime/bool.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type BoolValue struct {
+	value[bool]
+}
+
+func NewBoolValue(val bool) BoolValue {
+	return BoolValue{value: newValue(val, false)}
+}
+
+func NewNilBoolValue() BoolValue {
+	return BoolValue{value: newValue(false, true)}
+}
+
+func ToBoolValue(v Value) (BoolValue, error) {
+	if val, ok := v.(BoolValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return BoolValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"BoolValue\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return boolTransformFromString(val)
+	case Int64Value:
+		return boolTransformFromInt64(val)
+	case Float64Value:
+		return boolTransformFromFloat64(val)
+	case PValueValue:
+		return boolTransformFromPValue(val)
+	default:
+		return BoolValue{}, fmt.Errorf("unsupported type conversion from %T to \"bool\"", v)
+	}
+}
+
+// boolTransformFromPValue is a transformFunc that is capable of transforming PValueValue into BoolValue
+func boolTransformFromPValue(v PValueValue) (BoolValue, error) {
+	val := v.Val()
+	switch val.Type() {
+	case pcommon.ValueTypeInt:
+		return NewBoolValue(val.Int() != 0), nil
+	case pcommon.ValueTypeDouble:
+		return NewBoolValue(val.Double() != 0), nil
+	case pcommon.ValueTypeStr:
+		ret, err := strconv.ParseBool(val.Str())
+		if err != nil {
+			return BoolValue{}, fmt.Errorf("unable to convert string to bool: %w", err)
+		}
+		return NewBoolValue(ret), nil
+	case pcommon.ValueTypeBool:
+		return NewBoolValue(val.Bool()), nil
+	default:
+		return BoolValue{}, fmt.Errorf("unsupported type conversion from pcommon.Value[%q] to \"bool\"", val.Type())
+	}
+}
+
+// boolTransformFromString is a transformFunc that is capable of transforming StringValue into BoolValue
+func boolTransformFromString(v StringValue) (BoolValue, error) {
+	val, err := strconv.ParseBool(v.Val())
+	if err != nil {
+		return BoolValue{}, fmt.Errorf("unable to convert string to bool: %w", err)
+	}
+	return NewBoolValue(val), nil
+}
+
+// boolTransformFromInt64 is a transformFunc that is capable of transforming Int64Value into BoolValue
+func boolTransformFromInt64(v Int64Value) (BoolValue, error) {
+	return NewBoolValue(v.Val() != 0), nil
+}
+
+// boolTransformFromFloat64 is a transformFunc that is capable of transforming Float64Value into BoolValue
+func boolTransformFromFloat64(v Float64Value) (BoolValue, error) {
+	return NewBoolValue(v.Val() != 0), nil
+}

--- a/pkg/ottl/ottlruntime/bool_test.go
+++ b/pkg/ottl/ottlruntime/bool_test.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToBoolValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected bool
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "bool true",
+			input:    NewBoolValue(true),
+			expected: true,
+		},
+		{
+			name:     "bool false",
+			input:    NewBoolValue(false),
+			expected: false,
+		},
+		{
+			name:  "nil bool",
+			input: NewNilBoolValue(),
+			isNil: true,
+		},
+		{
+			name:     "string true",
+			input:    NewStringValue("true"),
+			expected: true,
+		},
+		{
+			name:     "string false",
+			input:    NewStringValue("false"),
+			expected: false,
+		},
+		{
+			name:    "invalid string",
+			input:   NewStringValue("not-a-bool"),
+			wantErr: true,
+		},
+		{
+			name:     "int64 non-zero",
+			input:    NewInt64Value(1),
+			expected: true,
+		},
+		{
+			name:     "int64 zero",
+			input:    NewInt64Value(0),
+			expected: false,
+		},
+		{
+			name:     "float64 non-zero",
+			input:    NewFloat64Value(1.5),
+			expected: true,
+		},
+		{
+			name:     "float64 zero",
+			input:    NewFloat64Value(0.0),
+			expected: false,
+		},
+		{
+			name:     "pvalue int non-zero",
+			input:    NewPValueValue(pcommon.NewValueInt(10)),
+			expected: true,
+		},
+		{
+			name:     "pvalue int zero",
+			input:    NewPValueValue(pcommon.NewValueInt(0)),
+			expected: false,
+		},
+		{
+			name:     "pvalue double non-zero",
+			input:    NewPValueValue(pcommon.NewValueDouble(1.2)),
+			expected: true,
+		},
+		{
+			name:     "pvalue double zero",
+			input:    NewPValueValue(pcommon.NewValueDouble(0.0)),
+			expected: false,
+		},
+		{
+			name:     "pvalue string true",
+			input:    NewPValueValue(pcommon.NewValueStr("true")),
+			expected: true,
+		},
+		{
+			name:     "pvalue string false",
+			input:    NewPValueValue(pcommon.NewValueStr("false")),
+			expected: false,
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-bool")),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue bool true",
+			input:    NewPValueValue(pcommon.NewValueBool(true)),
+			expected: true,
+		},
+		{
+			name:     "pvalue bool false",
+			input:    NewPValueValue(pcommon.NewValueBool(false)),
+			expected: false,
+		},
+		{
+			name:    "pvalue empty",
+			input:   NewPValueValue(pcommon.NewValueEmpty()),
+			wantErr: true,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type (PMap)",
+			input:   NewPMapValue(pcommon.NewMap()),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToBoolValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/duration.go
+++ b/pkg/ottl/ottlruntime/duration.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type DurationValue struct {
+	value[time.Duration]
+}
+
+func NewDurationValue(val time.Duration) DurationValue {
+	return DurationValue{value: newValue(val, false)}
+}
+
+func NewNilDurationValue() DurationValue {
+	return DurationValue{value: newValue(time.Duration(0), true)}
+}
+
+func ToDurationValue(v Value) (DurationValue, error) {
+	if val, ok := v.(DurationValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return DurationValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"DurationValue\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return durationTransformFromString(val)
+	case Int64Value:
+		return durationTransformFromInt64(val)
+	case PValueValue:
+		return durationTransformFromPValue(val)
+	default:
+		return DurationValue{}, fmt.Errorf("unsupported type conversion from %T to \"duration\"", v)
+	}
+}
+
+func durationTransformFromPValue(v PValueValue) (DurationValue, error) {
+	pv := v.Val()
+	switch pv.Type() {
+	case pcommon.ValueTypeInt:
+		return NewDurationValue(time.Duration(pv.Int())), nil
+	case pcommon.ValueTypeStr:
+		d, err := time.ParseDuration(pv.Str())
+		if err != nil {
+			return DurationValue{}, err
+		}
+		return NewDurationValue(d), nil
+	default:
+		return DurationValue{}, fmt.Errorf("unsupported type conversion from pcommon.Value[%q] to \"duration\"", pv.Type())
+	}
+}
+
+func durationTransformFromString(v StringValue) (DurationValue, error) {
+	d, err := time.ParseDuration(v.Val())
+	if err != nil {
+		return DurationValue{}, err
+	}
+	return NewDurationValue(d), nil
+}
+
+func durationTransformFromInt64(v Int64Value) (DurationValue, error) {
+	return NewDurationValue(time.Duration(v.Val())), nil
+}

--- a/pkg/ottl/ottlruntime/duration_test.go
+++ b/pkg/ottl/ottlruntime/duration_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToDurationValue(t *testing.T) {
+	d := 5 * time.Second
+
+	tests := []struct {
+		name     string
+		input    Value
+		expected time.Duration
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "duration",
+			input:    NewDurationValue(d),
+			expected: d,
+		},
+		{
+			name:  "nil duration",
+			input: NewNilDurationValue(),
+			isNil: true,
+		},
+		{
+			name:     "string duration",
+			input:    NewStringValue("5s"),
+			expected: d,
+		},
+		{
+			name:    "invalid string",
+			input:   NewStringValue("not-a-duration"),
+			wantErr: true,
+		},
+		{
+			name:    "nil string",
+			input:   NewNilStringValue(),
+			wantErr: true,
+		},
+		{
+			name:     "int64 (nanos)",
+			input:    NewInt64Value(d.Nanoseconds()),
+			expected: d,
+		},
+		{
+			name:    "nil int64",
+			input:   NewNilInt64Value(),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue int (nanos)",
+			input:    NewPValueValue(pcommon.NewValueInt(d.Nanoseconds())),
+			expected: d,
+		},
+		{
+			name:     "pvalue string",
+			input:    NewPValueValue(pcommon.NewValueStr("5s")),
+			expected: d,
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-duration")),
+			wantErr: true,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToDurationValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/float64.go
+++ b/pkg/ottl/ottlruntime/float64.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type Float64Value struct {
+	value[float64]
+}
+
+func NewFloat64Value(val float64) Float64Value {
+	return Float64Value{value: newValue(val, false)}
+}
+
+func NewNilFloat64Value() Float64Value {
+	return Float64Value{value: newValue(float64(0), true)}
+}
+
+func ToFloat64Value(v Value) (Float64Value, error) {
+	if val, ok := v.(Float64Value); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return Float64Value{}, fmt.Errorf("unsupported type conversion from nil %T to \"Float64Value\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return float64TransformFromString(val)
+	case Int64Value:
+		return float64TransformFromInt64(val)
+	case BoolValue:
+		return float64TransformFromBool(val)
+	case PValueValue:
+		return float64TransformFromPValue(val)
+	default:
+		return Float64Value{}, fmt.Errorf("unsupported type conversion from %T to \"float64\"", v)
+	}
+}
+
+// float64TransformFromPValue is a transformFunc that is capable of transforming PValueValue into Float64Value
+func float64TransformFromPValue(v PValueValue) (Float64Value, error) {
+	val := v.Val()
+	switch val.Type() {
+	case pcommon.ValueTypeInt:
+		return NewFloat64Value(float64(val.Int())), nil
+	case pcommon.ValueTypeDouble:
+		return NewFloat64Value(val.Double()), nil
+	case pcommon.ValueTypeStr:
+		ret, err := strconv.ParseFloat(val.Str(), 64)
+		if err != nil {
+			return Float64Value{}, fmt.Errorf("unable to convert string to float64: %w", err)
+		}
+		return NewFloat64Value(ret), nil
+	case pcommon.ValueTypeBool:
+		if val.Bool() {
+			return NewFloat64Value(float64(1)), nil
+		}
+		return NewFloat64Value(float64(0)), nil
+	default:
+		return Float64Value{}, fmt.Errorf("unsupported type conversion from pcommon.Map[%q] to \"float64\"", val.Type())
+	}
+}
+
+// float64TransformFromString is a transformFunc that is capable of transforming StringValue into Float64Value
+func float64TransformFromString(v StringValue) (Float64Value, error) {
+	val, err := strconv.ParseFloat(v.Val(), 64)
+	if err != nil {
+		return Float64Value{}, fmt.Errorf("unable to convert string to float64: %w", err)
+	}
+	return NewFloat64Value(val), nil
+}
+
+// float64TransformFromInt64 is a transformFunc that is capable of transforming Int64Value into Float64Value
+func float64TransformFromInt64(v Int64Value) (Float64Value, error) {
+	return NewFloat64Value(float64(v.Val())), nil
+}
+
+// float64TransformFromBool is a transformFunc that is capable of transforming BoolValue into Float64Value
+func float64TransformFromBool(v BoolValue) (Float64Value, error) {
+	if v.Val() {
+		return NewFloat64Value(float64(1)), nil
+	}
+	return NewFloat64Value(float64(0)), nil
+}

--- a/pkg/ottl/ottlruntime/float64_test.go
+++ b/pkg/ottl/ottlruntime/float64_test.go
@@ -1,0 +1,124 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToFloat64Value(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected float64
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "float64",
+			input:    NewFloat64Value(1.23),
+			expected: 1.23,
+		},
+		{
+			name:  "nil float64",
+			input: NewNilFloat64Value(),
+			isNil: true,
+		},
+		{
+			name:     "string",
+			input:    NewStringValue("1.23"),
+			expected: 1.23,
+		},
+		{
+			name:     "int64",
+			input:    NewInt64Value(123),
+			expected: 123.0,
+		},
+		{
+			name:     "bool true",
+			input:    NewBoolValue(true),
+			expected: 1.0,
+		},
+		{
+			name:     "bool false",
+			input:    NewBoolValue(false),
+			expected: 0.0,
+		},
+		{
+			name:    "nil string",
+			input:   NewNilStringValue(),
+			wantErr: true,
+		},
+		{
+			name:    "invalid string",
+			input:   NewStringValue("not-a-float"),
+			wantErr: true,
+		},
+		{
+			name:    "nil int64",
+			input:   NewNilInt64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil bool",
+			input:   NewNilBoolValue(),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue double",
+			input:    NewPValueValue(pcommon.NewValueDouble(10.5)),
+			expected: 10.5,
+		},
+		{
+			name:     "pvalue int",
+			input:    NewPValueValue(pcommon.NewValueInt(100)),
+			expected: 100.0,
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-float")),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue bool true",
+			input:    NewPValueValue(pcommon.NewValueBool(true)),
+			expected: 1.0,
+		},
+		{
+			name:     "pvalue bool false",
+			input:    NewPValueValue(pcommon.NewValueBool(false)),
+			expected: 0.0,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type (PMap)",
+			input:   NewPMapValue(pcommon.NewMap()),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToFloat64Value(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/int64.go
+++ b/pkg/ottl/ottlruntime/int64.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type Int64Value struct {
+	value[int64]
+}
+
+func NewInt64Value(val int64) Int64Value {
+	return Int64Value{value: newValue(val, false)}
+}
+
+func NewNilInt64Value() Int64Value {
+	return Int64Value{value: newValue(int64(0), true)}
+}
+
+func ToInt64Value(v Value) (Int64Value, error) {
+	if val, ok := v.(Int64Value); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return Int64Value{}, fmt.Errorf("unsupported type conversion from nil %T to \"Int64Value\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return int64TransformFromString(val)
+	case Float64Value:
+		return int64TransformFromFloat64(val)
+	case BoolValue:
+		return int64TransformFromBool(val)
+	case PValueValue:
+		return int64TransformFromPValue(val)
+	default:
+		return Int64Value{}, fmt.Errorf("unsupported type conversion from %T to \"int64\"", v)
+	}
+}
+
+// int64TransformFromPValue is a transformFunc that is capable of transforming pcommon.Value into Int64Value
+func int64TransformFromPValue(v PValueValue) (Int64Value, error) {
+	val := v.Val()
+	switch val.Type() {
+	case pcommon.ValueTypeInt:
+		return NewInt64Value(val.Int()), nil
+	case pcommon.ValueTypeDouble:
+		return NewInt64Value(int64(val.Double())), nil
+	case pcommon.ValueTypeStr:
+		ret, err := strconv.ParseInt(val.Str(), 10, 64)
+		if err != nil {
+			return Int64Value{}, fmt.Errorf("unable to convert string to int64: %w", err)
+		}
+		return NewInt64Value(ret), nil
+	case pcommon.ValueTypeBool:
+		if val.Bool() {
+			return NewInt64Value(int64(1)), nil
+		}
+		return NewInt64Value(int64(0)), nil
+	default:
+		return Int64Value{}, fmt.Errorf("unsupported type conversion from pcommon.Map[%q] to \"int64\"", val.Type())
+	}
+}
+
+// int64TransformFromString is a transformFunc that is capable of transforming string into Int64Value
+func int64TransformFromString(v StringValue) (Int64Value, error) {
+	val, err := strconv.ParseInt(v.Val(), 10, 64)
+	if err != nil {
+		return Int64Value{}, fmt.Errorf("unable to convert string to int64: %w", err)
+	}
+	return NewInt64Value(val), nil
+}
+
+// int64TransformFromFloat64 is a transformFunc that is capable of transforming float64 into Int64Value
+func int64TransformFromFloat64(v Float64Value) (Int64Value, error) {
+	return NewInt64Value(int64(v.Val())), nil
+}
+
+// int64TransformFromBool is a transformFunc that is capable of transforming bool into Int64Value
+func int64TransformFromBool(v BoolValue) (Int64Value, error) {
+	if v.Val() {
+		return NewInt64Value(int64(1)), nil
+	}
+	return NewInt64Value(int64(0)), nil
+}

--- a/pkg/ottl/ottlruntime/int64_test.go
+++ b/pkg/ottl/ottlruntime/int64_test.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToInt64Value(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected int64
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "int64",
+			input:    NewInt64Value(42),
+			expected: 42,
+		},
+		{
+			name:  "nil int64",
+			input: NewNilInt64Value(),
+			isNil: true,
+		},
+		{
+			name:     "string",
+			input:    NewStringValue("123"),
+			expected: 123,
+		},
+		{
+			name:     "float64",
+			input:    NewFloat64Value(1.9),
+			expected: 1,
+		},
+		{
+			name:     "bool true",
+			input:    NewBoolValue(true),
+			expected: 1,
+		},
+		{
+			name:     "bool false",
+			input:    NewBoolValue(false),
+			expected: 0,
+		},
+		{
+			name:     "pvalue string",
+			input:    NewPValueValue(pcommon.NewValueStr("100")),
+			expected: 100,
+		},
+		{
+			name:     "pvalue int",
+			input:    NewPValueValue(pcommon.NewValueInt(100)),
+			expected: 100,
+		},
+		{
+			name:     "pvalue float64",
+			input:    NewPValueValue(pcommon.NewValueDouble(100.9)),
+			expected: 100,
+		},
+		{
+			name:     "pvalue bool true",
+			input:    NewPValueValue(pcommon.NewValueBool(true)),
+			expected: 1,
+		},
+		{
+			name:     "pvalue bool false",
+			input:    NewPValueValue(pcommon.NewValueBool(false)),
+			expected: 0,
+		},
+		{
+			name:    "nil string",
+			input:   NewNilStringValue(),
+			wantErr: true,
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-an-int")),
+			wantErr: true,
+		},
+		{
+			name:    "nil float64",
+			input:   NewNilFloat64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil bool",
+			input:   NewNilBoolValue(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type (PMap)",
+			input:   NewPMapValue(pcommon.NewMap()),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToInt64Value(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/none.go
+++ b/pkg/ottl/ottlruntime/none.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+// NoneValue represents a value type that means nothing(void). Used for Expr that do not return any value.
+type NoneValue struct {
+	value[struct{}]
+}
+
+// NewNoneValue returns a None Value. Used for Expr that do not return any value.
+func NewNoneValue() NoneValue {
+	return NoneValue{value: newValue(struct{}{}, false)}
+}

--- a/pkg/ottl/ottlruntime/none_test.go
+++ b/pkg/ottl/ottlruntime/none_test.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNoneValue(t *testing.T) {
+	nv := NewNoneValue()
+	require.NotNil(t, nv)
+	assert.False(t, nv.IsNil())
+}

--- a/pkg/ottl/ottlruntime/pmap.go
+++ b/pkg/ottl/ottlruntime/pmap.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type PMapValue struct {
+	value[pcommon.Map]
+}
+
+func NewPMapValue(val pcommon.Map) PMapValue {
+	return PMapValue{value: newValue(val, false)}
+}
+
+func NewNilPMapValue() PMapValue {
+	return PMapValue{value: newValue(pcommon.Map{}, true)}
+}
+
+func ToPMapValue(v Value) (PMapValue, error) {
+	if val, ok := v.(PMapValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return PMapValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"PMapValue\"", v)
+	}
+	switch val := v.(type) {
+	case PValueValue:
+		return pMapTransformFromPValue(val)
+	default:
+		return PMapValue{}, fmt.Errorf("unsupported type conversion from %T to \"pcommon.Map\"", v)
+	}
+}
+
+// pMapTransformFromPMap is a transformFunc that is capable of transforming PValueValue into PMapValue
+func pMapTransformFromPValue(v PValueValue) (PMapValue, error) {
+	val := v.Val()
+	if val.Type() != pcommon.ValueTypeMap {
+		return PMapValue{}, fmt.Errorf("invalid type conversion from pcommon.Value[%T] to \"pcommon.Map\"", val)
+	}
+	return NewPMapValue(val.Map()), nil
+}

--- a/pkg/ottl/ottlruntime/pmap_test.go
+++ b/pkg/ottl/ottlruntime/pmap_test.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToPMapValue(t *testing.T) {
+	m := pcommon.NewMap()
+	m.PutStr("foo", "bar")
+
+	tests := []struct {
+		name     string
+		input    Value
+		expected pcommon.Map
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "pmap",
+			input:    NewPMapValue(m),
+			expected: m,
+		},
+		{
+			name:  "nil pmap",
+			input: NewNilPMapValue(),
+			isNil: true,
+		},
+		{
+			name:     "pvalue map",
+			input:    NewPValueValue(pcommon.NewValueMap()),
+			expected: pcommon.NewMap(),
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-map")),
+			wantErr: true,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type (string)",
+			input:   NewStringValue("foo"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToPMapValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/pslice.go
+++ b/pkg/ottl/ottlruntime/pslice.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type PSliceValue struct {
+	value[pcommon.Slice]
+}
+
+func NewPSliceValue(val pcommon.Slice) PSliceValue {
+	return PSliceValue{value: newValue(val, false)}
+}
+
+func NewNilPSliceValue() PSliceValue {
+	return PSliceValue{value: newValue(pcommon.Slice{}, true)}
+}
+
+func ToPSliceValue(v Value) (PSliceValue, error) {
+	if val, ok := v.(PSliceValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return PSliceValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"PSliceValue\"", v)
+	}
+	switch val := v.(type) {
+	case PValueValue:
+		return pSliceTransformFromPValue(val)
+	default:
+		return PSliceValue{}, fmt.Errorf("unsupported type conversion from %T to \"pcommon.Slice\"", v)
+	}
+}
+
+// pSliceTransformFromPSlice is a transformFunc that is capable of transforming PValueValue into PSliceValue
+func pSliceTransformFromPValue(v PValueValue) (PSliceValue, error) {
+	val := v.Val()
+	if val.Type() != pcommon.ValueTypeSlice {
+		return PSliceValue{}, fmt.Errorf("invalid type conversion from pcommon.Value[%T] to \"pcommon.Slice\"", val)
+	}
+	return NewPSliceValue(val.Slice()), nil
+}

--- a/pkg/ottl/ottlruntime/pslice_test.go
+++ b/pkg/ottl/ottlruntime/pslice_test.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToPSliceValue(t *testing.T) {
+	s := pcommon.NewSlice()
+	s.AppendEmpty().SetStr("foo")
+
+	tests := []struct {
+		name     string
+		input    Value
+		expected pcommon.Slice
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "pslice",
+			input:    NewPSliceValue(s),
+			expected: s,
+		},
+		{
+			name:  "nil pslice",
+			input: NewNilPSliceValue(),
+			isNil: true,
+		},
+		{
+			name:     "pvalue slice",
+			input:    NewPValueValue(pcommon.NewValueSlice()),
+			expected: pcommon.NewSlice(),
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-slice")),
+			wantErr: true,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type (string)",
+			input:   NewStringValue("foo"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToPSliceValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/pvalue.go
+++ b/pkg/ottl/ottlruntime/pvalue.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type PValueValue struct {
+	value[pcommon.Value]
+}
+
+func NewPValueValue(val pcommon.Value) PValueValue {
+	return PValueValue{value: newValue(val, false)}
+}
+
+func NewNilPValueValue() PValueValue {
+	return PValueValue{value: newValue(pcommon.Value{}, true)}
+}
+
+func ToPValueValue(v Value) (PValueValue, error) {
+	if val, ok := v.(PValueValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return PValueValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"PValueValue\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return pValueTransformFromString(val)
+	case Int64Value:
+		return pValueTransformFromInt64(val)
+	case Float64Value:
+		return pValueTransformFromFloat64(val)
+	case BoolValue:
+		return pValueTransformFromBool(val)
+	case PMapValue:
+		return pValueTransformFromPMap(val)
+	case PSliceValue:
+		return pValueTransformFromPSlice(val)
+	default:
+		return PValueValue{}, fmt.Errorf("unsupported type conversion from %T to \"pcommon.Value\"", v)
+	}
+}
+
+// pValueTransformFromPMap is a transformFunc that is capable of transforming PMapValue into PValueValue
+func pValueTransformFromPMap(v PMapValue) (PValueValue, error) {
+	ret := pcommon.NewValueMap()
+	v.Val().CopyTo(ret.Map())
+	return NewPValueValue(ret), nil
+}
+
+// pValueTransformFromPSlice is a transformFunc that is capable of transforming PSliceValue into PValueValue
+func pValueTransformFromPSlice(v PSliceValue) (PValueValue, error) {
+	ret := pcommon.NewValueSlice()
+	v.Val().CopyTo(ret.Slice())
+	return NewPValueValue(ret), nil
+}
+
+// pValueTransformFromString is a transformFunc that is capable of transforming any value into PValueValue
+func pValueTransformFromString(v StringValue) (PValueValue, error) {
+	return NewPValueValue(pcommon.NewValueStr(v.Val())), nil
+}
+
+// pValueTransformFromInt64 is a transformFunc that is capable of transforming any Int64Value into PValueValue
+func pValueTransformFromInt64(v Int64Value) (PValueValue, error) {
+	return NewPValueValue(pcommon.NewValueInt(v.Val())), nil
+}
+
+// pValueTransformFromFloat64 is a transformFunc that is capable of transforming any Float64Value into PValueValue
+func pValueTransformFromFloat64(v Float64Value) (PValueValue, error) {
+	return NewPValueValue(pcommon.NewValueDouble(v.Val())), nil
+}
+
+// pValueTransformFromDefault is a transformFunc that is capable of transforming any BoolValue into PValueValue
+func pValueTransformFromBool(v BoolValue) (PValueValue, error) {
+	return NewPValueValue(pcommon.NewValueBool(v.Val())), nil
+}

--- a/pkg/ottl/ottlruntime/pvalue_test.go
+++ b/pkg/ottl/ottlruntime/pvalue_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToPValueValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected pcommon.Value
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "pvalue",
+			input:    NewPValueValue(pcommon.NewValueInt(42)),
+			expected: pcommon.NewValueInt(42),
+		},
+		{
+			name:  "nil pvalue",
+			input: NewNilPValueValue(),
+			isNil: true,
+		},
+		{
+			name:     "string",
+			input:    NewStringValue("foo"),
+			expected: pcommon.NewValueStr("foo"),
+		},
+		{
+			name:     "int64",
+			input:    NewInt64Value(123),
+			expected: pcommon.NewValueInt(123),
+		},
+		{
+			name:     "float64",
+			input:    NewFloat64Value(1.23),
+			expected: pcommon.NewValueDouble(1.23),
+		},
+		{
+			name:     "bool true",
+			input:    NewBoolValue(true),
+			expected: pcommon.NewValueBool(true),
+		},
+		{
+			name:    "nil string",
+			input:   NewNilStringValue(),
+			wantErr: true,
+		},
+		{
+			name:    "nil int64",
+			input:   NewNilInt64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil float64",
+			input:   NewNilFloat64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil bool",
+			input:   NewNilBoolValue(),
+			wantErr: true,
+		},
+		{
+			name:  "pmap",
+			input: NewPMapValue(pcommon.NewMap()),
+			// Note: ToPValueValue creates a new ValueMap from the Map
+			expected: pcommon.NewValueMap(),
+		},
+		{
+			name:    "nil pmap",
+			input:   NewNilPMapValue(),
+			wantErr: true,
+		},
+		{
+			name:  "pslice",
+			input: NewPSliceValue(pcommon.NewSlice()),
+			// Note: ToPValueValue creates a new ValueSlice from the Slice
+			expected: pcommon.NewValueSlice(),
+		},
+		{
+			name:    "nil pslice",
+			input:   NewNilPSliceValue(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToPValueValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/string.go
+++ b/pkg/ottl/ottlruntime/string.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type StringValue struct {
+	value[string]
+}
+
+func NewStringValue(val string) StringValue {
+	return StringValue{value: newValue(val, false)}
+}
+
+func NewNilStringValue() StringValue {
+	return StringValue{value: newValue("", true)}
+}
+
+func ToStringValue(v Value) (StringValue, error) {
+	if val, ok := v.(StringValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return StringValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"StringValue\"", v)
+	}
+	switch val := v.(type) {
+	case Int64Value:
+		return stringTransformFromInt64(val)
+	case Float64Value:
+		return stringTransformFromFloat64(val)
+	case BoolValue:
+		return stringTransformFromBool(val)
+	case PMapValue:
+		return stringTransformFromPMap(val)
+	case PSliceValue:
+		return stringTransformFromPSlice(val)
+	case PValueValue:
+		return stringTransformFromPValue(val)
+	default:
+		return StringValue{}, fmt.Errorf("unsupported type conversion from %T to \"string\"", v)
+	}
+}
+
+// stringTransformFromPValue is a transformFunc that is capable of transforming pcommon.Value into string
+func stringTransformFromPValue(v PValueValue) (StringValue, error) {
+	return NewStringValue(v.Val().AsString()), nil
+}
+
+// stringTransformFromPMap is a transformFunc that is capable of transforming pcommon.Map into string
+func stringTransformFromPMap(v PMapValue) (StringValue, error) {
+	val, err := json.Marshal(v.Val().AsRaw())
+	if err != nil {
+		return StringValue{}, fmt.Errorf("unable to marshal pcommon.Map to string: %w", err)
+	}
+	return NewStringValue(string(val)), nil
+}
+
+// stringTransformFromPSlice is a transformFunc that is capable of transforming pcommon.Slice into string
+func stringTransformFromPSlice(v PSliceValue) (StringValue, error) {
+	val, err := json.Marshal(v.Val().AsRaw())
+	if err != nil {
+		return StringValue{}, fmt.Errorf("unable to convert pcommon.Slice to string: %w", err)
+	}
+	return NewStringValue(string(val)), nil
+}
+
+// stringTransformFromInt64 is a transformFunc that is capable of transforming any Int64Value into string
+func stringTransformFromInt64(v Int64Value) (StringValue, error) {
+	return NewStringValue(strconv.FormatInt(v.Val(), 10)), nil
+}
+
+// stringTransformFromFloat64 is a transformFunc that is capable of transforming any value into string
+func stringTransformFromFloat64(v Float64Value) (StringValue, error) {
+	return NewStringValue(strconv.FormatFloat(v.Val(), 'g', -1, 64)), nil
+}
+
+// stringTransformFromBool is a transformFunc that is capable of transforming any value into string
+func stringTransformFromBool(v BoolValue) (StringValue, error) {
+	return NewStringValue(strconv.FormatBool(v.Val())), nil
+}

--- a/pkg/ottl/ottlruntime/string_test.go
+++ b/pkg/ottl/ottlruntime/string_test.go
@@ -1,0 +1,109 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToStringValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Value
+		expected string
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "string",
+			input:    NewStringValue("foo"),
+			expected: "foo",
+		},
+		{
+			name:  "nil string",
+			input: NewNilStringValue(),
+			isNil: true,
+		},
+		{
+			name:     "int64",
+			input:    NewInt64Value(123),
+			expected: "123",
+		},
+		{
+			name:     "float64",
+			input:    NewFloat64Value(1.23),
+			expected: "1.23",
+		},
+		{
+			name:     "bool true",
+			input:    NewBoolValue(true),
+			expected: "true",
+		},
+		{
+			name:     "pvalue string",
+			input:    NewPValueValue(pcommon.NewValueStr("bar")),
+			expected: "bar",
+		},
+		{
+			name:    "nil int64",
+			input:   NewNilInt64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil float64",
+			input:   NewNilFloat64Value(),
+			wantErr: true,
+		},
+		{
+			name:    "nil bool",
+			input:   NewNilBoolValue(),
+			wantErr: true,
+		},
+		{
+			name:    "nil pmap",
+			input:   NewNilPMapValue(),
+			wantErr: true,
+		},
+		{
+			name:    "nil pslice",
+			input:   NewNilPSliceValue(),
+			wantErr: true,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+		{
+			name:     "pmap",
+			input:    NewPMapValue(pcommon.NewMap()),
+			expected: "{}",
+		},
+		{
+			name:     "pslice",
+			input:    NewPSliceValue(pcommon.NewSlice()),
+			expected: "[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToStringValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.Equal(t, tt.expected, res.Val())
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/time.go
+++ b/pkg/ottl/ottlruntime/time.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+import (
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type TimeValue struct {
+	value[time.Time]
+}
+
+func NewTimeValue(val time.Time) TimeValue {
+	return TimeValue{value: newValue(val, false)}
+}
+
+func NewNilTimeValue() TimeValue {
+	return TimeValue{value: newValue(time.Time{}, true)}
+}
+
+func ToTimeValue(v Value) (TimeValue, error) {
+	if val, ok := v.(TimeValue); ok {
+		return val, nil
+	}
+	if v.IsNil() {
+		return TimeValue{}, fmt.Errorf("unsupported type conversion from nil %T to \"TimeValue\"", v)
+	}
+	switch val := v.(type) {
+	case StringValue:
+		return timeTransformFromString(val)
+	case Int64Value:
+		return timeTransformFromInt64(val)
+	case PValueValue:
+		return timeTransformFromPValue(val)
+	default:
+		return TimeValue{}, fmt.Errorf("unsupported type conversion from %T to \"time\"", v)
+	}
+}
+
+func timeTransformFromPValue(v PValueValue) (TimeValue, error) {
+	pv := v.Val()
+	switch pv.Type() {
+	case pcommon.ValueTypeStr:
+		t, err := time.Parse(time.RFC3339, pv.Str())
+		if err != nil {
+			return TimeValue{}, fmt.Errorf("unable to parse string to time.Time: %w", err)
+		}
+		return NewTimeValue(t), nil
+	case pcommon.ValueTypeInt:
+		return NewTimeValue(time.Unix(0, pv.Int())), nil
+	default:
+		return TimeValue{}, fmt.Errorf("unsupported type conversion from pcommon.Value[%q] to \"time\"", pv.Type())
+	}
+}
+
+func timeTransformFromString(v StringValue) (TimeValue, error) {
+	t, err := time.Parse(time.RFC3339, v.Val())
+	if err != nil {
+		return TimeValue{}, fmt.Errorf("unable to parse string to time.Time: %w", err)
+	}
+	return NewTimeValue(t), nil
+}
+
+func timeTransformFromInt64(v Int64Value) (TimeValue, error) {
+	return NewTimeValue(time.Unix(0, v.Val())), nil
+}

--- a/pkg/ottl/ottlruntime/time_test.go
+++ b/pkg/ottl/ottlruntime/time_test.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestToTimeValue(t *testing.T) {
+	now := time.Now().Truncate(time.Second) // RFC3339 might lose precision depending on implementation
+	nowRFC := now.Format(time.RFC3339)
+	parsedNow, _ := time.Parse(time.RFC3339, nowRFC)
+
+	tests := []struct {
+		name     string
+		input    Value
+		expected time.Time
+		isNil    bool
+		wantErr  bool
+	}{
+		{
+			name:     "time",
+			input:    NewTimeValue(parsedNow),
+			expected: parsedNow,
+		},
+		{
+			name:  "nil time",
+			input: NewNilTimeValue(),
+			isNil: true,
+		},
+		{
+			name:     "string RFC3339",
+			input:    NewStringValue(nowRFC),
+			expected: parsedNow,
+		},
+		{
+			name:    "invalid string",
+			input:   NewStringValue("not-a-time"),
+			wantErr: true,
+		},
+		{
+			name:    "nil string RFC3339",
+			input:   NewNilStringValue(),
+			wantErr: true,
+		},
+		{
+			name:     "int64 (nanos)",
+			input:    NewInt64Value(parsedNow.UnixNano()),
+			expected: parsedNow,
+		},
+		{
+			name:    "nil int64",
+			input:   NewNilInt64Value(),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue string RFC3339",
+			input:    NewPValueValue(pcommon.NewValueStr(nowRFC)),
+			expected: parsedNow,
+		},
+		{
+			name:    "pvalue invalid string",
+			input:   NewPValueValue(pcommon.NewValueStr("not-a-time")),
+			wantErr: true,
+		},
+		{
+			name:     "pvalue int (nanos)",
+			input:    NewPValueValue(pcommon.NewValueInt(parsedNow.UnixNano())),
+			expected: parsedNow,
+		},
+		{
+			name:    "nil pvalue",
+			input:   NewNilPValueValue(),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ToTimeValue(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.isNil, res.IsNil())
+			if !tt.isNil {
+				assert.True(t, tt.expected.Equal(res.Val()))
+			}
+		})
+	}
+}

--- a/pkg/ottl/ottlruntime/value.go
+++ b/pkg/ottl/ottlruntime/value.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlruntime // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlruntime"
+
+// Value represents a runtime value which can be nil or a concrete value type.
+type Value interface {
+	IsNil() bool
+
+	// Disallow implementations outside this package.
+	unexportedFunc()
+}
+
+type value[V any] struct {
+	v     V
+	isNil bool
+}
+
+func newValue[V any](v V, isNil bool) value[V] {
+	return value[V]{v: v, isNil: isNil}
+}
+
+func (value[V]) unexportedFunc() {}
+
+func (v value[V]) IsNil() bool {
+	return v.isNil
+}
+
+func (v value[V]) Val() V {
+	if v.isNil {
+		panic("null pointer exception")
+	}
+	return v.v
+}


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45365

This PR adds all supported types and the concept of a "Value". A value can be a concrete type value or a nil value of that type. There is a special "NoneValue" that will be used for functions that don't return anything.

Skipping changelog since this code is not yet plugged to be used in the binary.