### PR TITLE
Add W3C tracestate parsing optimizations and benchmarks

### DIFF
--- a/.chloggen/pkg-sampling-w3c-tracestate-optimization.yaml
+++ b/.chloggen/pkg-sampling-w3c-tracestate-optimization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace regex-based W3C tracestate validation with hand-written validator for 30-65x performance improvement
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45734]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/sampling/w3ctracestate.go
+++ b/pkg/sampling/w3ctracestate.go
@@ -229,7 +229,7 @@ func isValidW3CTraceState(input string) bool {
 // multi-tenant-key = tenant-id "@" system-id
 // Note: Size limits are checked separately in scanKeyValues to return proper errors.
 func isValidW3CKey(key string) bool {
-	if len(key) == 0 {
+	if key == "" {
 		return false
 	}
 
@@ -239,7 +239,7 @@ func isValidW3CKey(key string) bool {
 		tenant := key[:atIdx]
 		system := key[atIdx+1:]
 
-		if len(tenant) == 0 || len(system) == 0 {
+		if tenant == "" || system == "" {
 			return false
 		}
 
@@ -267,7 +267,7 @@ func isValidW3CKey(key string) bool {
 // nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
 // chr = %x20 / nblk-chr
 func isValidW3CValue(value string) bool {
-	if len(value) == 0 || len(value) > 256 {
+	if value == "" || len(value) > 256 {
 		return false
 	}
 

--- a/pkg/sampling/w3ctracestate.go
+++ b/pkg/sampling/w3ctracestate.go
@@ -104,11 +104,14 @@ var (
 // NewW3CTraceState parses a W3C trace state, with special attention
 // to the embedded OpenTelemetry trace state field.
 func NewW3CTraceState(input string) (w3c W3CTraceState, _ error) {
+	if input == "" {
+		return w3c, nil
+	}
 	if len(input) > hardMaxW3CLength {
 		return w3c, ErrTraceStateSize
 	}
 
-	if !w3cTracestateRe.MatchString(input) {
+	if !isValidW3CTraceState(input) {
 		return w3c, strconv.ErrSyntax
 	}
 
@@ -174,4 +177,142 @@ func (w3c *W3CTraceState) Serialize(w io.StringWriter) error {
 		ser.write(kv.Value)
 	}
 	return ser.err
+}
+
+// isValidW3CTraceState validates W3C tracestate syntax without using regex.
+// This is significantly faster than regex-based validation (30-60x speedup).
+func isValidW3CTraceState(input string) bool {
+	if input == "" {
+		return true
+	}
+
+	// Process each member separated by commas
+	for input != "" {
+		// Find next comma
+		sep := strings.IndexByte(input, ',')
+		var member string
+		if sep < 0 {
+			member = input
+			input = ""
+		} else {
+			member = input[:sep]
+			input = input[sep+1:]
+		}
+
+		// Trim optional whitespace (OWS)
+		member = strings.Trim(member, " \t")
+
+		// Empty members are allowed
+		if member == "" {
+			continue
+		}
+
+		// Find the equals sign
+		eq := strings.IndexByte(member, '=')
+		if eq < 1 { // Must have at least one char before '='
+			return false
+		}
+
+		key := member[:eq]
+		value := member[eq+1:]
+
+		if !isValidW3CKey(key) || !isValidW3CValue(value) {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidW3CKey validates a W3C tracestate key syntax (not size limits).
+// key = simple-key / multi-tenant-key
+// simple-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+// multi-tenant-key = tenant-id "@" system-id
+// Note: Size limits are checked separately in scanKeyValues to return proper errors.
+func isValidW3CKey(key string) bool {
+	if len(key) == 0 {
+		return false
+	}
+
+	atIdx := strings.IndexByte(key, '@')
+	if atIdx >= 0 {
+		// Multi-tenant key
+		tenant := key[:atIdx]
+		system := key[atIdx+1:]
+
+		if len(tenant) == 0 || len(system) == 0 {
+			return false
+		}
+
+		// tenant-id starts with lcalpha or digit
+		if !isLcAlphaNum(tenant[0]) {
+			return false
+		}
+		// system-id starts with lcalpha only
+		if !isLcAlpha(system[0]) {
+			return false
+		}
+
+		return isValidKeyChars(tenant[1:]) && isValidKeyChars(system[1:])
+	}
+
+	// Simple key: must start with lcalpha
+	if !isLcAlpha(key[0]) {
+		return false
+	}
+	return isValidKeyChars(key[1:])
+}
+
+// isValidW3CValue validates a W3C tracestate value.
+// value = 0*255(chr) nblk-chr
+// nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
+// chr = %x20 / nblk-chr
+func isValidW3CValue(value string) bool {
+	if len(value) == 0 || len(value) > 256 {
+		return false
+	}
+
+	// Last char must be non-blank
+	last := value[len(value)-1]
+	if !isNonBlankValueChar(last) {
+		return false
+	}
+
+	// All chars must be valid value chars
+	for i := 0; i < len(value)-1; i++ {
+		if !isValueChar(value[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isLcAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z'
+}
+
+func isLcAlphaNum(c byte) bool {
+	return isLcAlpha(c) || (c >= '0' && c <= '9')
+}
+
+func isValidKeyChar(c byte) bool {
+	return isLcAlphaNum(c) || c == '_' || c == '-' || c == '*' || c == '/'
+}
+
+func isValidKeyChars(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isValidKeyChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// isNonBlankValueChar: %x21-2B / %x2D-3C / %x3E-7E
+func isNonBlankValueChar(c byte) bool {
+	return (c >= 0x21 && c <= 0x2B) || (c >= 0x2D && c <= 0x3C) || (c >= 0x3E && c <= 0x7E)
+}
+
+// isValueChar: %x20 / nblk-chr
+func isValueChar(c byte) bool {
+	return c == 0x20 || isNonBlankValueChar(c)
 }

--- a/pkg/sampling/w3ctracestate_benchmark_test.go
+++ b/pkg/sampling/w3ctracestate_benchmark_test.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampling
+
+import (
+	"strings"
+	"testing"
+)
+
+func BenchmarkNewW3CTraceState(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "Empty",
+			input: "",
+		},
+		{
+			name:  "OTelWithExtraFields",
+			input: "ot=th:c;rv:d29d6a7215ced0;pn:abc",
+		},
+		{
+			name:  "OTelPlusMultipleVendors",
+			input: "ot=th:c;rv:d29d6a7215ced0;pn:abc,zz=vendorcontent,aa=value1,bb=value2",
+		},
+		{
+			name:  "LongValue",
+			input: "ot=th:c,vendor=" + strings.Repeat("x", 200),
+		},
+		{
+			name:  "MaxPairs",
+			input: generateManyPairs(32),
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = NewW3CTraceState(bm.input)
+			}
+		})
+	}
+}
+
+// generateManyPairs creates a tracestate string with the specified number of key-value pairs.
+func generateManyPairs(n int) string {
+	var sb strings.Builder
+	sb.WriteString("ot=th:c")
+	for i := 1; i < n; i++ {
+		sb.WriteString(",v")
+		sb.WriteString(strings.Repeat("x", i%10))
+		sb.WriteString("=val")
+	}
+	return sb.String()
+}
+
+func BenchmarkNewW3CTraceStateParallel(b *testing.B) {
+	input := "ot=th:c;rv:d29d6a7215ced0;pn:abc,zz=vendorcontent"
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = NewW3CTraceState(input)
+		}
+	})
+}
+
+// =============================================================================
+// Benchmark: Hand-written Validator vs Regex
+// =============================================================================
+
+func BenchmarkW3CTracestateValidation(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input string
+	}{
+		{"Simple", "ot=th:c"},
+		{"Complex", "ot=th:c;rv:d29d6a7215ced0;pn:abc,zz=vendorcontent,aa=value1,bb=value2"},
+		{"LongValue", "ot=th:c,vendor=" + strings.Repeat("x", 200)},
+		{"MaxPairs", generateManyPairs(32)},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run("Regex/"+bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = w3cTracestateRe.MatchString(bm.input)
+			}
+		})
+
+		b.Run("NoRegex/"+bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = isValidW3CTraceState(bm.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
We replaced the use of regex for syntax checking with hand-written validator that proceeds sequentially. Performance improvement is 30-60X.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
This will be used by issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45539

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Functional test comparing use of regex and the new validation method.

A number of benchmark tests showed performance improvement from 30 to upper 60X.

### Benchmark Results

**Environment:** Apple M1 Max, darwin/arm64

#### `NewW3CTraceState` Performance

| Benchmark | ns/op | B/op | allocs/op |
|-----------|------:|-----:|----------:|
| Empty | 3.35 | 0 | 0 |
| OTelWithExtraFields | 540.9 | 32 | 1 |
| OTelPlusMultipleVendors | 757.2 | 256 | 4 |
| LongValue | 387.9 | 32 | 1 |
| MaxPairs | 1676 | 2144 | 6 |
| Parallel | 98.55 | 64 | 2 |

#### Validation: Regex vs Hand-Written

| Input | Regex (ns/op) | NoRegex (ns/op) | Speedup |
|-------|-------------:|----------------:|--------:|
| Simple | 528.6 | 18.25 | **29x** |
| Complex | 4645 | 109.1 | **43x** |
| LongValue | 14075 | 215.5 | **65x** |
| MaxPairs | 19710 | 615.7 | **32x** |

All validation benchmarks show **zero allocations** for both implementations.