### PR TITLE
[chore] Generate schemas for receivers #4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -702,7 +702,7 @@ generate-gh-issue-templates:
 SCHEMA_DIRS := $(shell find $(CURDIR) -path "*testdata*" -prune -o -name "config.schema.yaml" -exec dirname {} \; | sort -u)
 
 .PHONY: generate-schemas
-generate-schemas:
+generate-schemas: $(SCHEMAGEN)
 	@$(foreach dir,$(SCHEMA_DIRS), $(SCHEMAGEN) $(dir) -o $(dir);)
 
 .PHONY: checks

--- a/internal/docker/config.schema.yaml
+++ b/internal/docker/config.schema.yaml
@@ -1,0 +1,19 @@
+$defs:
+  config:
+    type: object
+    properties:
+      api_version:
+        description: Docker client API version.
+        type: string
+      endpoint:
+        description: The URL of the docker server. Default is "unix:///var/run/docker.sock" on non-Windows and "npipe:////./pipe/docker_engine" on Windows
+        type: string
+      excluded_images:
+        description: A list of filters whose matching images are to be excluded. Supports literals, globs, and regex.
+        type: array
+        items:
+          type: string
+      timeout:
+        description: The maximum amount of time to wait for docker API responses. Default is 5s
+        type: string
+        format: duration

