### PR TITLE
[chore][processor/k8sattributes] Add self-observability features documentation

### DIFF
--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -954,6 +954,18 @@ as tags.
 By default, the `k8s.pod.start_time` uses [Time.MarshalText()](https://pkg.go.dev/time#Time.MarshalText) to format the
 timestamp value as an RFC3339 compliant timestamp.
 
+## Self-Observability Features
+
+The processor exposes internal telemetry metrics for monitoring its operation. For a complete list of all available metrics, see the [Internal Telemetry documentation](./documentation.md#internal-telemetry).
+
+Key metrics to monitor:
+- **`otelcol_otelsvc_k8s_ip_lookup_miss`**: Number of times pod lookup by IP failed
+  - High values indicate association issues
+- **`otelcol_otelsvc_k8s_pod_added`** / **`otelcol_otelsvc_k8s_pod_deleted`**: Track pod churn rates
+  - Monitor for unexpected spikes in pod lifecycle events
+- **`otelcol_otelsvc_k8s_pod_table_size`**: Current size of pod metadata cache
+  - Use to monitor memory consumption trends
+
 ## Warnings
 
 - **Memory consumption**: Since the processor fetches and caches the K8s metadata for the resources


### PR DESCRIPTION
Documents processor-specific internal telemetry:
- Reference to complete internal telemetry documentation
- Key metrics for monitoring processor operation

Part of #44586 (stable requirement: component-specific self-observability features)
