### PR TITLE
[chore] Generate schemas for receivers #3

### DIFF
--- a/receiver/activedirectorydsreceiver/config.schema.yaml
+++ b/receiver/activedirectorydsreceiver/config.schema.yaml
@@ -1,0 +1,4 @@
+type: object
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/activedirectorydsreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/activedirectorydsreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,74 @@
+$defs:
+  attribute_bind_type:
+    description: AttributeBindType specifies the value bind_type attribute.
+    type: integer
+  attribute_direction:
+    description: AttributeDirection specifies the value direction attribute.
+    type: integer
+  attribute_network_data_type:
+    description: AttributeNetworkDataType specifies the value network_data_type attribute.
+    type: integer
+  attribute_operation_type:
+    description: AttributeOperationType specifies the value operation_type attribute.
+    type: integer
+  attribute_suboperation_type:
+    description: AttributeSuboperationType specifies the value suboperation_type attribute.
+    type: integer
+  attribute_sync_result:
+    description: AttributeSyncResult specifies the value sync_result attribute.
+    type: integer
+  attribute_value_type:
+    description: AttributeValueType specifies the value value_type attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for active_directory_ds metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+  metrics_config:
+    description: MetricsConfig provides config for active_directory_ds metrics.
+    type: object
+    properties:
+      active_directory.ds.bind.rate:
+        $ref: metric_config
+      active_directory.ds.ldap.bind.last_successful.time:
+        $ref: metric_config
+      active_directory.ds.ldap.bind.rate:
+        $ref: metric_config
+      active_directory.ds.ldap.client.session.count:
+        $ref: metric_config
+      active_directory.ds.ldap.search.rate:
+        $ref: metric_config
+      active_directory.ds.name_cache.hit_rate:
+        $ref: metric_config
+      active_directory.ds.notification.queued:
+        $ref: metric_config
+      active_directory.ds.operation.rate:
+        $ref: metric_config
+      active_directory.ds.replication.network.io:
+        $ref: metric_config
+      active_directory.ds.replication.object.rate:
+        $ref: metric_config
+      active_directory.ds.replication.operation.pending:
+        $ref: metric_config
+      active_directory.ds.replication.property.rate:
+        $ref: metric_config
+      active_directory.ds.replication.sync.object.pending:
+        $ref: metric_config
+      active_directory.ds.replication.sync.request.count:
+        $ref: metric_config
+      active_directory.ds.replication.value.rate:
+        $ref: metric_config
+      active_directory.ds.security_descriptor_propagations_event.queued:
+        $ref: metric_config
+      active_directory.ds.suboperation.rate:
+        $ref: metric_config
+      active_directory.ds.thread.count:
+        $ref: metric_config