--- a/pkg/datadog/config/config.schema.yaml
+++ b/pkg/datadog/config/config.schema.yaml
@@ -1,0 +1,245 @@
+$defs:
+  api_config:
+    description: APIConfig defines the API configuration options
+    type: object
+    properties:
+      fail_on_invalid_key:
+        description: FailOnInvalidKey states whether to exit at startup on invalid API key. The default value is false.
+        type: boolean
+      key:
+        description: 'Key is the Datadog API key to associate your Agent''s data with your organization. Create a new API key here: https://app.datadoghq.com/account/settings'
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
+      site:
+        description: Site is the site of the Datadog intake to send data to. The default value is "datadoghq.com".
+        type: string
+  config:
+    description: Config defines configuration for the Datadog exporter.
+    type: object
+    properties:
+      api:
+        description: API defines the Datadog API configuration.
+        $ref: api_config
+      host_metadata:
+        description: HostMetadata defines the host metadata specific configuration
+        $ref: host_metadata_config
+      hostname_detection_timeout:
+        description: HostnameDetectionTimeout defines the timeout for hostname detection. This is necessary for initializing datadog exporter On K8s, it must be set to less than `failureThreshold * periodSeconds` due to initialization blocking health_check liveness probes on startup. If set to zero duration, there will be no timeout applied. Default is 25 seconds.
+        type: string
+        format: duration
+      logs:
+        description: Logs defines the Logs exporter specific configuration
+        $ref: logs_config
+      metrics:
+        description: Metrics defines the Metrics exporter specific configuration
+        $ref: metrics_config
+      only_metadata:
+        description: OnlyMetadata defines whether to only send metadata This is useful for agent-collector setups, so that metadata about a host is sent to the backend even when telemetry data is reported via a different host. This flag is incompatible with disabling host metadata, `use_resource_metadata`, or `host_metadata::hostname_source != first_resource`
+        type: boolean
+      orchestrator_explorer:
+        $ref: orchestrator_explorer_config
+      sending_queue:
+        x-optional: true
+        $ref: go.opentelemetry.io/collector/exporter/exporterhelper.queue_batch_config
+      traces:
+        description: Traces defines the Traces exporter specific configuration
+        $ref: traces_exporter_config
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+      - $ref: go.opentelemetry.io/collector/config/configretry.back_off_config
+      - $ref: tags_config
+  connector_component_config:
+    description: ConnectorComponentConfig defines the configuration for the Datadog connector component
+    type: object
+    properties:
+      traces:
+        description: Traces defines the Traces specific configuration
+        $ref: traces_connector_config
+  cumulative_monotonic_sum_mode:
+    description: CumulativeMonotonicSumMode is the export mode for OTLP Sum metrics.
+    type: string
+  histogram_config:
+    description: HistogramConfig customizes export of OTLP Histograms.
+    type: object
+    properties:
+      mode:
+        description: Mode for exporting histograms. Valid values are 'distributions', 'counters' or 'nobuckets'. - 'distributions' sends histograms as Datadog distributions (recommended). - 'counters' sends histograms as Datadog counts, one metric per bucket. - 'nobuckets' sends no bucket histogram metrics. Aggregation metrics will still be sent if `send_aggregation_metrics` is enabled. The current default is 'distributions'.
+        $ref: histogram_mode
+      send_aggregation_metrics:
+        description: SendAggregations states if the exporter should send .sum, .count, .min and .max metrics for histograms. The default is false.
+        type: boolean
+      send_count_sum_metrics:
+        description: 'SendCountSum states if the export should send .sum and .count metrics for histograms. The default is false. Deprecated: [v0.75.0] Use `send_aggregation_metrics` (HistogramConfig.SendAggregations) instead.'
+        type: boolean
+  histogram_mode:
+    type: string
+  host_metadata_config:
+    description: HostMetadataConfig defines the host metadata related configuration. Host metadata is the information used for populating the infrastructure list, the host map and providing host tags functionality. The exporter will send host metadata for a single host, whose name is chosen according to `host_metadata::hostname_source`.
+    type: object
+    properties:
+      enabled:
+        description: Enabled enables the host metadata functionality.
+        type: boolean
+      hostname_source:
+        description: 'HostnameSource is the source for the hostname of host metadata. This hostname is used for identifying the infrastructure list, host map and host tag information related to the host where the Datadog exporter is running. Changing this setting will not change the host used to tag your metrics, traces and logs in any way. For remote hosts, see https://docs.datadoghq.com/opentelemetry/schema_semantics/host_metadata/. Valid values are ''first_resource'' and ''config_or_system'': - ''first_resource'' picks the host metadata hostname from the resource attributes on the first OTLP payload that gets to the exporter. If the first payload lacks hostname-like attributes, it will fallback to ''config_or_system''. **Do not use this hostname source if receiving data from multiple hosts**. - ''config_or_system'' picks the host metadata hostname from the ''hostname'' setting, If this is empty it will use available system APIs and cloud provider endpoints. The default is ''config_or_system''.'
+        $ref: hostname_source
+      reporter_period:
+        description: ReporterPeriod is the period at which the host metadata reporter will run.
+        type: string
+        format: duration
+      tags:
+        description: Tags is a list of host tags. These tags will be attached to telemetry signals that have the host metadata hostname. To attach tags to telemetry signals regardless of the host, use a processor instead.
+        type: array
+        items:
+          type: string
+  hostname_source:
+    description: HostnameSource is the source for the hostname of host metadata.
+    type: string
+  initial_value_mode:
+    description: InitialValueMode defines what the exporter should do with the initial value of a time series when transforming from cumulative to delta.
+    type: string
+  logs_config:
+    description: LogsConfig defines logs exporter specific configuration
+    type: object
+    properties:
+      batch_wait:
+        description: 'BatchWait represents the maximum time the logs agent waits to fill each batch of logs before sending. Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is disabled.'
+        type: integer
+      compression_level:
+        description: 'CompressionLevel accepts values from 0 (no compression) to 9 (maximum compression but higher resource usage). Only takes effect if UseCompression is set to true. Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is disabled.'
+        type: integer
+      use_compression:
+        description: 'UseCompression enables the logs agent to compress logs before sending them. Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is disabled.'
+        type: boolean
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confignet.tcp_addr_config
+  metrics_config:
+    description: MetricsConfig defines the metrics exporter specific configuration options
+    type: object
+    properties:
+      delta_ttl:
+        description: DeltaTTL defines the time that previous points of a cumulative monotonic metric are kept in memory to calculate deltas
+        type: integer
+        x-customType: int64
+      histograms:
+        description: HistConfig defines the export of OTLP Histograms.
+        $ref: histogram_config
+      summaries:
+        description: SummaryConfig defines the export for OTLP Summaries.
+        $ref: summary_config
+      sums:
+        description: SumConfig defines the export of OTLP Sums.
+        $ref: sum_config
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confignet.tcp_addr_config
+      - $ref: metrics_exporter_config
+  metrics_exporter_config:
+    description: MetricsExporterConfig provides options for a user to customize the behavior of the metrics exporter
+    type: object
+    properties:
+      instrumentation_scope_metadata_as_tags:
+        description: InstrumentationScopeMetadataAsTags, if set to true, adds the name and version of the instrumentation scope that created a metric to the metric tags
+        type: boolean
+      resource_attributes_as_tags:
+        description: ResourceAttributesAsTags, if set to true, will use the exporterhelper feature to transform all resource attributes into metric labels, which are then converted into tags
+        type: boolean
+  orchestrator_explorer_config:
+    description: OrchestratorExplorerConfig defines configuration for the Datadog orchestrator explorer.
+    type: object
+    properties:
+      enabled:
+        description: Enabled enables the orchestrator explorer.
+        type: boolean
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confignet.tcp_addr_config
+  sum_config:
+    description: SumConfig customizes export of OTLP Sums.
+    type: object
+    properties:
+      cumulative_monotonic_mode:
+        description: CumulativeMonotonicMode is the mode for exporting OTLP Cumulative Monotonic Sums. Valid values are 'to_delta' or 'raw_value'. - 'to_delta' calculates delta for cumulative monotonic sums and sends it as a Datadog count. - 'raw_value' sends the raw value of cumulative monotonic sums as Datadog gauges. The default is 'to_delta'. See https://docs.datadoghq.com/metrics/otlp/?tab=sum#mapping for details and examples.
+        $ref: cumulative_monotonic_sum_mode
+      initial_cumulative_monotonic_value:
+        description: InitialCumulativeMonotonicMode defines the behavior of the exporter when receiving the first value of a cumulative monotonic sum.
+        $ref: initial_value_mode
+  summary_config:
+    description: SummaryConfig customizes export of OTLP Summaries.
+    type: object
+    properties:
+      mode:
+        description: Mode is the mode for exporting OTLP Summaries. Valid values are 'noquantiles' or 'gauges'. - 'noquantiles' sends no `.quantile` metrics. `.sum` and `.count` metrics will still be sent. - 'gauges' sends `.quantile` metrics as gauges tagged by the quantile. The default is 'gauges'. See https://docs.datadoghq.com/metrics/otlp/?tab=summary#mapping for details and examples.
+        $ref: summary_mode
+  summary_mode:
+    description: SummaryMode is the export mode for OTLP Summary metrics.
+    type: string
+  tags_config:
+    description: TagsConfig defines the tag-related configuration It is embedded in the configuration
+    type: object
+    properties:
+      hostname:
+        description: Hostname is the fallback hostname used for payloads without hostname-identifying attributes. This option will NOT change the hostname applied to your metrics, traces and logs if they already have hostname-identifying attributes. If unset, the hostname will be determined automatically. See https://docs.datadoghq.com/opentelemetry/schema_semantics/hostname/?tab=datadogexporter#fallback-hostname-logic for details. Prefer using the `datadog.host.name` resource attribute over using this setting. See https://docs.datadoghq.com/opentelemetry/schema_semantics/hostname/?tab=datadogexporter#general-hostname-semantic-conventions for details.
+        type: string
+  traces_config:
+    description: TracesConfig defines the traces exporter specific configuration options
+    type: object
+    properties:
+      compute_stats_by_span_kind:
+        description: 'If set to true, enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer). If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed. NOTE: For stats computed from OTel traces, only top-level spans are considered when this option is off. If you are sending OTel traces and want stats on non-top-level spans, this flag will need to be enabled. If you are sending OTel traces and do not want stats computed by span kind, you need to disable this flag and disable `compute_top_level_by_span_kind`.'
+        type: boolean
+      compute_top_level_by_span_kind:
+        description: If set to true, root spans and spans with a server or consumer `span.kind` will be marked as top-level. Additionally, spans with a client or producer `span.kind` will have stats computed. Enabling this config option may increase the number of spans that generate trace metrics, and may change which spans appear as top-level in Datadog. ComputeTopLevelBySpanKind needs to be enabled in both the Datadog connector and Datadog exporter configs if both components are being used. The default value is `false`.
+        type: boolean
+      ignore_resources:
+        description: 'ignored resources A blacklist of regular expressions can be provided to disable certain traces based on their resource name all entries must be surrounded by double quotes and separated by commas. ignore_resources: ["(GET|POST) /healthcheck"]'
+        type: array
+        items:
+          type: string
+      peer_service_aggregation:
+        description: 'If set to true, enables `peer.service` aggregation in the exporter. If disabled, aggregated trace stats will not include `peer.service` as a dimension. For the best experience with `peer.service`, it is recommended to also enable `compute_stats_by_span_kind`. If enabling both causes the datadog exporter to consume too many resources, try disabling `compute_stats_by_span_kind` first. If the overhead remains high, it will be due to a high cardinality of `peer.service` values from the traces. You may need to check your instrumentation. Deprecated: Please use PeerTagsAggregation instead'
+        type: boolean
+      peer_tags:
+        description: '[BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags and will drop ones that are unapproved. The default set of peer tags can be found at https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.'
+        type: array
+        items:
+          type: string
+      peer_tags_aggregation:
+        description: If set to true, enables aggregation of peer related tags (e.g., `peer.service`, `db.instance`, etc.) in the datadog exporter. If disabled, aggregated trace stats will not include these tags as dimensions on trace metrics. For the best experience with peer tags, Datadog also recommends enabling `compute_stats_by_span_kind`. If you are using an OTel tracer, it's best to have both enabled because client/producer spans with relevant peer tags may not be marked by the datadog exporter as top-level spans. If enabling both causes the datadog exporter to consume too many resources, try disabling `compute_stats_by_span_kind` first. A high cardinality of peer tags or APM resources can also contribute to higher CPU and memory consumption. You can check for the cardinality of these fields by making trace search queries in the Datadog UI. The default list of peer tags can be found in https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/concentrator.go.
+        type: boolean
+      span_name_as_resource_name:
+        description: If set to true the OpenTelemetry span name will used in the Datadog resource name. If set to false the resource name will be filled with the instrumentation library name + span kind. The default value is `false`.
+        type: boolean
+      span_name_remappings:
+        description: 'SpanNameRemappings is the map of datadog span names and preferred name to map to. This can be used to automatically map Datadog Span Operation Names to an updated value. All entries should be key/value pairs. span_name_remappings: io.opentelemetry.javaagent.spring.client: spring.client instrumentation:express.server: express go.opentelemetry.io_contrib_instrumentation_net_http_otelhttp.client: http.client'
+        type: object
+        additionalProperties:
+          type: string
+  traces_connector_config:
+    description: TracesConnectorConfig Traces configuration in DD connector
+    type: object
+    properties:
+      bucket_interval:
+        description: BucketInterval specifies the time interval size of aggregation buckets that aggregate the Datadog trace metrics. It is also the time interval that Datadog trace metrics payloads are flushed to the pipeline. If you are concerned about the metric volume generated by the Datadog connector and the resulting networking egress, try increasing bucket_interval. Default is 10s if unset.
+        type: string
+        format: duration
+      ignore_missing_datadog_fields:
+        description: IgnoreMissingDatadogFields specifies whether we should recompute DD span fields if the corresponding "datadog." namespaced span attributes are missing. If it is false (default), we will use the incoming "datadog." namespaced OTLP span attributes to construct the DD span, and if they are missing, we will recompute them from the other OTLP semantic convention attributes. If it is true, we will only populate a field if its associated "datadog." OTLP span attribute exists, otherwise we will leave it empty.
+        type: boolean
+      resource_attributes_as_container_tags:
+        description: ResourceAttributesAsContainerTags specifies the list of resource attributes to be used as container tags.
+        type: array
+        items:
+          type: string
+      trace_buffer:
+        description: TraceBuffer specifies the number of Datadog Agent TracerPayloads to buffer before dropping. The default value is 1000.
+        type: integer
+    allOf:
+      - $ref: traces_config
+  traces_exporter_config:
+    description: TracesExporterConfig Traces configuration in DD exporter
+    type: object
+    properties:
+      trace_buffer:
+        description: TraceBuffer specifies the number of Datadog Agent TracerPayloads to buffer before dropping. The default value is 0, meaning the Datadog Agent TracerPayloads are unbuffered.
+        type: integer
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confignet.tcp_addr_config
+      - $ref: traces_config

