### PR TITLE
[receiver/mysql] Add service.instance.id resource attribute

### DIFF
--- a/.chloggen/arve_mysqlreceiver-uuid.yaml
+++ b/.chloggen/arve_mysqlreceiver-uuid.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `service.name` and `service.instance.id` resource attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45444]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - `service.name`: constant value "mysql"
+  - `service.instance.id`: deterministic UUID v5 based on the endpoint
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/arve_mysqlreceiver-uuid.yaml
+++ b/.chloggen/arve_mysqlreceiver-uuid.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/mysql
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add `service.name` and `service.instance.id` resource attributes
+note: Add `service.instance.id` resource attribute
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [45444]
@@ -16,7 +16,6 @@ issues: [45444]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  - `service.name`: constant value "mysql"
   - `service.instance.id`: deterministic UUID v5 based on the endpoint
 
 # If your change doesn't affect end users or the exported elements of any package,

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -733,3 +733,5 @@ This provides insights into query performance and resource usage, helping users 
 | Name | Description | Values | Enabled | Semantic Convention |
 | ---- | ----------- | ------ | ------- | ------------------- |
 | mysql.instance.endpoint | Endpoint of the MySQL instance. | Any Str | true | - |
+| service.instance.id | A unique identifier of the MySQL instance as a UUID v5, derived from the endpoint. | Any Str | true | - |
+| service.name | The database management system name (mysql). | Any Str | true | - |

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -734,4 +734,3 @@ This provides insights into query performance and resource usage, helping users 
 | ---- | ----------- | ------ | ------- | ------------------- |
 | mysql.instance.endpoint | Endpoint of the MySQL instance. | Any Str | true | - |
 | service.instance.id | A unique identifier of the MySQL instance as a UUID v5, derived from the endpoint. | Any Str | true | - |
-| service.name | The database management system name (mysql). | Any Str | true | - |

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.155.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.155.0
@@ -80,7 +81,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-version v1.9.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -124,6 +124,7 @@ func TestIntegration(t *testing.T) {
 				),
 				scraperinttest.WithCompareOptions(
 					pmetrictest.IgnoreResourceAttributeValue("mysql.instance.endpoint"),
+					pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
 					pmetrictest.IgnoreMetricValues(),
 					pmetrictest.IgnoreMetricDataPointsOrder(),
 					pmetrictest.IgnoreStartTimestamp(),

--- a/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/config.schema.yaml
@@ -1035,6 +1035,33 @@ $defs:
             type: array
             items:
               $ref: go.opentelemetry.io/collector/filter.config
+      service.instance.id:
+        description: ResourceAttributeConfig provides common config for a service.instance.id resource attribute.
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+          metrics_include:
+            description: "Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          metrics_exclude:
+            description: "Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_include:
+            description: "Experimental: EventsInclude defines a list of filters for attribute values. If the list is not empty, only events with matching resource attribute values will be emitted."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
+          events_exclude:
+            description: "Experimental: EventsExclude defines a list of filters for attribute values. If the list is not empty, events with matching resource attribute values will not be emitted. EventsInclude has higher priority than EventsExclude."
+            type: array
+            items:
+              $ref: go.opentelemetry.io/collector/filter.config
   metrics_builder_config:
     description: MetricsBuilderConfig is a configuration for mysql metrics builder.
     type: object

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -2380,7 +2380,6 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 type ResourceAttributesConfig struct {
 	MysqlInstanceEndpoint ResourceAttributeConfig `mapstructure:"mysql.instance.endpoint"`
 	ServiceInstanceID     ResourceAttributeConfig `mapstructure:"service.instance.id"`
-	ServiceName           ResourceAttributeConfig `mapstructure:"service.name"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
@@ -2389,9 +2388,6 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		ServiceInstanceID: ResourceAttributeConfig{
-			Enabled: true,
-		},
-		ServiceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -2379,11 +2379,19 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 // ResourceAttributesConfig provides config for mysql resource attributes.
 type ResourceAttributesConfig struct {
 	MysqlInstanceEndpoint ResourceAttributeConfig `mapstructure:"mysql.instance.endpoint"`
+	ServiceInstanceID     ResourceAttributeConfig `mapstructure:"service.instance.id"`
+	ServiceName           ResourceAttributeConfig `mapstructure:"service.name"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
 		MysqlInstanceEndpoint: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		ServiceInstanceID: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		ServiceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -248,7 +248,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: true},
 					ServiceInstanceID:     ResourceAttributeConfig{Enabled: true},
-					ServiceName:           ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -478,7 +477,6 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: false},
 					ServiceInstanceID:     ResourceAttributeConfig{Enabled: false},
