### PR TITLE
Fix marshalling to avoid validation errors when http is set as protocol

### DIFF
--- a/.chloggen/45677.yaml
+++ b/.chloggen/45677.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/coralogix
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix unmarshalling to avoid validation errors with profiles when protocol is set to http.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45677]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/http_exporter.go
+++ b/exporter/coralogixexporter/http_exporter.go
@@ -45,49 +45,28 @@ func (e *httpError) Error() string {
 }
 
 func newHTTPLogsExporter(client *http.Client, config *Config) httpLogsExporter {
-	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
-	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
-	endpoint := config.Logs.Endpoint
-	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
-	}
-
 	return httpLogsExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: endpoint,
+			Endpoint: config.Logs.Endpoint,
 		},
 	}
 }
 
 func newHTTPMetricsExporter(client *http.Client, config *Config) httpMetricsExporter {
-	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
-	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
-	endpoint := config.Metrics.Endpoint
-	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
-	}
-
 	return httpMetricsExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: endpoint,
+			Endpoint: config.Metrics.Endpoint,
 		},
 	}
 }
 
 func newHTTPTracesExporter(client *http.Client, config *Config) httpTracesExporter {
-	// TODO: Refactor tests and remove redundant assignment, already done in Unmarshal.
-	// See github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
-	endpoint := config.Traces.Endpoint
-	if isEmpty(endpoint) {
-		endpoint = ensureHTTPScheme(setDomainGrpcSettings(config))
-	}
-
 	return httpTracesExporter{
 		httpExporter: httpExporter{
 			Client:   client,
-			Endpoint: endpoint,
+			Endpoint: config.Traces.Endpoint,
 		},
 	}
 }

--- a/exporter/coralogixexporter/http_exporter_test.go
+++ b/exporter/coralogixexporter/http_exporter_test.go
@@ -55,6 +55,11 @@ func TestNewHTTPLogsExporter(t *testing.T) {
 			name: "with domain",
 			config: &Config{
 				Domain: "example.com",
+				Logs: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "https://ingress.example.com:443",
+					},
+				},
 			},
 			expected: "https://ingress.example.com:443",
 		},
@@ -92,6 +97,11 @@ func TestNewHTTPMetricsExporter(t *testing.T) {
 			name: "with domain",
 			config: &Config{
 				Domain: "example.com",
+				Metrics: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "https://ingress.example.com:443",
+					},
+				},
 			},
 			expected: "https://ingress.example.com:443",
 		},
@@ -129,6 +139,11 @@ func TestNewHTTPTracesExporter(t *testing.T) {
 			name: "with domain",
 			config: &Config{
 				Domain: "example.com",
+				Traces: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "https://ingress.example.com:443",
+					},
+				},
 			},
 			expected: "https://ingress.example.com:443",
 		},

--- a/exporter/coralogixexporter/logs_client_test.go
+++ b/exporter/coralogixexporter/logs_client_test.go
@@ -167,6 +167,11 @@ func TestLogsExporter_PushLogs_WhenCannotSend(t *testing.T) {
 			cfg := &Config{
 				Domain:     "test.domain.com",
 				PrivateKey: "test-key",
+				Logs: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "ingress.test.domain.com:443",
+					},
+				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   tt.enabled,
 					Threshold: 1,

--- a/exporter/coralogixexporter/metrics_client_test.go
+++ b/exporter/coralogixexporter/metrics_client_test.go
@@ -179,6 +179,11 @@ func TestMetricsExporter_PushMetrics_WhenCannotSend(t *testing.T) {
 			cfg := &Config{
 				Domain:     "test.domain.com",
 				PrivateKey: "test-key",
+				Metrics: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "ingress.test.domain.com:443",
+					},
+				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   tt.enabled,
 					Threshold: 1,

--- a/exporter/coralogixexporter/profiles_client_test.go
+++ b/exporter/coralogixexporter/profiles_client_test.go
@@ -164,6 +164,9 @@ func TestProfilesExporter_PushProfiles_WhenCannotSend(t *testing.T) {
 			cfg := &Config{
 				Domain:     "test.domain.com",
 				PrivateKey: "test-key",
+				Profiles: configgrpc.ClientConfig{
+					Endpoint: "ingress.test.domain.com:443",
+				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   tt.enabled,
 					Threshold: 1,

--- a/exporter/coralogixexporter/signals.go
+++ b/exporter/coralogixexporter/signals.go
@@ -139,21 +139,13 @@ func (e *signalExporter) startSignalExporter(ctx context.Context, host component
 		return errors.New("unexpected signal config type")
 	}
 
-	var transportConfig *TransportConfig
-	if !isEmpty(e.config.Domain) && isEmpty(signalConfig.GetEndpoint()) {
-		// TODO: Remove this function call, already done in Unmarshal, see github.com/open-telemetry/opentelemetry-collector-contrib/issues/44731
-		transportConfig = setMergedTransportConfig(e.config, &e.config.DomainSettings, signalConfigWrapper.config)
-	} else {
-		transportConfig = signalConfigWrapper.config
-	}
-
 	if e.config.Protocol == httpProtocol {
-		e.clientHTTP, err = transportConfig.ToHTTPClient(ctx, host, e.settings)
+		e.clientHTTP, err = signalConfigWrapper.config.ToHTTPClient(ctx, host, e.settings)
 		if err != nil {
 			return err
 		}
 	} else {
-		if e.clientConn, err = transportConfig.ToClientConn(ctx, host.GetExtensions(), e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
+		if e.clientConn, err = signalConfigWrapper.config.ToClientConn(ctx, host.GetExtensions(), e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
 			return err
 		}
 		callOptions := []grpc.CallOption{

--- a/exporter/coralogixexporter/testdata/config.yaml
+++ b/exporter/coralogixexporter/testdata/config.yaml
@@ -66,3 +66,15 @@ coralogix/domain_endpoints:
   application_name: "APP_NAME"
   subsystem_name: "SUBSYSTEM_NAME"
   timeout: 5s
+
+coralogix/http_protocol:
+  protocol: "http"
+  domain: "coralogix.com"
+  application_name_attributes:
+    - "service.namespace"
+  subsystem_name_attributes:
+    - "service.name"
+  private_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name: "APP_NAME"
+  subsystem_name: "SUBSYSTEM_NAME"
+  timeout: 5s

--- a/exporter/coralogixexporter/traces_client_test.go
+++ b/exporter/coralogixexporter/traces_client_test.go
@@ -168,6 +168,11 @@ func TestTracesExporter_PushTraces_WhenCannotSend(t *testing.T) {
 			cfg := &Config{
 				Domain:     "test.domain.com",
 				PrivateKey: "test-key",
+				Traces: TransportConfig{
+					ClientConfig: configgrpc.ClientConfig{
+						Endpoint: "ingress.test.domain.com:443",
+					},
+				},
 				RateLimiter: RateLimiterConfig{
 					Enabled:   tt.configEnabled,
 					Threshold: 1,


### PR DESCRIPTION
#### Link to tracking issue
Fixes #45677

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested with:
```yaml
receivers:
  otlp:
    protocols:
      grpc:

exporters:
  coralogix:
    domain: "eu2.coralogix.com"
    private_key: "${env:CORALOGIX_PRIVATE_KEY}"
    application_name: "APP_NAME"
    timeout: 5s
    protocol: http

service:
  pipelines:
    traces:
      receivers: [otlp]
      exporters: [coralogix]

```