### PR TITLE
[receiver/datadog] prune stale metrics series to prevent memory leak

### DIFF
--- a/.chloggen/datadogreceiver-fix-infinite-memory-growth.yaml
+++ b/.chloggen/datadogreceiver-fix-infinite-memory-growth.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix infinite memory growth in metrics translator by pruning stale streams that have not received data within the configured series_idle_timeout.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45523]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Previously, high cardinality tags would cause the receiver to retain state indefinitely, leading to OOM.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -24,8 +24,8 @@ Configuration wise is very simple, just need to specify where the Datadog receiv
 
 Then, the receiver must be configured in the pipeline where it will be used.
 
-The feature gate `receiver.datadogreceiver.Enable128BitTraceID` (disabled by default) enables the receiver to 
-reconstruct 128-bit trace ids from spans coming from a datadog instrumented service. This is necessary if a trace is 
+The feature gate `receiver.datadogreceiver.Enable128BitTraceID` (disabled by default) enables the receiver to
+reconstruct 128-bit trace ids from spans coming from a datadog instrumented service. This is necessary if a trace is
 initiated with a 128-bit trace id by a service that then calls a datadog instrumented one. Without this, spans from the
 datadog instrumented service will not correlate with the other spans.
 
@@ -35,6 +35,7 @@ receivers:
     endpoint: localhost:8126
     read_timeout: 60s
     trace_id_cache_size: 100
+    series_idle_timeout: 60m
 
 exporters:
   debug:
@@ -60,6 +61,13 @@ The size of the LRU cache used to cache 64-bit trace ids and their matching 128-
 when the feature gate `receiver.datadogreceiver.Enable128BitTraceID` is enabled.
 
 Default: 100
+
+### series_idle_timeout (Optional)
+The duration a specific series (metric name + unique tags) can be idle (not receive data) before being considered stale and removed from memory. This is useful to release memory in High Cardinality scenarios (e.g. ephemeral pods) where the number of series grows indefinitely.
+
+Recommendation: If enabled, ensure this value is significantly higher than the interval of your slowest emitting metric or cronjob. For example, if you have a job that runs every 30 minutes, set this to at least 60m to avoid resetting the start timestamp for those metrics.
+
+Default: 0s (Disabled - series are kept indefinitely)
 
 ### HTTP Service Config
 
@@ -101,7 +109,7 @@ If the `receiver.datadogreceiver.EnableMultiTagParsing` feature gate is enabled,
 
 ### Optional Attributes
 
-- `_dd.span_links`: This receiver supports DD Agent's `_dd.span_links` attribute for span links creation, as produced by Datadog's tracing libraries. 
+- `_dd.span_links`: This receiver supports DD Agent's `_dd.span_links` attribute for span links creation, as produced by Datadog's tracing libraries.
 Format example can be found [here](./internal/translator/traces_translator_test.go).
 
 ### Datadog's API support

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -35,7 +35,8 @@ receivers:
     endpoint: localhost:8126
     read_timeout: 60s
     trace_id_cache_size: 100
-    series_idle_timeout: 60m
+    idle_series_timeout: 60m
+    idle_series_cleanup_interval: 5m
 
 exporters:
   debug:
@@ -62,12 +63,18 @@ when the feature gate `receiver.datadogreceiver.Enable128BitTraceID` is enabled.
 
 Default: 100
 
-### series_idle_timeout (Optional)
+### idle_series_timeout (Optional)
 The duration a specific series (metric name + unique tags) can be idle (not receive data) before being considered stale and removed from memory. This is useful to release memory in High Cardinality scenarios (e.g. ephemeral pods) where the number of series grows indefinitely.
 
 Recommendation: If enabled, ensure this value is significantly higher than the interval of your slowest emitting metric or cronjob. For example, if you have a job that runs every 30 minutes, set this to at least 60m to avoid resetting the start timestamp for those metrics.
 
 Default: 0s (Disabled - series are kept indefinitely)
+
+### idle_series_cleanup_interval (Optional)
+The duration between runs of the idle series cleanup task. This setting is only used when idle_series_timeout is enabled (greater than 0).
+The value must be a string with a unit (e.g. "5m", "60s").
+
+Default: "5m"
 
 ### HTTP Service Config
 

--- a/receiver/datadogreceiver/config.go
+++ b/receiver/datadogreceiver/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	TraceIDCacheSize int `mapstructure:"trace_id_cache_size"`
 	// Intake controls the `/intake` endpoint behavior
 	Intake IntakeConfig `mapstructure:"intake"`
