### PR TITLE
[receiver/hostmetricsreceiver] Add service.instance.id resource attribute

### DIFF
--- a/.chloggen/arve_hostmetrics-uuid.yaml
+++ b/.chloggen/arve_hostmetrics-uuid.yaml
@@ -18,6 +18,8 @@ issues: [45548]
 subtext: |
   service.instance.id is a deterministic UUID v5 derived from hostname.
   For the process scraper, service.instance.id is unique per process.
+  This can be disabled via resource_attributes.service.instance.id.enabled: false for users
+  who prefer to manage service.instance.id through the resourcedetectionprocessor or other means.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/arve_hostmetrics-uuid.yaml
+++ b/.chloggen/arve_hostmetrics-uuid.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/hostmetrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add service.name and service.instance.id resource attributes to all scrapers
+note: Add service.instance.id resource attribute to all scrapers
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [45548]
@@ -16,7 +16,6 @@ issues: [45548]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  service.name is set to "hostmetrics" for all scrapers.
   service.instance.id is a deterministic UUID v5 derived from hostname.
   For the process scraper, service.instance.id is unique per process.
 

--- a/.chloggen/arve_hostmetrics-uuid.yaml
+++ b/.chloggen/arve_hostmetrics-uuid.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/hostmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add service.name and service.instance.id resource attributes to all scrapers
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45548]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  service.name is set to "hostmetrics" for all scrapers.
+  service.instance.id is a deterministic UUID v5 derived from hostname.
+  For the process scraper, service.instance.id is unique per process.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/config.go
+++ b/receiver/hostmetricsreceiver/config.go
@@ -18,6 +18,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 )
 
