### PR TITLE
[receiver/github] Fix span hierarchy: make step spans children of job span instead of queue-job span

### DIFF
--- a/.chloggen/gh-fix-propagation-queue-span.yaml
+++ b/.chloggen/gh-fix-propagation-queue-span.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: githubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make step spans siblings of queue-job span under job span instead of children of queue-job span"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42623]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change improves a workflow job trace structure by making step spans siblings of the queue-job span under the job span.
+  Reflecting that queuing and step execution are sequential phases rather than nested operations
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/gh-fix-propagation-queue-span.yaml
+++ b/.chloggen/gh-fix-propagation-queue-span.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: receiver/github
@@ -17,7 +17,7 @@ issues: [42623]
 # Use pipe (|) for multiline entries.
 subtext: |
   This change improves a workflow job trace structure by making step spans siblings of the queue-job span under the job span.
-  Reflecting that queuing and step execution are sequential phases rather than nested operations
+  Reflecting that queuing and step execution are sequential phases rather than nested operations which more accurately aligns with the specification.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/gh-fix-propagation-queue-span.yaml
+++ b/.chloggen/gh-fix-propagation-queue-span.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: githubreceiver
+component: receiver/github
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Make step spans siblings of queue-job span under job span instead of children of queue-job span"

--- a/receiver/githubreceiver/testdata/workflow-job-expected.yaml
+++ b/receiver/githubreceiver/testdata/workflow-job-expected.yaml
@@ -96,7 +96,7 @@ resourceSpans:
             endTimeUnixNano: "1744837744000000000"
             kind: 1
             name: Set up job
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: 103b52e85d34ae1c
             startTimeUnixNano: "1744837742000000000"
             status:
@@ -115,7 +115,7 @@ resourceSpans:
             endTimeUnixNano: "1744837745000000000"
             kind: 1
             name: Run actions/checkout@v4
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: b0a2cdd89199b9a5
             startTimeUnixNano: "1744837744000000000"
             status:
@@ -134,7 +134,7 @@ resourceSpans:
             endTimeUnixNano: "1744837745000000000"
             kind: 1
             name: Set up Go
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: c04460ffd6bf3917
             startTimeUnixNano: "1744837745000000000"
             status:
@@ -153,7 +153,7 @@ resourceSpans:
             endTimeUnixNano: "1744837820000000000"
             kind: 1
             name: Make test-all
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: 1684627ec86a096c
             startTimeUnixNano: "1744837746000000000"
             status:
@@ -172,7 +172,7 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Upload coverage to Codecov
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: 25aeeca484f9f7e5
             startTimeUnixNano: "1744837820000000000"
             status:
@@ -191,7 +191,7 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Post Set up Go
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: 0715a13bb338e46e
             startTimeUnixNano: "1744837823000000000"
             status:
@@ -210,7 +210,7 @@ resourceSpans:
             endTimeUnixNano: "1744837825000000000"
             kind: 1
             name: Post Run actions/checkout@v4
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: e231dce10420723b
             startTimeUnixNano: "1744837825000000000"
             status:
@@ -229,7 +229,7 @@ resourceSpans:
             endTimeUnixNano: "1744837823000000000"
             kind: 1
             name: Complete job
-            parentSpanId: d328504edfc4f5dc
+            parentSpanId: e68a36b3514c8634
             spanId: bb94c07ba3717632
             startTimeUnixNano: "1744837823000000000"
             status:

--- a/receiver/githubreceiver/trace_event_handling.go
+++ b/receiver/githubreceiver/trace_event_handling.go
@@ -68,13 +68,13 @@ func (gtr *githubTracesReceiver) handleWorkflowJob(e *github.WorkflowJobEvent, r
 		return ptrace.Traces{}, errors.New("failed to create parent span")
 	}
 
-	queueSpanID, err := gtr.createJobQueueSpan(r, e, traceID, parentID)
+	_, err = gtr.createJobQueueSpan(r, e, traceID, parentID)
 	if err != nil {
 		gtr.logger.Sugar().Error("failed to create job queue span", zap.Error(err))
 		return ptrace.Traces{}, errors.New("failed to create job queue span")
 	}
 