+	// SeriesIdleTimeout defines the maximum duration a series can remain idle before being removed.
+	// This allows releasing memory used by high cardinality tags that are no longer active.
+	SeriesIdleTimeout time.Duration `mapstructure:"series_idle_timeout"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/receiver/datadogreceiver/config.go
+++ b/receiver/datadogreceiver/config.go
@@ -38,9 +38,13 @@ type Config struct {
 	TraceIDCacheSize int `mapstructure:"trace_id_cache_size"`
 	// Intake controls the `/intake` endpoint behavior
 	Intake IntakeConfig `mapstructure:"intake"`
-	// SeriesIdleTimeout defines the maximum duration a series can remain idle before being removed.
-	// This allows releasing memory used by high cardinality tags that are no longer active.
-	SeriesIdleTimeout time.Duration `mapstructure:"series_idle_timeout"`
+	// IdleSeriesTimeout is the duration after which a series is considered stale
+	// and removed from memory if no new data points are received.
+	// The default value is 0, which disables this feature.
+	IdleSeriesTimeout time.Duration `mapstructure:"idle_series_timeout"`
+	// IdleSeriesCleanupInterval defines how frequently the receiver checks for
+	// and removes idle series. Defaults to 5 minutes.
+	IdleSeriesCleanupInterval time.Duration `mapstructure:"idle_series_cleanup_interval"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/receiver/datadogreceiver/config.schema.yaml
+++ b/receiver/datadogreceiver/config.schema.yaml
@@ -18,6 +18,14 @@ $defs:
         $ref: /pkg/datadog/config.api_config
 type: object
 properties:
+  idle_series_cleanup_interval:
+    description: IdleSeriesCleanupInterval defines how frequently the receiver checks for and removes idle series. Defaults to 5 minutes.
+    type: string
+    format: duration
+  idle_series_timeout:
+    description: IdleSeriesTimeout is the duration after which a series is considered stale and removed from memory if no new data points are received. The default value is 0, which disables this feature.
+    type: string
+    format: duration
   intake:
     description: Intake controls the `/intake` endpoint behavior
     $ref: intake_config