--- a/receiver/carbonreceiver/config.schema.yaml
+++ b/receiver/carbonreceiver/config.schema.yaml
@@ -1,0 +1,13 @@
+description: Config defines configuration for the Carbon receiver.
+type: object
+properties:
+  parser:
+    description: Parser specifies a parser and the respective configuration to be used by the receiver.
+    x-pointer: true
+    $ref: ./protocol.config
+  tcp_idle_timeout:
+    description: TCPIdleTimeout is the timeout for idle TCP connections, it is ignored if transport being used is UDP.
+    type: string
+    format: duration
+allOf:
+  - $ref: go.opentelemetry.io/collector/config/confignet.addr_config

--- a/receiver/carbonreceiver/protocol/config.schema.yaml
+++ b/receiver/carbonreceiver/protocol/config.schema.yaml
@@ -1,0 +1,44 @@
+$defs:
+  config:
+    description: Config is the general configuration for the parser to be used.
+    type: object
+    properties:
+      config:
+        description: Config placeholder for the configuration object of the selected parser.
+        $ref: parser_config
+      type:
+        description: Type of the parser to be used with the arriving data.
+        type: string
+  regex_parser_config:
+    description: 'RegexParserConfig has the configuration for a parser that can breakdown a Carbon "metric path" and transform it in corresponding metric labels according to a series of regular expressions rules (see below for details). This is typically used to extract labels from a "naming hierarchy", see https://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy Examples: 1. Rule: - regexp: "(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.cpu\.seconds" name_prefix: cpu_seconds labels: k: v Metric path: "service_name.host00.cpu.seconds" Resulting metric: name: cpu_seconds label keys: {"svc", "host", "k"} label values: {"service_name", "host00", "k"} 2. Rule: - regexp: "^(?P<key_svc>[^.]+)\.(?P<key_host>[^.]+)\.(?P<name_0>[^.]+).(?P<name_1>[^.]+)$" Metric path: "svc_02.host02.avg.duration" Resulting metric: name: avgduration label keys: {"svc", "host"} label values: {"svc_02", "host02"}'
+    type: object
+    properties:
+      name_separator:
+        description: MetricNameSeparator is used when joining the name prefix of each individual rule and the respective named captures that start with the prefix "name_" (see RegexRule for more information).
+        type: string
+      rules:
+        description: Rules contains the regular expression rules to be used by the parser. The first rule that matches and applies the transformations configured in the respective RegexRule struct. If no rules match the metric is then processed by the "plaintext" parser.
+        type: array
+        items:
+          x-pointer: true
+          $ref: regex_rule
+  regex_rule:
+    description: RegexRule describes how parts of the name of metric are going to be mapped to metric labels. The rule is only applied if the name matches the given regular expression.
+    type: object
+    properties:
+      labels:
+        description: Labels are key-value pairs added as labels to the metrics that match this rule.
+        type: object
+        additionalProperties:
+          type: string
+      name_prefix:
+        description: NamePrefix is the prefix added to the metric name after extracting the parts that will form labels and final metric name.
+        type: string
+      regexp:
+        description: Regular expression from which named matches are used to extract label keys and values from Carbon metric paths.
+        type: string
+      type:
+        description: MetricType selects the type of metric to be generated, supported values are "gauge" (the default) and "cumulative".
+        type: string
+  target_metric_type:
+    type: string

