### PR TITLE
[processor/resourcedetection] Ensure some resource attributes are not emmited empty on Azure detector

### DIFF
--- a/.chloggen/resdetection_azure_availabilityzone.yaml
+++ b/.chloggen/resdetection_azure_availabilityzone.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "processor/azuredetector"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Avoid set cloud.availability_zone when Azure Availability Zone is not assigned"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In cases where an Azure VM is not assigned to any Availability Zone,
+  the `cloud.availability_zone` attribute was being set to an empty string.
+  This fix ensures that the attribute is only set when an Availability Zone
+  is indeed assigned, preventing misleading empty values.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/resdetection_azure_hostname.yaml
+++ b/.chloggen/resdetection_azure_hostname.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "processor/azuredetector"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fallback to VM Name when osProfile.computerName is unavailable"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In certain Azure images, the `osProfile.computerName` field may not be set.
+  This fix ensures that the hostname detection falls back to using the VM Name
+  from the instance metadata service when `osProfile.computerName` is empty.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/resdetection_azure_scalesetname.yaml
+++ b/.chloggen/resdetection_azure_scalesetname.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "processor/azuredetector"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Avoid set azure.vm.scaleset.name empty when VM not in scale set"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In scenarios where a VM is not part of a scale set, the
+  `azure.vm.scaleset.name` attribute was being set to an empty string.
+  This fix ensures that the attribute is only set when the VM is indeed
+  part of a scale set, preventing misleading empty values.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

On Azure is there some cases where some current `resource.attributes` can be empty. This PR ensures empty values are not emitted.

* When `osProfile.computerName` is empty, the detector will fallback to `compute.Name`
  * It is empty on specialized images: https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/computer-names-missing-blank
  * Was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43969
* `compute.VMScaleSetName` can be empty if a VM is not part of a scale set
* `compute.AvailabilityZone` can be empty when a VM is created with the configuration `No infrastructure redundancy is required` on the `Availability options.`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45642

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests to cover all of these changes, and I also personally tested in Azure VMs (Specialized and Generalized) to ensure it is working properly