--- a/receiver/datadogreceiver/factory.go
+++ b/receiver/datadogreceiver/factory.go
@@ -35,9 +35,10 @@ func createDefaultConfig() component.Config {
 	netAddr.Endpoint = "localhost:8126"
 
 	return &Config{
-		ServerConfig:     confighttp.ServerConfig{NetAddr: netAddr},
-		ReadTimeout:      60 * time.Second,
-		TraceIDCacheSize: 100,
+		ServerConfig:      confighttp.ServerConfig{NetAddr: netAddr},
+		ReadTimeout:       60 * time.Second,
+		SeriesIdleTimeout: 0,
+		TraceIDCacheSize:  100,
 		Intake: IntakeConfig{
 			Behavior: defaultConfigIntakeBehavior,
 			Proxy: ProxyConfig{

--- a/receiver/datadogreceiver/factory.go
+++ b/receiver/datadogreceiver/factory.go
@@ -35,10 +35,11 @@ func createDefaultConfig() component.Config {
 	netAddr.Endpoint = "localhost:8126"
 
 	return &Config{
-		ServerConfig:      confighttp.ServerConfig{NetAddr: netAddr},
-		ReadTimeout:       60 * time.Second,
-		SeriesIdleTimeout: 0,
-		TraceIDCacheSize:  100,
+		ServerConfig:              confighttp.ServerConfig{NetAddr: netAddr},
+		ReadTimeout:               60 * time.Second,
+		IdleSeriesTimeout:         0,
+		IdleSeriesCleanupInterval: 5 * time.Minute,
+		TraceIDCacheSize:          100,
 		Intake: IntakeConfig{
 			Behavior: defaultConfigIntakeBehavior,
 			Proxy: ProxyConfig{

--- a/receiver/datadogreceiver/internal/translator/metrics_translator.go
+++ b/receiver/datadogreceiver/internal/translator/metrics_translator.go
@@ -5,6 +5,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -14,16 +15,18 @@ import (
 
 type MetricsTranslator struct {
 	sync.RWMutex
-	buildInfo  component.BuildInfo
-	lastTs     map[identity.Stream]pcommon.Timestamp
-	stringPool *StringPool
+	buildInfo         component.BuildInfo
+	lastTs            map[identity.Stream]pcommon.Timestamp
+	stringPool        *StringPool
+	seriesIdleTimeout time.Duration
 }
 
-func NewMetricsTranslator(buildInfo component.BuildInfo) *MetricsTranslator {
+func NewMetricsTranslator(buildInfo component.BuildInfo, seriesIdleTimeout time.Duration) *MetricsTranslator {
 	return &MetricsTranslator{
-		buildInfo:  buildInfo,
-		lastTs:     make(map[identity.Stream]pcommon.Timestamp),
-		stringPool: newStringPool(),
+		buildInfo:         buildInfo,
+		lastTs:            make(map[identity.Stream]pcommon.Timestamp),
+		stringPool:        newStringPool(),
+		seriesIdleTimeout: seriesIdleTimeout,
 	}
 }
 
@@ -38,4 +41,51 @@ func (mt *MetricsTranslator) updateLastTsForStream(stream identity.Stream, ts pc
 	mt.Lock()
 	defer mt.Unlock()
 	mt.lastTs[stream] = ts
+}
+
+// Prune recreates the map keeping only the recent items.
+// It returns the number of removed items.
+func (mt *MetricsTranslator) Prune() int {
+	// If the timeout is 0, the feature is disabled.
+	// Return 0 immediately to preserve legacy behavior (keep all series).
+	if mt.seriesIdleTimeout == 0 {
+		return 0
+	}
+	// Full Lock is required here because we are swapping the entire map reference.
+	// During this process, no one can read or write.
+	mt.Lock()
+	defer mt.Unlock()
+
+	now := time.Now()
+	originalSize := len(mt.lastTs)
+
+	// Optimization: if the map is empty, do nothing.
+	if originalSize == 0 {
+		return 0
+	}
+
+	// Create a new map.
+	// We let it grow organically to avoid allocating memory for the stale data.
+	newMap := make(map[identity.Stream]pcommon.Timestamp)
+
+	for stream, ts := range mt.lastTs {
+		// Convert pcommon timestamp (nanos) to time.Time.
+		tsTime := time.Unix(0, int64(ts))
+
+		// If the age is less than the max idle time, keep it.
+		if now.Sub(tsTime) < mt.seriesIdleTimeout {
+			newMap[stream] = ts
+		}
+	}
+
+	// Swap the pointer. The old map (mt.lastTs) loses the reference.
+	// The Go Garbage Collector will detect this and release all memory allocated
+	// by the old buckets.
+	mt.lastTs = newMap
+
+	// Reset the string pool as well since we cleaned up the streams.
+	mt.stringPool = newStringPool()
+
+	// Return the number of removed items.
+	return originalSize - len(newMap)
 }

--- a/receiver/datadogreceiver/internal/translator/metrics_translator.go
+++ b/receiver/datadogreceiver/internal/translator/metrics_translator.go
@@ -18,15 +18,15 @@ type MetricsTranslator struct {
 	buildInfo         component.BuildInfo
 	lastTs            map[identity.Stream]pcommon.Timestamp
 	stringPool        *StringPool
-	seriesIdleTimeout time.Duration
+	idleSeriesTimeout time.Duration
 }
 
-func NewMetricsTranslator(buildInfo component.BuildInfo, seriesIdleTimeout time.Duration) *MetricsTranslator {
+func NewMetricsTranslator(buildInfo component.BuildInfo, idleSeriesTimeout time.Duration) *MetricsTranslator {
 	return &MetricsTranslator{
 		buildInfo:         buildInfo,
 		lastTs:            make(map[identity.Stream]pcommon.Timestamp),
 		stringPool:        newStringPool(),
-		seriesIdleTimeout: seriesIdleTimeout,
+		idleSeriesTimeout: idleSeriesTimeout,
 	}
 }
 
@@ -48,7 +48,7 @@ func (mt *MetricsTranslator) updateLastTsForStream(stream identity.Stream, ts pc
 func (mt *MetricsTranslator) Prune() int {
 	// If the timeout is 0, the feature is disabled.
 	// Return 0 immediately to preserve legacy behavior (keep all series).
-	if mt.seriesIdleTimeout == 0 {
+	if mt.idleSeriesTimeout == 0 {
 		return 0
 	}
 	// Full Lock is required here because we are swapping the entire map reference.
@@ -73,7 +73,7 @@ func (mt *MetricsTranslator) Prune() int {
 		tsTime := time.Unix(0, int64(ts))
 
 		// If the age is less than the max idle time, keep it.
-		if now.Sub(tsTime) < mt.seriesIdleTimeout {
+		if now.Sub(tsTime) < mt.idleSeriesTimeout {
 			newMap[stream] = ts
 		}
 	}

--- a/receiver/datadogreceiver/internal/translator/testutil.go
+++ b/receiver/datadogreceiver/internal/translator/testutil.go
@@ -5,6 +5,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -19,7 +20,7 @@ func createMetricsTranslator() *MetricsTranslator {
 		Command:     "otelcol",
 		Description: "OpenTelemetry Collector",
 		Version:     "latest",
-	})
+	}, 30*time.Minute)
 	return mt
 }
 

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -258,11 +258,7 @@ func (ddr *datadogReceiver) Start(ctx context.Context, host component.Host) erro
 			)
 		}
 
-		ddr.wg.Add(1)
-		go func() {
-			defer ddr.wg.Done()
-			ddr.runIdleSeriesCleanup()
-		}()
+		ddr.wg.Go(ddr.runIdleSeriesCleanup)
 	}
 
 	return nil

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -206,7 +207,7 @@ func newDataDogReceiver(ctx context.Context, config *Config, params receiver.Set
 		config:             config,
 		intakeReverseProxy: intakeReverseProxy,
 		tReceiver:          instance,
-		metricsTranslator:  translator.NewMetricsTranslator(params.BuildInfo),
+		metricsTranslator:  translator.NewMetricsTranslator(params.BuildInfo, config.SeriesIdleTimeout),
 		statsTranslator:    translator.NewStatsTranslator(),
 		traceIDCache:       cache,
 	}, nil
@@ -242,6 +243,9 @@ func (ddr *datadogReceiver) Start(ctx context.Context, host component.Host) erro
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(fmt.Errorf("error starting datadog receiver: %w", err)))
 		}
 	}()
+
+	// Starts the sweeper loop to clean up stale data
+	go ddr.runSweeper(ctx)
 	return nil
 }
 
@@ -698,6 +702,37 @@ func createIntakeReverseProxyDirector(site, key string) func(*http.Request) {
 		// but it appears as though the value of that field does not matter,
 		// at least when it comes to matching the actual `DD-API-KEY` we set in the header above.
 		// So, to avoid a bunch of extra expensive work in the collector, we don't touch the body.
+	}
+}
+
+func (ddr *datadogReceiver) runSweeper(ctx context.Context) {
+	// If SeriesIdleTimeout is 0, the feature is disabled (default behavior).
+	if ddr.config.SeriesIdleTimeout == 0 {
+		return
+	}
+
+	// Run the cleanup more frequently than the timeout to ensure precision.
+	// If the timeout is 30m, checking every 5m is healthy.
+	sweepInterval := 5 * time.Minute
+
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+
+	ddr.params.Logger.Info("Starting series memory sweeper",
+		zap.Duration("series_idle_timeout", ddr.config.SeriesIdleTimeout),
+		zap.Duration("sweep_interval", sweepInterval))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			removedCount := ddr.metricsTranslator.Prune()
+			if removedCount > 0 {
+				ddr.params.Logger.Debug("Pruned stale series from memory",
+					zap.Int("removed_series", removedCount))
+			}
+		}
 	}
 }
 

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
@@ -51,6 +52,9 @@ type datadogReceiver struct {
 	tReceiver *receiverhelper.ObsReport
 
 	traceIDCache *lru.Cache[uint64, pcommon.TraceID]
+
+	shutdownCh chan struct{}
+	wg         sync.WaitGroup
 }
 
 // Endpoint specifies an API endpoint definition.
@@ -207,9 +211,10 @@ func newDataDogReceiver(ctx context.Context, config *Config, params receiver.Set
 		config:             config,
 		intakeReverseProxy: intakeReverseProxy,
 		tReceiver:          instance,
-		metricsTranslator:  translator.NewMetricsTranslator(params.BuildInfo, config.SeriesIdleTimeout),
+		metricsTranslator:  translator.NewMetricsTranslator(params.BuildInfo, config.IdleSeriesTimeout),
 		statsTranslator:    translator.NewStatsTranslator(),
 		traceIDCache:       cache,
+		shutdownCh:         make(chan struct{}),
 	}, nil
 }
 