--- a/receiver/chronyreceiver/config.schema.yaml
+++ b/receiver/chronyreceiver/config.schema.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  endpoint:
+    description: 'Endpoint is the published address or unix socket that allows clients to connect to: The allowed format is: unix:///path/to/chronyd/unix.sock udp://localhost:323 The default value is unix:///var/run/chrony/chronyd.sock'
+    type: string
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/chronyreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/chronyreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,34 @@
+$defs:
+  attribute_leap_status:
+    description: AttributeLeapStatus specifies the value leap.status attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for chrony metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+  metrics_config:
+    description: MetricsConfig provides config for chrony metrics.
+    type: object
+    properties:
+      ntp.frequency.offset:
+        $ref: metric_config
+      ntp.skew:
+        $ref: metric_config
+      ntp.stratum:
+        $ref: metric_config
+      ntp.time.correction:
+        $ref: metric_config
+      ntp.time.last_offset:
+        $ref: metric_config
+      ntp.time.rms_offset:
+        $ref: metric_config
+      ntp.time.root_delay:
+        $ref: metric_config

--- a/receiver/ciscoosreceiver/config.schema.yaml
+++ b/receiver/ciscoosreceiver/config.schema.yaml
@@ -1,0 +1,7 @@
+description: Config defines configuration for Cisco OS receiver.
+type: object
+properties:
+  device:
+    $ref: ./internal/connection.device_config
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config

