### PR TITLE
Allow contributors to add Skip Changelog label

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   add-labels:
-    if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') && github.repository_owner == 'open-telemetry' }}
+    if: ${{ startsWith(github.event.comment.body, '/label') && github.repository_owner == 'open-telemetry' }}
     permissions:
       issues: write
 

--- a/.github/workflows/scripts/add-labels.sh
+++ b/.github/workflows/scripts/add-labels.sh
@@ -36,6 +36,7 @@ COMMON_LABELS["priority:p2"]="priority:p2"
 COMMON_LABELS["priority:p3"]="priority:p3"
 COMMON_LABELS["stale"]="Stale"
 COMMON_LABELS["never-stale"]="never stale"
+COMMON_LABELS["skip-changelog"]="Skip Changelog"
 
 LABELS=$(echo "${COMMENT}" | sed -E 's%^/label%%')
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,7 @@ The following general labels are supported:
 | `priority:p3`             | `priority:p3`             |
 | `Stale`                   | `stale`                   |
 | `never stale`             | `never-stale`             |
+| `Skip Changelog`          | `skip-changelog`          |
 
 To delete a label, prepend the label with `-`. Note that you must make a new comment to modify labels; you cannot edit an existing comment.
 


### PR DESCRIPTION
#### Description

It would be nice to allow Code Owners and PR authors to add the Skip Changelog label to their pull requests without asking a maintainer to do so. I

It looks like adding labels only works for issues right now, and that might be desired so I am not sure this is ok or not.

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45761