--- a/receiver/aerospikereceiver/config.schema.yaml
+++ b/receiver/aerospikereceiver/config.schema.yaml
@@ -1,0 +1,22 @@
+description: Config is the receiver configuration
+type: object
+properties:
+  collect_cluster_metrics:
+    type: boolean
+  endpoint:
+    type: string
+  password:
+    $ref: go.opentelemetry.io/collector/config/configopaque.string
+  timeout:
+    type: string
+    format: duration
+  tls:
+    x-pointer: true
+    $ref: go.opentelemetry.io/collector/config/configtls.client_config
+  tlsname:
+    type: string
+  username:
+    type: string
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/aerospikereceiver/internal/metadata/config.schema.yaml
+++ b/receiver/aerospikereceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,101 @@
+$defs:
+  attribute_connection_op:
+    description: AttributeConnectionOp specifies the value connection_op attribute.
+    type: integer
+  attribute_connection_type:
+    description: AttributeConnectionType specifies the value connection_type attribute.
+    type: integer
+  attribute_index_type:
+    description: AttributeIndexType specifies the value index_type attribute.
+    type: integer
+  attribute_namespace_component:
+    description: AttributeNamespaceComponent specifies the value namespace_component attribute.
+    type: integer
+  attribute_query_result:
+    description: AttributeQueryResult specifies the value query_result attribute.
+    type: integer
+  attribute_query_type:
+    description: AttributeQueryType specifies the value query_type attribute.
+    type: integer
+  attribute_scan_result:
+    description: AttributeScanResult specifies the value scan_result attribute.
+    type: integer
+  attribute_scan_type:
+    description: AttributeScanType specifies the value scan_type attribute.
+    type: integer
+  attribute_transaction_result:
+    description: AttributeTransactionResult specifies the value transaction_result attribute.
+    type: integer
+  attribute_transaction_type:
+    description: AttributeTransactionType specifies the value transaction_type attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for aerospike metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for aerospike metrics.
+    type: object
+    properties:
+      aerospike.namespace.disk.available:
+        $ref: metric_config
+      aerospike.namespace.geojson.region_query_cells:
+        $ref: metric_config
+      aerospike.namespace.geojson.region_query_false_positive:
+        $ref: metric_config
+      aerospike.namespace.geojson.region_query_points:
+        $ref: metric_config
+      aerospike.namespace.geojson.region_query_requests:
+        $ref: metric_config
+      aerospike.namespace.memory.free:
+        $ref: metric_config
+      aerospike.namespace.memory.usage:
+        $ref: metric_config
+      aerospike.namespace.query.count:
+        $ref: metric_config
+      aerospike.namespace.scan.count:
+        $ref: metric_config
+      aerospike.namespace.transaction.count:
+        $ref: metric_config
+      aerospike.node.connection.count:
+        $ref: metric_config
+      aerospike.node.connection.open:
+        $ref: metric_config
+      aerospike.node.memory.free:
+        $ref: metric_config
+      aerospike.node.query.tracked:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for aerospike resource attributes.
+    type: object
+    properties:
+      aerospike.namespace:
+        $ref: resource_attribute_config
+      aerospike.node.name:
+        $ref: resource_attribute_config

--- a/receiver/apachereceiver/config.schema.yaml
+++ b/receiver/apachereceiver/config.schema.yaml
@@ -1,0 +1,5 @@
+type: object
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/apachereceiver/internal/metadata/config.schema.yaml
+++ b/receiver/apachereceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,84 @@
+$defs:
+  attribute_connection_state:
+    description: AttributeConnectionState specifies the value connection_state attribute.
+    type: integer
+  attribute_cpu_level:
+    description: AttributeCPULevel specifies the value cpu_level attribute.
+    type: integer
+  attribute_cpu_mode:
+    description: AttributeCPUMode specifies the value cpu_mode attribute.
+    type: integer
+  attribute_scoreboard_state:
+    description: AttributeScoreboardState specifies the value scoreboard_state attribute.
+    type: integer
+  attribute_workers_state:
+    description: AttributeWorkersState specifies the value workers_state attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for apache metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for apache metrics.
+    type: object
+    properties:
+      apache.connections.async:
+        $ref: metric_config
+      apache.cpu.load:
+        $ref: metric_config
+      apache.cpu.time:
+        $ref: metric_config
+      apache.current_connections:
+        $ref: metric_config
+      apache.load.1:
+        $ref: metric_config
+      apache.load.5:
+        $ref: metric_config
+      apache.load.15:
+        $ref: metric_config
+      apache.request.time:
+        $ref: metric_config
+      apache.requests:
+        $ref: metric_config
+      apache.scoreboard:
+        $ref: metric_config
+      apache.traffic:
+        $ref: metric_config
+      apache.uptime:
+        $ref: metric_config
+      apache.workers:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for apache resource attributes.
+    type: object
+    properties:
+      apache.server.name:
+        $ref: resource_attribute_config
+      apache.server.port:
+        $ref: resource_attribute_config

--- a/receiver/apachesparkreceiver/config.schema.yaml
+++ b/receiver/apachesparkreceiver/config.schema.yaml
@@ -1,0 +1,11 @@
+description: Config defines the configuration for the various elements of the receiver agent.
+type: object
+properties:
+  application_names:
+    type: array
+    items:
+      type: string
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config
+  - $ref: go.opentelemetry.io/collector/config/confighttp.client_config