--- a/receiver/ciscoosreceiver/internal/connection/config.schema.yaml
+++ b/receiver/ciscoosreceiver/internal/connection/config.schema.yaml
@@ -1,0 +1,35 @@
+$defs:
+  auth_config:
+    description: AuthConfig represents authentication configuration
+    type: object
+    properties:
+      key_file:
+        type: string
+      password:
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
+      username:
+        type: string
+  device_config:
+    description: DeviceConfig represents configuration for a single Cisco device using semantic conventions
+    type: object
+    properties:
+      auth:
+        $ref: auth_config
+      device:
+        $ref: device_info
+  device_info:
+    description: DeviceInfo follows semantic conventions for device identification
+    type: object
+    properties:
+      host:
+        $ref: host_info
+  host_info:
+    description: HostInfo contains host-specific information
+    type: object
+    properties:
+      ip:
+        type: string
+      name:
+        type: string
+      port:
+        type: integer

--- a/receiver/cloudflarereceiver/config.schema.yaml
+++ b/receiver/cloudflarereceiver/config.schema.yaml
@@ -1,0 +1,26 @@
+$defs:
+  logs_config:
+    type: object
+    properties:
+      attributes:
+        type: object
+        additionalProperties:
+          type: string
+      endpoint:
+        type: string
+      secret:
+        type: string
+      separator:
+        type: string
+      timestamp_field:
+        type: string
+      timestamp_format:
+        type: string
+      tls:
+        x-pointer: true
+        $ref: go.opentelemetry.io/collector/config/configtls.server_config
+description: Config holds all the parameters to start an HTTP server that can be sent logs from CloudFlare
+type: object
+properties:
+  logs:
+    $ref: logs_config

