### PR TITLE
[exporter/kafkaexporter] Break up traces when exporting to kafka

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ repository:
 
   The actual name of the binary will depend on your platform. For example, on Linux x64, use `./bin/otelcontribcol_linux_amd64`.
 
-Replace `otel-config.yaml` with the appropriate configuration file as needed.
+Replace `otel-config.yaml` with the appropriate configuration file as needed. You may find example configurations in the main `opentelemetry-collector` repository too. 
 
 3. Verify that your changes are reflected in the contrib Collector's behavior by
    testing it against the provided configuration.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -92,6 +92,8 @@ The following settings can be optionally configured:
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
   - `max_elapsed_time` (default = 300s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
 - `sending_queue`: see [Exporter Helper](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper/README.md) for the full set of available options.
+  If `sending_queue::batch` is not set, the exporter enables batching by default with the bytes sizer and `max_size` = `producer.max_message_bytes` minus a reserved overhead (for Kafka message key and headers), so that produced messages stay within Kafka's message size limits.
+  If you set `sending_queue::batch` explicitly, ensure `max_size` accounts for Kafka's `max_message_bytes` and key/header overhead to avoid `MessageTooLarge` errors.
   - `enabled` (default = true)
   - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
   - `queue_size` (default = 1000): Maximum number of batches kept in memory before dropping data; ignored if `enabled` is `false`;

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -5,6 +5,7 @@ package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"errors"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -14,6 +15,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 )
+
+// kafkaOverheadBytes is the reserved bytes for Kafka message key and headers so that
+// batch max_size stays under producer max_message_bytes when the exporter adds keys/headers.
+const kafkaOverheadBytes = 256
 
 var _ component.Config = (*Config)(nil)
 
@@ -84,6 +89,10 @@ type Config struct {
 	// selection falls back to the Kafka client’s default strategy. Resource
 	// attributes are not used for the key when this option is enabled.
 	PartitionLogsByTraceID bool `mapstructure:"partition_logs_by_trace_id"`
+
+	// userSetSendingQueueBatch is set during Unmarshal when the user explicitly sets sending_queue::batch.
+	// The factory uses it to log a warning so users consider Kafka max_message_bytes.
+	userSetSendingQueueBatch bool
 }
 
 func (c *Config) Validate() (err error) {
@@ -132,6 +141,30 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 			c.Profiles.Encoding = c.Encoding
 		}
 	}
+
+	// We break up traces into smaller messages so they fit on kafka using sending_queue's batch mechanism.
+	// If a user has already set sending_queue::batch, we log warnings saying they may want to
+	// set it to what we recommend for the kafkaexporter to correctly break up traces that will
+	// fit into kafka messages.
+	// If a user has not set sending_queue::batch, we set it to what we recommend.
+	if conf.IsSet("sending_queue::batch") {
+		c.userSetSendingQueueBatch = true
+	} else {
+		queueConfig := c.QueueBatchConfig.GetOrInsertDefault()
+
+		// The batch mechanism sizes traces, but the kafkaexporter inevitably adds
+		// more bytes, which would increase the total kf message size.
+		batchMaxSize := c.Producer.MaxMessageBytes - kafkaOverheadBytes
+		if batchMaxSize > 0 {
+			queueConfig.Batch = configoptional.Some(exporterhelper.BatchConfig{
+				Sizer:        exporterhelper.RequestSizerTypeBytes,
+				MaxSize:      int64(batchMaxSize),
+				FlushTimeout: 200 * time.Millisecond,
+				MinSize:      0,
+			})
+		}
+	}
+
 	return conf.Unmarshal(c)
 }
 

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -20,6 +21,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
 )