-					ServiceName:           ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},
@@ -969,7 +967,6 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: true},
 				ServiceInstanceID:     ResourceAttributeConfig{Enabled: true},
-				ServiceName:           ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
@@ -977,7 +974,6 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: false},
 				ServiceInstanceID:     ResourceAttributeConfig{Enabled: false},
-				ServiceName:           ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config_test.go
@@ -247,6 +247,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: true},
+					ServiceInstanceID:     ResourceAttributeConfig{Enabled: true},
+					ServiceName:           ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -475,6 +477,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: false},
+					ServiceInstanceID:     ResourceAttributeConfig{Enabled: false},
+					ServiceName:           ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},
@@ -964,12 +968,16 @@ func TestResourceAttributesConfig(t *testing.T) {
 			name: "all_set",
 			want: ResourceAttributesConfig{
 				MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: true},
+				ServiceInstanceID:     ResourceAttributeConfig{Enabled: true},
+				ServiceName:           ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
 				MysqlInstanceEndpoint: ResourceAttributeConfig{Enabled: false},
+				ServiceInstanceID:     ResourceAttributeConfig{Enabled: false},
+				ServiceName:           ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_logs.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_logs.go
@@ -145,6 +145,18 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 	if lbc.ResourceAttributes.MysqlInstanceEndpoint.EventsExclude != nil {
 		lb.resourceAttributeExcludeFilter["mysql.instance.endpoint"] = filter.CreateFilter(lbc.ResourceAttributes.MysqlInstanceEndpoint.EventsExclude)
 	}
+	if lbc.ResourceAttributes.ServiceInstanceID.EventsInclude != nil {
+		lb.resourceAttributeIncludeFilter["service.instance.id"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceInstanceID.EventsInclude)
+	}
+	if lbc.ResourceAttributes.ServiceInstanceID.EventsExclude != nil {
+		lb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceInstanceID.EventsExclude)
+	}
+	if lbc.ResourceAttributes.ServiceName.EventsInclude != nil {
+		lb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsInclude)
+	}
+	if lbc.ResourceAttributes.ServiceName.EventsExclude != nil {
+		lb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsExclude)
+	}
 
 	return lb
 }

--- a/receiver/mysqlreceiver/internal/metadata/generated_logs.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_logs.go
@@ -151,12 +151,6 @@ func NewLogsBuilder(lbc LogsBuilderConfig, settings receiver.Settings) *LogsBuil
 	if lbc.ResourceAttributes.ServiceInstanceID.EventsExclude != nil {
 		lb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceInstanceID.EventsExclude)
 	}
-	if lbc.ResourceAttributes.ServiceName.EventsInclude != nil {
-		lb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsInclude)
-	}
-	if lbc.ResourceAttributes.ServiceName.EventsExclude != nil {
-		lb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(lbc.ResourceAttributes.ServiceName.EventsExclude)
-	}
 
 	return lb
 }

--- a/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
@@ -33,7 +33,6 @@ func TestLogsBuilderAppendLogRecord(t *testing.T) {
 	rb := lb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
 	rb.SetServiceInstanceID("service.instance.id-val")
-	rb.SetServiceName("service.name-val")
 	res := rb.Emit()
 
 	// append the first log record
@@ -139,7 +138,6 @@ func TestLogsBuilder(t *testing.T) {
 			rb := lb.NewResourceBuilder()
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
-			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			logs := lb.Emit(WithLogsResource(res))
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_logs_test.go
@@ -32,6 +32,8 @@ func TestLogsBuilderAppendLogRecord(t *testing.T) {
 
 	rb := lb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
+	rb.SetServiceInstanceID("service.instance.id-val")
+	rb.SetServiceName("service.name-val")
 	res := rb.Emit()
 
 	// append the first log record
@@ -136,6 +138,8 @@ func TestLogsBuilder(t *testing.T) {
 
 			rb := lb.NewResourceBuilder()
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
+			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			logs := lb.Emit(WithLogsResource(res))
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -5462,12 +5462,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude)
 	}
-	if mbc.ResourceAttributes.ServiceName.MetricsInclude != nil {
-		mb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsInclude)
-	}
-	if mbc.ResourceAttributes.ServiceName.MetricsExclude != nil {
-		mb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsExclude)
-	}
 
 	for _, op := range options {
 		op.apply(mb)

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -5456,6 +5456,18 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.MysqlInstanceEndpoint.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["mysql.instance.endpoint"] = filter.CreateFilter(mbc.ResourceAttributes.MysqlInstanceEndpoint.MetricsExclude)
 	}