--- a/receiver/apachesparkreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/apachesparkreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,207 @@
+$defs:
+  attribute_direction:
+    description: AttributeDirection specifies the value direction attribute.
+    type: integer
+  attribute_executor_task_result:
+    description: AttributeExecutorTaskResult specifies the value executor_task_result attribute.
+    type: integer
+  attribute_gc_type:
+    description: AttributeGcType specifies the value gc_type attribute.
+    type: integer
+  attribute_job_result:
+    description: AttributeJobResult specifies the value job_result attribute.
+    type: integer
+  attribute_location:
+    description: AttributeLocation specifies the value location attribute.
+    type: integer
+  attribute_pool_memory_type:
+    description: AttributePoolMemoryType specifies the value pool_memory_type attribute.
+    type: integer
+  attribute_scheduler_status:
+    description: AttributeSchedulerStatus specifies the value scheduler_status attribute.
+    type: integer
+  attribute_source:
+    description: AttributeSource specifies the value source attribute.
+    type: integer
+  attribute_stage_task_result:
+    description: AttributeStageTaskResult specifies the value stage_task_result attribute.
+    type: integer
+  attribute_state:
+    description: AttributeState specifies the value state attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for apachespark metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for apachespark metrics.
+    type: object
+    properties:
+      spark.driver.block_manager.disk.usage:
+        $ref: metric_config
+      spark.driver.block_manager.memory.usage:
+        $ref: metric_config
+      spark.driver.code_generator.compilation.average_time:
+        $ref: metric_config
+      spark.driver.code_generator.compilation.count:
+        $ref: metric_config
+      spark.driver.code_generator.generated_class.average_size:
+        $ref: metric_config
+      spark.driver.code_generator.generated_class.count:
+        $ref: metric_config
+      spark.driver.code_generator.generated_method.average_size:
+        $ref: metric_config
+      spark.driver.code_generator.generated_method.count:
+        $ref: metric_config
+      spark.driver.code_generator.source_code.average_size:
+        $ref: metric_config
+      spark.driver.code_generator.source_code.operations:
+        $ref: metric_config
+      spark.driver.dag_scheduler.job.active:
+        $ref: metric_config
+      spark.driver.dag_scheduler.job.count:
+        $ref: metric_config
+      spark.driver.dag_scheduler.stage.count:
+        $ref: metric_config
+      spark.driver.dag_scheduler.stage.failed:
+        $ref: metric_config
+      spark.driver.executor.gc.operations:
+        $ref: metric_config
+      spark.driver.executor.gc.time:
+        $ref: metric_config
+      spark.driver.executor.memory.execution:
+        $ref: metric_config
+      spark.driver.executor.memory.jvm:
+        $ref: metric_config
+      spark.driver.executor.memory.pool:
+        $ref: metric_config
+      spark.driver.executor.memory.storage:
+        $ref: metric_config
+      spark.driver.hive_external_catalog.file_cache_hits:
+        $ref: metric_config
+      spark.driver.hive_external_catalog.files_discovered:
+        $ref: metric_config
+      spark.driver.hive_external_catalog.hive_client_calls:
+        $ref: metric_config
+      spark.driver.hive_external_catalog.parallel_listing_jobs:
+        $ref: metric_config
+      spark.driver.hive_external_catalog.partitions_fetched:
+        $ref: metric_config
+      spark.driver.jvm_cpu_time:
+        $ref: metric_config
+      spark.driver.live_listener_bus.dropped:
+        $ref: metric_config
+      spark.driver.live_listener_bus.posted:
+        $ref: metric_config
+      spark.driver.live_listener_bus.processing_time.average:
+        $ref: metric_config
+      spark.driver.live_listener_bus.queue_size:
+        $ref: metric_config
+      spark.executor.disk.usage:
+        $ref: metric_config
+      spark.executor.gc_time:
+        $ref: metric_config
+      spark.executor.input_size:
+        $ref: metric_config
+      spark.executor.memory.usage:
+        $ref: metric_config
+      spark.executor.shuffle.io.size:
+        $ref: metric_config
+      spark.executor.storage_memory.usage:
+        $ref: metric_config
+      spark.executor.task.active:
+        $ref: metric_config
+      spark.executor.task.limit:
+        $ref: metric_config
+      spark.executor.task.result:
+        $ref: metric_config
+      spark.executor.time:
+        $ref: metric_config
+      spark.job.stage.active:
+        $ref: metric_config
+      spark.job.stage.result:
+        $ref: metric_config
+      spark.job.task.active:
+        $ref: metric_config
+      spark.job.task.result:
+        $ref: metric_config
+      spark.stage.disk.spilled:
+        $ref: metric_config
+      spark.stage.executor.cpu_time:
+        $ref: metric_config
+      spark.stage.executor.run_time:
+        $ref: metric_config
+      spark.stage.io.records:
+        $ref: metric_config
+      spark.stage.io.size:
+        $ref: metric_config
+      spark.stage.jvm_gc_time:
+        $ref: metric_config
+      spark.stage.memory.peak:
+        $ref: metric_config
+      spark.stage.memory.spilled:
+        $ref: metric_config
+      spark.stage.shuffle.blocks_fetched:
+        $ref: metric_config
+      spark.stage.shuffle.fetch_wait_time:
+        $ref: metric_config
+      spark.stage.shuffle.io.disk:
+        $ref: metric_config
+      spark.stage.shuffle.io.read.size:
+        $ref: metric_config
+      spark.stage.shuffle.io.records:
+        $ref: metric_config
+      spark.stage.shuffle.io.write.size:
+        $ref: metric_config
+      spark.stage.shuffle.write_time:
+        $ref: metric_config
+      spark.stage.status:
+        $ref: metric_config
+      spark.stage.task.active:
+        $ref: metric_config
+      spark.stage.task.result:
+        $ref: metric_config
+      spark.stage.task.result_size:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for apachespark resource attributes.
+    type: object
+    properties:
+      spark.application.id:
+        $ref: resource_attribute_config
+      spark.application.name:
+        $ref: resource_attribute_config
+      spark.executor.id:
+        $ref: resource_attribute_config
+      spark.job.id:
+        $ref: resource_attribute_config
+      spark.stage.attempt.id:
+        $ref: resource_attribute_config
+      spark.stage.id:
+        $ref: resource_attribute_config