--- a/receiver/cloudfoundryreceiver/config.schema.yaml
+++ b/receiver/cloudfoundryreceiver/config.schema.yaml
@@ -1,0 +1,38 @@
+$defs:
+  limited_client_config:
+    description: LimitedClientConfig is a subset of ClientConfig, implemented as a separate type due to the library this configuration is used with not taking a preconfigured http.Client as input, but only taking these specific options
+    type: object
+    properties:
+      endpoint:
+        type: string
+      tls:
+        $ref: limited_tls_client_setting
+  limited_tls_client_setting:
+    description: LimitedTLSClientSetting is a subset of TLSClientSetting, see LimitedClientConfig for more details
+    type: object
+    properties:
+      insecure_skip_verify:
+        type: boolean
+  rlp_gateway_config:
+    type: object
+    properties:
+      shard_id:
+        type: string
+    allOf:
+      - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+  uaa_config:
+    type: object
+    properties:
+      password:
+        $ref: go.opentelemetry.io/collector/config/configopaque.string
+      username:
+        type: string
+    allOf:
+      - $ref: limited_client_config
+description: Config defines configuration for Collectd receiver.
+type: object
+properties:
+  rlp_gateway:
+    $ref: rlp_gateway_config
+  uaa:
+    $ref: uaa_config

--- a/receiver/collectdreceiver/config.schema.yaml
+++ b/receiver/collectdreceiver/config.schema.yaml
@@ -1,0 +1,12 @@
+description: Config defines configuration for Collectd receiver.
+type: object
+properties:
+  attributes_prefix:
+    type: string
+  encoding:
+    type: string
+  timeout:
+    type: string
+    format: duration
+allOf:
+  - $ref: go.opentelemetry.io/collector/config/confighttp.server_config

--- a/receiver/couchdbreceiver/config.schema.yaml
+++ b/receiver/couchdbreceiver/config.schema.yaml
@@ -1,0 +1,11 @@
+description: Config defines the configuration for the various elements of the receiver agent.
+type: object
+properties:
+  password:
+    $ref: go.opentelemetry.io/collector/config/configopaque.string
+  username:
+    type: string
+allOf:
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: go.opentelemetry.io/collector/config/confighttp.client_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/couchdbreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/couchdbreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,66 @@
+$defs:
+  attribute_http_method:
+    description: AttributeHTTPMethod specifies the value http.method attribute.
+    type: integer
+  attribute_operation:
+    description: AttributeOperation specifies the value operation attribute.
+    type: integer
+  attribute_view:
+    description: AttributeView specifies the value view attribute.
+    type: integer
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for couchdb metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for couchdb metrics.
+    type: object
+    properties:
+      couchdb.average_request_time:
+        $ref: metric_config
+      couchdb.database.open:
+        $ref: metric_config
+      couchdb.database.operations:
+        $ref: metric_config
+      couchdb.file_descriptor.open:
+        $ref: metric_config
+      couchdb.httpd.bulk_requests:
+        $ref: metric_config
+      couchdb.httpd.requests:
+        $ref: metric_config
+      couchdb.httpd.responses:
+        $ref: metric_config
+      couchdb.httpd.views:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for couchdb resource attributes.
+    type: object
+    properties:
+      couchdb.node.name:
+        $ref: resource_attribute_config

