### PR TITLE
[pkg/translator/azure] Updated OpenTelemetry semantic conversion to t…

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/azure
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updated OpenTelemetry semantic conversion to the latest version 1.38.0 in azure pkg.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44801]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/pkg/translator/azure/resourcelogs_to_logs.go
+++ b/pkg/translator/azure/resourcelogs_to_logs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/relvacode/iso8601"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventionsv125 "go.opentelemetry.io/otel/semconv/v1.25.0"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -222,7 +221,7 @@ func extractRawAttributes(log azureLogRecord) map[string]any {
 	setIf(attrs, string(conventions.CloudRegionKey), log.Location)
 	attrs[string(conventions.CloudProviderKey)] = conventions.CloudProviderAzure.Value.AsString()
 
-	setIf(attrs, string(conventionsv125.NetSockPeerAddrKey), log.CallerIPAddress)
+	setIf(attrs, string(conventions.NetworkPeerAddressKey), log.CallerIPAddress)
 	return attrs
 }
 

--- a/pkg/translator/azure/resourcelogs_to_logs_test.go
+++ b/pkg/translator/azure/resourcelogs_to_logs_test.go
@@ -52,7 +52,7 @@ var maximumLogRecord1 = func() plog.LogRecord {
 	lr.Attributes().PutStr(azureResultSignature, "Signature")
 	lr.Attributes().PutStr(azureResultDescription, "Description")
 	lr.Attributes().PutInt(azureDuration, 1234)
-	lr.Attributes().PutStr("net.sock.peer.addr", "127.0.0.1")
+	lr.Attributes().PutStr("network.peer.address", "127.0.0.1")
 	lr.Attributes().PutStr("cloud.region", "ukso")
 	lr.Attributes().PutStr("cloud.provider", "azure")
 
@@ -86,7 +86,7 @@ var maximumLogRecord2 = func() []plog.LogRecord {
 	lr.Attributes().PutStr(azureResultSignature, "Signature")
 	lr.Attributes().PutStr(azureResultDescription, "Description")
 	lr.Attributes().PutInt(azureDuration, 4321)
-	lr.Attributes().PutStr("net.sock.peer.addr", "127.0.0.1")
+	lr.Attributes().PutStr("network.peer.address", "127.0.0.1")
 	lr.Attributes().PutStr("cloud.region", "ukso")
 	lr.Attributes().PutStr("cloud.provider", "azure")
 
@@ -112,7 +112,7 @@ var maximumLogRecord2 = func() []plog.LogRecord {
 	lr2.Attributes().PutStr(azureResultSignature, "Signature")
 	lr2.Attributes().PutStr(azureResultDescription, "Description")
 	lr2.Attributes().PutInt(azureDuration, 321)
-	lr2.Attributes().PutStr("net.sock.peer.addr", "127.0.0.1")
+	lr2.Attributes().PutStr("network.peer.address", "127.0.0.1")
 	lr2.Attributes().PutStr("cloud.region", "ukso")
 	lr2.Attributes().PutStr("cloud.provider", "azure")
 
@@ -141,7 +141,7 @@ var badLevelLogRecord = func() plog.LogRecord {
 	lr.Attributes().PutStr(azureCorrelationID, guid)
 	lr.Attributes().PutStr(azureResultType, "Succeeded")
 	lr.Attributes().PutInt(azureDuration, 243)
-	lr.Attributes().PutStr("net.sock.peer.addr", "13.14.15.16")
+	lr.Attributes().PutStr("network.peer.address", "13.14.15.16")
 	lr.Attributes().PutStr("cloud.region", "West US")
 	lr.Attributes().PutStr("cloud.provider", "azure")
 
@@ -364,7 +364,7 @@ func TestExtractRawAttributes(t *testing.T) {
 				azureResultSignature:   "result.signature",
 				azureResultDescription: "result.description",
 				azureDuration:          int64(1234),
-				"net.sock.peer.addr":   "127.0.0.1",
+				"network.peer.address": "127.0.0.1",
 				azureIdentity:          "someone",
 				"cloud.region":         "location",
 				"cloud.provider":       "azure",

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -155,7 +155,7 @@ and the OpenTelemetry attributes.
 
 | Azure                            | OpenTelemetry                          |
 |----------------------------------|----------------------------------------|
-| callerIpAddress (optional)       | net.sock.peer.addr (attribute)         |
+| callerIpAddress (optional)       | network.peer.address (attribute)       |
 | correlationId (optional)         | azure.correlation.id (attribute)       |
 | category (optional)              | azure.category (attribute)             |
 | durationMs (optional)            | azure.duration (attribute)             |


### PR DESCRIPTION
…he latest version 1.38.0 (#44801)

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Removed module `go.opentelemetry/otel/semconv` v1.25.0 in `pkg/translator/azure` to use the latest semantic convention in v1.38.0.   
- Changed the convention key from `NetSockPeerAddrKey` to `NetworkPeerAddressKey`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44801 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

All unit tests were ran locally and passed.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