-	err = gtr.createStepSpans(r, e, traceID, queueSpanID)
+	err = gtr.createStepSpans(r, e, traceID, parentID)
 	if err != nil {
 		gtr.logger.Sugar().Error("failed to create step spans", zap.Error(err))
 		return ptrace.Traces{}, errors.New("failed to create step spans")

--- a/receiver/githubreceiver/trace_event_handling.go
+++ b/receiver/githubreceiver/trace_event_handling.go
@@ -68,7 +68,7 @@ func (gtr *githubTracesReceiver) handleWorkflowJob(e *github.WorkflowJobEvent, r
 		return ptrace.Traces{}, errors.New("failed to create parent span")
 	}
 
-	_, err = gtr.createJobQueueSpan(r, e, traceID, parentID)
+	err = gtr.createJobQueueSpan(r, e, traceID, parentID)
 	if err != nil {
 		gtr.logger.Sugar().Error("failed to create job queue span", zap.Error(err))
 		return ptrace.Traces{}, errors.New("failed to create job queue span")
@@ -403,7 +403,7 @@ func (*githubTracesReceiver) createJobQueueSpan(
 	event *github.WorkflowJobEvent,
 	traceID pcommon.TraceID,
 	parentSpanID pcommon.SpanID,
-) (pcommon.SpanID, error) {
+) error {
 	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
 	span := scopeSpans.Spans().AppendEmpty()
 	jobName := event.GetWorkflowJob().GetName()
@@ -418,7 +418,7 @@ func (*githubTracesReceiver) createJobQueueSpan(
 	runAttempt := int(event.GetWorkflowJob().GetRunAttempt())
 	spanID, err := newStepSpanID(runID, runAttempt, jobName, spanName, 1)
 	if err != nil {
-		return pcommon.SpanID{}, fmt.Errorf("failed to generate step span ID: %w", err)
+		return fmt.Errorf("failed to generate step span ID: %w", err)
 	}
 
 	span.SetSpanID(spanID)
@@ -432,5 +432,5 @@ func (*githubTracesReceiver) createJobQueueSpan(
 	attrs := span.Attributes()
 	attrs.PutDouble(AttributeCICDPipelineRunQueueDuration, float64(duration.Nanoseconds()))
 
-	return spanID, nil
+	return nil
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change improves the workflow job traces structure by making step spans siblings of the queue-job span under the job span.
This reflects that job queuing and step execution are sequential phases rather than nested operations.


A workflow job trace structure would now look like this

```
├── workflow span
│   └── job 1 span
│       ├── queue-job 1 span
│       ├── setup job span
│       ├── step 1 span
│       ├── step 2 span
│       ├── ...
│       └── complete job span
│   └── job 2 span
│       ├── queue-job 2 span
│       ├── setup job span
│       ├── step 1 span
│       ├── step 2 span
│       ├── ...
│       └── complete job span
```


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes [42623](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42623)

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Updated golden tests. The `parentSpanId` of step spans are now the `spanId` of Job span and not anymore the `spanId` of Queue-job span.


Also tested it out with github / ngrok / jaeger:

```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4319
  github:
    scrapers:
      scraper:
    webhook:
      endpoint: 0.0.0.0:19418
      path: /events
      health_path: /health
      secret: xxxx
      service_name: github-actions
exporters:
  otlphttp/jaeger:
    endpoint: http://localhost:4318
processors:
  batch:
    timeout: 5s
    send_batch_size: 1000
service:
  pipelines:
    traces:
      receivers:
        - github
        - otlp
      processors:
        - batch
      exporters:
        - otlphttp/jaeger
```

with this github workflow: (I've used the `krzko/run-with-telemetry` action to prove it actually solves the propagation mentioned in the issue above)
```yaml
name: TestCustomGHASpan

on:
  push:
    branches:
      - master

permissions: read-all

env:
  otel-exporter-otlp-endpoint: xxx
  otel-service-name: github-actions

jobs:
  CustomSpans:
    name: custom spans
    runs-on: ubuntu-latest
    steps:
      - name: checkout code
        uses: actions/checkout@v4
      
      - name: add custom span
        uses: krzko/run-with-telemetry@v0.5.0
        with:
          otel-exporter-otlp-endpoint: ${{ env.otel-exporter-otlp-endpoint }}
          otel-service-name: ${{ env.otel-service-name }}
          step-name: "sleep-1"
          job-as-parent: true
          run: |
            sleep 1

      - name: add custom span 2
        uses: krzko/run-with-telemetry@v0.5.0
        with:
          otel-exporter-otlp-endpoint: ${{ env.otel-exporter-otlp-endpoint }}
          otel-service-name: ${{ env.otel-service-name }}
          step-name: "sleep-2"
          job-as-parent: true
          run: |
            sleep 2
```
<img width="2551" height="646" alt="Screenshot 2025-09-11 at 11 32 57" src="https://github.com/user-attachments/assets/710b6a5d-b1f8-4796-a7d7-ec26fac35c62" />