+	if mbc.ResourceAttributes.ServiceInstanceID.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["service.instance.id"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceInstanceID.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["service.instance.id"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceInstanceID.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.ServiceName.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ServiceName.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["service.name"] = filter.CreateFilter(mbc.ResourceAttributes.ServiceName.MetricsExclude)
+	}
 
 	for _, op := range options {
 		op.apply(mb)

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -370,6 +370,8 @@ func TestMetricsBuilder(t *testing.T) {
 
 			rb := mb.NewResourceBuilder()
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
+			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -371,7 +371,6 @@ func TestMetricsBuilder(t *testing.T) {
 			rb := mb.NewResourceBuilder()
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
-			rb.SetServiceName("service.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 			if tt.name == "reaggregate_set" {

--- a/receiver/mysqlreceiver/internal/metadata/generated_resource.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_resource.go
@@ -28,6 +28,20 @@ func (rb *ResourceBuilder) SetMysqlInstanceEndpoint(val string) {
 	}
 }
 
+// SetServiceInstanceID sets provided value as "service.instance.id" attribute.
+func (rb *ResourceBuilder) SetServiceInstanceID(val string) {
+	if rb.config.ServiceInstanceID.Enabled {
+		rb.res.Attributes().PutStr("service.instance.id", val)
+	}
+}
+
+// SetServiceName sets provided value as "service.name" attribute.
+func (rb *ResourceBuilder) SetServiceName(val string) {
+	if rb.config.ServiceName.Enabled {
+		rb.res.Attributes().PutStr("service.name", val)
+	}
+}
+
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/receiver/mysqlreceiver/internal/metadata/generated_resource.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_resource.go
@@ -35,13 +35,6 @@ func (rb *ResourceBuilder) SetServiceInstanceID(val string) {
 	}
 }
 
-// SetServiceName sets provided value as "service.name" attribute.
-func (rb *ResourceBuilder) SetServiceName(val string) {
-	if rb.config.ServiceName.Enabled {
-		rb.res.Attributes().PutStr("service.name", val)
-	}
-}
-
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/receiver/mysqlreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_resource_test.go
@@ -15,16 +15,15 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
 			rb.SetServiceInstanceID("service.instance.id-val")
-			rb.SetServiceName("service.name-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch tt {
 			case "default":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 2, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 2, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -40,11 +39,6 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "service.instance.id-val", serviceInstanceIDAttrVal.Str())
-			}
-			serviceNameAttrVal, ok := res.Attributes().Get("service.name")
-			assert.True(t, ok)
-			if ok {
-				assert.Equal(t, "service.name-val", serviceNameAttrVal.Str())
 			}
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_resource_test.go
@@ -14,15 +14,17 @@ func TestResourceBuilder(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, tt)
 			rb := NewResourceBuilder(cfg)
 			rb.SetMysqlInstanceEndpoint("mysql.instance.endpoint-val")
+			rb.SetServiceInstanceID("service.instance.id-val")
+			rb.SetServiceName("service.name-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch tt {
 			case "default":
-				assert.Equal(t, 1, res.Attributes().Len())
+				assert.Equal(t, 3, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 1, res.Attributes().Len())
+				assert.Equal(t, 3, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -33,6 +35,16 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, "mysql.instance.endpoint-val", mysqlInstanceEndpointAttrVal.Str())
+			}
+			serviceInstanceIDAttrVal, ok := res.Attributes().Get("service.instance.id")
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, "service.instance.id-val", serviceInstanceIDAttrVal.Str())
+			}
+			serviceNameAttrVal, ok := res.Attributes().Get("service.name")
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, "service.name-val", serviceNameAttrVal.Str())
 			}
 		})
 	}

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -142,6 +142,8 @@ all_set:
   resource_attributes:
     mysql.instance.endpoint:
       enabled: true
+    service.instance.id:
+      enabled: true
 reaggregate_set:
   metrics:
     mysql.buffer_pool.data_pages:
