### PR TITLE
tailsamplingprocessor: add optional interface `StoppableEvaluator`

### DIFF
--- a/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
+++ b/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional interface `StoppableEvaluator` to allow evaluators to clean up resources
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  More complex evaluators might allocate resources to manage their internal state, this PR adds an
+  optional interface `StoppableEvaluator` which allows the tailsamplingprocessor to call `Stop`
+  when the evaluator is unloaded. `Stop` is expected to not block and will be called when the policy
+  is replaced or the processor is shut down.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
+++ b/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
@@ -10,7 +10,7 @@ component: processor/tailsamplingprocessor
 note: Add optional interface `StoppableEvaluator` to allow evaluators to clean up resources
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [45645]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
+++ b/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
@@ -28,4 +28,4 @@ subtext: |
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [api]
+change_logs: []

--- a/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
+++ b/.chloggen/tailsamplingprocessor-stoppable evaluator.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: processor/tailsamplingprocessor
+component: processor/tail_sampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add optional interface `StoppableEvaluator` to allow evaluators to clean up resources

--- a/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
+++ b/processor/tailsamplingprocessor/pkg/samplingpolicy/samplingpolicy.go
@@ -56,6 +56,15 @@ type Evaluator interface {
 	Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error)
 }
 
+// StoppableEvaluator is an optional interface that Evaluators can implement.
+// If implemented, the tail sampling processor will call Stop before removing or
+// replacing the evaluator.
+type StoppableEvaluator interface {
+	// Stop gives the evaluator a chance to release any resources. Calling Stop
+	// should not block as it can be called in between ticks.
+	Stop()
+}
+
 type Extension interface {
 	NewEvaluator(policyName string, cfg map[string]any) (Evaluator, error)
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -500,6 +500,11 @@ func (tsp *tailSamplingSpanProcessor) iter(tickChan <-chan time.Time, workChan <
 			tsp.processTrace(trace.id, trace.rss, trace.spanCount, trace.rootSpan != nil)
 		}
 	case cmd := <-tsp.newPolicyChan:
+		for _, policy := range tsp.policies {
+			if evaluator, ok := policy.evaluator.(samplingpolicy.StoppableEvaluator); ok {
+				evaluator.Stop()
+			}
+		}
 		tsp.policies = cmd.policies
 		tsp.logger.Debug("New policies loaded", zap.Int("policies.len", len(tsp.policies)))
 	case maxTraceSize := <-tsp.newTraceSizeChan:
@@ -864,6 +869,13 @@ func (tsp *tailSamplingSpanProcessor) Shutdown(context.Context) error {
 	if tsp.doneChan != nil {
 		<-tsp.doneChan
 	}
+
+	for _, policy := range tsp.policies {
+		if evaluator, ok := policy.evaluator.(samplingpolicy.StoppableEvaluator); ok {
+			evaluator.Stop()
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Description

This PR adds an optional interface `StoppableEvaluator`. This interface can be seen as an extension of `Evaluator` in `samplingpolicy` and will support development of more advanced evaluators.

More complex evaluators might allocate resources to manage their internal state. By implementing `StoppableEvaluator`, the evaluator can signal the tailsamplingprocessor to call `Stop` when the evaluator is unloaded. `Stop` is expected to not block and will be called when the policy is replaced or the entire processor is shut down.

#### Testing

Added test cases to cover both situations in which policies are replaced/removed.