@@ -244,12 +249,31 @@ func (ddr *datadogReceiver) Start(ctx context.Context, host component.Host) erro
 		}
 	}()
 
-	// Starts the sweeper loop to clean up stale data
-	go ddr.runSweeper(ctx)
+	// Starts the cleanup loop to remove idle series
+	if ddr.config.IdleSeriesTimeout > 0 {
+		if ddr.config.IdleSeriesCleanupInterval <= 0 {
+			return fmt.Errorf(
+				"idle_series_cleanup_interval must be positive when idle_series_timeout is enabled; found %v",
+				ddr.config.IdleSeriesCleanupInterval,
+			)
+		}
+
+		ddr.wg.Add(1)
+		go func() {
+			defer ddr.wg.Done()
+			ddr.runIdleSeriesCleanup()
+		}()
+	}
+
 	return nil
 }
 
 func (ddr *datadogReceiver) Shutdown(ctx context.Context) (err error) {
+	// Signal background goroutines to stop
+	close(ddr.shutdownCh)
+	// Wait for them to finish
+	ddr.wg.Wait()
+
 	if ddr.server == nil {
 		return nil
 	}
@@ -705,31 +729,27 @@ func createIntakeReverseProxyDirector(site, key string) func(*http.Request) {
 	}
 }
 