+// ResourceAttributeConfig is used to enable/disable a single resource attribute.
+type ResourceAttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// ResourceAttributesConfig controls which resource attributes the receiver sets.
+type ResourceAttributesConfig struct {
+	ServiceInstanceID ResourceAttributeConfig `mapstructure:"service.instance.id"`
+}
+
 // Config defines configuration for HostMetrics receiver.
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
@@ -31,6 +41,9 @@ type Config struct {
 	// Setting the duration to 0 will disable periodic collection (however will not impact
 	// metadata collection on changes).
 	MetadataCollectionInterval time.Duration `mapstructure:"metadata_collection_interval"`
+
+	// ResourceAttributes controls which resource attributes the receiver sets.
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 var (

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -60,6 +60,9 @@ func TestLoadConfig(t *testing.T) {
 					CollectionInterval: 30 * time.Second,
 					InitialDelay:       time.Second,
 				},
+				ResourceAttributes: ResourceAttributesConfig{
+					ServiceInstanceID: ResourceAttributeConfig{Enabled: true},
+				},
 				Scrapers: map[component.Type]component.Config{
 					component.MustNewType("cpu"):  cpuscraper.NewFactory().CreateDefaultConfig(),
 					component.MustNewType("disk"): diskscraper.NewFactory().CreateDefaultConfig(),

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -79,6 +79,9 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ControllerConfig:           scraperhelper.NewDefaultControllerConfig(),
 		MetadataCollectionInterval: defaultMetadataCollectionInterval,
+		ResourceAttributes: ResourceAttributesConfig{
+			ServiceInstanceID: ResourceAttributeConfig{Enabled: true},
+		},
 	}
 }
 
@@ -126,21 +129,26 @@ func createAddScraperOptions(
 
 	envMap := gopsutilenv.SetGoPsutilEnvVars(cfg.RootPath)
 
-	// Get hostname once for all scrapers to use in service.instance.id generation.
-	// If hostname unavailable, fall back to "unknown" to ensure scrapers still work.
-	hostname, err := os.Hostname()
-	if err != nil {
-		hostname = "unknown"
+	addResourceAttributes := cfg.ResourceAttributes.ServiceInstanceID.Enabled
+	var hostname string
+	if addResourceAttributes {
+		// Get hostname once for all scrapers to use in service.instance.id generation.
+		// If hostname unavailable, fall back to "unknown" to ensure scrapers still work.
+		var hostnameErr error
+		hostname, hostnameErr = os.Hostname()
+		if hostnameErr != nil {
+			hostname = "unknown"
+		}
 	}
-
 	for key, cfg := range cfg.Scrapers {
 		factory, err := getFactory(key, factories)
 		if err != nil {
 			return nil, err
 		}
-		// Apply wrappers in order: envVar first, then resourceAttribute
 		factory = internal.NewEnvVarFactory(factory, envMap)
-		factory = internal.NewResourceAttributeFactory(factory, hostname)
+		if addResourceAttributes {
+			factory = internal.NewResourceAttributeFactory(factory, hostname)
+		}
 		scraperControllerOptions = append(scraperControllerOptions, scraperhelper.AddFactoryWithConfig(factory, cfg))
 	}
 

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv v0.145.0
@@ -59,7 +60,6 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -84,6 +84,9 @@ func TestGatherMetrics_EndToEnd(t *testing.T) {
 		ControllerConfig: scraperhelper.ControllerConfig{
 			CollectionInterval: 100 * time.Millisecond,
 		},
+		ResourceAttributes: ResourceAttributesConfig{
+			ServiceInstanceID: ResourceAttributeConfig{Enabled: true},
+		},
 		Scrapers: newScrapersConfigs(
 			cpuscraper.NewFactory(),
 			diskscraper.NewFactory(),

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -142,12 +142,9 @@ func assertIncludesExpectedMetrics(t *testing.T, got pmetric.Metrics) {
 		assert.Equal(t, "https://opentelemetry.io/schemas/1.9.0", rm.SchemaUrl(),
 			"SchemaURL is incorrect for metrics: %v", returnedMetricNames)
 
-		// Verify service.name and service.instance.id are present
+		// Verify service.instance.id is present
 		attrs := rm.Resource().Attributes()
-		serviceName, ok := attrs.Get("service.name")
-		require.True(t, ok, "service.name should be present")
-		assert.Equal(t, "hostmetrics", serviceName.Str())
-		_, ok = attrs.Get("service.instance.id")
+		_, ok := attrs.Get("service.instance.id")
 		require.True(t, ok, "service.instance.id should be present")
 
 		// Differentiate host-level metrics from process metrics by checking for process.pid

--- a/receiver/hostmetricsreceiver/integration_test.go
+++ b/receiver/hostmetricsreceiver/integration_test.go
@@ -51,7 +51,6 @@ func Test_ProcessScrape(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("process.parent_pid"),
 			pmetrictest.IgnoreResourceAttributeValue("process.pid"),
 			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
-			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),
@@ -81,7 +80,6 @@ func Test_ProcessScrapeWithCustomRootPath(t *testing.T) {
 		scraperinttest.WithExpectedFile(expectedFile),
 		scraperinttest.WithCompareOptions(
 			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
-			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),
@@ -113,7 +111,6 @@ func Test_ProcessScrapeWithBadRootPathAndEnvVar(t *testing.T) {
 		scraperinttest.WithExpectedFile(expectedFile),
 		scraperinttest.WithCompareOptions(
 			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
-			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),

--- a/receiver/hostmetricsreceiver/integration_test.go
+++ b/receiver/hostmetricsreceiver/integration_test.go
@@ -50,6 +50,8 @@ func Test_ProcessScrape(t *testing.T) {
 			pmetrictest.IgnoreResourceAttributeValue("process.owner"),
 			pmetrictest.IgnoreResourceAttributeValue("process.parent_pid"),
 			pmetrictest.IgnoreResourceAttributeValue("process.pid"),
+			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
+			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),
@@ -78,6 +80,8 @@ func Test_ProcessScrapeWithCustomRootPath(t *testing.T) {
 			}),
 		scraperinttest.WithExpectedFile(expectedFile),
 		scraperinttest.WithCompareOptions(
+			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
+			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),
@@ -108,6 +112,8 @@ func Test_ProcessScrapeWithBadRootPathAndEnvVar(t *testing.T) {
 			}),
 		scraperinttest.WithExpectedFile(expectedFile),
 		scraperinttest.WithCompareOptions(
+			pmetrictest.IgnoreResourceAttributeValue("service.instance.id"),
+			pmetrictest.IgnoreResourceAttributeValue("service.name"),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 			pmetrictest.IgnoreMetricValues(),
 			pmetrictest.IgnoreMetricDataPointsOrder(),

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -5,12 +5,19 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/shirou/gopsutil/v4/common"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/scraper"
 )
+
+// otelNamespaceUUID is the official OTel namespace UUID for deterministic UUID v5 generation,
+// as recommended by the semantic conventions for service.instance.id.
+// See: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+var otelNamespaceUUID = uuid.MustParse("4d63009a-8d0f-11ee-aad7-4c796ed8e320")
 
 // Config is the configuration of a scraper.
 type Config interface {
@@ -47,4 +54,92 @@ func (evs *envVarScraper) ScrapeMetrics(ctx context.Context) (pmetric.Metrics, e
 func (evs *envVarScraper) Shutdown(ctx context.Context) error {
 	ctx = context.WithValue(ctx, common.EnvKey, evs.envMap)
 	return evs.delegate.Shutdown(ctx)
+}
+
+// NewResourceAttributeFactory creates a factory that wraps scrapers with resource attribute injection.
+// It adds service.name and service.instance.id to all emitted metrics.
+func NewResourceAttributeFactory(delegate scraper.Factory, hostname string) scraper.Factory {
+	baseInstanceID := generateServiceInstanceID(hostname)
+
+	return scraper.NewFactory(delegate.Type(), func() component.Config {
+		return delegate.CreateDefaultConfig()
+	}, scraper.WithMetrics(func(ctx context.Context, settings scraper.Settings, config component.Config) (scraper.Metrics, error) {
+		scrp, err := delegate.CreateMetrics(ctx, settings, config)
+		if err != nil {
+			return nil, err
+		}
+		return &resourceAttributeScraper{
+			delegate:       scrp,
+			serviceName:    "hostmetrics",
+			baseInstanceID: baseInstanceID,
+			scraperType:    delegate.Type(),
+		}, nil
+	}, delegate.MetricsStability()))
+}
+
+// resourceAttributeScraper wraps a scraper.Metrics to inject service.name and service.instance.id
+// resource attributes into all emitted metrics.
+type resourceAttributeScraper struct {
+	delegate       scraper.Metrics
+	serviceName    string
+	baseInstanceID string // UUID v5 from hostname
+	scraperType    component.Type
+}
+
+func (ras *resourceAttributeScraper) Start(ctx context.Context, host component.Host) error {
+	return ras.delegate.Start(ctx, host)
+}
+
+func (ras *resourceAttributeScraper) ScrapeMetrics(ctx context.Context) (pmetric.Metrics, error) {
+	metrics, err := ras.delegate.ScrapeMetrics(ctx)
+
+	// Inject resource attributes into all ResourceMetrics, even on partial errors.
+	// Scrapers frequently return partial scrape errors along with valid metrics.
+	ras.injectResourceAttributes(metrics)
+
+	return metrics, err
+}
+
+func (ras *resourceAttributeScraper) Shutdown(ctx context.Context) error {
+	return ras.delegate.Shutdown(ctx)
+}
+
+func (ras *resourceAttributeScraper) injectResourceAttributes(metrics pmetric.Metrics) {
+	// Iterate through all ResourceMetrics
+	for i := range metrics.ResourceMetrics().Len() {
+		rm := metrics.ResourceMetrics().At(i)
+		attrs := rm.Resource().Attributes()
+
+		// Add service.name
+		attrs.PutStr("service.name", ras.serviceName)
+
+		// Add service.instance.id
+		// For process scraper, generate unique ID per process using process.pid
+		if ras.scraperType.String() == "process" {
+			if pidVal, ok := attrs.Get("process.pid"); ok {
+				pid := pidVal.Int()
+				instanceID := generateProcessServiceInstanceID(ras.baseInstanceID, pid)
+				attrs.PutStr("service.instance.id", instanceID)
+			} else {
+				// Fallback to base instance ID if no PID found
+				attrs.PutStr("service.instance.id", ras.baseInstanceID)
+			}
+		} else {
+			// Host-level scrapers use base instance ID
+			attrs.PutStr("service.instance.id", ras.baseInstanceID)
+		}
+	}
+}
+
+// generateServiceInstanceID creates a deterministic UUID v5 from hostname using
+// the OTel namespace UUID.
+func generateServiceInstanceID(hostname string) string {
+	return uuid.NewSHA1(otelNamespaceUUID, []byte(hostname)).String()
+}
+
+// generateProcessServiceInstanceID creates a deterministic UUID v5 that is unique
+// per process by combining the base hostname UUID with the process PID.
+func generateProcessServiceInstanceID(baseInstanceID string, pid int64) string {
+	combined := fmt.Sprintf("%s:%d", baseInstanceID, pid)
+	return uuid.NewSHA1(otelNamespaceUUID, []byte(combined)).String()
 }

--- a/receiver/hostmetricsreceiver/internal/scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper_test.go
@@ -1,0 +1,260 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestGenerateServiceInstanceID(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		// Same hostname should produce the same UUID
+		id1 := generateServiceInstanceID("myhost.example.com")
+		id2 := generateServiceInstanceID("myhost.example.com")
+		assert.Equal(t, id1, id2, "same hostname should produce same UUID")
+	})
+
+	t.Run("unique for different hostnames", func(t *testing.T) {
+		id1 := generateServiceInstanceID("host1.example.com")
+		id2 := generateServiceInstanceID("host2.example.com")
+		assert.NotEqual(t, id1, id2, "different hostnames should produce different UUIDs")
+	})
+
+	t.Run("valid UUID format", func(t *testing.T) {
+		id := generateServiceInstanceID("myhost.example.com")
+		// UUID v5 format: xxxxxxxx-xxxx-5xxx-xxxx-xxxxxxxxxxxx
+		assert.Len(t, id, 36, "UUID should be 36 characters")
+		assert.Equal(t, '-', rune(id[8]), "UUID should have hyphen at position 8")
+		assert.Equal(t, '-', rune(id[13]), "UUID should have hyphen at position 13")
+		assert.Equal(t, '5', rune(id[14]), "UUID v5 should have '5' at position 14")
+	})
+}
+
+func TestGenerateProcessServiceInstanceID(t *testing.T) {
+	baseID := generateServiceInstanceID("myhost.example.com")
+
+	t.Run("deterministic", func(t *testing.T) {
+		// Same inputs should produce the same UUID
+		id1 := generateProcessServiceInstanceID(baseID, 1234)
+		id2 := generateProcessServiceInstanceID(baseID, 1234)
+		assert.Equal(t, id1, id2, "same inputs should produce same UUID")
+	})
+
+	t.Run("unique for different PIDs", func(t *testing.T) {
+		id1 := generateProcessServiceInstanceID(baseID, 1234)
+		id2 := generateProcessServiceInstanceID(baseID, 5678)
+		assert.NotEqual(t, id1, id2, "different PIDs should produce different UUIDs")
+	})
+
+	t.Run("different from base ID", func(t *testing.T) {
+		processID := generateProcessServiceInstanceID(baseID, 1234)
+		assert.NotEqual(t, baseID, processID, "process ID should differ from base ID")
+	})
+}
+
+// mockScraper is a test scraper that returns predefined metrics
+type mockScraper struct {
+	metrics pmetric.Metrics
+	started bool
+	stopped bool
+}
+
+func (m *mockScraper) Start(_ context.Context, _ component.Host) error {
+	m.started = true
+	return nil
+}
+
+func (m *mockScraper) ScrapeMetrics(_ context.Context) (pmetric.Metrics, error) {
+	return m.metrics, nil
+}
+
+func (m *mockScraper) Shutdown(_ context.Context) error {
+	m.stopped = true
+	return nil
+}
+
+func TestResourceAttributeScraper_HostLevel(t *testing.T) {
+	// Create metrics with one ResourceMetrics (typical for host-level scrapers)
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("system.cpu.time")
+
+	mock := &mockScraper{metrics: metrics}
+
+	scraper := &resourceAttributeScraper{
+		delegate:       mock,
+		serviceName:    "hostmetrics",
+		baseInstanceID: generateServiceInstanceID("testhost"),
+		scraperType:    component.MustNewType("cpu"),
+	}
+
+	// Test Start
+	err := scraper.Start(t.Context(), nil)
+	require.NoError(t, err)
+	assert.True(t, mock.started)
+
+	// Test ScrapeMetrics
+	result, err := scraper.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+
+	// Verify resource attributes were injected
+	require.Equal(t, 1, result.ResourceMetrics().Len())
+	attrs := result.ResourceMetrics().At(0).Resource().Attributes()
+
+	serviceName, ok := attrs.Get("service.name")
+	require.True(t, ok, "service.name should be set")
+	assert.Equal(t, "hostmetrics", serviceName.Str())
+
+	instanceID, ok := attrs.Get("service.instance.id")
+	require.True(t, ok, "service.instance.id should be set")
+	assert.Equal(t, scraper.baseInstanceID, instanceID.Str())
+
+	// Test Shutdown
+	err = scraper.Shutdown(t.Context())
+	require.NoError(t, err)
+	assert.True(t, mock.stopped)
+}
+
+func TestResourceAttributeScraper_ProcessLevel(t *testing.T) {
+	// Create metrics with multiple ResourceMetrics (typical for process scraper)
+	metrics := pmetric.NewMetrics()
+
+	// Process 1
+	rm1 := metrics.ResourceMetrics().AppendEmpty()
+	rm1.Resource().Attributes().PutInt("process.pid", 1234)
+	rm1.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("process.cpu.time")
+
+	// Process 2
+	rm2 := metrics.ResourceMetrics().AppendEmpty()
+	rm2.Resource().Attributes().PutInt("process.pid", 5678)
+	rm2.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("process.cpu.time")
+
+	mock := &mockScraper{metrics: metrics}
+	baseInstanceID := generateServiceInstanceID("testhost")
+
+	scraper := &resourceAttributeScraper{
+		delegate:       mock,
+		serviceName:    "hostmetrics",
+		baseInstanceID: baseInstanceID,
+		scraperType:    component.MustNewType("process"),
+	}
+
+	result, err := scraper.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, result.ResourceMetrics().Len())
+
+	// Verify first process
+	attrs1 := result.ResourceMetrics().At(0).Resource().Attributes()
+	serviceName1, ok := attrs1.Get("service.name")
+	require.True(t, ok)
+	assert.Equal(t, "hostmetrics", serviceName1.Str())
+
+	instanceID1, ok := attrs1.Get("service.instance.id")
+	require.True(t, ok)
+	expectedID1 := generateProcessServiceInstanceID(baseInstanceID, 1234)
+	assert.Equal(t, expectedID1, instanceID1.Str())
+
+	// Verify second process
+	attrs2 := result.ResourceMetrics().At(1).Resource().Attributes()
+	serviceName2, ok := attrs2.Get("service.name")
+	require.True(t, ok)
+	assert.Equal(t, "hostmetrics", serviceName2.Str())
+
+	instanceID2, ok := attrs2.Get("service.instance.id")
+	require.True(t, ok)
+	expectedID2 := generateProcessServiceInstanceID(baseInstanceID, 5678)
+	assert.Equal(t, expectedID2, instanceID2.Str())
+
+	// Verify the two processes have different instance IDs
+	assert.NotEqual(t, instanceID1.Str(), instanceID2.Str(),
+		"different processes should have different service.instance.id")
+}
+
+func TestResourceAttributeScraper_ProcessWithoutPID(t *testing.T) {
+	// Edge case: process scraper returns ResourceMetrics without process.pid
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("process.cpu.time")
+	// Note: no process.pid attribute set
+
+	mock := &mockScraper{metrics: metrics}
+	baseInstanceID := generateServiceInstanceID("testhost")
+
+	scraper := &resourceAttributeScraper{
+		delegate:       mock,
+		serviceName:    "hostmetrics",
+		baseInstanceID: baseInstanceID,
+		scraperType:    component.MustNewType("process"),
+	}
+
+	result, err := scraper.ScrapeMetrics(t.Context())
+	require.NoError(t, err)
+
+	// Should fall back to base instance ID
+	attrs := result.ResourceMetrics().At(0).Resource().Attributes()
+	instanceID, ok := attrs.Get("service.instance.id")
+	require.True(t, ok)
+	assert.Equal(t, baseInstanceID, instanceID.Str(),
+		"should fall back to base instance ID when process.pid is missing")
+}
+
+// mockScraperWithError is a test scraper that returns both metrics and an error
+type mockScraperWithError struct {
+	metrics pmetric.Metrics
+	err     error
+}
+
+func (*mockScraperWithError) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (m *mockScraperWithError) ScrapeMetrics(_ context.Context) (pmetric.Metrics, error) {
+	return m.metrics, m.err
+}
+
+func (*mockScraperWithError) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func TestResourceAttributeScraper_PartialError(t *testing.T) {
+	// Test that resource attributes are injected even when there's a partial error
+	// This is a common scenario in the hostmetricsreceiver
+	metrics := pmetric.NewMetrics()
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("system.cpu.time")
+
+	partialErr := assert.AnError // Simulate a partial scrape error
+
+	mock := &mockScraperWithError{metrics: metrics, err: partialErr}
+
+	scraper := &resourceAttributeScraper{
+		delegate:       mock,
+		serviceName:    "hostmetrics",
+		baseInstanceID: generateServiceInstanceID("testhost"),
+		scraperType:    component.MustNewType("cpu"),
+	}
+
+	result, err := scraper.ScrapeMetrics(t.Context())
+
+	// Should return the original error
+	assert.ErrorIs(t, err, partialErr)
+
+	// But resource attributes should still be injected
+	require.Equal(t, 1, result.ResourceMetrics().Len())
+	attrs := result.ResourceMetrics().At(0).Resource().Attributes()
+
+	serviceName, ok := attrs.Get("service.name")
+	require.True(t, ok, "service.name should be set even on partial error")
+	assert.Equal(t, "hostmetrics", serviceName.Str())
+
+	_, ok = attrs.Get("service.instance.id")
+	require.True(t, ok, "service.instance.id should be set even on partial error")
+}

--- a/receiver/hostmetricsreceiver/internal/scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper_test.go
@@ -90,7 +90,6 @@ func TestResourceAttributeScraper_HostLevel(t *testing.T) {
 
 	scraper := &resourceAttributeScraper{
 		delegate:       mock,
-		serviceName:    "hostmetrics",
 		baseInstanceID: generateServiceInstanceID("testhost"),
 		scraperType:    component.MustNewType("cpu"),
 	}
@@ -107,10 +106,6 @@ func TestResourceAttributeScraper_HostLevel(t *testing.T) {
 	// Verify resource attributes were injected
 	require.Equal(t, 1, result.ResourceMetrics().Len())
 	attrs := result.ResourceMetrics().At(0).Resource().Attributes()
-
-	serviceName, ok := attrs.Get("service.name")
-	require.True(t, ok, "service.name should be set")
-	assert.Equal(t, "hostmetrics", serviceName.Str())
 
 	instanceID, ok := attrs.Get("service.instance.id")
 	require.True(t, ok, "service.instance.id should be set")
@@ -141,7 +136,6 @@ func TestResourceAttributeScraper_ProcessLevel(t *testing.T) {
 
 	scraper := &resourceAttributeScraper{
 		delegate:       mock,
-		serviceName:    "hostmetrics",
 		baseInstanceID: baseInstanceID,
 		scraperType:    component.MustNewType("process"),
 	}
@@ -153,10 +147,6 @@ func TestResourceAttributeScraper_ProcessLevel(t *testing.T) {
 
 	// Verify first process
 	attrs1 := result.ResourceMetrics().At(0).Resource().Attributes()
-	serviceName1, ok := attrs1.Get("service.name")
-	require.True(t, ok)
-	assert.Equal(t, "hostmetrics", serviceName1.Str())
-
 	instanceID1, ok := attrs1.Get("service.instance.id")
 	require.True(t, ok)
 	expectedID1 := generateProcessServiceInstanceID(baseInstanceID, 1234)
@@ -164,10 +154,6 @@ func TestResourceAttributeScraper_ProcessLevel(t *testing.T) {
 
 	// Verify second process
 	attrs2 := result.ResourceMetrics().At(1).Resource().Attributes()
-	serviceName2, ok := attrs2.Get("service.name")
-	require.True(t, ok)
-	assert.Equal(t, "hostmetrics", serviceName2.Str())
-
 	instanceID2, ok := attrs2.Get("service.instance.id")
 	require.True(t, ok)
 	expectedID2 := generateProcessServiceInstanceID(baseInstanceID, 5678)
@@ -190,7 +176,6 @@ func TestResourceAttributeScraper_ProcessWithoutPID(t *testing.T) {
 
 	scraper := &resourceAttributeScraper{
 		delegate:       mock,
-		serviceName:    "hostmetrics",
 		baseInstanceID: baseInstanceID,
 		scraperType:    component.MustNewType("process"),
 	}
@@ -237,7 +222,6 @@ func TestResourceAttributeScraper_PartialError(t *testing.T) {
 
 	scraper := &resourceAttributeScraper{
 		delegate:       mock,
-		serviceName:    "hostmetrics",
 		baseInstanceID: generateServiceInstanceID("testhost"),
 		scraperType:    component.MustNewType("cpu"),
 	}
@@ -251,10 +235,6 @@ func TestResourceAttributeScraper_PartialError(t *testing.T) {
 	require.Equal(t, 1, result.ResourceMetrics().Len())
 	attrs := result.ResourceMetrics().At(0).Resource().Attributes()
 
-	serviceName, ok := attrs.Get("service.name")
-	require.True(t, ok, "service.name should be set even on partial error")
-	assert.Equal(t, "hostmetrics", serviceName.Str())
-
-	_, ok = attrs.Get("service.instance.id")
+	_, ok := attrs.Get("service.instance.id")
 	require.True(t, ok, "service.instance.id should be set even on partial error")
 }


### PR DESCRIPTION
## Summary

- Add _configurable_ `service.instance.id` resource attribute to all hostmetricsreceiver scrapers (default on)
- `service.instance.id` is a deterministic UUID v5 derived from hostname using the official OTel namespace UUID
- For the process scraper, `service.instance.id` is unique per process by combining the hostname-based UUID with the process PID

## Implementation

Uses a scraper wrapper pattern (similar to the existing `envVarScraper`) to inject attributes without modifying individual scraper implementations. This minimizes code changes while ensuring all 11 scrapers emit the new resource attributes.

## Test plan

- [x] Unit tests for UUID generation determinism and uniqueness
- [x] Unit tests for host-level and process-level scraper wrapping
- [x] Unit tests for partial error handling (attributes still injected)
- [x] Integration test updated to verify new attributes
- [x] All existing tests pass
- [x] Lint clean