### PR TITLE
[chore] [cmd/schemagen] Parse all non-component code as a packages

### DIFF
--- a/cmd/schemagen/internal/config.go
+++ b/cmd/schemagen/internal/config.go
@@ -103,15 +103,8 @@ func ReadConfig() (*Config, error) {
 			switch class {
 			case "receiver", "processor", "exporter", "connector", "extension":
 				mode = Component
-			case "", "pkg":
-				mode = Package
 			default:
-				isSubClass := strings.HasPrefix(class, "pkg/")
-				if !isSubClass {
-					return nil, fmt.Errorf("schema generation for class '%s' is not supported", md.Status.Class)
-				}
 				mode = Package
-				class = "pkg"
 			}
 		}
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Schemagen parser runs in component and package modes. The decision on which mode to use is made based on the `class` attribute in the metadata.yaml file. Changes in this PR cause all classes except receivers, processors, exporters, connectors and extensions to be parsed in package mode.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/42214

<!--Describe what testing was performed and which tests were added.-->
#### Testing

* unit tests 