--- a/receiver/datadogreceiver/config.schema.yaml
+++ b/receiver/datadogreceiver/config.schema.yaml
@@ -1,0 +1,32 @@
+$defs:
+  intake_config:
+    description: IntakeConfig controls the `/intake` endpoint behavior
+    type: object
+    properties:
+      behavior:
+        description: 'Behavior sets how the `/intake` endpoint should behave. The value should be one of: `disable` (default) - disable the endpoint entirely `proxy` - proxy the requests to Datadog itself'
+        type: string
+      proxy:
+        description: Proxy controls how the `/intake` proxy operates
+        $ref: proxy_config
+  proxy_config:
+    description: ProxyConfig controls how the `/intake` proxy operates
+    type: object
+    properties:
+      api:
+        description: API defines the settings for calling Datadog with the proxied requests
+        $ref: github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.api_config
+type: object
+properties:
+  intake:
+    description: Intake controls the `/intake` endpoint behavior
+    $ref: intake_config
+  read_timeout:
+    description: ReadTimeout of the http server
+    type: string
+    format: duration
+  trace_id_cache_size:
+    description: TraceIDCacheSize sets the cache size for the 64 bits to 128 bits mapping
+    type: integer
+allOf:
+  - $ref: go.opentelemetry.io/collector/config/confighttp.server_config

--- a/receiver/dockerstatsreceiver/config.schema.yaml
+++ b/receiver/dockerstatsreceiver/config.schema.yaml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  container_labels_to_metric_labels:
+    description: 'A mapping of container label names to MetricDescriptor label keys. The corresponding container label value will become the DataPoint label value for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a MetricDescriptor label called `container_spec_name` whose Metric DataPoints have the value of the `io.kubernetes.container.name` container label.'
+    type: object
+    additionalProperties:
+      type: string
+  env_vars_to_metric_labels:
+    description: 'A mapping of container environment variable names to MetricDescriptor label keys.  The corresponding env var values become the DataPoint label value. E.g. `APP_VERSION: version` would result MetricDescriptors having a label key called `version` whose DataPoint label values are the value of the `APP_VERSION` environment variable configured for that particular container, if present.'
+    type: object
+    additionalProperties:
+      type: string
+allOf:
+  - $ref: github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker.config
+  - $ref: go.opentelemetry.io/collector/scraper/scraperhelper.controller_config
+  - $ref: ./internal/metadata.metrics_builder_config

