### PR TITLE
[chore][pkg/ottl] Fix misleading context inferrer debug log

### DIFF
--- a/pkg/ottl/context_inferrer.go
+++ b/pkg/ottl/context_inferrer.go
@@ -166,9 +166,13 @@ func (s *priorityContextInferrer) inferFromHints(hints []priorityContextInferrer
 			requiredEnums[enum] = struct{}{}
 		}
 	}
-	// No inferred context or nothing left to verify.
-	if inferredContext == "" || (len(requiredFunctions) == 0 && len(requiredEnums) == 0) {
-		s.telemetrySettings.Logger.Debug("No context candidate found in the ottls")
+	// No inferred context
+	if inferredContext == "" {
+		s.telemetrySettings.Logger.Debug("No context candidate found in the OTTLs")
+		return "", nil
+	}
+	// If no functions or enums are required, return the inferred context directly.
+	if len(requiredFunctions) == 0 && len(requiredEnums) == 0 {
 		return inferredContext, nil
 	}
 	if err = s.validateContextCandidate(inferredContext, requiredFunctions, requiredEnums); err == nil {

--- a/pkg/ottl/context_inferrer.go
+++ b/pkg/ottl/context_inferrer.go
@@ -168,7 +168,7 @@ func (s *priorityContextInferrer) inferFromHints(hints []priorityContextInferrer
 	}
 	// No inferred context
 	if inferredContext == "" {
-		s.telemetrySettings.Logger.Debug("No context candidate found in the OTTLs")
+		s.telemetrySettings.Logger.Debug("No OTTL context candidate found")
 		return "", nil
 	}
 	// If no functions or enums are required, return the inferred context directly.


### PR DESCRIPTION
A debug log with the message `No context candidate found in the ottls` were being emitted when the context was inferred from the hints, but no functions or enums were required for the inferred context. 