### PR TITLE
chore: fix contextcheck linter errors

### DIFF
--- a/cmd/opampsupervisor/supervisor/commander/commander.go
+++ b/cmd/opampsupervisor/supervisor/commander/commander.go
@@ -222,10 +222,9 @@ func (c *Commander) watch() {
 // StartOneShot starts the Collector with the expectation that it will immediately
 // exit after it finishes a quick operation. This is useful for situations like reading stdout/sterr
 // to e.g. check the feature gate the Collector supports.
-func (c *Commander) StartOneShot() ([]byte, []byte, error) {
+func (c *Commander) StartOneShot(ctx context.Context) ([]byte, []byte, error) {
 	stdout := []byte{}
 	stderr := []byte{}
-	ctx := context.Background()
 
 	cmd := exec.CommandContext(ctx, c.cfg.Executable, c.args...) // #nosec G204
 	cmd.Env = envVarMapToEnvMapSlice(c.cfg.Env)

--- a/cmd/opampsupervisor/supervisor/supervisor_metrics_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_metrics_test.go
@@ -60,7 +60,7 @@ func TestSupervisorMetrics(t *testing.T) {
 	supervisor.runCtx, supervisor.runCtxCancel = context.WithCancel(t.Context())
 
 	supervisor.telemetrySettings.MeterProvider = mp
-	metrics, err := supervisorTelemetry.NewMetrics(mp)
+	metrics, err := supervisorTelemetry.NewMetrics(t.Context(), mp)
 	require.NoError(t, err)
 	supervisor.metrics = metrics
 
@@ -106,7 +106,7 @@ func TestSupervisorMetricsLifecycle(t *testing.T) {
 	supervisor.runCtx, supervisor.runCtxCancel = context.WithCancel(t.Context())
 
 	supervisor.telemetrySettings.MeterProvider = mp
-	metrics, err := supervisorTelemetry.NewMetrics(mp)
+	metrics, err := supervisorTelemetry.NewMetrics(t.Context(), mp)
 	require.NoError(t, err)
 	supervisor.metrics = metrics
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -760,7 +760,7 @@ service:
 		configStorageDir := t.TempDir()
 
 		mp := metric.NewMeterProvider()
-		metrics, err := telemetry.NewMetrics(mp)
+		metrics, err := telemetry.NewMetrics(t.Context(), mp)
 		require.NoError(t, err)
 		defer func() {
 			_ = mp.Shutdown(t.Context())
@@ -1270,7 +1270,7 @@ func Test_handleAgentOpAMPMessage(t *testing.T) {
 
 		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
 		mp := metric.NewMeterProvider()
-		metrics, err := telemetry.NewMetrics(mp)
+		metrics, err := telemetry.NewMetrics(t.Context(), mp)
 		require.NoError(t, err)
 		defer func() {
 			_ = mp.Shutdown(t.Context())

--- a/cmd/opampsupervisor/supervisor/telemetry/metrics.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/metrics.go
@@ -18,7 +18,7 @@ type Metrics struct {
 	healthStatus                bool
 }
 
-func NewMetrics(meterProvider metric.MeterProvider) (*Metrics, error) {
+func NewMetrics(ctx context.Context, meterProvider metric.MeterProvider) (*Metrics, error) {
 	meter := meterProvider.Meter("opamp-supervisor")
 
 	healthStatus, err := meter.Int64UpDownCounter(
@@ -30,7 +30,7 @@ func NewMetrics(meterProvider metric.MeterProvider) (*Metrics, error) {
 	}
 
 	// Initialize metrics to 0 to ensure they are exported
-	healthStatus.Add(context.Background(), 0)
+	healthStatus.Add(ctx, 0)
 	return &Metrics{
 		collectorHealthStatusMetric: healthStatus,
 		healthStatus:                false,

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -157,10 +157,10 @@ func newConnector(set component.TelemetrySettings, config component.Config, next
 	}, nil
 }
 
-func (p *serviceGraphConnector) Start(context.Context, component.Host) error {
+func (p *serviceGraphConnector) Start(ctx context.Context, _ component.Host) error {
 	p.store = store.NewStore(p.config.Store.TTL, p.config.Store.MaxItems, p.onComplete, p.onExpire)
 
-	go p.metricFlushLoop(*p.config.MetricsFlushInterval)
+	go p.metricFlushLoop(ctx, *p.config.MetricsFlushInterval)
 
 	go p.cacheLoop(p.config.CacheLoop)
 
@@ -170,7 +170,7 @@ func (p *serviceGraphConnector) Start(context.Context, component.Host) error {
 	return nil
 }
 
-func (p *serviceGraphConnector) metricFlushLoop(flushInterval time.Duration) {
+func (p *serviceGraphConnector) metricFlushLoop(ctx context.Context, flushInterval time.Duration) {
 	if flushInterval <= 0 {
 		return
 	}
@@ -181,7 +181,7 @@ func (p *serviceGraphConnector) metricFlushLoop(flushInterval time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			if err := p.flushMetrics(context.Background()); err != nil {
+			if err := p.flushMetrics(ctx); err != nil {
 				p.logger.Error("failed to flush metrics", zap.Error(err))
 			}
 		case <-p.shutdownCh:

--- a/extension/azureauthextension/extension.go
+++ b/extension/azureauthextension/extension.go
@@ -239,7 +239,7 @@ func (r *roundTripper) RoundTrip(request *http.Request) (*http.Response, error) 
 		}
 	}
 
-	token, err := r.auth.getTokenForHost(req.Context(), host)
+	token, err := r.auth.getTokenForHost(request.Context(), host)
 	if err != nil {
 		return nil, fmt.Errorf("azureauth: failed to get token: %w", err)
 	}

--- a/extension/jaegerremotesampling/extension.go
+++ b/extension/jaegerremotesampling/extension.go
@@ -50,7 +50,7 @@ func (jrse *jrsExtension) Start(ctx context.Context, host component.Host) error 
 			StrategiesFile: jrse.cfg.Source.File,
 			ReloadInterval: jrse.cfg.Source.ReloadInterval,
 		}
-		ss, err := filesource.NewFileSource(opts, jrse.telemetry.Logger)
+		ss, err := filesource.NewFileSource(ctx, opts, jrse.telemetry.Logger)
 		if err != nil {
 			return fmt.Errorf("failed to create the local file strategy store: %w", err)
 		}
@@ -67,6 +67,7 @@ func (jrse *jrsExtension) Start(ctx context.Context, host component.Host) error 
 		}
 		jrse.closers = append(jrse.closers, conn.Close)
 		remoteStore, closer := remotesource.NewRemoteSource(
+			ctx,
 			conn,
 			jrse.cfg.Source.Remote,
 			jrse.cfg.Source.ReloadInterval,

--- a/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache.go
+++ b/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache.go
@@ -38,7 +38,7 @@ type serviceStrategyTTLCache struct {
 // Initial size of cache's underlying map
 const initialRemoteResponseCacheSize = 32
 
-func newServiceStrategyCache(itemTTL time.Duration) serviceStrategyCache {
+func newServiceStrategyCache(ctx context.Context, itemTTL time.Duration) serviceStrategyCache {
 	result := &serviceStrategyTTLCache{
 		itemTTL: itemTTL,
 		items:   make(map[string]serviceStrategyCacheEntry, initialRemoteResponseCacheSize),
@@ -47,7 +47,7 @@ func newServiceStrategyCache(itemTTL time.Duration) serviceStrategyCache {
 
 	// Launches a "cleaner" goroutine that naively blows away stale items with a frequency equal to the item TTL.
 	// Note that this is for memory usage and not for correctness (the get() function checks item validity).
-	go result.periodicallyClearCache(context.Background(), itemTTL)
+	go result.periodicallyClearCache(ctx, itemTTL)
 	return result
 }
 

--- a/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache_test.go
+++ b/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_cache_test.go
@@ -54,7 +54,7 @@ func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 	ctx, cancel := context.WithCancel(clockwork.AddToContext(t.Context(), mock))
 	defer cancel()
 
-	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	cache := newServiceStrategyCache(t.Context(), cacheTestItemTTL).(*serviceStrategyTTLCache)
 	defer func() {
 		assert.NoError(t, cache.Close())
 	}()
@@ -139,7 +139,7 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	ctx, cancel := context.WithCancel(clockwork.AddToContext(t.Context(), mock))
 	defer cancel()
 
-	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	cache := newServiceStrategyCache(t.Context(), cacheTestItemTTL).(*serviceStrategyTTLCache)
 	defer func() {
 		assert.NoError(t, cache.Close())
 	}()
@@ -231,7 +231,7 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 func Test_serviceStrategyCache_Concurrency(t *testing.T) {
 	defer leaktest.CheckTimeout(t, time.Minute*3)
 
-	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	cache := newServiceStrategyCache(t.Context(), cacheTestItemTTL).(*serviceStrategyTTLCache)
 	defer func() {
 		assert.NoError(t, cache.Close())
 	}()

--- a/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_store.go
+++ b/extension/jaegerremotesampling/internal/source/remotesource/remote_strategy_store.go
@@ -29,13 +29,14 @@ type grpcRemoteStrategyStore struct {
 // Note: it would be nice to expand the configuration surface to include an optional TTL-based caching behavior
 // for service-specific outbound GetSamplingStrategy calls.
 func NewRemoteSource(
+	ctx context.Context,
 	conn *grpc.ClientConn,
 	grpcClientSettings *configgrpc.ClientConfig,
 	reloadInterval time.Duration,
 ) (source.Source, io.Closer) {
 	cache := newNoopStrategyCache()
 	if reloadInterval > 0 {
-		cache = newServiceStrategyCache(reloadInterval)
+		cache = newServiceStrategyCache(ctx, reloadInterval)
 	}
 
 	return &grpcRemoteStrategyStore{

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -52,10 +52,10 @@ var _ oauth2.TokenSource = (*errorWrappingTokenSource)(nil)
 // errFailedToGetSecurityToken indicates a problem communicating with OAuth2 server.
 var errFailedToGetSecurityToken = errors.New("failed to get security token from token endpoint")
 
-func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticator, error) {
+func newClientAuthenticator(ctx context.Context, cfg *Config, logger *zap.Logger) (*clientAuthenticator, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 
-	tlsCfg, err := cfg.TLS.LoadTLSConfig(context.Background())
+	tlsCfg, err := cfg.TLS.LoadTLSConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -276,7 +276,7 @@ func TestRoundTripper(t *testing.T) {
 
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			oauth2Authenticator, err := newClientAuthenticator(testcase.settings, zap.NewNop())
+			oauth2Authenticator, err := newClientAuthenticator(t.Context(), testcase.settings, zap.NewNop())
 			if testcase.shouldError {
 				assert.Error(t, err)
 				assert.Nil(t, oauth2Authenticator)
@@ -333,7 +333,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 
 	for _, testcase := range tests {
 		t.Run(testcase.name, func(t *testing.T) {
-			oauth2Authenticator, err := newClientAuthenticator(testcase.settings, zap.NewNop())
+			oauth2Authenticator, err := newClientAuthenticator(t.Context(), testcase.settings, zap.NewNop())
 			if testcase.shouldError {
 				assert.Error(t, err)
 				assert.Nil(t, oauth2Authenticator)
@@ -360,7 +360,7 @@ func TestFailContactingOAuth(t *testing.T) {
 	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	oauth2Authenticator, err := newClientAuthenticator(&Config{
+	oauth2Authenticator, err := newClientAuthenticator(t.Context(), &Config{
 		ClientID:     "dummy",
 		ClientSecret: "ABC",
 		TokenURL:     serverURL.String(),
@@ -450,7 +450,7 @@ func TestJwtOAuth(t *testing.T) {
 	serverURL, err := url.Parse(tokenTS.URL)
 	require.NoError(t, err)
 
-	oauth2Authenticator, err := newClientAuthenticator(&Config{
+	oauth2Authenticator, err := newClientAuthenticator(t.Context(), &Config{
 		ClientID:                 "1",
 		ClientCertificateKeyFile: "testdata/client.key",
 		GrantType:                "urn:ietf:params:oauth:grant-type:jwt-bearer",

--- a/extension/oauth2clientauthextension/factory.go
+++ b/extension/oauth2clientauthextension/factory.go
@@ -29,6 +29,6 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createExtension(_ context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
-	return newClientAuthenticator(cfg.(*Config), set.Logger)
+func createExtension(ctx context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {
+	return newClientAuthenticator(ctx, cfg.(*Config), set.Logger)
 }

--- a/extension/opampextension/factory_test.go
+++ b/extension/opampextension/factory_test.go
@@ -21,6 +21,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	ext, err := createExtension(t.Context(), extensiontest.NewNopSettings(f.Type()), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, ext)
+	require.NoError(t, ext.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, ext.Shutdown(t.Context()))
 }
 

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -253,6 +253,7 @@ func TestStartAvailableComponents(t *testing.T) {
 	cfg := createDefaultConfig()
 	agentConfig := cfg.(*Config)
 	agentConfig.Capabilities.ReportsAvailableComponents = true
+	agentConfig.Capabilities.ReportsHealth = false // not testing health
 	set := extensiontest.NewNopSettings(extensiontest.NopType)
 	o, err := newOpampAgent(agentConfig, set)
 	o.opampClient = mockOpAMPClient{}
@@ -472,8 +473,6 @@ func TestHealthReportingReceiveUpdateFromAggregator(t *testing.T) {
 
 	o := newTestOpampAgent(cfg, set, mockOpampClient, sa)
 
-	o.initHealthReporting()
-
 	assert.NoError(t, o.Start(t.Context(), componenttest.NewNopHost()))
 
 	statusUpdateChannel <- nil
@@ -540,8 +539,6 @@ func TestHealthReportingForwardComponentHealthToAggregator(t *testing.T) {
 				return nil
 			},
 		}, sa)
-
-	o.initHealthReporting()
 
 	assert.NoError(t, o.Start(t.Context(), componenttest.NewNopHost()))
 
@@ -649,8 +646,6 @@ func TestHealthReportingExitsOnClosedContext(t *testing.T) {
 	}
 
 	o := newTestOpampAgent(cfg, set, mockOpampClient, sa)
-
-	o.initHealthReporting()
 
 	assert.NoError(t, o.Start(t.Context(), componenttest.NewNopHost()))
 

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -29,7 +29,7 @@ type pprofExtension struct {
 	telemetrySettings component.TelemetrySettings
 }
 
-func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
+func (p *pprofExtension) Start(ctx context.Context, host component.Host) error {
 	// The runtime settings are global to the application, so while in principle it
 	// is possible to have more than one instance, running multiple will mean that
 	// the settings of the last started instance will prevail. In order to avoid
@@ -50,7 +50,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	// Start the listener here so we can have earlier failure if port is
 	// already in use.
 	var ln net.Listener
-	ln, startErr = p.config.TCPAddr.Listen(context.Background())
+	ln, startErr = p.config.TCPAddr.Listen(ctx)
 	if startErr != nil {
 		return startErr
 	}

--- a/extension/sigv4authextension/signingroundtripper.go
+++ b/extension/sigv4authextension/signingroundtripper.go
@@ -72,7 +72,9 @@ func (si *signingRoundTripper) signRequest(req *http.Request) (*http.Request, er
 	if si.credsProvider == nil {
 		return nil, errors.New("a credentials provider is not set")
 	}
-	creds, err := (*si.credsProvider).Retrieve(req2.Context())
+	// Use req.Context() (not req2.Context()) to inherit the original request's context.
+	// cloneRequest does a shallow copy, so both return the same context anyway.
+	creds, err := (*si.credsProvider).Retrieve(req.Context())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving credentials: %w", err)
 	}

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -48,7 +48,14 @@ func bboltOptions(timeout time.Duration, noSync bool) *bbolt.Options {
 	}
 }
 
-func newClient(logger *zap.Logger, filePath string, timeout time.Duration, compactionCfg *CompactionConfig, noSync bool) (*fileStorageClient, error) {
+func newClient(
+	ctx context.Context,
+	logger *zap.Logger,
+	filePath string,
+	timeout time.Duration,
+	compactionCfg *CompactionConfig,
+	noSync bool,
+) (*fileStorageClient, error) {
 	options := bboltOptions(timeout, noSync)
 	db, err := bbolt.Open(filePath, 0o600, options)
 	if err != nil {
@@ -66,7 +73,7 @@ func newClient(logger *zap.Logger, filePath string, timeout time.Duration, compa
 
 	client := &fileStorageClient{logger: logger, db: db, compactionCfg: compactionCfg, openTimeout: timeout}
 	if compactionCfg.OnRebound {
-		client.startCompactionLoop(context.Background())
+		client.startCompactionLoop(ctx)
 	}
 
 	return client, nil

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -20,7 +20,7 @@ import (
 func TestClientOperations(t *testing.T) {
 	dbFile := filepath.Join(t.TempDir(), "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(t.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, client.Close(t.Context()))
@@ -58,7 +58,7 @@ func TestClientBatchOperations(t *testing.T) {
 	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(t.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, client.Close(t.Context()))
@@ -176,7 +176,7 @@ func TestNewClientTransactionErrors(t *testing.T) {
 			tempDir := t.TempDir()
 			dbFile := filepath.Join(tempDir, "my_db")
 
-			client, err := newClient(zap.NewNop(), dbFile, timeout, &CompactionConfig{}, false)
+			client, err := newClient(t.Context(), zap.NewNop(), dbFile, timeout, &CompactionConfig{}, false)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, client.Close(t.Context()))
@@ -200,7 +200,7 @@ func TestNewClientErrorsOnInvalidBucket(t *testing.T) {
 	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(t.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.Error(t, err)
 	require.Nil(t, client)
 
@@ -250,7 +250,7 @@ func TestClientReboundCompaction(t *testing.T) {
 			checkInterval := time.Second
 
 			logger, _ := zap.NewDevelopment()
-			client, err := newClient(logger, dbFile, time.Second, &CompactionConfig{
+			client, err := newClient(t.Context(), logger, dbFile, time.Second, &CompactionConfig{
 				OnRebound:                  true,
 				CheckInterval:              checkInterval,
 				ReboundNeededThresholdMiB:  testCase.reboundNeededThresholdMiB,
@@ -339,7 +339,7 @@ func TestClientConcurrentCompaction(t *testing.T) {
 
 	stepInterval := time.Millisecond * 5
 
-	client, err := newClient(logger, dbFile, time.Second, &CompactionConfig{
+	client, err := newClient(t.Context(), logger, dbFile, time.Second, &CompactionConfig{
 		OnRebound:                  true,
 		CheckInterval:              stepInterval * 2,
 		ReboundNeededThresholdMiB:  1,
@@ -403,7 +403,7 @@ func BenchmarkClientGet(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -422,7 +422,7 @@ func BenchmarkClientGet100(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -444,7 +444,7 @@ func BenchmarkClientSet(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -463,7 +463,7 @@ func BenchmarkClientSet100(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -484,7 +484,7 @@ func BenchmarkClientDelete(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -509,7 +509,7 @@ func BenchmarkClientSetLargeDB(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -546,7 +546,7 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -565,7 +565,7 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 	var tempClient *fileStorageClient
 
 	for b.Loop() {
-		tempClient, err = newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+		tempClient, err = newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StopTimer()
 		err = tempClient.Close(ctx)
@@ -583,7 +583,7 @@ func BenchmarkClientCompactLargeDBFile(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -608,7 +608,7 @@ func BenchmarkClientCompactLargeDBFile(b *testing.B) {
 		testDbFile := filepath.Join(tempDir, fmt.Sprintf("my_db%d", n))
 		err = os.Link(dbFile, testDbFile)
 		require.NoError(b, err)
-		client, err = newClient(zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
+		client, err = newClient(b.Context(), zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StartTimer()
 		require.NoError(b, client.Compact(tempDir, time.Second, 65536))
@@ -625,7 +625,7 @@ func BenchmarkClientCompactDb(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
-	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	client, err := newClient(b.Context(), zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
 	require.NoError(b, err)
 	b.Cleanup(func() {
 		require.NoError(b, client.Close(b.Context()))
@@ -650,7 +650,7 @@ func BenchmarkClientCompactDb(b *testing.B) {
 		testDbFile := filepath.Join(tempDir, fmt.Sprintf("my_db%d", n))
 		err = os.Link(dbFile, testDbFile)
 		require.NoError(b, err)
-		client, err = newClient(zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
+		client, err = newClient(b.Context(), zap.NewNop(), testDbFile, time.Second, &CompactionConfig{}, false)
 		require.NoError(b, err)
 		b.StartTimer()
 		require.NoError(b, client.Compact(tempDir, time.Second, 65536))


### PR DESCRIPTION
#### Description

Fix `contextcheck` linter errors by properly threading context through function calls.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Part of #45575.