### PR TITLE
[receiver/tlscheckreceiver] allow scraping all certs

### DIFF
--- a/.chloggen/tlscheck-scrape-all-certs.yaml
+++ b/.chloggen/tlscheck-scrape-all-certs.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: receiver/tlscheck
+note: Add a "scrape_all_certs" option to TLS Check Receiver to record metrics for all certificates found on an endpoint or in a file.
+issues: [45615]
+subtext: This can be useful for monitoring intermediate certificates on an endpoint, or monitoring several CA certificates in a PEM bundle file.
+change_logs: [user]

--- a/receiver/tlscheckreceiver/README.md
+++ b/receiver/tlscheckreceiver/README.md
@@ -21,7 +21,7 @@ By default, the TLS Check Receiver will emit a single metric, `tlscheck.time_lef
 
 ## Example Configuration
 
-Targets are configured as either remote enpoints accessed via TCP, or PEM-encoded certificate files stored locally on disk.
+Targets are configured as either remote enpoints accessed via TCP, or PEM-encoded certificate files stored locally on disk. By default only the first certificate in a file or presented by an endpoint (i.e. the leaf certificate) is monitored. The `scrape_all_certs` option can be used to monitor all certificates in a PEM bundle or all certificates presented by an endpoint.
 
 ```yaml
 receivers:
@@ -29,6 +29,10 @@ receivers:
     targets:
       # Monitor a local PEM file
       - file_path: /etc/istio/certs/cert-chain.pem
+      
+      # Monitor all certificates in a PEM bundle
+      - file_path: /etc/ssl/certs/ca-bundle.crt
+        scrape_all_certs: true
       
       # Monitor a remote endpoint
       - endpoint: example.com:443

--- a/receiver/tlscheckreceiver/config.go
+++ b/receiver/tlscheckreceiver/config.go
@@ -21,6 +21,7 @@ var errInvalidEndpoint = errors.New(`"endpoint" must be in the form of <hostname
 type CertificateTarget struct {
 	confignet.TCPAddrConfig `mapstructure:",squash"`
 	FilePath                string `mapstructure:"file_path"`
+	ScrapeAllCerts          bool   `mapstructure:"scrape_all_certs"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}


### PR DESCRIPTION
#### Description

This allows scraping all certificates in a PEM bundle, or all certificates returned by an endpoint, rather than just the leaf certificate. It can be useful to monitor which certificates are used in a bundle, or monitor when intermediate or CA certificates are due to expire.

Our use case for this is monitoring our private CA rotation process. We have a private CA with a relatively short-lived CA certificate, and rotate the CA cert by rolling out the new cert in a PEM bundle of trusted CAs, alongside the old CA cert. While the CA rotation is in progress, the PEM bundle contains both CA certificates, and servers using it will trust both CAs. It's therefore useful for us to be able to monitor all certificates in a PEM bundle, to confirm all servers have both CA certs in their file, and to monitor if any servers are still using an old CA cert which expires soon.

#### Link to tracking issue

This PR #45615

#### Testing

`scraper_test.go` tests scraping 2 certs in a file, I've also tested this in a real pipeline feeding to our internal Prometheus which produces the expected datapoints for a CA bundle with two different certificates in.

#### Documentation

Documentation of this option and an example has been added to the README.