### PR TITLE
[extension/datadog] Populate active components even when missing go mod/version info

### DIFF
--- a/.chloggen/stanley.liu_fix-extension-check.yaml
+++ b/.chloggen/stanley.liu_fix-extension-check.yaml
@@ -7,10 +7,10 @@ change_type: bug_fix
 component: extension/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Datadog extension no longer throws an error for missing extensions when getting a list of active components.
+note: Datadog extension no longer throws an error for missing extensions when getting a list of active components, and now populates active components even when missing go mod/version info.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [45358]
+issues: [45358, 45460]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/extension/datadogextension/internal/componentchecker/componentchecker.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker.go
@@ -114,7 +114,6 @@ func PopulateActiveComponents(logger *zap.Logger, c *confmap.Conf, moduleInfoJSO
 		} else {
 			// This extension may be a custom component from the datadog-agent repository (i.e. ddflareextension)
 			logger.Warn("extension not found in Module Info, something has gone wrong with status parsing for extension ID", zap.String("extensionID", extensionID.String()))
-			continue
 		}
 		// TODO: Add component status parsing, potentially via pkg/status
 		serviceComponents = append(serviceComponents, extension)
@@ -173,9 +172,6 @@ func PopulateActiveComponents(logger *zap.Logger, c *confmap.Conf, moduleInfoJSO
 				if module, ok := moduleInfoJSON.GetComponent(component.Type, component.Kind); ok {
 					component.Gomod = module.Gomod
 					component.Version = module.Version
-				} else {
-					// This component exists but is the wrong type (e.g. a connector in the exporters pipeline)
-					continue
 				}
 				// TODO: Add component status parsing, potentially via pkg/status
 				serviceComponents = append(serviceComponents, component)

--- a/extension/datadogextension/internal/componentchecker/componentchecker_test.go
+++ b/extension/datadogextension/internal/componentchecker/componentchecker_test.go
@@ -505,9 +505,48 @@ func TestPopulateActiveComponents(t *testing.T) {
 					"extensions": []any{"missing_extension"},
 				},
 			},
-			moduleInfoJSON:     payload.NewModuleInfoJSON(),
-			expectedComponents: []payload.ServiceComponent{},
-			expectedError:      "",
+			moduleInfoJSON: payload.NewModuleInfoJSON(),
+			expectedComponents: []payload.ServiceComponent{
+				{
+					ID:      "missing_extension",
+					Name:    "",
+					Type:    "missing_extension",
+					Kind:    "extension",
+					Gomod:   "",
+					Version: "",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "Exporter not found in module info",
+			collectorConfigStringMap: map[string]any{
+				"exporters": map[string]any{
+					"missing_exporter": map[string]any{},
+				},
+				"service": map[string]any{
+					"pipelines": map[string]any{
+						"traces": map[string]any{
+							"exporters": []any{
+								"missing_exporter",
+							},
+						},
+					},
+				},
+			},
+			moduleInfoJSON: payload.NewModuleInfoJSON(),
+			expectedComponents: []payload.ServiceComponent{
+				{
+					ID:       "missing_exporter",
+					Name:     "",
+					Type:     "missing_exporter",
+					Kind:     "exporter",
+					Pipeline: "traces",
+					Gomod:    "",
+					Version:  "",
+				},
+			},
+			expectedError: "",
 		},
 	}
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds components to `active_components` even when missing go mod/version info

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