+
+// megabyte is 1 MB in bytes (decimal, 10^6). Used for test config values matching Kafka's max.message.bytes.
+const megabyte = 1_000_000
+
+// testdata/config.yaml sets producer.max_message_bytes to this value (10 MB) for the "kafka" test case.
+const testConfigYAMLMaxMessageBytes = 10 * megabyte
 
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()
@@ -48,6 +55,14 @@ func TestLoadConfig(t *testing.T) {
 					queue := exporterhelper.NewDefaultQueueConfig()
 					queue.NumConsumers = 2
 					queue.QueueSize = 10
+					// Unmarshal auto-populates a default batch when sending_queue::batch is not set
+					// (from producer.max_message_bytes - kafkaOverheadBytes). Expected config must match.
+					queue.Batch = configoptional.Some(exporterhelper.BatchConfig{
+						Sizer:        exporterhelper.RequestSizerTypeBytes,
+						MaxSize:      int64(testConfigYAMLMaxMessageBytes - kafkaOverheadBytes),
+						FlushTimeout: 200 * time.Millisecond,
+						MinSize:      0,
+					})
 					return queue
 				}()),
 				ClientConfig: func() configkafka.ClientConfig {
@@ -57,7 +72,7 @@ func TestLoadConfig(t *testing.T) {
 				}(),
 				Producer: func() configkafka.ProducerConfig {
 					config := configkafka.NewDefaultProducerConfig()
-					config.MaxMessageBytes = 10000000
+					config.MaxMessageBytes = testConfigYAMLMaxMessageBytes
 					config.RequiredAcks = configkafka.WaitForAll
 					return config
 				}(),
@@ -89,9 +104,20 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
 				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
-				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
-				ClientConfig:     configkafka.NewDefaultClientConfig(),
-				Producer:         configkafka.NewDefaultProducerConfig(),
+				QueueBatchConfig: configoptional.Some(func() exporterhelper.QueueBatchConfig {
+					q := exporterhelper.NewDefaultQueueConfig()
+					// Unmarshal auto-populates a default batch when sending_queue::batch is not set
+					// (from producer.max_message_bytes - kafkaOverheadBytes). Expected config must match.
+					q.Batch = configoptional.Some(exporterhelper.BatchConfig{
+						Sizer:        exporterhelper.RequestSizerTypeBytes,
+						MaxSize:      int64(1000000 - kafkaOverheadBytes),
+						FlushTimeout: 200 * time.Millisecond,
+						MinSize:      0,
+					})
+					return q
+				}()),
+				ClientConfig: configkafka.NewDefaultClientConfig(),
+				Producer:     configkafka.NewDefaultProducerConfig(),
 				Logs: SignalConfig{
 					Topic:                "legacy_topic",
 					Encoding:             "otlp_proto",
@@ -117,9 +143,20 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
 				BackOffConfig:    configretry.NewDefaultBackOffConfig(),
-				QueueBatchConfig: configoptional.Some(exporterhelper.NewDefaultQueueConfig()),
-				ClientConfig:     configkafka.NewDefaultClientConfig(),
-				Producer:         configkafka.NewDefaultProducerConfig(),
+				QueueBatchConfig: configoptional.Some(func() exporterhelper.QueueBatchConfig {
+					q := exporterhelper.NewDefaultQueueConfig()
+					// Unmarshal auto-populates a default batch when sending_queue::batch is not set
+					// (from producer.max_message_bytes - kafkaOverheadBytes). Expected config must match.
+					q.Batch = configoptional.Some(exporterhelper.BatchConfig{
+						Sizer:        exporterhelper.RequestSizerTypeBytes,
+						MaxSize:      int64(1000000 - kafkaOverheadBytes),
+						FlushTimeout: 200 * time.Millisecond,
+						MinSize:      0,
+					})
+					return q
+				}()),
+				ClientConfig: configkafka.NewDefaultClientConfig(),
+				Producer:     configkafka.NewDefaultProducerConfig(),
 				Logs: SignalConfig{
 					Topic:    "otlp_logs",
 					Encoding: "legacy_encoding",
@@ -184,4 +221,65 @@ func TestLoadConfigFailed(t *testing.T) {
 			assert.ErrorIs(t, xconfmap.Validate(cfg), tt.expectedError)
 		})
 	}
+}
+
+func TestConfig_DefaultSendingQueueBatchWhenNotSet(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: config with producer.max_message_bytes set and sending_queue::batch not set
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"producer": map[string]any{
+			"max_message_bytes": megabyte,
+		},
+	})
+
+	// WHEN: config is unmarshaled
+	require.NoError(t, cfg.Unmarshal(conf))
+
+	// THEN: userSetSendingQueueBatch is false and default batch is applied (bytes sizer,
+	// max_size = producer.max_message_bytes - kafkaOverheadBytes, default flush_timeout and min_size)
+	assert.False(t, cfg.userSetSendingQueueBatch)
+	require.True(t, cfg.QueueBatchConfig.HasValue())
+	queueBatchConfig := cfg.QueueBatchConfig.GetOrInsertDefault()
+	require.True(t, queueBatchConfig.Batch.HasValue())
+	batch := queueBatchConfig.Batch.Get()
+	assert.Equal(t, exporterhelper.RequestSizerTypeBytes, batch.Sizer)
+	assert.Equal(t, int64(megabyte - kafkaOverheadBytes), batch.MaxSize)
+	assert.Equal(t, 200*time.Millisecond, batch.FlushTimeout)
+	assert.Equal(t, int64(0), batch.MinSize)
+}
+
+func TestConfig_UserSetSendingQueueBatchPreserved(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN: config with producer.max_message_bytes and sending_queue::batch explicitly set
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"producer": map[string]any{
+			"max_message_bytes": 2000000,
+		},
+		"sending_queue": map[string]any{
+			"batch": map[string]any{
+				"sizer":         "bytes",
+				"max_size":      5000,
+				"min_size":      100,
+				"flush_timeout": "100ms",
+			},
+		},
+	})
+
+	// WHEN: config is unmarshaled
+	require.NoError(t, cfg.Unmarshal(conf))
+
+	// THEN: userSetSendingQueueBatch is true and user batch values are preserved
+	assert.True(t, cfg.userSetSendingQueueBatch)
+	require.True(t, cfg.QueueBatchConfig.HasValue())
+	queueBatchConfig := cfg.QueueBatchConfig.GetOrInsertDefault()
+	require.True(t, queueBatchConfig.Batch.HasValue())
+	batch := queueBatchConfig.Batch.Get()
+	assert.Equal(t, exporterhelper.RequestSizerTypeBytes, batch.Sizer)
+	assert.Equal(t, int64(5000), batch.MaxSize)
+	assert.Equal(t, int64(100), batch.MinSize)
+	assert.Equal(t, 100*time.Millisecond, batch.FlushTimeout)
 }

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -5,6 +5,7 @@ package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configoptional"
@@ -14,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
 	"go.opentelemetry.io/collector/exporter/xexporter"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka"
