### PR TITLE
[chore] update references to otlphttp -> otlp_http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3336,11 +3336,11 @@ This functionality is disabled by default, you can enable it by passing the foll
 ### 🚩 Deprecations 🚩
 
 - `sapmexporter`: Deprecate SAPM exporter (#36028)
-  The SAPM exporter is being marked as deprecated. Please use the `otlphttp` exporter with the configuration shown
+  The SAPM exporter is being marked as deprecated. Please use the `otlp_http` exporter with the configuration shown
   below. Also update your pipeline configuration for Traces accordingly.
   ```yaml
     exporters:
-        otlphttp:
+        otlp_http:
             traces_endpoint: "${SPLUNK_INGEST_URL}/v2/trace/otlp"
             headers:
                 "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -346,7 +346,7 @@ connectors:
   spanmetrics:
 
 exporters:
-  otlphttp/observability-backend:
+  otlp_http/observability-backend:
   ...
 
 service:
@@ -354,11 +354,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [transform/sanitize_spans, ...]
-      exporters: [otlphttp/observability-backend, spanmetrics]
+      exporters: [otlp_http/observability-backend, spanmetrics]
     metrics:
       receivers: [otlp, spanmetrics]
       processors: [...]
-      exporters: [otlphttp/observability-backend]
+      exporters: [otlp_http/observability-backend]
     # ...
 ```
 
@@ -402,7 +402,7 @@ connectors:
   spanmetrics:
 
 exporters:
-  otlphttp/observability-backend:
+  otlp_http/observability-backend:
   ...
 
 service:
@@ -410,11 +410,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [transform/sanitize_spans, ...]
-      exporters: [otlphttp/observability-backend, spanmetrics]
+      exporters: [otlp_http/observability-backend, spanmetrics]
     metrics:
       receivers: [otlp, spanmetrics]
       processors: [...]
-      exporters: [otlphttp/observability-backend]
+      exporters: [otlp_http/observability-backend]
     # ...
 ```
 

--- a/examples/nomad/otel-collector.nomad
+++ b/examples/nomad/otel-collector.nomad
@@ -31,7 +31,7 @@ job "otel-collector" {
       port "otlp" {
         to = 4317
       }
-      port "otlphttp" {
+      port "otlp-http" {
         to = 4318
       }
       port "zipkin" {
@@ -55,7 +55,7 @@ job "otel-collector" {
         ]
 
         ports = [
-  "otlphttp",
+  "otlp-http",
   "zipkin",
   "zpages",
   "healthcheck",
@@ -173,7 +173,7 @@ EOH
           "traefik.http.routers.otel-collector-http.tls=false",
           "traefik.enable=true",
         ]
-        port = "otlphttp"
+        port = "otlp-http"
       }
 
     }

--- a/exporter/datasetexporter/README.md
+++ b/exporter/datasetexporter/README.md
@@ -308,7 +308,7 @@ To enable metrics you have to:
        metrics:
          # add prometheus among metrics receivers
          receivers: [prometheus]
-         exporters: [otlphttp/prometheus, debug]
+         exporters: [otlp_http/prometheus, debug]
    ```
 
 ### Available Metrics

--- a/exporter/logzioexporter/exporter.go
+++ b/exporter/logzioexporter/exporter.go
@@ -163,7 +163,7 @@ func (exporter *logzioExporter) pushTraceData(ctx context.Context, traces ptrace
 	return exporter.export(ctx, exporter.config.Endpoint, request)
 }
 
-// export is similar to otlphttp export method with changes in log messages + Permanent error for `StatusUnauthorized` and `StatusForbidden`
+// export is similar to otlp_http export method with changes in log messages + Permanent error for `StatusUnauthorized` and `StatusForbidden`
 // https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlphttpexporter/otlp.go#L127
 func (exporter *logzioExporter) export(ctx context.Context, url string, request []byte) error {
 	exporter.logger.Debug(fmt.Sprintf("Preparing to make HTTP request with %d bytes", len(request)))

--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -25,7 +25,7 @@
 
 ```yaml
 exporters:
-  otlphttp:
+  otlp_http:
     traces_endpoint: "${SPLUNK_INGEST_URL}/v2/trace/otlp"
     headers:
         "X-SF-Token": "${SPLUNK_ACCESS_TOKEN}"

--- a/exporter/sumologicexporter/README.md
+++ b/exporter/sumologicexporter/README.md
@@ -70,7 +70,7 @@ After the new exporter will be moved to this repository:
 ## Configuration
 
 This exporter supports sending logs and metrics data to [Sumo Logic](https://www.sumologic.com/).
-Traces are exported using the [native otlphttp exporter](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing).
+Traces are exported using the [native otlp_http exporter](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing).
 
 Configuration is specified via the yaml in the following structure:
 

--- a/extension/asapauthextension/README.md
+++ b/extension/asapauthextension/README.md
@@ -35,7 +35,7 @@ extensions:
     ttl: 60s
     
 exporters:
-  otlphttp/withauth:
+  otlp_http/withauth:
     endpoint: http://localhost:9000
     auth:
       authenticator: asapclient

--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -66,7 +66,7 @@ exporters:
     auth:
       authenticator: bearertokenauth
 
-  otlphttp/withauth:
+  otlp_http/withauth:
     endpoint: http://localhost:9000
     auth:
       authenticator: bearertokenauth/withscheme
@@ -77,5 +77,5 @@ service:
     metrics:
       receivers: [hostmetrics]
       processors: []
-      exporters: [otlp/withauth, otlphttp/withauth]
+      exporters: [otlp/withauth, otlp_http/withauth]
 ```

--- a/extension/datadogextension/integration_test.go
+++ b/extension/datadogextension/integration_test.go
@@ -73,7 +73,7 @@ func TestPopulateActiveComponentsIntegration(t *testing.T) {
 	// - hostmetrics: 1 time (metrics)
 	// - memory_limiter: 3 times (traces, metrics, logs)
 	// - debug: 3 times (traces, metrics, logs)
-	// - otlphttp: 3 times (traces, metrics, logs)
+	// - otlp_http: 3 times (traces, metrics, logs)
 	// - datadog/connector: 2 times (traces exporter, metrics receiver)
 	// Total: 2 + 3 + 1 + 3 + 3 + 3 + 2 = 17
 	expectedComponentCount := 17
@@ -116,7 +116,7 @@ func TestPopulateActiveComponentsIntegration(t *testing.T) {
 			hasDebug = true
 			assert.Equal(t, "exporter", component.Kind)
 			assert.Contains(t, []string{"traces", "metrics", "logs"}, component.Pipeline)
-		case "otlphttp":
+		case "otlp_http":
 			hasOtlphttp = true
 			assert.Equal(t, "exporter", component.Kind)
 			assert.Contains(t, []string{"traces", "metrics", "logs"}, component.Pipeline)
@@ -137,7 +137,7 @@ func TestPopulateActiveComponentsIntegration(t *testing.T) {
 	assert.True(t, hasHostmetrics, "should have hostmetrics receiver")
 	assert.True(t, hasMemoryLimiter, "should have memory_limiter processor")
 	assert.True(t, hasDebug, "should have debug exporter")
-	assert.True(t, hasOtlphttp, "should have otlphttp exporter")
+	assert.True(t, hasOtlphttp, "should have otlp_http exporter")
 }
 
 func TestDataToFlattenedJSONStringIntegration(t *testing.T) {
@@ -441,7 +441,7 @@ func createModuleInfoFromSampleConfig() *payload.ModuleInfoJSON {
 			Configured: true,
 		},
 		{
-			Type:       "otlphttp",
+			Type:       "otlp_http",
 			Kind:       "exporter",
 			Gomod:      "go.opentelemetry.io/collector/exporter/otlphttpexporter",
 			Version:    "v0.127.0",

--- a/extension/datadogextension/internal/componentchecker/testdata/sample-config.yaml
+++ b/extension/datadogextension/internal/componentchecker/testdata/sample-config.yaml
@@ -21,7 +21,7 @@ processors:
 exporters:
   debug:
     verbosity: detailed
-  otlphttp:
+  otlp_http:
     endpoint: "http://localhost:4318"
     sending_queue:
       batch:
@@ -46,12 +46,12 @@ service:
     traces:
       receivers: [otlp]
       processors: [memory_limiter]
-      exporters: [debug, otlphttp, datadog/connector]
+      exporters: [debug, otlp_http, datadog/connector]
     metrics:
       receivers: [otlp, hostmetrics, datadog/connector]
       processors: [memory_limiter]
-      exporters: [debug, otlphttp]
+      exporters: [debug, otlp_http]
     logs:
       receivers: [otlp]
       processors: [memory_limiter]
-      exporters: [debug, otlphttp]
+      exporters: [debug, otlp_http]

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -130,7 +130,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 			"debug": {
 				"verbosity": "detailed"
 			},
-			"otlphttp": {
+			"otlp_http": {
 				"endpoint": "http://localhost:4318"
 			}
 		},
@@ -139,12 +139,12 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 				"traces": {
 					"receivers": ["otlp"],
 					"processors": ["memory_limiter", "batch"],
-					"exporters": ["debug", "otlphttp"]
+					"exporters": ["debug", "otlp_http"]
 				},
 				"metrics": {
 					"receivers": ["otlp", "hostmetrics"],
 					"processors": ["memory_limiter", "batch"],
-					"exporters": ["debug", "otlphttp"]
+					"exporters": ["debug", "otlp_http"]
 				}
 			}
 		}
@@ -209,7 +209,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 			Configured: true,
 		},
 		{
-			Type:       "otlphttp",
+			Type:       "otlp_http",
 			Kind:       "exporter",
 			Gomod:      "go.opentelemetry.io/collector/exporter/otlphttpexporter",
 			Version:    "v0.127.0",
@@ -327,7 +327,7 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 	assert.Contains(t, testPayload.Metadata.FullComponents, fullComponents[2]) // batch processor
 	assert.Contains(t, testPayload.Metadata.FullComponents, fullComponents[3]) // memory_limiter processor
 	assert.Contains(t, testPayload.Metadata.FullComponents, fullComponents[4]) // debug exporter
-	assert.Contains(t, testPayload.Metadata.FullComponents, fullComponents[5]) // otlphttp exporter
+	assert.Contains(t, testPayload.Metadata.FullComponents, fullComponents[5]) // otlp_http exporter
 
 	// Test active components
 	assert.Len(t, testPayload.Metadata.ActiveComponents, 7)

--- a/extension/healthcheckv2extension/README.md
+++ b/extension/healthcheckv2extension/README.md
@@ -245,7 +245,7 @@ response body such as:
             "status": "StatusOK",
             "status_time": "2024-01-18T17:27:12.571625-08:00",
             "components": {
-                "exporter:otlphttp/staging": {
+                "exporter:otlp_http/staging": {
                     "healthy": true,
                     "status": "StatusOK",
                     "status_time": "2024-01-18T17:27:12.571615-08:00"
@@ -309,7 +309,7 @@ a response body such as:
     "status": "StatusOK",
     "status_time": "2024-01-18T17:27:12.571625-08:00",
     "components": {
-        "exporter:otlphttp/staging": {
+        "exporter:otlp_http/staging": {
             "healthy": true,
             "status": "StatusOK",
             "status_time": "2024-01-18T17:27:12.571615-08:00"

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -52,7 +52,7 @@ receivers:
       grpc:
 
 exporters:
-  otlphttp/withauth:
+  otlp_http/withauth:
     endpoint: http://localhost:9000
     auth:
       authenticator: oauth2client
@@ -70,7 +70,7 @@ service:
     metrics:
       receivers: [hostmetrics]
       processors: []
-      exporters: [otlphttp/withauth, otlp/withauth]
+      exporters: [otlp_http/withauth, otlp/withauth]
 ```
 
 Following are the configuration fields

--- a/receiver/awslambdareceiver/README.md
+++ b/receiver/awslambdareceiver/README.md
@@ -101,7 +101,7 @@ extensions:
       file_format: plain-text
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "https://my-backend:443"
 
 service:
@@ -110,12 +110,12 @@ service:
   pipelines:
     logs:
       receivers: [awslambda]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 In this example, the `awslambdareceiver` is expected to be triggered when a VPC flow log is created at S3 bucket.
 The receiver retrieves the log file from S3 and decodes it using the `awslogs_encoding` extension with the `vpcflow` format.
-Parsed logs are forwarded to an OTLP listener via the `otlphttp` exporter.
+Parsed logs are forwarded to an OTLP listener via the `otlp_http` exporter.
 
 ### Example 2: ELB Access Logs from S3
 
@@ -132,7 +132,7 @@ extensions:
       file_format: plain-text
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "https://my-backend:443"
 
 service:
@@ -141,7 +141,7 @@ service:
   pipelines:
     logs:
       receivers: [awslambda]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 Similar to the first example, this configuration is for collecting ELB access logs stored in S3.
@@ -153,19 +153,19 @@ receivers:
   awslambda:
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "https://my-backend:443"
 
 service:
   pipelines:
     logs:
       receivers: [awslambda]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 For this deployment configuration, when receiver is triggered by a CloudWatch Logs subscription filter, the CloudWatch 
 messages will be extracted and converted to an OpenTelemetry log record. 
-These logs then get forwarded to an OTLP listener via the `otlphttp` exporter.
+These logs then get forwarded to an OTLP listener via the `otlp_http` exporter.
 
 ### Example 4: Arbitrary S3 content (logs or metrics)
 
@@ -174,14 +174,14 @@ receivers:
   awslambda:
 
 exporters:
-  otlphttp:
+  otlp_http:
     endpoint: "https://my-backend:443"
 
 service:
   pipelines:
     logs:
       receivers: [awslambda]
-      exporters: [otlphttp]
+      exporters: [otlp_http]
 ```
 
 For this deployment configuration, when receiver is triggered by an S3 event, 

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -51,7 +51,7 @@ const (
 // BaseOTLPDataReceiver implements the OTLP format receiver.
 type BaseOTLPDataReceiver struct {
 	DataReceiverBase
-	// One of the "otlp" for OTLP over gRPC or "otlphttp" for OTLP over HTTP.
+	// One of the "otlp" for OTLP over gRPC or "otlp_http" for OTLP over HTTP.
 	exporterType    string
 	traceReceiver   receiver.Traces
 	metricsReceiver receiver.Metrics
@@ -140,7 +140,7 @@ func (bor *BaseOTLPDataReceiver) ProtocolName() string {
 
 func (bor *BaseOTLPDataReceiver) GenConfigYAMLStr() string {
 	addr := fmt.Sprintf("127.0.0.1:%d", bor.Port)
-	if bor.exporterType == "otlphttp" {
+	if bor.exporterType == "otlp_http" {
 		addr = "http://" + addr
 	}
 	// Note that this generates an exporter config for agent.
@@ -179,6 +179,6 @@ func NewOTLPDataReceiver(port int) *BaseOTLPDataReceiver {
 func NewOTLPHTTPDataReceiver(port int) *BaseOTLPDataReceiver {
 	return &BaseOTLPDataReceiver{
 		DataReceiverBase: DataReceiverBase{Port: port},
-		exporterType:     "otlphttp",
+		exporterType:     "otlp_http",
 	}
 }


### PR DESCRIPTION
Following the release of 0.144.0, updating examples to use the otlp_http.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/14429
