### PR TITLE
Fix nil pointer dereference for exceptions without ID

### DIFF
--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -57,8 +57,7 @@ func addCause(seg *awsxray.Segment, span ptrace.Span) {
 			attrs := evt.Attributes()
 			attrs.EnsureCapacity(8)
 
-			// ID is a required field
-			attrs.PutStr(awsxray.AWSXrayExceptionIDAttribute, *excp.ID)
+			addString(excp.ID, awsxray.AWSXrayExceptionIDAttribute, attrs)
 			addString(excp.Message, string(conventions.ExceptionMessageKey), attrs)
 			addString(excp.Type, string(conventions.ExceptionTypeKey), attrs)
 			addBool(excp.Remote, awsxray.AWSXrayExceptionRemoteAttribute, attrs)


### PR DESCRIPTION
I've seen the receiver panicking with `invalid memory address or nil pointer dereference` processing spans with exceptions which don't have an ID set. The code expects this though. But so far I couldn't find proof for this to be the case. I'd like to make the code tolerate missing IDs. By default e.g. the aws-xray-sdk for ruby doesn't set the ID.