### PR TITLE
[receiver/googlecloudmonitoring] Support boolean-typed metrics

### DIFF
--- a/.chloggen/google_bool_metrics.yaml
+++ b/.chloggen/google_bool_metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/googlecloudmonitoring
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix boolean metrics conversion to int values
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45423]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion.go
@@ -64,6 +64,12 @@ func (mb *MetricsBuilder) ConvertGaugeToMetrics(ts *monitoringpb.TimeSeries, m p
 			dp.SetDoubleValue(v.DoubleValue)
 		case *monitoringpb.TypedValue_Int64Value:
 			dp.SetIntValue(v.Int64Value)
+		case *monitoringpb.TypedValue_BoolValue:
+			if v.BoolValue {
+				dp.SetIntValue(1)
+			} else {
+				dp.SetIntValue(0)
+			}
 		default:
 			mb.logger.Info("Unhandled metric value type:", zap.Reflect("Type", v))
 		}

--- a/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metrics_conversion_test.go
@@ -66,6 +66,46 @@ func TestConvertGaugeToMetrics(t *testing.T) {
 			},
 			fileNameExpected: "TestConvertGaugeToMetrics_InvalidEndTime.yaml",
 		},
+		{
+			name: "valid boolean true",
+			ts: &monitoringpb.TimeSeries{
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							StartTime: &timestamppb.Timestamp{Seconds: 10},
+							EndTime:   &timestamppb.Timestamp{Seconds: 20},
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_BoolValue{BoolValue: true},
+						},
+					},
+				},
+				Metric: &metric.Metric{
+					Labels: map[string]string{"boolKey": "trueValue"},
+				},
+			},
+			fileNameExpected: "TestConvertGaugeToMetrics_ValidBooleanTrue.yaml",
+		},
+		{
+			name: "valid boolean false",
+			ts: &monitoringpb.TimeSeries{
+				Points: []*monitoringpb.Point{
+					{
+						Interval: &monitoringpb.TimeInterval{
+							StartTime: &timestamppb.Timestamp{Seconds: 30},
+							EndTime:   &timestamppb.Timestamp{Seconds: 40},
+						},
+						Value: &monitoringpb.TypedValue{
+							Value: &monitoringpb.TypedValue_BoolValue{BoolValue: false},
+						},
+					},
+				},
+				Metric: &metric.Metric{
+					Labels: map[string]string{"boolKey": "falseValue"},
+				},
+			},
+			fileNameExpected: "TestConvertGaugeToMetrics_ValidBooleanFalse.yaml",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := zap.NewNop()

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidBooleanFalse.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidBooleanFalse.yaml
@@ -1,0 +1,14 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "30000000000"
+                  timeUnixNano: "40000000000"
+                  attributes:
+                    - key: boolKey
+                      value:
+                        stringValue: falseValue
+        scope: {}

--- a/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidBooleanTrue.yaml
+++ b/receiver/googlecloudmonitoringreceiver/internal/testdata/TestConvertGaugeToMetrics_ValidBooleanTrue.yaml
@@ -1,0 +1,14 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "10000000000"
+                  timeUnixNano: "20000000000"
+                  attributes:
+                    - key: boolKey
+                      value:
+                        stringValue: trueValue
+        scope: {}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Previously, the googlecloudmonitoring receiver didn't support handling boolean-typed metrics, causing metrics to fail. This PR adds support to explicitly ingest booleans as integers 0 (false) or 1 (true), instead.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45423

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added tests for both true and false cases.

<!--Describe the documentation added.-->
#### Documentation

N/A. Bug fix to support expected behavior

<!--Please delete paragraphs that you did not use before submitting.-->