--- a/receiver/azureblobreceiver/config.schema.yaml
+++ b/receiver/azureblobreceiver/config.schema.yaml
@@ -1,0 +1,61 @@
+$defs:
+  auth_type:
+    type: string
+  cloud_type:
+    type: string
+  event_hub_config:
+    type: object
+    properties:
+      endpoint:
+        description: Azure Event Hub endpoint triggering on the `Blob Create` event
+        type: string
+  logs_config:
+    type: object
+    properties:
+      container_name:
+        description: Name of the blob container with the logs (default = "logs")
+        type: string
+  service_principal_config:
+    type: object
+    properties:
+      client_id:
+        description: Client ID, used with Service Principal authentication
+        type: string
+      client_secret:
+        description: Client secret, used with Service Principal authentication
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
+      tenant_id:
+        description: Tenant ID, used with Service Principal authentication
+        type: string
+  traces_config:
+    type: object
+    properties:
+      container_name:
+        description: Name of the blob container with the traces (default = "traces")
+        type: string
+type: object
+properties:
+  auth:
+    description: Type of authentication to use
+    $ref: auth_type
+  cloud:
+    description: Azure Cloud to authenticate against, used with Service Principal authentication
+    $ref: cloud_type
+  connection_string:
+    description: Azure Blob Storage connection key, which can be found in the Azure Blob Storage resource on the Azure Portal. (no default)
+    type: string
+  event_hub:
+    description: Configurations of Azure Event Hub triggering on the `Blob Create` event
+    $ref: event_hub_config
+  logs:
+    description: Logs related configurations
+    $ref: logs_config
+  service_principal:
+    description: Configuration for the Service Principal credentials
+    $ref: service_principal_config
+  storage_account_url:
+    description: Storage Account URL, used with Service Principal authentication
+    type: string
+  traces:
+    description: Traces related configurations
+    $ref: traces_config

