### PR TITLE
[ci] update semconv deepguard rule to allow v1.39.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -175,9 +175,9 @@ linters:
           list-mode: lax
           deny:
             - pkg: go.opentelemetry.io/otel/semconv
-              desc: Use go.opentelemetry.io/otel/semconv/v1.38.0 instead. If a newer semconv version has been released, update the depguard rule.
+              desc: Use go.opentelemetry.io/otel/semconv/v1.39.0 instead. If a newer semconv version has been released, update the depguard rule.
           allow:
-            # TODO: Remove older semconv versions after v1.38.0 migration is complete.
+            # TODO: Remove older semconv versions after v1.39.0 migration is complete.
             # If for any reason an individual package needs to use an older semconv version,
             # add a nolint directive on the import line.
             # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35325
@@ -219,15 +219,16 @@ linters:
             # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45034
             - go.opentelemetry.io/otel/semconv/v1.34.0
             - go.opentelemetry.io/otel/semconv/v1.38.0
-        
+            - go.opentelemetry.io/otel/semconv/v1.39.0
+
         semconv-in-test:
           list-mode: lax
           deny:
             - pkg: go.opentelemetry.io/otel/semconv
               desc: Don't import semconv packages in test files, use strings directly instead.
-              
+
           files:
-            - '**/*_test.go'
+            - "**/*_test.go"
 
         # Add a different guard rule so that we can ignore tests.
         ignore-in-test:
@@ -237,7 +238,7 @@ linters:
 
           # Allow in tests for testing pdata or other receivers/exporters that expect OTLP.
           files:
-            - '!**/*_test.go'
+            - "!**/*_test.go"
 
     exhaustive:
       # Presence of "default" case in switch statements satisfies exhaustiveness,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Allow usage of the latest semantic conventions package version v1.39.0