### PR TITLE
[receiver/faro] Updates faroreceiver http server to respond to collect calls with http.StatusAccepted (status code 202) as per the faro openAPI schema

### DIFF
--- a/.chloggen/avijay-fix-faroreceiver-status-code.yaml
+++ b/.chloggen/avijay-fix-faroreceiver-status-code.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: 'receiver/faro'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Updates Faroreceiver to return HTTP 202 Accepted status code upon successful data ingestion to comply with the OpenAPI specification.'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45648]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/faroreceiver/receiver.go
+++ b/receiver/faroreceiver/receiver.go
@@ -213,7 +213,7 @@ func (r *faroReceiver) handleFaroRequest(resp http.ResponseWriter, req *http.Req
 		return
 	}
 
-	resp.WriteHeader(http.StatusOK)
+	resp.WriteHeader(http.StatusAccepted)
 }
 
 type errorResponse struct {

--- a/receiver/faroreceiver/receiver_test.go
+++ b/receiver/faroreceiver/receiver_test.go
@@ -40,19 +40,19 @@ func TestFaroReceiver_Start(t *testing.T) {
 		{
 			name:               "minimal-traces-only",
 			payload:            filepath.Join("testdata", "traces", "minimal-traces-only.json"),
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusAccepted,
 			expectedTraces:     filepath.Join("testdata", "golden", "minimal-traces-only.yaml"),
 		},
 		{
 			name:               "minimal-logs-only",
 			payload:            filepath.Join("testdata", "logs", "minimal-logs-only.json"),
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusAccepted,
 			expectedLogs:       filepath.Join("testdata", "golden", "minimal-logs-only.yaml"),
 		},
 		{
 			name:               "minimal-logs-and-traces-only",
 			payload:            filepath.Join("testdata", "logsandtraces", "minimal-only.json"),
-			expectedStatusCode: http.StatusOK,
+			expectedStatusCode: http.StatusAccepted,
 			expectedLogs:       filepath.Join("testdata", "golden", "minimal-logs-only.yaml"),
 			expectedTraces:     filepath.Join("testdata", "golden", "minimal-traces-only.yaml"),
 		},


### PR DESCRIPTION
#### Description
Hey folks - this is a small PR to update the faroreceiver http response code to conform to the official [Faro OpenAPI Schema](https://github.com/grafana/faro/blob/main/spec/gen/faro.gen.yaml#L41).  In addition we can also see that this is what is followed by [Faro collector in Grafana Alloy](https://github.com/grafana/alloy/blob/main/internal/component/faro/receiver/handler.go#L197). 


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Given that this is such a small PR I have not created a issue for it yet. If this is a required step - I'm happy to create one. 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Ran the fork in a docker compose environment to validate the response codes are now returning status 202 to conform to the OpenAPI spec. 

<!--Describe the documentation added.-->
#### Documentation
No docs added. 