--- a/receiver/azureeventhubreceiver/config.schema.yaml
+++ b/receiver/azureeventhubreceiver/config.schema.yaml
@@ -1,0 +1,59 @@
+$defs:
+  event_hub_config:
+    description: EventHubConfig defines the configuration for an Azure Event Hub when using authentication.
+    type: object
+    properties:
+      name:
+        description: Name is the name of the Event Hub.
+        type: string
+      namespace:
+        description: Namespace is the fully qualified namespace of the Event Hub.
+        type: string
+  time_format:
+    type: object
+    properties:
+      logs:
+        type: array
+        items:
+          type: string
+      metrics:
+        type: array
+        items:
+          type: string
+      traces:
+        type: array
+        items:
+          type: string
+type: object
+properties:
+  apply_semantic_conventions:
+    type: boolean
+  auth:
+    x-pointer: true
+    type: string
+    x-customType: go.opentelemetry.io/collector/component.ID
+  connection:
+    type: string
+  event_hub:
+    $ref: event_hub_config
+  format:
+    type: string
+  group:
+    type: string
+  max_poll_events:
+    type: integer
+  metric_aggregation:
+    type: string
+  offset:
+    type: string
+  partition:
+    type: string
+  poll_rate:
+    description: azeventhub lib specific
+    type: integer
+  storage:
+    x-pointer: true
+    type: string
+    x-customType: go.opentelemetry.io/collector/component.ID
+  time_formats:
+    $ref: time_format

--- a/receiver/azuremonitorreceiver/config.schema.yaml
+++ b/receiver/azuremonitorreceiver/config.schema.yaml
@@ -1,0 +1,77 @@
+$defs:
+  auth_config:
+    description: AuthConfig defines the auth settings for the azure receiver.
+    type: object
+    properties:
+      authenticator:
+        description: AuthenticatorID specifies the name of the azure extension to authenticate the requests to azure monitor.
+        type: string
+        x-customType: go.opentelemetry.io/collector/component.ID
+  dimensions_config:
+    type: object
+    properties:
+      enabled:
+        x-pointer: true
+        type: boolean
+      overrides:
+        $ref: nested_list_alias
+description: Config defines the configuration for the various elements of the receiver agent.
+type: object
+properties:
+  append_tags_as_attributes:
+    type: array
+    items:
+      type: string
+  auth:
+    description: Authentication accepts the component azureauthextension, and uses it to get an access token to make requests. Using this, `credentials` and any related fields become useless.
+    x-pointer: true
+    $ref: auth_config
+  cache_resources:
+    type: number
+    x-customType: float64
+  cache_resources_definitions:
+    type: number
+    x-customType: float64
+  client_id:
+    type: string
+  client_secret:
+    type: string
+  cloud:
+    type: string
+  credentials:
+    description: 'Deprecated: Credentials is deprecated.'
+    type: string
+  dimensions:
+    $ref: dimensions_config
+  discover_subscriptions:
+    type: boolean
+  federated_token_file:
+    type: string
+  maximum_number_of_metrics_in_a_call:
+    type: integer
+  maximum_number_of_records_per_resource:
+    type: integer
+    x-customType: int32
+  maximum_resources_per_batch:
+    type: integer
+  metrics:
+    $ref: nested_list_alias
+  resource_groups:
+    type: array
+    items:
+      type: string
+  services:
+    type: array
+    items:
+      type: string
+  subscription_ids:
+    type: array
+    items:
+      type: string
+  tenant_id:
+    type: string
+  use_batch_api:
+    type: boolean
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/azuremonitorreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/azuremonitorreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,23 @@
+$defs:
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
+    type: object
+    properties:
+      resource_attributes:
+        $ref: resource_attributes_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for azuremonitor resource attributes.
+    type: object
+    properties:
+      azuremonitor.subscription:
+        $ref: resource_attribute_config
+      azuremonitor.subscription_id:
+        $ref: resource_attribute_config
+      azuremonitor.tenant_id:
+        $ref: resource_attribute_config

