### PR TITLE
[ci] ensure auto-assign is skipped if is there 1 assignee already

### DIFF
--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -1,4 +1,4 @@
-name: 'Auto Assign'
+name: "Auto Assign"
 on:
   pull_request_target:
     types:
@@ -17,10 +17,10 @@ jobs:
     permissions:
       pull-requests: write # required for assigning reviewers to PRs
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && toJSON(github.event.pull_request.assignees) == '[]' }}
     steps:
       - name: run
         uses: kentaro-m/auto-assign-action@a6d59add3a817df08cafa9b166367768d2c337f8 # v2.0.1
         with:
           configuration-path: ".github/auto_assign.yml"
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

When a PR already has an assignee, when it is moved back to draft and back again to ready, a new assignee will be added. That action will happen every time a PR is moved back from draft to ready, with a possibility of all possible assignees being assigned to a PR.

This change ensures the action will run only when there is no assignee defined. The impact is small, and I think it is valuable to keep the assignment process clean.

Relates to https://github.com/kentaro-m/auto-assign-action/issues/16