--- a/receiver/dockerstatsreceiver/internal/metadata/config.schema.yaml
+++ b/receiver/dockerstatsreceiver/internal/metadata/config.schema.yaml
@@ -1,0 +1,195 @@
+$defs:
+  metric_config:
+    description: MetricConfig provides common config for a particular metric.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+  metrics_builder_config:
+    description: MetricsBuilderConfig is a configuration for docker_stats metrics builder.
+    type: object
+    properties:
+      metrics:
+        $ref: metrics_config
+      resource_attributes:
+        $ref: resource_attributes_config
+  metrics_config:
+    description: MetricsConfig provides config for docker_stats metrics.
+    type: object
+    properties:
+      container.blockio.io_merged_recursive:
+        $ref: metric_config
+      container.blockio.io_queued_recursive:
+        $ref: metric_config
+      container.blockio.io_service_bytes_recursive:
+        $ref: metric_config
+      container.blockio.io_service_time_recursive:
+        $ref: metric_config
+      container.blockio.io_serviced_recursive:
+        $ref: metric_config
+      container.blockio.io_time_recursive:
+        $ref: metric_config
+      container.blockio.io_wait_time_recursive:
+        $ref: metric_config
+      container.blockio.sectors_recursive:
+        $ref: metric_config
+      container.cpu.limit:
+        $ref: metric_config
+      container.cpu.logical.count:
+        $ref: metric_config
+      container.cpu.shares:
+        $ref: metric_config
+      container.cpu.throttling_data.periods:
+        $ref: metric_config
+      container.cpu.throttling_data.throttled_periods:
+        $ref: metric_config
+      container.cpu.throttling_data.throttled_time:
+        $ref: metric_config
+      container.cpu.usage.kernelmode:
+        $ref: metric_config
+      container.cpu.usage.percpu:
+        $ref: metric_config
+      container.cpu.usage.system:
+        $ref: metric_config
+      container.cpu.usage.total:
+        $ref: metric_config
+      container.cpu.usage.usermode:
+        $ref: metric_config
+      container.cpu.utilization:
+        $ref: metric_config
+      container.memory.active_anon:
+        $ref: metric_config
+      container.memory.active_file:
+        $ref: metric_config
+      container.memory.anon:
+        $ref: metric_config
+      container.memory.cache:
+        $ref: metric_config
+      container.memory.dirty:
+        $ref: metric_config
+      container.memory.fails:
+        $ref: metric_config
+      container.memory.file:
+        $ref: metric_config
+      container.memory.hierarchical_memory_limit:
+        $ref: metric_config
+      container.memory.hierarchical_memsw_limit:
+        $ref: metric_config
+      container.memory.inactive_anon:
+        $ref: metric_config
+      container.memory.inactive_file:
+        $ref: metric_config
+      container.memory.mapped_file:
+        $ref: metric_config
+      container.memory.percent:
+        $ref: metric_config
+      container.memory.pgfault:
+        $ref: metric_config
+      container.memory.pgmajfault:
+        $ref: metric_config
+      container.memory.pgpgin:
+        $ref: metric_config
+      container.memory.pgpgout:
+        $ref: metric_config
+      container.memory.rss:
+        $ref: metric_config
+      container.memory.rss_huge:
+        $ref: metric_config
+      container.memory.total_active_anon:
+        $ref: metric_config
+      container.memory.total_active_file:
+        $ref: metric_config
+      container.memory.total_cache:
+        $ref: metric_config
+      container.memory.total_dirty:
+        $ref: metric_config
+      container.memory.total_inactive_anon:
+        $ref: metric_config
+      container.memory.total_inactive_file:
+        $ref: metric_config
+      container.memory.total_mapped_file:
+        $ref: metric_config
+      container.memory.total_pgfault:
+        $ref: metric_config
+      container.memory.total_pgmajfault:
+        $ref: metric_config
+      container.memory.total_pgpgin:
+        $ref: metric_config
+      container.memory.total_pgpgout:
+        $ref: metric_config
+      container.memory.total_rss:
+        $ref: metric_config
+      container.memory.total_rss_huge:
+        $ref: metric_config
+      container.memory.total_unevictable:
+        $ref: metric_config
+      container.memory.total_writeback:
+        $ref: metric_config
+      container.memory.unevictable:
+        $ref: metric_config
+      container.memory.usage.limit:
+        $ref: metric_config
+      container.memory.usage.max:
+        $ref: metric_config
+      container.memory.usage.total:
+        $ref: metric_config
+      container.memory.writeback:
+        $ref: metric_config
+      container.network.io.usage.rx_bytes:
+        $ref: metric_config
+      container.network.io.usage.rx_dropped:
+        $ref: metric_config
+      container.network.io.usage.rx_errors:
+        $ref: metric_config
+      container.network.io.usage.rx_packets:
+        $ref: metric_config
+      container.network.io.usage.tx_bytes:
+        $ref: metric_config
+      container.network.io.usage.tx_dropped:
+        $ref: metric_config
+      container.network.io.usage.tx_errors:
+        $ref: metric_config
+      container.network.io.usage.tx_packets:
+        $ref: metric_config
+      container.pids.count:
+        $ref: metric_config
+      container.pids.limit:
+        $ref: metric_config
+      container.restarts:
+        $ref: metric_config
+      container.uptime:
+        $ref: metric_config
+  resource_attribute_config:
+    description: ResourceAttributeConfig provides common config for a particular resource attribute.
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      metrics_exclude:
+        description: 'Experimental: MetricsExclude defines a list of filters for attribute values. If the list is not empty, metrics with matching resource attribute values will not be emitted. MetricsInclude has higher priority than MetricsExclude.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+      metrics_include:
+        description: 'Experimental: MetricsInclude defines a list of filters for attribute values. If the list is not empty, only metrics with matching resource attribute values will be emitted.'
+        type: array
+        items:
+          $ref: go.opentelemetry.io/collector/filter.config
+  resource_attributes_config:
+    description: ResourceAttributesConfig provides config for docker_stats resource attributes.
+    type: object
+    properties:
+      container.command_line:
+        $ref: resource_attribute_config
+      container.hostname:
+        $ref: resource_attribute_config
+      container.id:
+        $ref: resource_attribute_config
+      container.image.id:
+        $ref: resource_attribute_config
+      container.image.name:
+        $ref: resource_attribute_config
+      container.name:
+        $ref: resource_attribute_config
+      container.runtime:
+        $ref: resource_attribute_config


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added configuration schemas to following components:

* carbonreceiver
* chronyreceiver
* ciscoosreceiver
* cloudflarereceiver
* cloudfoundryreceiver
* collectdreceiver
* couchdbreceiver
* datadogreceiver
* dockerstatsreceiver


Schemas were generated with [schemagen](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/schemagen/README.md) script.

Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42214