### PR TITLE
[chore] pkg/stanza: use unsafe.Add to fix modernize lint

### DIFF
--- a/pkg/stanza/operator/input/windows/event.go
+++ b/pkg/stanza/operator/input/windows/event.go
@@ -63,7 +63,7 @@ func utf16PtrToString(s *uint16) string {
 	utf16Len := 0
 	curPtr := unsafe.Pointer(s)
 	for *(*uint16)(curPtr) != 0 {
-		curPtr = unsafe.Pointer(uintptr(curPtr) + unsafe.Sizeof(*s))
+		curPtr = unsafe.Add(unsafe.Pointer(uintptr(curPtr)), unsafe.Sizeof(*s))
 		utf16Len++
 	}
 


### PR DESCRIPTION
#### Description

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/21018188720/job/60427729281?pr=45308

> Error: pkg/stanza/operator/input/windows/event.go:66:27: unsafefuncs: pointer + integer can be simplified using unsafe.Add (modernize)

#### Link to tracking issue

None

#### Testing

Unit tests

#### Documentation

None