@@ -286,8 +288,6 @@ reaggregate_set:
     mysql.instance.endpoint:
       enabled: true
     service.instance.id:
-      enabled: true
-    service.name:
       enabled: true
 none_set:
   metrics:
@@ -434,8 +434,6 @@ none_set:
       enabled: false
     service.instance.id:
       enabled: false
-    service.name:
-      enabled: false
 filter_set_include:
   resource_attributes:
     mysql.instance.endpoint:
@@ -445,12 +443,6 @@ filter_set_include:
       events_include:
         - regexp: ".*"
     service.instance.id:
-      enabled: true
-      metrics_include:
-        - regexp: ".*"
-      events_include:
-        - regexp: ".*"
-    service.name:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -470,9 +462,3 @@ filter_set_exclude:
         - strict: "service.instance.id-val"
       events_exclude:
         - strict: "service.instance.id-val"
-    service.name:
-      enabled: true
-      metrics_exclude:
-        - strict: "service.name-val"
-      events_exclude:
-        - strict: "service.name-val"

--- a/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mysqlreceiver/internal/metadata/testdata/config.yaml
@@ -285,6 +285,10 @@ reaggregate_set:
   resource_attributes:
     mysql.instance.endpoint:
       enabled: true
+    service.instance.id:
+      enabled: true
+    service.name:
+      enabled: true
 none_set:
   metrics:
     mysql.buffer_pool.data_pages:
@@ -428,9 +432,25 @@ none_set:
   resource_attributes:
     mysql.instance.endpoint:
       enabled: false
+    service.instance.id:
+      enabled: false
+    service.name:
+      enabled: false
 filter_set_include:
   resource_attributes:
     mysql.instance.endpoint:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+      events_include:
+        - regexp: ".*"
+    service.instance.id:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+      events_include:
+        - regexp: ".*"
+    service.name:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -444,3 +464,15 @@ filter_set_exclude:
         - strict: "mysql.instance.endpoint-val"
       events_exclude:
         - strict: "mysql.instance.endpoint-val"
+    service.instance.id:
+      enabled: true
+      metrics_exclude:
+        - strict: "service.instance.id-val"
+      events_exclude:
+        - strict: "service.instance.id-val"
+    service.name:
+      enabled: true
+      metrics_exclude:
+        - strict: "service.name-val"
+      events_exclude:
+        - strict: "service.name-val"

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -17,6 +17,14 @@ resource_attributes:
     description: Endpoint of the MySQL instance.
     enabled: true
     type: string
+  service.instance.id:
+    description: A unique identifier of the MySQL instance as a UUID v5, derived from the endpoint.
+    enabled: true
+    type: string
+  service.name:
+    description: The database management system name (mysql).
+    enabled: true
+    type: string
 
 attributes:
   buffer_pool_data:

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -21,10 +21,6 @@ resource_attributes:
     description: A unique identifier of the MySQL instance as a UUID v5, derived from the endpoint.
     enabled: true
     type: string
-  service.name:
-    description: The database management system name (mysql).
-    enabled: true
-    type: string
 
 attributes:
   buffer_pool_data:

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -183,7 +183,6 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 	rb := m.mb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint(m.config.Endpoint)
-	rb.SetServiceName("mysql")
 	rb.SetServiceInstanceID(uuid.NewSHA1(otelNamespaceUUID, []byte(m.config.Endpoint)).String())
 	m.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 
@@ -195,7 +194,6 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 func (m *mySQLScraper) emitLogsWithScopeAttrs(errs *scrapererror.ScrapeErrors) (plog.Logs, error) {
 	rb := m.lb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint(m.config.Endpoint)
-	rb.SetServiceName("mysql")
 	rb.SetServiceInstanceID(uuid.NewSHA1(otelNamespaceUUID, []byte(m.config.Endpoint)).String())
 	logs := m.lb.Emit(metadata.WithLogsResource(rb.Emit()))
 	m.setScopeAttributes(logs)

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"go.opentelemetry.io/collector/component"
@@ -29,6 +30,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/priorityqueue"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver/internal/metadata"
 )