-func (ddr *datadogReceiver) runSweeper(ctx context.Context) {
-	// If SeriesIdleTimeout is 0, the feature is disabled (default behavior).
-	if ddr.config.SeriesIdleTimeout == 0 {
-		return
-	}
+// runIdleSeriesCleanup runs the loop that checks for and removes idle series.
+func (ddr *datadogReceiver) runIdleSeriesCleanup() {
+	cleanupInterval := ddr.config.IdleSeriesCleanupInterval
+	idleTimeout := ddr.config.IdleSeriesTimeout
 
-	// Run the cleanup more frequently than the timeout to ensure precision.
-	// If the timeout is 30m, checking every 5m is healthy.
-	sweepInterval := 5 * time.Minute
-
-	ticker := time.NewTicker(sweepInterval)
+	// Assumes validation was done in Start(), so cleanupInterval is positive.
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
-	ddr.params.Logger.Info("Starting series memory sweeper",
-		zap.Duration("series_idle_timeout", ddr.config.SeriesIdleTimeout),
-		zap.Duration("sweep_interval", sweepInterval))
+	ddr.params.Logger.Info("Starting idle series cleanup",
+		zap.Duration("idle_series_timeout", idleTimeout),
+		zap.Duration("idle_series_cleanup_interval", cleanupInterval))
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-ddr.shutdownCh:
 			return
 		case <-ticker.C:
 			removedCount := ddr.metricsTranslator.Prune()
 			if removedCount > 0 {
-				ddr.params.Logger.Debug("Pruned stale series from memory",
+				ddr.params.Logger.Debug("Pruned idle series from memory",
 					zap.Int("removed_series", removedCount))
 			}
 		}


### PR DESCRIPTION
#### Description

This PR addresses a memory leak issue in the `datadogreceiver`'s metrics translator when handling high cardinality data.

**The Problem:**
The `MetricsTranslator` maintains an internal map (`lastTs`) to track the timestamps of metric series for SetStartTimestamp(). Currently, this map grows indefinitely because stale series (e.g., from ephemeral pods or one-off jobs) are never removed. In high cardinality scenarios, this leads to linear memory growth and eventual OOM.

**The Solution:**
- Implemented a `Prune()` method in `MetricsTranslator` to remove series that have not received data for a specific duration.
- Added a new configuration parameter: `series_idle_timeout`.
  - **Default: `0s` (Disabled).** This ensures backward compatibility and prevents data loss for sparse metrics (e.g., hourly cronjobs) where the state must be preserved.
  - Users experiencing high memory usage can configure this (e.g., `60m`) to automatically clean up stale series.
- Added a background sweeper in `receiver.go` that triggers the pruning process periodically if the timeout is configured.

**Design Considerations:**
We chose `series_idle_timeout` as the name to strictly define the behavior: it cleans up specific *series* based on *idle* time, distinct from connection timeouts (confighttp).

#### Link to tracking issue
Fixes #45523

#### Documentation

- Updated `receiver/datadogreceiver/README.md` to document the new `series_idle_timeout` parameter and provide recommendations for its usage.
- Added code comments explaining the "opt-in" nature of this fix to protect sparse metrics.