@@ -36,6 +38,40 @@ const (
 	// partitioning logs by trace id is disabled by default
 	defaultPartitionLogsByTraceIDEnabled = false
 )
+
+// logSendingQueueBatchWarnings logs warnings when the user set sending_queue::batch
+// but the config may lead to MessageTooLarge errors: (1) batch sizer is not "bytes",
+// or (2) batch uses bytes sizer but max_size exceeds producer max_message_bytes minus overhead.
+func logSendingQueueBatchWarnings(cfg *Config, logger *zap.Logger) {
+	if !cfg.userSetSendingQueueBatch {
+		// User did not set sending_queue::batch. No possible conflicting settings
+		// to warn about.
+		return
+	}
+	if !cfg.QueueBatchConfig.HasValue() {
+		return
+	}
+	queueConfig := cfg.QueueBatchConfig.GetOrInsertDefault()
+	if !queueConfig.Batch.HasValue() {
+		return
+	}
+	batch := queueConfig.Batch.Get()
+	recommendedMaxSize := cfg.Producer.MaxMessageBytes - kafkaOverheadBytes
+
+	if batch.Sizer != exporterhelper.RequestSizerTypeBytes {
+		logger.Warn(
+			"sending_queue::batch was explicitly set; for Kafka, set batch::sizer to \"bytes\" so payloads sent stay within Kafka message size limits.",
+		)
+	}
+	if batch.Sizer == exporterhelper.RequestSizerTypeBytes && batch.MaxSize > 0 && int64(recommendedMaxSize) < batch.MaxSize {
+		logger.Warn(
+			fmt.Sprintf(
+				"sending_queue::batch was explicitly set with bytes sizer; set batch::max_size to at most producer.max_message_bytes minus key/header overhead (%d bytes) to avoid MessageTooLarge errors.",
+				recommendedMaxSize,
+			),
+		)
+	}
+}
 
 // NewFactory creates Kafka exporter factory.
 func NewFactory() exporter.Factory {
@@ -84,6 +120,7 @@ func createTracesExporter(
 	cfg component.Config,
 ) (exporter.Traces, error) {
 	oCfg := *(cfg.(*Config)) // Clone the config
+	logSendingQueueBatchWarnings(&oCfg, set.Logger)
 	exp := newTracesExporter(oCfg, set)
 	return exporterhelper.NewTraces(
 		ctx,

--- a/exporter/kafkaexporter/internal/marshaler/pdata_marshaler.go
+++ b/exporter/kafkaexporter/internal/marshaler/pdata_marshaler.go
@@ -65,9 +65,6 @@ type pdataTracesMarshaler struct {
 // ptrace.Traces using the given ptrace.Marshaler. This can be used
 // with the standard OTLP marshalers in the ptrace package, or with
 // encoding extensions.
-//
-// We split each trace's spans into its own payload to reduce the size of the
-// payload and increase the chances it will fit a single kafka message.
 func NewPdataTracesMarshaler(m ptrace.Marshaler) TracesMarshaler {
 	return pdataTracesMarshaler{marshaler: m}
 }

--- a/exporter/kafkaexporter/internal/marshaler/pdata_marshaler.go
+++ b/exporter/kafkaexporter/internal/marshaler/pdata_marshaler.go
@@ -8,7 +8,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pprofile"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/multierr"
 )
 
 var (
@@ -74,36 +73,11 @@ func NewPdataTracesMarshaler(m ptrace.Marshaler) TracesMarshaler {
 }
 
 func (p pdataTracesMarshaler) MarshalTraces(td ptrace.Traces) ([]Message, error) {
-	resourceSpans := td.ResourceSpans()
-	var messages []Message
-	var errs error
-
-	for i := 0; i < resourceSpans.Len(); i++ {
-		rs := resourceSpans.At(i)
-		scopeSpans := rs.ScopeSpans()
-		for j := 0; j < scopeSpans.Len(); j++ {
-			ss := scopeSpans.At(j)
-			spans := ss.Spans()
-			for k := 0; k < spans.Len(); k++ {
-				singleSpanTraces := ptrace.NewTraces()
-				newRS := singleSpanTraces.ResourceSpans().AppendEmpty()
-				rs.Resource().CopyTo(newRS.Resource())
-				newRS.SetSchemaUrl(rs.SchemaUrl())
-				newSS := newRS.ScopeSpans().AppendEmpty()
-				ss.Scope().CopyTo(newSS.Scope())
-				newSS.SetSchemaUrl(ss.SchemaUrl())
-				spans.At(k).CopyTo(newSS.Spans().AppendEmpty())
-
-				bts, err := p.marshaler.MarshalTraces(singleSpanTraces)
-				if err != nil {
-					errs = multierr.Append(errs, err)
-					continue
-				}
-				messages = append(messages, Message{Value: bts})
-			}
-		}
+	bts, err := p.marshaler.MarshalTraces(td)
+	if err != nil {
+		return nil, err
 	}
-	return messages, errs
+	return []Message{{Value: bts}}, nil
 }
 
 type pdataProfilesMarshaler struct {

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -6,6 +6,7 @@ package kafkaexporter
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -128,7 +130,7 @@ func TestTracesPusher_ctx_Kgo(t *testing.T) {
 func TestTracesPusher_max_message_bytes_Kgo(t *testing.T) {
 	t.Run("WithLowSpanCount", func(t *testing.T) {
 		config := createDefaultConfig().(*Config)
-		config.Producer.MaxMessageBytes = 512
+		config.Producer.MaxMessageBytes = 10_000
 		exp, fakeCluster := newKgoMockTracesExporter(t, *config,
 			componenttest.NewNopHost(), config.Traces.Topic,
 		)
@@ -146,27 +148,83 @@ func TestTracesPusher_max_message_bytes_Kgo(t *testing.T) {
 	})
 
 	t.Run("WithHighSpanCount", func(t *testing.T) {
-		// GIVEN
-		config := createDefaultConfig().(*Config)
-		config.Producer.MaxMessageBytes = 512
-		exp, fakeCluster := newKgoMockTracesExporter(t, *config,
-			componenttest.NewNopHost(), config.Traces.Topic,
-		)
-		defer fakeCluster.Close()
+		// GIVEN a Kafka exporter with a small max message size and the full pipeline (sending_queue
+		// does batching so each batch fits; we use the factory so that path is exercised).
+		cluster, kcfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, defaultTracesTopic))
+		defer cluster.Close()
 
-		// WHEN
-		largeSpanCount := 10000
+		cfg := createDefaultConfig().(*Config)
+		cfg.Producer.MaxMessageBytes = 10_000
+		require.NoError(t, cfg.Unmarshal(confmap.NewFromStringMap(map[string]any{})))
+		cfg.ClientConfig = kcfg
+		cfg.Metadata.Full = false
+		cfg.QueueBatchConfig.GetOrInsertDefault().WaitForResult = true
+
+		factory := NewFactory()
+		exp, err := factory.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+		t.Cleanup(func() { assert.NoError(t, exp.Shutdown(t.Context())) })
+
+		// WHEN we export a large number of spans that would exceed max message size as one payload.
+		largeSpanCount := 1_000
 		traces := coretestdata.GenerateTracesManySpansSameResource(largeSpanCount)
-		err := exp.exportData(t.Context(), traces)
-
-		// THEN
+		err = exp.ConsumeTraces(t.Context(), traces)
 		require.NoError(t, err)
 
-		records := fetchKgoRecordsAtLeast(t,
-			fakeCluster.ListenAddrs(), config.Traces.Topic, largeSpanCount,
+		// THEN the queue batches by size: we get multiple Kafka messages (each within the limit)
+		records := fetchKgoRecordsExhaust(t,
+			cluster.ListenAddrs(), cfg.Traces.Topic,
+			30*time.Second, 2*time.Second,
 		)
-		require.Len(t, records, largeSpanCount, "expected one message per span")
+		messageCount := len(records)
+		t.Logf("received %d messages from Kafka for %d spans (batched)", messageCount, largeSpanCount)
+		require.GreaterOrEqual(t, messageCount, 2, "expected multiple batches when span count is large")
+		require.Less(t, messageCount, largeSpanCount,
+			"expected fewer Kafka messages than spans because multiple spans can fit into one kf message")
+		maxMessageBytes := 10_000
+		for _, r := range records {
+			require.LessOrEqual(t, len(r.Value), maxMessageBytes,
+				"each Kafka message must be within producer.max_message_bytes")
+		}
 	})
+}
+
+func TestTracesExporter_SingleSpanExceedsBatchMaxSize(t *testing.T) {
+	// GIVEN: a Kafka cluster and exporter with default batch max_size, and a trace with one span
+	// whose serialized size exceeds that max_size
+	cluster, kcfg := kafkatest.NewCluster(t, kfake.SeedTopics(1, defaultTracesTopic))
+	defer cluster.Close()
+
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, cfg.Unmarshal(confmap.NewFromStringMap(map[string]any{})))
+	cfg.ClientConfig = kcfg
+	cfg.Metadata.Full = false
+	cfg.QueueBatchConfig.GetOrInsertDefault().WaitForResult = true
+
+	factory := NewFactory()
+	exp, err := factory.CreateTraces(t.Context(), exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() { assert.NoError(t, exp.Shutdown(t.Context())) })
+
+	defaultBatchMaxSize := cfg.Producer.MaxMessageBytes - kafkaOverheadBytes
+	require.Greater(t, defaultBatchMaxSize, 0, "test assumes default batch max_size is positive")
+	bigPayload := strings.Repeat("x", defaultBatchMaxSize+1)
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	ss := rs.ScopeSpans().AppendEmpty()
+	span := ss.Spans().AppendEmpty()
+	span.SetName("big_span")
+	span.Attributes().PutStr("big_attr", bigPayload)
+
+	// WHEN: ConsumeTraces is called with that trace
+	err = exp.ConsumeTraces(t.Context(), td)
+
+	// THEN: an error is returned (batch layer rejects the oversized span)
+	require.Error(t, err)
+	t.Logf("ConsumeTraces error (expected, single span exceeds batch max size): %v", err)
 }
 
 func TestTracesPusher_conf_err(t *testing.T) {
@@ -1059,6 +1117,42 @@ func fetchKgoRecordsAtLeast(tb testing.TB, brokers []string, topic string, minRe
 	}
 	if lastErr != nil && !errors.Is(lastErr, context.DeadlineExceeded) {
 		require.NoError(tb, lastErr, "error polling records")
+	}
+	return records
+}
+
+// fetchKgoRecordsExhaust consumes from the topic until no records are received for idleTimeout
+// or the context deadline is reached, and returns all records collected.
+func fetchKgoRecordsExhaust(tb testing.TB, brokers []string, topic string, totalTimeout, idleTimeout time.Duration) []*kgo.Record {
+	clientOpts := []kgo.Opt{
+		kgo.SeedBrokers(brokers...),
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumerGroup("group-id" + topic),
+	}
+	consumerClient, err := kgo.NewClient(clientOpts...)
+	require.NoError(tb, err, "failed to create kgo consumer client")
+	defer consumerClient.Close()
+
+	var records []*kgo.Record
+	ctx, cancel := context.WithTimeout(tb.Context(), totalTimeout)
+	defer cancel()
+	idleDeadline := time.Now().Add(idleTimeout)
+	for ctx.Err() == nil {
+		fetches := consumerClient.PollRecords(ctx, 10000)
+		n := 0
+		fetches.EachRecord(func(r *kgo.Record) {
+			records = append(records, r)
+			n++
+		})
+		if fetches.Err() != nil && !errors.Is(fetches.Err(), context.DeadlineExceeded) {
+			require.NoError(tb, fetches.Err(), "error polling records")
+		}
+		if n > 0 {
+			idleDeadline = time.Now().Add(idleTimeout)
+		}
+		if time.Now().After(idleDeadline) {
+			break
+		}
 	}
 	return records
 }

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -175,7 +175,7 @@ func TestTracesPusher_max_message_bytes_Kgo(t *testing.T) {
 		// THEN the queue batches by size: we get multiple Kafka messages (each within the limit)
 		records := fetchKgoRecordsExhaust(t,
 			cluster.ListenAddrs(), cfg.Traces.Topic,
-			30*time.Second, 2*time.Second,
+			10*time.Second, 2*time.Second,
 		)
 		messageCount := len(records)
 		t.Logf("received %d messages from Kafka for %d spans (batched)", messageCount, largeSpanCount)
@@ -1084,40 +1084,6 @@ func fetchKgoRecordsAtMost(tb testing.TB, brokers []string, topic string, maxRec
 	fetches.EachRecord(func(r *kgo.Record) {
 		records = append(records, r)
 	})
-	return records
-}
-
-// fetchKgoRecordsAtLeast polls until it fetches at least minRecords or times out.
-func fetchKgoRecordsAtLeast(tb testing.TB, brokers []string, topic string, minRecords int) []*kgo.Record {
-	clientOpts := []kgo.Opt{
-		kgo.SeedBrokers(brokers...),
-		kgo.ConsumeTopics(topic),
-		kgo.ConsumerGroup("group-id" + topic),
-	}
-	consumerClient, err := kgo.NewClient(clientOpts...)
-	require.NoError(tb, err, "failed to create kgo consumer client")
-	defer consumerClient.Close()
-
-	var records []*kgo.Record
-	ctx, cancel := context.WithTimeout(tb.Context(), 10*time.Second)
-	defer cancel()
-	var lastErr error
-	for len(records) < minRecords && ctx.Err() == nil {
-		remaining := minRecords - len(records)
-		fetches := consumerClient.PollRecords(ctx, remaining)
-		fetches.EachRecord(func(r *kgo.Record) {
-			records = append(records, r)
-		})
-		if fetches.Err() != nil {
-			lastErr = fetches.Err()
-			if !errors.Is(lastErr, context.DeadlineExceeded) {
-				break
-			}
-		}
-	}
-	if lastErr != nil && !errors.Is(lastErr, context.DeadlineExceeded) {
-		require.NoError(tb, lastErr, "error polling records")
-	}
 	return records
 }
 

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -173,7 +173,7 @@ func TestTracesPusher_max_message_bytes_Kgo(t *testing.T) {
 		require.NoError(t, err)
 
 		// THEN the queue batches by size: we get multiple Kafka messages (each within the limit)
-		records := fetchKgoRecordsExhaust(t,
+		records := fetchKgoRecordsForTime(t,
 			cluster.ListenAddrs(), cfg.Traces.Topic,
 			10*time.Second, 2*time.Second,
 		)
@@ -1087,9 +1087,9 @@ func fetchKgoRecordsAtMost(tb testing.TB, brokers []string, topic string, maxRec
 	return records
 }
 
-// fetchKgoRecordsExhaust consumes from the topic until no records are received for idleTimeout
+// fetchKgoRecordsForTime consumes from the topic until no records are received for idleTimeout.
 // or the context deadline is reached, and returns all records collected.
-func fetchKgoRecordsExhaust(tb testing.TB, brokers []string, topic string, totalTimeout, idleTimeout time.Duration) []*kgo.Record {
+func fetchKgoRecordsForTime(tb testing.TB, brokers []string, topic string, totalTimeout, idleTimeout time.Duration) []*kgo.Record {
 	clientOpts := []kgo.Opt{
 		kgo.SeedBrokers(brokers...),
 		kgo.ConsumeTopics(topic),

--- a/pkg/kafka/configkafka/config.go
+++ b/pkg/kafka/configkafka/config.go
@@ -256,10 +256,10 @@ type ProducerConfig struct {
 
 func NewDefaultProducerConfig() ProducerConfig {
 	return ProducerConfig{
-		MaxMessageBytes:        1000000,
+		MaxMessageBytes:        1_000_000,
 		RequiredAcks:           WaitForLocal,
 		Compression:            "none",
-		FlushMaxMessages:       10000,
+		FlushMaxMessages:       10_000,
 		AllowAutoTopicCreation: true,
 		Linger:                 10 * time.Millisecond,
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Per #36982, it seems that the otel collector is breaking a promise: it can receive a trace but fail to export it if the trace size is too large to export to kafka. 

From reading the previous discussion on the issue, it seems there are several fixes that could help: 
1. Change the collector so that it does not accept messages that are too big to get exported. 
  a. (Or maybe I misunderstand and it's ok for a collector to receive anything, and it can choose what to process)
2. Break up all signals (spans, traces, logs) the collector receives into chunks that will fit kafka's `MaxMessageBytes`
3. Change the logic so that instead of sending all of a trace's spans at once, we send one span at a time.

This PR addresses 3 since it's a backwards compatible change. If I understand correctly, sending spans of a trace in separate kafka messages is OK because the spans still have information about which trace they belong to. 

This solution still doesn't fully address the issue. As noted in the discussions, a large span will still get rejected by kafka, but I think that can be addressed in 2. 

My implementation right now is also not the most optimal. I'm breaking up a trace into its constituent spans and sending one kf message per span. This helps avoid the issue of a trace being too large to send, but comes at the tradeoff of sending more messages to kafka. If anyone has thoughts on optimizing this part, like how to batch or pick a message size, I'm all ears. But I believe this solves the functional requirement of breaking up a trace into smaller pieces. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Partially fixes #36982

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added a test where we try to export to kafka a trace that has 10,000 spans, which exceeds the configured `MaxMessageBytes`
- Without sending one span at a time, this test fails: 
```
donassamongkol@Dons-MacBook-Air-2 kafkaexporter % go test -v -run 'TestTracesPusher_max_message_bytes_Kgo' -count=1
=== RUN   TestTracesPusher_max_message_bytes_Kgo
=== RUN   TestTracesPusher_max_message_bytes_Kgo/WithLowSpanCount
=== RUN   TestTracesPusher_max_message_bytes_Kgo/WithHighSpanCount
    kafka_exporter_test.go:163: 
                Error Trace:    /Users/donassamongkol/repos/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter/kafka_exporter_test.go:163
                Error:          Received unexpected error:
                                Permanent error: error exporting to topic "otlp_spans": MESSAGE_TOO_LARGE: The request included a message larger than the max message size the server will accept.
                Test:           TestTracesPusher_max_message_bytes_Kgo/WithHighSpanCount
--- FAIL: TestTracesPusher_max_message_bytes_Kgo (0.03s)
    --- PASS: TestTracesPusher_max_message_bytes_Kgo/WithLowSpanCount (0.02s)
    --- FAIL: TestTracesPusher_max_message_bytes_Kgo/WithHighSpanCount (0.01s)
FAIL
exit status 1
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter        0.462s
```

With the new changes, this test passes: 
```
donassamongkol@Dons-MacBook-Air-2 kafkaexporter % go test -v -run 'TestTracesPusher_max_message_bytes_Kgo' -count=1
=== RUN   TestTracesPusher_max_message_bytes_Kgo
=== RUN   TestTracesPusher_max_message_bytes_Kgo/WithLowSpanCount
=== RUN   TestTracesPusher_max_message_bytes_Kgo/WithHighSpanCount
--- PASS: TestTracesPusher_max_message_bytes_Kgo (0.34s)
    --- PASS: TestTracesPusher_max_message_bytes_Kgo/WithLowSpanCount (0.02s)
    --- PASS: TestTracesPusher_max_message_bytes_Kgo/WithHighSpanCount (0.32s)
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter        0.721s
```

#### Documentation
N/a