--- a/receiver/bigipreceiver/config.schema.yaml
+++ b/receiver/bigipreceiver/config.schema.yaml
@@ -1,0 +1,11 @@
+description: Config defines the configuration for the various elements of the receiver agent.
+type: object
+properties:
+  password:
+    $ref: go.opentelemetry.io/collector/config/configopaque.string
+  username:
+    type: string
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/bigipreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/bigipreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,119 @@
+$defs:
+  attribute_active_status:
+    description: AttributeActiveStatus specifies the value active.status attribute.
+    type: integer
+  attribute_availability_status:
+    description: AttributeAvailabilityStatus specifies the value availability.status attribute.
+    type: integer
+  attribute_direction:
+    description: AttributeDirection specifies the value direction attribute.
+    type: integer
+  attribute_enabled_status:
+    description: AttributeEnabledStatus specifies the value enabled.status attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for bigip metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for bigip metrics.
+    type: object
+    properties:
+      bigip.node.availability:
+        $ref: metric_config
+      bigip.node.connection.count:
+        $ref: metric_config
+      bigip.node.data.transmitted:
+        $ref: metric_config
+      bigip.node.enabled:
+        $ref: metric_config
+      bigip.node.packet.count:
+        $ref: metric_config
+      bigip.node.request.count:
+        $ref: metric_config
+      bigip.node.session.count:
+        $ref: metric_config
+      bigip.pool.availability:
+        $ref: metric_config
+      bigip.pool.connection.count:
+        $ref: metric_config
+      bigip.pool.data.transmitted:
+        $ref: metric_config
+      bigip.pool.enabled:
+        $ref: metric_config
+      bigip.pool.member.count:
+        $ref: metric_config
+      bigip.pool.packet.count:
+        $ref: metric_config
+      bigip.pool.request.count:
+        $ref: metric_config
+      bigip.pool_member.availability:
+        $ref: metric_config
+      bigip.pool_member.connection.count:
+        $ref: metric_config
+      bigip.pool_member.data.transmitted:
+        $ref: metric_config
+      bigip.pool_member.enabled:
+        $ref: metric_config
+      bigip.pool_member.packet.count:
+        $ref: metric_config
+      bigip.pool_member.request.count:
+        $ref: metric_config
+      bigip.pool_member.session.count:
+        $ref: metric_config
+      bigip.virtual_server.availability:
+        $ref: metric_config
+      bigip.virtual_server.connection.count:
+        $ref: metric_config
+      bigip.virtual_server.data.transmitted:
+        $ref: metric_config
+      bigip.virtual_server.enabled:
+        $ref: metric_config
+      bigip.virtual_server.packet.count:
+        $ref: metric_config
+      bigip.virtual_server.request.count:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for bigip resource attributes.
+    type: object
+    properties:
+      bigip.node.ip_address:
+        $ref: resource_attribute_config
+      bigip.node.name:
+        $ref: resource_attribute_config
+      bigip.pool.name:
+        $ref: resource_attribute_config
+      bigip.pool_member.ip_address:
+        $ref: resource_attribute_config
+      bigip.pool_member.name:
+        $ref: resource_attribute_config
+      bigip.virtual_server.destination:
+        $ref: resource_attribute_config
+      bigip.virtual_server.name:
+        $ref: resource_attribute_config


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added configuration schemas to following components:

* activedirectorydsreceiver
* aerospikereceiver
* apachereceiver
* apachesparkreceiver
* azureblobreceiver
* azureeventhubreceiver
* azuremonitorreceiver
* bigipreceiver

Schemas were generated with [schemagen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/schemagen/README.md) script.

Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42214