+
+// otelNamespaceUUID is the official OTel namespace UUID for deterministic UUID v5 generation,
+// as recommended by the semantic conventions for service.instance.id.
+// See: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+var otelNamespaceUUID = uuid.MustParse("4d63009a-8d0f-11ee-aad7-4c796ed8e320")
 
 type mySQLScraper struct {
 	sqlclient              client
@@ -177,6 +183,8 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 	rb := m.mb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint(m.config.Endpoint)
+	rb.SetServiceName("mysql")
+	rb.SetServiceInstanceID(uuid.NewSHA1(otelNamespaceUUID, []byte(m.config.Endpoint)).String())
 	m.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 
 	return m.mb.Emit(), errs.Combine()
@@ -187,6 +195,8 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 func (m *mySQLScraper) emitLogsWithScopeAttrs(errs *scrapererror.ScrapeErrors) (plog.Logs, error) {
 	rb := m.lb.NewResourceBuilder()
 	rb.SetMysqlInstanceEndpoint(m.config.Endpoint)
+	rb.SetServiceName("mysql")
+	rb.SetServiceInstanceID(uuid.NewSHA1(otelNamespaceUUID, []byte(m.config.Endpoint)).String())
 	logs := m.lb.Emit(metadata.WithLogsResource(rb.Emit()))
 	m.setScopeAttributes(logs)
 	return logs, errs.Combine()

--- a/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
@@ -4,6 +4,12 @@ resourceMetrics:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: ""
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mariadb.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: service.instance.id
           value:
             stringValue: ""
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
@@ -4,6 +4,12 @@ resourceMetrics:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: ""
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected-mysql.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: service.instance.id
           value:
             stringValue: ""
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -4,6 +4,12 @@ resourceMetrics:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: service.instance.id
           value:
             stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expectedQuerySamples.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expectedQuerySamples.yaml
@@ -4,6 +4,12 @@ resourceLogs:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/mysqlreceiver/testdata/scraper/expectedQuerySamples.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expectedQuerySamples.yaml
@@ -7,9 +7,6 @@ resourceLogs:
         - key: service.instance.id
           value:
             stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/mysqlreceiver/testdata/scraper/expectedTopQueries.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expectedTopQueries.yaml
@@ -4,6 +4,12 @@ resourceLogs:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/mysqlreceiver/testdata/scraper/expectedTopQueries.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expectedTopQueries.yaml
@@ -7,9 +7,6 @@ resourceLogs:
         - key: service.instance.id
           value:
             stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeLogs:
       - logRecords:
           - attributes:

--- a/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
@@ -4,6 +4,12 @@ resourceMetrics:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_oob.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: service.instance.id
           value:
             stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of data pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
@@ -4,6 +4,12 @@ resourceMetrics:
         - key: mysql.instance.endpoint
           value:
             stringValue: localhost:3306
+        - key: service.instance.id
+          value:
+            stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
+        - key: service.name
+          value:
+            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of pages in the InnoDB buffer pool.

--- a/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: service.instance.id
           value:
             stringValue: 2b0d1f0c-857b-5a7c-9f20-6e0ecae7598f
-        - key: service.name
-          value:
-            stringValue: mysql
     scopeMetrics:
       - metrics:
           - description: The number of pages in the InnoDB buffer pool.


### PR DESCRIPTION
#### Description

Add `service.instance.id` resource attribute to the MySQL receiver, following the pattern established in the PostgreSQL receiver PR #45345.

The motivation is to fix OTLP interop with Prometheus, which depends on the identifying OTel [service attribute semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/) triplet (`service.namespace`, `service.name`, `service.instance.id`) to successfully convert OTLP resource attributes (as per the [OTLP Metric Points to Prometheus spec](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#resource-attributes-1)).

Changes:
- Add `service.instance.id` resource attribute (deterministic UUID v5 based on endpoint)
- Fix pre-existing bug: initialize `LogsBuilderConfig` with defaults in `createDefaultConfig()`
- Fix pre-existing bug: set resource attributes on logs (previously logs had empty resources)

New resource attributes:
| Attribute | Description |
|-----------|-------------|
| `service.instance.id` | Deterministic UUID v5 derived from the endpoint using the OTel namespace UUID |

#### Link to tracking issue

No separate tracking issue. This PR follows the pattern from #45345 (PostgreSQL receiver).

#### Testing

- Unit tests added and passing for the new `service.instance.id` resource attribute
- Existing unit tests updated to verify resource attributes on logs
- Integration tests pass (require MySQL container)
- Linter passes

#### Documentation

- Auto-generated `documentation.md` updated with the new resource attribute
- Changelog entry added via `.chloggen` yaml file