### PR TITLE
[exporter/signalfx] Add entity event processing support

### DIFF
--- a/.chloggen/signalfxexporter-entity-events.yaml
+++ b/.chloggen/signalfxexporter-entity-events.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for processing entity events from logs pipeline to send as dimension property updates
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27890]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The SignalFx exporter now supports processing entity events (e.g., from k8s_cluster receiver)
+  received via the logs pipeline and converting them to dimension property updates. This provides
+  an alternative to the metadata_exporters option and enables consistent metadata handling.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/signalfxexporter-entity-events.yaml
+++ b/.chloggen/signalfxexporter-entity-events.yaml
@@ -19,6 +19,7 @@ subtext: |
   The SignalFx exporter now supports processing entity events (e.g., from k8s_cluster receiver)
   received via the logs pipeline and converting them to dimension property updates. This provides
   an alternative to the metadata_exporters option and enables consistent metadata handling.
+  This feature is behind the `exporter.signalfx.consumeEntityEvents` feature gate (disabled by default).
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"sync"
 
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
@@ -50,15 +52,16 @@ func (sme *signalfMetadataExporter) ConsumeMetadata(metadata []*metadata.Metadat
 }
 
 type signalfxExporter struct {
-	config             *Config
-	version            string
-	logger             *zap.Logger
-	telemetrySettings  component.TelemetrySettings
-	pushMetricsData    func(ctx context.Context, md pmetric.Metrics) (droppedTimeSeries int, err error)
-	pushLogsData       func(ctx context.Context, ld plog.Logs) (droppedLogRecords int, err error)
-	hostMetadataSyncer *hostmetadata.Syncer
-	converter          *translation.MetricsConverter
-	dimClient          *dimensions.DimensionClient
+	config                 *Config
+	version                string
+	logger                 *zap.Logger
+	telemetrySettings      component.TelemetrySettings
+	pushMetricsData        func(ctx context.Context, md pmetric.Metrics) (droppedTimeSeries int, err error)
+	hostMetadataSyncer     *hostmetadata.Syncer
+	converter              *translation.MetricsConverter
+	dimClient              *dimensions.DimensionClient
+	eventClient            *sfxEventClient
+	entityEventTransformer *dimensions.EntityEventTransformer
 }
 
 // newSignalFxExporter returns a new SignalFx exporter.
@@ -126,6 +129,20 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 		sendOTLPHistograms:     se.config.SendOTLPHistograms,
 	}
 
+	if err := se.startDimensionClient(ctx); err != nil {
+		return err
+	}
+
+	if se.config.SyncHostMetadata {
+		envMap := gopsutilenv.SetGoPsutilEnvVars(se.config.RootPath)
+		se.hostMetadataSyncer = hostmetadata.NewSyncer(se.logger, se.dimClient, envMap)
+	}
+	se.pushMetricsData = dpClient.pushMetricsData
+
+	return nil
+}
+
+func (se *signalfxExporter) startDimensionClient(ctx context.Context) error {
 	apiTLSCfg, err := se.config.APITLSs.LoadTLSConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("could not load API TLS config: %w", err)
@@ -157,15 +174,7 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 			DropTags:            se.config.DimensionClient.DropTags,
 		})
 	dimClient.Start()
-
-	var hms *hostmetadata.Syncer
-	if se.config.SyncHostMetadata {
-		envMap := gopsutilenv.SetGoPsutilEnvVars(se.config.RootPath)
-		hms = hostmetadata.NewSyncer(se.logger, dimClient, envMap)
-	}
 	se.dimClient = dimClient
-	se.pushMetricsData = dpClient.pushMetricsData
-	se.hostMetadataSyncer = hms
 	return nil
 }
 
@@ -180,11 +189,28 @@ func newEventExporter(config *Config, createSettings exporter.Settings) (*signal
 		return nil, errors.New("nil config")
 	}
 
+	// The converter is needed only for dimension updates from entity events.
+	// TODO: Refactor it to extract only the dimension update logic from the metrics converter.
+	converter, err := translation.NewMetricsConverter(
+		createSettings.Logger,
+		nil,
+		config.ExcludeMetrics,
+		config.IncludeMetrics,
+		config.NonAlphanumericDimensionChars,
+		config.DropHistogramBuckets,
+		!config.SendOTLPHistograms,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &signalfxExporter{
-		config:            config,
-		version:           createSettings.BuildInfo.Version,
-		logger:            createSettings.Logger,
-		telemetrySettings: createSettings.TelemetrySettings,
+		config:                 config,
+		version:                createSettings.BuildInfo.Version,
+		logger:                 createSettings.Logger,
+		telemetrySettings:      createSettings.TelemetrySettings,
+		converter:              converter,
+		entityEventTransformer: dimensions.NewEntityEventTransformer(config.DefaultProperties),
 	}, nil
 }
 
