### PR TITLE
[CHORE] Force conversion of classic histograms into NHCB

### DIFF
--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -188,6 +188,10 @@ In case a metric has both the conventional (aka classic) buckets and also native
 taken into account to create the corresponding exponential histogram. To scrape the classic buckets instead use the
 [scrape option](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) `always_scrape_classic_histograms`.
 
+The Prometheus receiver also forces classic histograms to be converted into native histograms with custom buckets
+(`convert_classic_histograms_to_nhcb: true`) for all scrape configs for performance reasons. Both Classic Histograms and NHCB are translated into the same
+OTLP Explicit Histogram metrics, but converting NHCB is way more efficient.
+
 ## OpenTelemetry Operator
 Additional to this static job definitions this receiver allows to query a list of jobs from the 
 OpenTelemetryOperators TargetAllocator or a compatible endpoint. 

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -185,12 +185,13 @@ receivers:
 
 This feature applies to the most common integer counter histograms; gauge histograms are dropped.
 In case a metric has both the conventional (aka classic) buckets and also native histogram buckets, only the native histogram buckets will be
-taken into account to create the corresponding exponential histogram. To scrape the classic buckets instead use the
-[scrape option](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) `always_scrape_classic_histograms`.
+taken into account to create the corresponding exponential histogram.
 
-The Prometheus receiver also forces classic histograms to be converted into native histograms with custom buckets
-(`convert_classic_histograms_to_nhcb: true`) for all scrape configs for performance reasons. Both Classic Histograms and NHCB are translated into the same
-OTLP Explicit Histogram metrics, but converting NHCB is way more efficient.
+The Prometheus receiver forces the following scrape configuration options for performance reasons:
+- `convert_classic_histograms_to_nhcb: true` - Classic histograms are converted to native histograms with custom buckets (NHCB).
+- `always_scrape_classic_histograms: false` - Classic histogram buckets are not scraped separately.
+
+Both Classic Histograms and NHCB are translated into the same OTLP Explicit Histogram metrics, but converting NHCB is significantly more efficient as it avoids per-bucket series state tracking.
 
 ## OpenTelemetry Operator
 Additional to this static job definitions this receiver allows to query a list of jobs from the 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -203,10 +203,17 @@ func forceClassicHistogramConversionToNHCB(cfg *PromConfig) {
 		return
 	}
 
+	// Force NHCB conversion and disable classic histogram scraping for performance reasons.
+	// Both classic histograms and NHCBs produce the same OTLP Explicit Histogram output,
+	// but NHCB conversion is significantly more efficient.
 	cfg.GlobalConfig.ConvertClassicHistogramsToNHCB = true
+	cfg.GlobalConfig.AlwaysScrapeClassicHistograms = false
+
 	enabled := true
+	disabled := false
 	for _, sc := range cfg.ScrapeConfigs {
 		sc.ConvertClassicHistogramsToNHCB = &enabled
+		sc.AlwaysScrapeClassicHistograms = &disabled
 	}
 }
 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -194,7 +194,20 @@ func reloadPromConfig(dst *PromConfig, src any) error {
 	}
 	copyStaticConfig((*PromConfig)(newCfg), src)
 	*dst = PromConfig(*newCfg)
+	forceClassicHistogramConversionToNHCB(dst)
 	return nil
+}
+
+func forceClassicHistogramConversionToNHCB(cfg *PromConfig) {
+	if cfg == nil {
+		return
+	}
+
+	cfg.GlobalConfig.ConvertClassicHistogramsToNHCB = true
+	enabled := true
+	for _, sc := range cfg.ScrapeConfigs {
+		sc.ConvertClassicHistogramsToNHCB = &enabled
+	}
 }
 
 func validateHTTPClientConfig(cfg *commonconfig.HTTPClientConfig) error {

--- a/receiver/prometheusreceiver/internal/targetallocator/manager.go
+++ b/receiver/prometheusreceiver/internal/targetallocator/manager.go
@@ -145,6 +145,7 @@ func (m *Manager) sync(compareHash uint64, httpClient *http.Client) (uint64, err
 	copy(initialConfig, m.initialScrapeConfigs)
 
 	m.promCfg.ScrapeConfigs = initialConfig
+	convertClassicHistograms := true
 
 	for jobName, scrapeConfig := range scrapeConfigsResponse {
 		var httpSD promHTTP.SDConfig
@@ -176,6 +177,8 @@ func (m *Manager) sync(compareHash uint64, httpClient *http.Client) (uint64, err
 		if scrapeConfig.ScrapeFallbackProtocol == "" {
 			scrapeConfig.ScrapeFallbackProtocol = promconfig.PrometheusText0_0_4
 		}
+
+		scrapeConfig.ConvertClassicHistogramsToNHCB = &convertClassicHistograms
 
 		// Validate the scrape config and also fill in the defaults from the global config as needed.
 		err = scrapeConfig.Validate(m.promCfg.GlobalConfig)

--- a/receiver/prometheusreceiver/internal/targetallocator/manager.go
+++ b/receiver/prometheusreceiver/internal/targetallocator/manager.go
@@ -146,6 +146,7 @@ func (m *Manager) sync(compareHash uint64, httpClient *http.Client) (uint64, err
 
 	m.promCfg.ScrapeConfigs = initialConfig
 	convertClassicHistograms := true
+	alwaysScrapeClassic := false
 
 	for jobName, scrapeConfig := range scrapeConfigsResponse {
 		var httpSD promHTTP.SDConfig
@@ -179,6 +180,7 @@ func (m *Manager) sync(compareHash uint64, httpClient *http.Client) (uint64, err
 		}
 
 		scrapeConfig.ConvertClassicHistogramsToNHCB = &convertClassicHistograms
+		scrapeConfig.AlwaysScrapeClassicHistograms = &alwaysScrapeClassic
 
 		// Validate the scrape config and also fill in the defaults from the global config as needed.
 		err = scrapeConfig.Validate(m.promCfg.GlobalConfig)

--- a/receiver/prometheusreceiver/internal/targetallocator/manager_test.go
+++ b/receiver/prometheusreceiver/internal/targetallocator/manager_test.go
@@ -108,6 +108,7 @@ func TestSyncForcesClassicHistogramConversionToNHCB(t *testing.T) {
 			_, _ = w.Write([]byte(`test:
   job_name: "test"
   convert_classic_histograms_to_nhcb: false
+  always_scrape_classic_histograms: true
 `))
 			return
 		}
@@ -148,8 +149,12 @@ func TestSyncForcesClassicHistogramConversionToNHCB(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, manager.promCfg.ScrapeConfigs, 1)
+	// Verify NHCB conversion is forced to true
 	require.NotNil(t, manager.promCfg.ScrapeConfigs[0].ConvertClassicHistogramsToNHCB)
 	assert.True(t, *manager.promCfg.ScrapeConfigs[0].ConvertClassicHistogramsToNHCB)
+	// Verify classic histogram scraping is forced to false
+	require.NotNil(t, manager.promCfg.ScrapeConfigs[0].AlwaysScrapeClassicHistograms)
+	assert.False(t, *manager.promCfg.ScrapeConfigs[0].AlwaysScrapeClassicHistograms)
 }
 
 func TestInstantiateShard(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This idea came up after talking with @bwplotka about the appenderv2 adoption. Is there a reason not to force ScrapeManager to convert classic histograms into NHCB? If we assume all histograms are ingested that way, we could eventually get rid of state handling for classic histograms.

I'm not adding a changelog entry because, theoretically, it has no impact on the end user. 

Would love to get your opinions here @dashpole @krajorama 