### PR TITLE
[chore] fix a typo in the stef docs

### DIFF
--- a/exporter/stefexporter/README.md
+++ b/exporter/stefexporter/README.md
@@ -96,7 +96,7 @@ To enable compression, configure as follows:
 
 ```yaml
 exporters:
-  otlp:
+  stef:
     ...
     compression: zstd
 ```


### PR DESCRIPTION
The exporter example showed the name as `otlp` when it should have been `stef`.