@@ -211,7 +237,11 @@ func (se *signalfxExporter) startLogs(ctx context.Context, host component.Host) 
 		accessTokenPassthrough: se.config.AccessTokenPassthrough,
 	}
 
-	se.pushLogsData = eventClient.pushLogsData
+	// Initialize dimension client for entity event processing
+	if err := se.startDimensionClient(ctx); err != nil {
+		return err
+	}
+	se.eventClient = eventClient
 	return nil
 }
 
@@ -230,8 +260,63 @@ func (se *signalfxExporter) pushMetrics(ctx context.Context, md pmetric.Metrics)
 }
 
 func (se *signalfxExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
-	_, err := se.pushLogsData(ctx, ld)
-	return err
+	rls := ld.ResourceLogs()
+	if rls.Len() == 0 {
+		return nil
+	}
+
+	var sfxEvents []*sfxpb.Event
+
+	for i := 0; i < rls.Len(); i++ {
+		rl := rls.At(i)
+		ills := rl.ScopeLogs()
+		for j := 0; j < ills.Len(); j++ {
+			sl := ills.At(j)
+
+			// Process logs that represent entity events and skip regular event conversion
+			if isEntityEventScope(sl) {
+				err := se.processEntityEvents(sl.LogRecords())
+				if err != nil {
+					return fmt.Errorf("failed to process entity events: %w", err)
+				}
+				continue
+			}
+
+			events, _ := translation.LogRecordSliceToSignalFxV2(se.logger, sl.LogRecords(), rl.Resource().Attributes())
+			sfxEvents = append(sfxEvents, events...)
+		}
+	}
+
+	if len(sfxEvents) > 0 {
+		err := se.eventClient.pushEvents(ctx, rls.At(0), sfxEvents)
+		if err != nil {
+			return fmt.Errorf("failed to push events: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (se *signalfxExporter) processEntityEvents(logs plog.LogRecordSlice) error {
+	entityEventsSlice := metadata.NewEntityEventsSliceFromLogs(logs)
+	for i := 0; i < entityEventsSlice.Len(); i++ {
+		entityEvent := entityEventsSlice.At(i)
+
+		dimUpdate, err := se.entityEventTransformer.TransformEntityEvent(entityEvent)
+		if dimUpdate == nil {
+			if err != nil {
+				se.logger.Warn("Failed to transform entity event to dimension update", zap.Error(err))
+			}
+			continue
+		}
+
+		// Failure to accept dimension likely means exceeded buffer. Reject all further
+		// dimension updates for this export cycle.
+		if err := se.dimClient.AcceptDimension(dimUpdate); err != nil {
+			return fmt.Errorf("failed to accept dimension update: %w", err)
+		}
+	}
+	return nil
 }
 
 func (se *signalfxExporter) shutdown(_ context.Context) error {
@@ -250,6 +335,11 @@ func (se *signalfxExporter) pushMetadata(metadata []*metadata.MetadataUpdate) er
 		return errNotStarted
 	}
 	return se.dimClient.PushMetadata(metadata)
+}
+
+func isEntityEventScope(sl plog.ScopeLogs) bool {
+	marker, ok := sl.Scope().Attributes().Get(metadata.SemconvOtelEntityEventAsScope)
+	return ok && marker.Type() == pcommon.ValueTypeBool && marker.Bool()
 }
 
 func buildHeaders(config *Config, version string) map[string]string {

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/correlation"
@@ -35,6 +36,12 @@ const (
 	defaultDimMaxIdleConns        = 20
 	defaultDimMaxIdleConnsPerHost = 20
 )
+
+var entityEventsFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.signalfx.consumeEntityEvents",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Process entity events from logs pipeline and convert to dimension property updates"),
+	featuregate.WithRegisterFromVersion("v0.145.0"))
 
 // NewFactory creates a factory for SignalFx exporter.
 func NewFactory() exporter.Factory {

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -174,7 +174,8 @@ func createLogsExporter(
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(expCfg.BackOffConfig),
 		exporterhelper.WithQueue(expCfg.QueueSettings),
-		exporterhelper.WithStart(exp.startLogs))
+		exporterhelper.WithStart(exp.startLogs),
+		exporterhelper.WithShutdown(exp.shutdown))
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -95,6 +95,7 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	require.NotNil(t, logExp)
 
 	assert.NoError(t, exp.Shutdown(t.Context()))
+	assert.NoError(t, logExp.Shutdown(t.Context()))
 }
 
 func TestCreateMetrics_CustomConfig(t *testing.T) {

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/collector/exporter v1.50.1-0.20260121161034-55399d4743af
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.144.1-0.20260121161034-55399d4743af
 	go.opentelemetry.io/collector/exporter/exportertest v0.144.1-0.20260121161034-55399d4743af
+	go.opentelemetry.io/collector/featuregate v1.50.1-0.20260121161034-55399d4743af
 	go.opentelemetry.io/collector/pdata v1.50.1-0.20260121161034-55399d4743af
 	go.opentelemetry.io/otel v1.39.0
 	go.uber.org/goleak v1.3.0
@@ -90,7 +91,6 @@ require (
 	go.opentelemetry.io/collector/extension/extensionauth v1.50.1-0.20260121161034-55399d4743af // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.144.1-0.20260121161034-55399d4743af // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.144.1-0.20260121161034-55399d4743af // indirect
-	go.opentelemetry.io/collector/featuregate v1.50.1-0.20260121161034-55399d4743af // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.144.1-0.20260121161034-55399d4743af // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.144.1-0.20260121161034-55399d4743af // indirect
 	go.opentelemetry.io/collector/pdata/xpdata v0.144.1-0.20260121161034-55399d4743af // indirect

--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -145,9 +145,9 @@ func (dc *DimensionClient) Shutdown() {
 	}
 }
 
-// acceptDimension to be sent to the API.  This will return fairly quickly and
+// AcceptDimension to be sent to the API.  This will return fairly quickly and
 // won't block. If the buffer is full, the dim update will be dropped.
-func (dc *DimensionClient) acceptDimension(dimUpdate *DimensionUpdate) error {
+func (dc *DimensionClient) AcceptDimension(dimUpdate *DimensionUpdate) error {
 	if dimUpdate = dc.filterDimensionUpdate(dimUpdate); dimUpdate == nil {
 		return nil
 	}
@@ -271,7 +271,7 @@ func (dc *DimensionClient) handleDimensionUpdate(ctx context.Context, dimUpdate 
 			// temporary API failures.  If the API is down for significant
 			// periods of time, dimension updates will probably eventually back
 			// up beyond PropertiesMaxBuffered and start dropping.
-			if err := dc.acceptDimension(dimUpdate); err != nil {
+			if err := dc.AcceptDimension(dimUpdate); err != nil {
 				dc.logger.Error(
 					"Failed to retry dimension update",
 					zap.Error(err),

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -128,7 +128,7 @@ func TestDimensionClient(t *testing.T) {
 
 	t.Run("send dimension update with properties and tags", func(t *testing.T) {
 		server.reset()
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -161,7 +161,7 @@ func TestDimensionClient(t *testing.T) {
 
 	t.Run("same dimension with different values", func(t *testing.T) {
 		server.reset()
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -192,7 +192,7 @@ func TestDimensionClient(t *testing.T) {
 		client.dropTags = true
 		defer func() { client.dropTags = false }()
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -226,7 +226,7 @@ func TestDimensionClient(t *testing.T) {
 		server.respCode = http.StatusInternalServerError
 
 		// send a distinct prop/tag set for same dim with an error
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -261,7 +261,7 @@ func TestDimensionClient(t *testing.T) {
 		server.respCode = http.StatusBadRequest
 
 		// send a distinct prop/tag set for same dim with an error
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "aslfkj",
 			Properties: map[string]*string{
@@ -283,7 +283,7 @@ func TestDimensionClient(t *testing.T) {
 		server.respCode = http.StatusNotFound
 
 		// send a distinct prop/tag set for same dim with an error
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "id404",
 			Properties: map[string]*string{
@@ -312,7 +312,7 @@ func TestDimensionClient(t *testing.T) {
 		server.reset()
 		server.respCode = http.StatusBadRequest
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -344,7 +344,7 @@ func TestDimensionClient(t *testing.T) {
 		server.reset()
 		server.respCode = http.StatusBadRequest
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -368,7 +368,7 @@ func TestDimensionClient(t *testing.T) {
 	t.Run("send successive quick updates to same dim", func(t *testing.T) {
 		server.reset()
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -379,7 +379,7 @@ func TestDimensionClient(t *testing.T) {
 			},
 		}))
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -391,7 +391,7 @@ func TestDimensionClient(t *testing.T) {
 			},
 		}))
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "AWSUniqueID",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -428,7 +428,7 @@ func TestFlappyUpdates(t *testing.T) {
 
 	// Do some flappy updates
 	for i := range 5 {
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "pod_uid",
 			Value: "abcd",
 			Properties: map[string]*string{
@@ -436,7 +436,7 @@ func TestFlappyUpdates(t *testing.T) {
 			},
 		}))
 
-		require.NoError(t, client.acceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 			Name:  "pod_uid",
 			Value: "efgh",
 			Properties: map[string]*string{
@@ -470,7 +470,7 @@ func TestInvalidUpdatesNotSent(t *testing.T) {
 	client, server := setupTestClientServer(t)
 	defer server.shutdown()
 	defer client.Shutdown()
-	require.NoError(t, client.acceptDimension(&DimensionUpdate{
+	require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 		Name:  "host",
 		Value: "",
 		Properties: map[string]*string{
@@ -483,7 +483,7 @@ func TestInvalidUpdatesNotSent(t *testing.T) {
 	}))
 	server.handleRequest()
 
-	require.NoError(t, client.acceptDimension(&DimensionUpdate{
+	require.NoError(t, client.AcceptDimension(&DimensionUpdate{
 		Name:  "",
 		Value: "asdf",
 		Properties: map[string]*string{

--- a/exporter/signalfxexporter/internal/dimensions/entity_events.go
+++ b/exporter/signalfxexporter/internal/dimensions/entity_events.go
@@ -1,0 +1,132 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dimensions // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/dimensions"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
+)
+
+type EntityEventTransformer struct {
+	defaultProperties map[string]string
+}
+
+func NewEntityEventTransformer(defaultProperties map[string]string) *EntityEventTransformer {
+	return &EntityEventTransformer{
+		defaultProperties: defaultProperties,
+	}
+}
+
+func (t *EntityEventTransformer) TransformEntityEvent(event metadata.EntityEvent) (*DimensionUpdate, error) {
+	if event.EventType() != metadata.EventTypeState {
+		return nil, nil
+	}
+
+	state := event.EntityStateDetails()
+	entityType := state.EntityType()
+	entityID := event.ID()
+
+	dimKey, dimValue, err := extractDimensionKeyValue(entityType, entityID)
+	if err != nil {
+		return nil, err
+	}
+
+	properties, tags := t.extractPropertiesAndTags(state.Attributes())
+
+	return &DimensionUpdate{
+		Name:       dimKey,
+		Value:      dimValue,
+		Properties: properties,
+		Tags:       tags,
+	}, nil
+}
+
+func (t *EntityEventTransformer) extractPropertiesAndTags(attrs pcommon.Map) (map[string]*string, map[string]bool) {
+	properties := make(map[string]*string)
+	tags := make(map[string]bool)
+
+	for k, v := range t.defaultProperties {
+		properties[k] = &v
+	}
+
+	attrs.Range(func(k string, v pcommon.Value) bool {
+		key := sanitizeProperty(k)
+		if key == "" {
+			return true
+		}
+
+		valueStr := v.AsString()
+
+		if valueStr == "" {
+			tags[key] = true
+		} else {
+			propVal := valueStr
+			properties[key] = &propVal
+		}
+
+		return true
+	})
+
+	return properties, tags
+}
+
+func extractDimensionKeyValue(entityType string, entityID pcommon.Map) (string, string, error) {
+	switch entityType {
+	case "k8s.pod":
+		if v, ok := entityID.Get("k8s.pod.uid"); ok {
+			return "k8s.pod.uid", v.Str(), nil
+		}
+	case "k8s.node":
+		if v, ok := entityID.Get("k8s.node.uid"); ok {
+			return "k8s.node.uid", v.Str(), nil
+		}
+	case "k8s.namespace":
+		if v, ok := entityID.Get("k8s.namespace.uid"); ok {
+			return "k8s.namespace.uid", v.Str(), nil
+		}
+	case "k8s.replicaset":
+		if v, ok := entityID.Get("k8s.replicaset.uid"); ok {
+			return "k8s.replicaset.uid", v.Str(), nil
+		}
+	case "k8s.deployment":
+		if v, ok := entityID.Get("k8s.deployment.uid"); ok {
+			return "k8s.deployment.uid", v.Str(), nil
+		}
+	case "k8s.statefulset":
+		if v, ok := entityID.Get("k8s.statefulset.uid"); ok {
+			return "k8s.statefulset.uid", v.Str(), nil
+		}
+	case "k8s.daemonset":
+		if v, ok := entityID.Get("k8s.daemonset.uid"); ok {
+			return "k8s.daemonset.uid", v.Str(), nil
+		}
+	case "k8s.cronjob":
+		if v, ok := entityID.Get("k8s.cronjob.uid"); ok {
+			return "k8s.cronjob.uid", v.Str(), nil
+		}
+	case "k8s.job":
+		if v, ok := entityID.Get("k8s.job.uid"); ok {
+			return "k8s.job.uid", v.Str(), nil
+		}
+	case "k8s.hpa":
+		if v, ok := entityID.Get("k8s.hpa.uid"); ok {
+			return "k8s.hpa.uid", v.Str(), nil
+		}
+	case "k8s.replicationcontroller":
+		if v, ok := entityID.Get("k8s.replicationcontroller.uid"); ok {
+			return "k8s.replicationcontroller.uid", v.Str(), nil
+		}
+	case "container":
+		if v, ok := entityID.Get("container.id"); ok {
+			return "container.id", v.Str(), nil
+		}
+	default:
+		return "", "", fmt.Errorf("unsupported entity type: %s", entityType)
+	}
+
+	return "", "", fmt.Errorf("entity ID not found for type: %s", entityType)
+}

--- a/exporter/signalfxexporter/internal/dimensions/entity_events.go
+++ b/exporter/signalfxexporter/internal/dimensions/entity_events.go
@@ -76,53 +76,53 @@ func (t *EntityEventTransformer) extractPropertiesAndTags(attrs pcommon.Map) (ma
 
 func extractDimensionKeyValue(entityType string, entityID pcommon.Map) (string, string, error) {
 	switch entityType {
-	case "k8s.pod":
-		if v, ok := entityID.Get("k8s.pod.uid"); ok {
-			return "k8s.pod.uid", v.Str(), nil
-		}
-	case "k8s.node":
-		if v, ok := entityID.Get("k8s.node.uid"); ok {
-			return "k8s.node.uid", v.Str(), nil
-		}
-	case "k8s.namespace":
-		if v, ok := entityID.Get("k8s.namespace.uid"); ok {
-			return "k8s.namespace.uid", v.Str(), nil
-		}
-	case "k8s.replicaset":
-		if v, ok := entityID.Get("k8s.replicaset.uid"); ok {
-			return "k8s.replicaset.uid", v.Str(), nil
-		}
-	case "k8s.deployment":
-		if v, ok := entityID.Get("k8s.deployment.uid"); ok {
-			return "k8s.deployment.uid", v.Str(), nil
-		}
-	case "k8s.statefulset":
-		if v, ok := entityID.Get("k8s.statefulset.uid"); ok {
-			return "k8s.statefulset.uid", v.Str(), nil
-		}
-	case "k8s.daemonset":
-		if v, ok := entityID.Get("k8s.daemonset.uid"); ok {
-			return "k8s.daemonset.uid", v.Str(), nil
+	case "container":
+		if v, ok := entityID.Get("container.id"); ok {
+			return "container.id", v.Str(), nil
 		}
 	case "k8s.cronjob":
 		if v, ok := entityID.Get("k8s.cronjob.uid"); ok {
 			return "k8s.cronjob.uid", v.Str(), nil
 		}
-	case "k8s.job":
-		if v, ok := entityID.Get("k8s.job.uid"); ok {
-			return "k8s.job.uid", v.Str(), nil
+	case "k8s.daemonset":
+		if v, ok := entityID.Get("k8s.daemonset.uid"); ok {
+			return "k8s.daemonset.uid", v.Str(), nil
+		}
+	case "k8s.deployment":
+		if v, ok := entityID.Get("k8s.deployment.uid"); ok {
+			return "k8s.deployment.uid", v.Str(), nil
 		}
 	case "k8s.hpa":
 		if v, ok := entityID.Get("k8s.hpa.uid"); ok {
 			return "k8s.hpa.uid", v.Str(), nil
 		}
+	case "k8s.job":
+		if v, ok := entityID.Get("k8s.job.uid"); ok {
+			return "k8s.job.uid", v.Str(), nil
+		}
+	case "k8s.namespace":
+		if v, ok := entityID.Get("k8s.namespace.uid"); ok {
+			return "k8s.namespace.uid", v.Str(), nil
+		}
+	case "k8s.node":
+		if v, ok := entityID.Get("k8s.node.uid"); ok {
+			return "k8s.node.uid", v.Str(), nil
+		}
+	case "k8s.pod":
+		if v, ok := entityID.Get("k8s.pod.uid"); ok {
+			return "k8s.pod.uid", v.Str(), nil
+		}
+	case "k8s.replicaset":
+		if v, ok := entityID.Get("k8s.replicaset.uid"); ok {
+			return "k8s.replicaset.uid", v.Str(), nil
+		}
 	case "k8s.replicationcontroller":
 		if v, ok := entityID.Get("k8s.replicationcontroller.uid"); ok {
 			return "k8s.replicationcontroller.uid", v.Str(), nil
 		}
-	case "container":
-		if v, ok := entityID.Get("container.id"); ok {
-			return "container.id", v.Str(), nil
+	case "k8s.statefulset":
+		if v, ok := entityID.Get("k8s.statefulset.uid"); ok {
+			return "k8s.statefulset.uid", v.Str(), nil
 		}
 	default:
 		return "", "", fmt.Errorf("unsupported entity type: %s", entityType)

--- a/exporter/signalfxexporter/internal/dimensions/entity_events_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/entity_events_test.go
@@ -1,0 +1,334 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dimensions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
+)
+
+func TestEntityEventTransformer_TransformEntityEvent(t *testing.T) {
+	defaultProps := map[string]string{
+		"default_prop": "default_value",
+	}
+
+	transformer := NewEntityEventTransformer(defaultProps)
+
+	tests := []struct {
+		name           string
+		entityType     string
+		entityIDKey    string
+		entityIDValue  string
+		attributes     map[string]any
+		wantDimKey     string
+		wantDimValue   string
+		wantProperties map[string]*string
+		wantTags       map[string]bool
+		wantErr        bool
+	}{
+		{
+			name:          "k8s.pod with properties and tags",
+			entityType:    "k8s.pod",
+			entityIDKey:   "k8s.pod.uid",
+			entityIDValue: "pod-123",
+			attributes: map[string]any{
+				"k8s.pod.name":       "my-pod",
+				"k8s.namespace.name": "default",
+				"app":                "web",
+				"empty_tag":          "",
+			},
+			wantDimKey:   "k8s.pod.uid",
+			wantDimValue: "pod-123",
+			wantProperties: map[string]*string{
+				"default_prop":       strPtr("default_value"),
+				"k8s.pod.name":       strPtr("my-pod"),
+				"k8s.namespace.name": strPtr("default"),
+				"app":                strPtr("web"),
+			},
+			wantTags: map[string]bool{
+				"empty_tag": true,
+			},
+		},
+		{
+			name:          "k8s.node",
+			entityType:    "k8s.node",
+			entityIDKey:   "k8s.node.uid",
+			entityIDValue: "node-456",
+			attributes: map[string]any{
+				"k8s.node.name": "worker-1",
+			},
+			wantDimKey:   "k8s.node.uid",
+			wantDimValue: "node-456",
+			wantProperties: map[string]*string{
+				"default_prop":  strPtr("default_value"),
+				"k8s.node.name": strPtr("worker-1"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.namespace",
+			entityType:    "k8s.namespace",
+			entityIDKey:   "k8s.namespace.uid",
+			entityIDValue: "ns-789",
+			attributes: map[string]any{
+				"k8s.namespace.name": "production",
+			},
+			wantDimKey:   "k8s.namespace.uid",
+			wantDimValue: "ns-789",
+			wantProperties: map[string]*string{
+				"default_prop":       strPtr("default_value"),
+				"k8s.namespace.name": strPtr("production"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.deployment",
+			entityType:    "k8s.deployment",
+			entityIDKey:   "k8s.deployment.uid",
+			entityIDValue: "deploy-123",
+			attributes: map[string]any{
+				"k8s.deployment.name": "my-deployment",
+			},
+			wantDimKey:   "k8s.deployment.uid",
+			wantDimValue: "deploy-123",
+			wantProperties: map[string]*string{
+				"default_prop":        strPtr("default_value"),
+				"k8s.deployment.name": strPtr("my-deployment"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.replicaset",
+			entityType:    "k8s.replicaset",
+			entityIDKey:   "k8s.replicaset.uid",
+			entityIDValue: "rs-123",
+			attributes: map[string]any{
+				"k8s.replicaset.name": "my-rs",
+			},
+			wantDimKey:   "k8s.replicaset.uid",
+			wantDimValue: "rs-123",
+			wantProperties: map[string]*string{
+				"default_prop":        strPtr("default_value"),
+				"k8s.replicaset.name": strPtr("my-rs"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.statefulset",
+			entityType:    "k8s.statefulset",
+			entityIDKey:   "k8s.statefulset.uid",
+			entityIDValue: "ss-123",
+			attributes: map[string]any{
+				"k8s.statefulset.name": "my-statefulset",
+			},
+			wantDimKey:   "k8s.statefulset.uid",
+			wantDimValue: "ss-123",
+			wantProperties: map[string]*string{
+				"default_prop":         strPtr("default_value"),
+				"k8s.statefulset.name": strPtr("my-statefulset"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.daemonset",
+			entityType:    "k8s.daemonset",
+			entityIDKey:   "k8s.daemonset.uid",
+			entityIDValue: "ds-123",
+			attributes: map[string]any{
+				"k8s.daemonset.name": "my-daemonset",
+			},
+			wantDimKey:   "k8s.daemonset.uid",
+			wantDimValue: "ds-123",
+			wantProperties: map[string]*string{
+				"default_prop":       strPtr("default_value"),
+				"k8s.daemonset.name": strPtr("my-daemonset"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.cronjob",
+			entityType:    "k8s.cronjob",
+			entityIDKey:   "k8s.cronjob.uid",
+			entityIDValue: "cj-123",
+			attributes: map[string]any{
+				"k8s.cronjob.name": "my-cronjob",
+			},
+			wantDimKey:   "k8s.cronjob.uid",
+			wantDimValue: "cj-123",
+			wantProperties: map[string]*string{
+				"default_prop":     strPtr("default_value"),
+				"k8s.cronjob.name": strPtr("my-cronjob"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.job",
+			entityType:    "k8s.job",
+			entityIDKey:   "k8s.job.uid",
+			entityIDValue: "job-123",
+			attributes: map[string]any{
+				"k8s.job.name": "my-job",
+			},
+			wantDimKey:   "k8s.job.uid",
+			wantDimValue: "job-123",
+			wantProperties: map[string]*string{
+				"default_prop": strPtr("default_value"),
+				"k8s.job.name": strPtr("my-job"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.hpa",
+			entityType:    "k8s.hpa",
+			entityIDKey:   "k8s.hpa.uid",
+			entityIDValue: "hpa-123",
+			attributes: map[string]any{
+				"k8s.hpa.name": "my-hpa",
+			},
+			wantDimKey:   "k8s.hpa.uid",
+			wantDimValue: "hpa-123",
+			wantProperties: map[string]*string{
+				"default_prop": strPtr("default_value"),
+				"k8s.hpa.name": strPtr("my-hpa"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.replicationcontroller",
+			entityType:    "k8s.replicationcontroller",
+			entityIDKey:   "k8s.replicationcontroller.uid",
+			entityIDValue: "rc-123",
+			attributes: map[string]any{
+				"k8s.replicationcontroller.name": "my-rc",
+			},
+			wantDimKey:   "k8s.replicationcontroller.uid",
+			wantDimValue: "rc-123",
+			wantProperties: map[string]*string{
+				"default_prop":                   strPtr("default_value"),
+				"k8s.replicationcontroller.name": strPtr("my-rc"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "container",
+			entityType:    "container",
+			entityIDKey:   "container.id",
+			entityIDValue: "container-123",
+			attributes: map[string]any{
+				"container.name": "my-container",
+			},
+			wantDimKey:   "container.id",
+			wantDimValue: "container-123",
+			wantProperties: map[string]*string{
+				"default_prop":   strPtr("default_value"),
+				"container.name": strPtr("my-container"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:          "k8s.service property renaming",
+			entityType:    "k8s.pod",
+			entityIDKey:   "k8s.pod.uid",
+			entityIDValue: "pod-789",
+			attributes: map[string]any{
+				"k8s.service.name": "my-service",
+				"k8s.service.uid":  "svc-123",
+			},
+			wantDimKey:   "k8s.pod.uid",
+			wantDimValue: "pod-789",
+			wantProperties: map[string]*string{
+				"default_prop":            strPtr("default_value"),
+				"kubernetes_service_name": strPtr("my-service"),
+				"kubernetes_service_uid":  strPtr("svc-123"),
+			},
+			wantTags: map[string]bool{},
+		},
+		{
+			name:       "unsupported entity type",
+			entityType: "unknown.type",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create entity event slice and get an event from it
+			entityEvents := metadata.NewEntityEventsSlice()
+			entityEvent := entityEvents.AppendEmpty()
+
+			state := entityEvent.SetEntityState()
+			state.SetEntityType(tt.entityType)
+
+			// Set entity ID
+			if tt.entityIDKey != "" {
+				entityEvent.ID().PutStr(tt.entityIDKey, tt.entityIDValue)
+			}
+
+			// Set attributes
+			attrs := state.Attributes()
+			for k, v := range tt.attributes {
+				switch val := v.(type) {
+				case string:
+					attrs.PutStr(k, val)
+				case int:
+					attrs.PutInt(k, int64(val))
+				}
+			}
+
+			// Transform
+			dimUpdate, err := transformer.TransformEntityEvent(entityEvent)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, dimUpdate)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, dimUpdate)
+
+			assert.Equal(t, tt.wantDimKey, dimUpdate.Name)
+			assert.Equal(t, tt.wantDimValue, dimUpdate.Value)
+			assert.Equal(t, tt.wantProperties, dimUpdate.Properties)
+			assert.Equal(t, tt.wantTags, dimUpdate.Tags)
+		})
+	}
+}
+
+func TestEntityEventTransformer_DeleteEvent(t *testing.T) {
+	transformer := NewEntityEventTransformer(nil)
+
+	// Create delete event
+	entityEvents := metadata.NewEntityEventsSlice()
+	entityEvent := entityEvents.AppendEmpty()
+	deleteEvent := entityEvent.SetEntityDelete()
+	deleteEvent.SetEntityType("k8s.pod")
+
+	dimUpdate, err := transformer.TransformEntityEvent(entityEvent)
+	require.NoError(t, err)
+	assert.Nil(t, dimUpdate, "delete events should return nil")
+}
+
+func TestEntityEventTransformer_MissingEntityID(t *testing.T) {
+	transformer := NewEntityEventTransformer(nil)
+
+	// Create entity event without ID
+	entityEvents := metadata.NewEntityEventsSlice()
+	entityEvent := entityEvents.AppendEmpty()
+	state := entityEvent.SetEntityState()
+	state.SetEntityType("k8s.pod")
+
+	dimUpdate, err := transformer.TransformEntityEvent(entityEvent)
+	assert.Error(t, err)
+	assert.Nil(t, dimUpdate)
+	assert.Contains(t, err.Error(), "entity ID not found")
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/exporter/signalfxexporter/internal/dimensions/metadata.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata.go
@@ -108,7 +108,7 @@ func (dc *DimensionClient) PushMetadata(metadata []*metadata.MetadataUpdate) err
 			return fmt.Errorf("dimensionUpdate %v is missing Name or value, cannot send", dimensionUpdate)
 		}
 
-		errs = multierr.Append(errs, dc.acceptDimension(dimensionUpdate))
+		errs = multierr.Append(errs, dc.AcceptDimension(dimensionUpdate))
 	}
 
 	return errs

--- a/pkg/experimentalmetricmetadata/entity_events.go
+++ b/pkg/experimentalmetricmetadata/entity_events.go
@@ -23,7 +23,7 @@ const (
 	semconvOtelEntityInterval   = "otel.entity.interval"
 	semconvOtelEntityAttributes = "otel.entity.attributes"
 
-	semconvOtelEntityEventAsScope = "otel.entity.event_as_log"
+	SemconvOtelEntityEventAsScope = "otel.entity.event_as_log"
 )
 
 // EntityEventsSlice is a slice of EntityEvent.
@@ -34,6 +34,11 @@ type EntityEventsSlice struct {
 // NewEntityEventsSlice creates an empty EntityEventsSlice.
 func NewEntityEventsSlice() EntityEventsSlice {
 	return EntityEventsSlice{orig: plog.NewLogRecordSlice()}
+}
+
+// NewEntityEventsSliceFromLogs creates an EntityEventsSlice from a plog.LogRecordSlice.
+func NewEntityEventsSliceFromLogs(logs plog.LogRecordSlice) EntityEventsSlice {
+	return EntityEventsSlice{orig: logs}
 }
 
 // AppendEmpty will append to the end of the slice an empty EntityEvent.
@@ -65,7 +70,7 @@ func (s EntityEventsSlice) ConvertAndMoveToLogs() plog.Logs {
 	scopeLogs := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
 
 	// Set the scope marker.
-	scopeLogs.Scope().Attributes().PutBool(semconvOtelEntityEventAsScope, true)
+	scopeLogs.Scope().Attributes().PutBool(SemconvOtelEntityEventAsScope, true)
 
 	// Move all events. Note that this remove all
 	s.orig.MoveAndAppendTo(scopeLogs.LogRecords())

--- a/pkg/experimentalmetricmetadata/entity_events_test.go
+++ b/pkg/experimentalmetricmetadata/entity_events_test.go
@@ -92,7 +92,7 @@ func Test_EntityEventsSlice_ConvertAndMoveToLogs(t *testing.T) {
 	scopeLogs := logs.ResourceLogs().At(0).ScopeLogs().At(0)
 
 	// Check the Scope
-	v, ok := scopeLogs.Scope().Attributes().Get(semconvOtelEntityEventAsScope)
+	v, ok := scopeLogs.Scope().Attributes().Get(SemconvOtelEntityEventAsScope)
 	assert.True(t, ok)
 	assert.True(t, v.Bool())
 


### PR DESCRIPTION
Add support for processing entity events received via the logs pipeline and converting them to dimension property updates in the SignalFx exporter.

Fixes #27890
