### PR TITLE
Fix race condition in gohai host metadata payload

### DIFF
--- a/.chloggen/fix-gohai-race-condition.yaml
+++ b/.chloggen/fix-gohai-race-condition.yaml
@@ -4,7 +4,7 @@
 change_type: "bug_fix"
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: "internal/datadog/hostmetadata"
+component: "internal/datadog"
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fix race condition in gohai host metadata payload causing concurrent map access panic"

--- a/.chloggen/fix-gohai-race-condition.yaml
+++ b/.chloggen/fix-gohai-race-condition.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: "internal/datadog/hostmetadata"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix race condition in gohai host metadata payload causing concurrent map access panic"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30438]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Deep copy the host metadata payload before passing it to ConsumeHostMetadata() to prevent
+  concurrent map access when the reporter's gohai collector refreshes maps while JSON marshaling
+  iterates over them. This fixes the "fatal error: concurrent map iteration and map write" panic
+  that occurred with multiple concurrent metric consumers and host metadata enabled.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/datadog/hostmetadata/metadata.go
+++ b/internal/datadog/hostmetadata/metadata.go
@@ -178,12 +178,12 @@ func deepCopyHostMetadata(hm payload.HostMetadata) (payload.HostMetadata, error)
 		return payload.HostMetadata{}, fmt.Errorf("failed to marshal host metadata for deep copy: %w", err)
 	}
 
-	var copy payload.HostMetadata
-	if err := json.Unmarshal(marshaled, &copy); err != nil {
+	var copied payload.HostMetadata
+	if err := json.Unmarshal(marshaled, &copied); err != nil {
 		return payload.HostMetadata{}, fmt.Errorf("failed to unmarshal host metadata for deep copy: %w", err)
 	}
 
-	return copy, nil
+	return copied, nil
 }
 
 // RunPusher to push host metadata payloads from the host where the Collector is running periodically to Datadog intake.

--- a/internal/datadog/hostmetadata/metadata_test.go
+++ b/internal/datadog/hostmetadata/metadata_test.go
@@ -274,15 +274,15 @@ func TestDeepCopyHostMetadata(t *testing.T) {
 	}
 
 	// Deep copy the payload
-	copy, err := deepCopyHostMetadata(original)
+	copied, err := deepCopyHostMetadata(original)
 	require.NoError(t, err)
 
 	// Verify the copy has the same values
-	assert.Equal(t, original.InternalHostname, copy.InternalHostname)
-	assert.Equal(t, original.Flavor, copy.Flavor)
-	assert.Equal(t, original.Version, copy.Version)
-	assert.Equal(t, original.Meta.Hostname, copy.Meta.Hostname)
-	assert.Equal(t, original.Tags.OTel, copy.Tags.OTel)
+	assert.Equal(t, original.InternalHostname, copied.InternalHostname)
+	assert.Equal(t, original.Flavor, copied.Flavor)
+	assert.Equal(t, original.Version, copied.Version)
+	assert.Equal(t, original.Meta.Hostname, copied.Meta.Hostname)
+	assert.Equal(t, original.Tags.OTel, copied.Tags.OTel)
 
 	// Modify the original
 	original.InternalHostname = "modified-hostname"
@@ -291,12 +291,12 @@ func TestDeepCopyHostMetadata(t *testing.T) {
 	original.Tags.OTel = append(original.Tags.OTel, "new:tag")
 
 	// Verify the copy is not affected
-	assert.NotEqual(t, original.InternalHostname, copy.InternalHostname)
-	assert.NotEqual(t, original.Flavor, copy.Flavor)
-	assert.NotEqual(t, original.Meta.Hostname, copy.Meta.Hostname)
-	assert.NotEqual(t, len(original.Tags.OTel), len(copy.Tags.OTel))
-	assert.Equal(t, "test-hostname", copy.InternalHostname)
-	assert.Equal(t, "otelcontribcol", copy.Flavor)
-	assert.Equal(t, "test-hostname", copy.Meta.Hostname)
-	assert.Equal(t, []string{"key1:val1"}, copy.Tags.OTel)
+	assert.NotEqual(t, original.InternalHostname, copied.InternalHostname)
+	assert.NotEqual(t, original.Flavor, copied.Flavor)
+	assert.NotEqual(t, original.Meta.Hostname, copied.Meta.Hostname)
+	assert.NotEqual(t, len(original.Tags.OTel), len(copied.Tags.OTel))
+	assert.Equal(t, "test-hostname", copied.InternalHostname)
+	assert.Equal(t, "otelcontribcol", copied.Flavor)
+	assert.Equal(t, "test-hostname", copied.Meta.Hostname)
+	assert.Equal(t, []string{"key1:val1"}, copied.Tags.OTel)
 }

--- a/internal/datadog/hostmetadata/metadata_test.go
+++ b/internal/datadog/hostmetadata/metadata_test.go
@@ -274,8 +274,7 @@ func TestDeepCopyHostMetadata(t *testing.T) {
 	}
 
 	// Deep copy the payload
-	copied, err := deepCopyHostMetadata(original)
-	require.NoError(t, err)
+	copied := deepCopyHostMetadata(original)
 
 	// Verify the copy has the same values
 	assert.Equal(t, original.InternalHostname, copied.InternalHostname)


### PR DESCRIPTION
#### Description

This PR fixes concurrent map access panic when host metadata payload is shared between the reporter's gohai collector refresh and JSON marshaling.

The issue occurred because:
- The same hostMetadata payload (containing gohai maps) was reused and passed to `reporter.ConsumeHostMetadata()` multiple times
- The reporter's internal gohai collector periodically calls `Refresh()` which writes to the same maps (CPU, Memory, Network, Platform)
- Concurrently, `json.Marshal()` iterates over these maps during payload serialization
- This causes `fatal error: concurrent map iteration and map write`

The fix:
- Added `deepCopyHostMetadata()` function that creates a deep copy of the payload using JSON marshal/unmarshal
- Modified `RunPusher()` to deep copy the payload before each `ConsumeHostMetadata()` call
- Added error handling with fallback to original payload if copy fails
- Added `TestDeepCopyHostMetadata()` to verify the deep copy works correctly

This ensures the reporter's gohai collector can refresh its internal maps without interfering with JSON marshaling operations, preventing the race condition.

#### Link to tracking issue
Potentially fixes one of the callouts in issue #30438 ([ref](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30438#:~:text=clientutil%0A./exporter/datadogexporter/internal/hostmetadata-,./exporter/datadogexporter/internal/hostmetadata/internal/gohai,-./exporter/datadogexporter/internal/hostmetadata/provider))

#### Testing
Existing unit tests pass, and a new test was added to verify the deep copy functionality:

```bash
cd internal/datadog/hostmetadata
go test -v
```