### PR TITLE
[chore][exporter/signalfx] Remove rename_dimension_keys translation rule

### DIFF
--- a/exporter/signalfxexporter/internal/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata_test.go
@@ -15,16 +15,9 @@ import (
 )
 
 func TestGetDimensionUpdateFromMetadata(t *testing.T) {
-	translator, _ := translation.NewMetricTranslator([]translation.Rule{
-		{
-			Action:  translation.ActionRenameDimensionKeys,
-			Mapping: map[string]string{"name": "translated_name"},
-		},
-	}, 1, make(chan struct{}))
 	type args struct {
-		defaults         map[string]string
-		metadata         metadata.MetadataUpdate
-		metricTranslator *translation.MetricTranslator
+		defaults map[string]string
+		metadata metadata.MetadataUpdate
 	}
 	tests := []struct {
 		name string
@@ -47,7 +40,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 						MetadataToUpdate: map[string]string{},
 					},
 				},
-				metricTranslator: nil,
 			},
 			&DimensionUpdate{
 				Name:       "name",
@@ -78,7 +70,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 						},
 					},
 				},
-				metricTranslator: nil,
 			},
 			&DimensionUpdate{
 				Name:  "name",
@@ -113,7 +104,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 						},
 					},
 				},
-				metricTranslator: nil,
 			},
 			&DimensionUpdate{
 				Name:  "name",
@@ -122,44 +112,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 					"prope/rty1": "value1",
 					"prope.rty2": "",
 					"prope_rty3": "value33",
-					"prope.rty4": "",
-				}),
-				Tags: map[string]bool{
-					"ta.g1": true,
-					"ta/g2": false,
-				},
-			},
-		},
-		{
-			"Test dimensions translation",
-			args{
-				metadata: metadata.MetadataUpdate{
-					ResourceIDKey: "name",
-					ResourceID:    "val",
-					MetadataDelta: metadata.MetadataDelta{
-						MetadataToAdd: map[string]string{
-							"prope/rty1": "value1",
-							"ta.g1":      "",
-						},
-						MetadataToRemove: map[string]string{
-							"prope_rty2": "value2",
-							"ta/g2":      "",
-						},
-						MetadataToUpdate: map[string]string{
-							"prope.rty3": "value33",
-							"prope.rty4": "",
-						},
-					},
-				},
-				metricTranslator: translator,
-			},
-			&DimensionUpdate{
-				Name:  "translated_name",
-				Value: "val",
-				Properties: getMapToPointers(map[string]string{
-					"prope/rty1": "value1",
-					"prope_rty2": "",
-					"prope.rty3": "value33",
 					"prope.rty4": "",
 				}),
 				Tags: map[string]bool{
@@ -183,7 +135,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 						},
 					},
 				},
-				metricTranslator: nil,
 			},
 			&DimensionUpdate{
 				Name:       "name",
@@ -211,7 +162,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 						},
 					},
 				},
-				metricTranslator: nil,
 			},
 			&DimensionUpdate{
 				Name:  "name",
@@ -228,7 +178,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			converter, err := translation.NewMetricsConverter(
 				zap.NewNop(),
-				tt.args.metricTranslator,
+				nil,
 				nil,
 				nil,
 				"-_.",

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -160,11 +160,7 @@ func resourceToDimensions(res pcommon.Resource) []*sfxpb.Dimension {
 }
 
 func (c *MetricsConverter) ConvertDimension(dim string) string {
-	res := dim
-	if c.metricTranslator != nil {
-		res = c.metricTranslator.translateDimension(dim)
-	}
-	return filterKeyChars(res, c.datapointValidator.nonAlphanumericDimChars)
+	return filterKeyChars(dim, c.datapointValidator.nonAlphanumericDimChars)
 }
 
 func (c *MetricsConverter) Shutdown() {

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1099,84 +1099,6 @@ func Test_MetricDataToSignalFxV2WithHistogramBuckets(t *testing.T) {
 	}
 }
 
-func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
-	translator, err := NewMetricTranslator([]Rule{
-		{
-			Action: ActionRenameDimensionKeys,
-			Mapping: map[string]string{
-				"old.dim": "new.dim",
-			},
-		},
-	}, 1, make(chan struct{}))
-	require.NoError(t, err)
-
-	md := pmetric.NewMetrics()
-	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("metric1")
-	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
-	dp.SetIntValue(123)
-	dp.Attributes().PutStr("old.dim", "val1")
-
-	gaugeType := sfxpb.MetricType_GAUGE
-	expected := []*sfxpb.DataPoint{
-		{
-			Metric: "metric1",
-			Value: sfxpb.Datum{
-				IntValue: generateIntPtr(123),
-			},
-			MetricType: &gaugeType,
-			Dimensions: []*sfxpb.Dimension{
-				{
-					Key:   "new_dim",
-					Value: "val1",
-				},
-			},
-		},
-	}
-	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "", false, true)
-	require.NoError(t, err)
-	assert.Equal(t, expected, c.MetricsToSignalFxV2(md))
-}
-
-func TestDimensionKeyCharsWithPeriod(t *testing.T) {
-	translator, err := NewMetricTranslator([]Rule{
-		{
-			Action: ActionRenameDimensionKeys,
-			Mapping: map[string]string{
-				"old.dim.with.periods": "new.dim.with.periods",
-			},
-		},
-	}, 1, make(chan struct{}))
-	require.NoError(t, err)
-
-	md := pmetric.NewMetrics()
-	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("metric1")
-	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
-	dp.SetIntValue(123)
-	dp.Attributes().PutStr("old.dim.with.periods", "val1")
-
-	gaugeType := sfxpb.MetricType_GAUGE
-	expected := []*sfxpb.DataPoint{
-		{
-			Metric: "metric1",
-			Value: sfxpb.Datum{
-				IntValue: generateIntPtr(123),
-			},
-			MetricType: &gaugeType,
-			Dimensions: []*sfxpb.Dimension{
-				{
-					Key:   "new.dim.with.periods",
-					Value: "val1",
-				},
-			},
-		},
-	}
-	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "_-.", false, true)
-	require.NoError(t, err)
-	assert.Equal(t, expected, c.MetricsToSignalFxV2(md))
-}
-
 func TestInvalidNumberOfDimensions(t *testing.T) {
 	observedZapCore, observedLogs := observer.New(zap.DebugLevel)
 	logger := zap.New(observedZapCore)
@@ -1330,27 +1252,6 @@ func TestMetricsConverter_ConvertDimension(t *testing.T) {
 				dim: "d.i.m",
 			},
 			want: "d_i_m",
-		},
-		{
-			name: "With translations",
-			fields: fields{
-				metricTranslator: func() *MetricTranslator {
-					t, _ := NewMetricTranslator([]Rule{
-						{
-							Action: ActionRenameDimensionKeys,
-							Mapping: map[string]string{
-								"d.i.m": "di.m",
-							},
-						},
-					}, 0, make(chan struct{}))
-					return t
-				}(),
-				nonAlphanumericDimChars: "_-",
-			},
-			args: args{
-				dim: "d.i.m",
-			},
-			want: "di_m",
 		},
 	}
 	for _, tt := range tests {

--- a/exporter/signalfxexporter/internal/translation/translator_test.go
+++ b/exporter/signalfxexporter/internal/translation/translator_test.go
@@ -47,10 +47,9 @@ func (dims byDimensions) Swap(i, j int) { dims[i], dims[j] = dims[j], dims[i] }
 
 func TestNewMetricTranslator(t *testing.T) {
 	tests := []struct {
-		name              string
-		trs               []Rule
-		wantDimensionsMap map[string]string
-		wantError         string
+		name      string
+		trs       []Rule
+		wantError string
 	}{
 		{
 			name: "invalid_rule",
@@ -59,53 +58,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: "invalid_rule",
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "unknown \"action\" value: \"invalid_rule\"",
-		},
-		{
-			name: "rename_dimension_keys_valid",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"k8s.cluster.name": "kubernetes_cluster",
-					},
-				},
-			},
-			wantDimensionsMap: map[string]string{
-				"k8s.cluster.name": "kubernetes_cluster",
-			},
-			wantError: "",
-		},
-		{
-			name: "rename_dimension_keys_no_mapping",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-				},
-			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"mapping\" is required for \"rename_dimension_keys\" translation rule",
-		},
-		{
-			name: "rename_dimension_keys_many_actions_invalid",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"dimension1": "dimension2",
-						"dimension3": "dimension4",
-					},
-				},
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"dimension4": "dimension5",
-					},
-				},
-			},
-			wantDimensionsMap: nil,
-			wantError:         "only one \"rename_dimension_keys\" translation rule without \"metric_names\" can be specified",
+			wantError: "unknown \"action\" value: \"invalid_rule\"",
 		},
 		{
 			name: "rename_metric_valid",
@@ -117,8 +70,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "rename_metric_valid_add_dimensions",
@@ -133,8 +85,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "rename_metric_valid_copy_dimensions",
@@ -149,8 +100,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "rename_metric_invalid",
@@ -159,8 +109,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionRenameMetrics,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"mapping\" is required for \"rename_metrics\" translation rule",
+			wantError: "field \"mapping\" is required for \"rename_metrics\" translation rule",
 		},
 		{
 			name: "rename_metric_invalid_copy_dimensions",
@@ -175,31 +124,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         `mapping "copy_dimensions" for "rename_metrics" translation rule must not contain empty string keys or values`,
-		},
-		{
-			name: "rename_dimensions_and_metrics_valid",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"dimension1": "dimension2",
-						"dimension3": "dimension4",
-					},
-				},
-				{
-					Action: ActionRenameMetrics,
-					Mapping: map[string]string{
-						"metric1": "metric2",
-					},
-				},
-			},
-			wantDimensionsMap: map[string]string{
-				"dimension1": "dimension2",
-				"dimension3": "dimension4",
-			},
-			wantError: "",
+			wantError: `mapping "copy_dimensions" for "rename_metrics" translation rule must not contain empty string keys or values`,
 		},
 		{
 			name: "multiply_int_valid",
@@ -211,8 +136,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "multiply_int_invalid",
@@ -221,8 +145,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionMultiplyInt,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"scale_factors_int\" is required for \"multiply_int\" translation rule",
+			wantError: "field \"scale_factors_int\" is required for \"multiply_int\" translation rule",
 		},
 		{
 			name: "divide_int_valid",
@@ -234,8 +157,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "divide_int_invalid_no_scale_factors",
@@ -244,8 +166,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionDivideInt,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"scale_factors_int\" is required for \"divide_int\" translation rule",
+			wantError: "field \"scale_factors_int\" is required for \"divide_int\" translation rule",
 		},
 		{
 			name: "divide_int_invalid_zero",
@@ -258,8 +179,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "\"scale_factors_int\" for \"divide_int\" translation rule has 0 value for \"metric2\" metric",
+			wantError: "\"scale_factors_int\" for \"divide_int\" translation rule has 0 value for \"metric2\" metric",
 		},
 		{
 			name: "multiply_float_valid",
@@ -271,8 +191,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "multiply_float_invalid",
@@ -281,8 +200,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionMultiplyFloat,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"scale_factors_float\" is required for \"multiply_float\" translation rule",
+			wantError: "field \"scale_factors_float\" is required for \"multiply_float\" translation rule",
 		},
 		{
 			name: "copy_metric_valid",
@@ -294,8 +212,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "copy_metric_invalid_no_mapping",
@@ -304,8 +221,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionCopyMetrics,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"mapping\" is required for \"copy_metrics\" translation rule",
+			wantError: "field \"mapping\" is required for \"copy_metrics\" translation rule",
 		},
 		{
 			name: "copy_metric_invalid_no_dimensions_filter",
@@ -318,7 +234,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					DimensionKey: "dim1",
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: "\"dimension_values_filer\" has to be provided if \"dimension_key\" is set " +
 				"for \"copy_metrics\" translation rule",
 		},
@@ -334,8 +249,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "split_metric_invalid",
@@ -346,7 +260,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					DimensionKey: "dim1",
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: "fields \"metric_name\", \"dimension_key\", and \"mapping\" are required " +
 				"for \"split_metric\" translation rule",
 		},
@@ -360,8 +273,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "convert_values_invalid_no_mapping",
@@ -370,8 +282,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionConvertValues,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "field \"types_mapping\" are required for \"convert_values\" translation rule",
+			wantError: "field \"types_mapping\" are required for \"convert_values\" translation rule",
 		},
 		{
 			name: "convert_values_invalid_type",
@@ -383,8 +294,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "invalid value type \"invalid-type\" set for metric \"metric1\" in \"types_mapping\"",
+			wantError: "invalid value type \"invalid-type\" set for metric \"metric1\" in \"types_mapping\"",
 		},
 		{
 			name: "aggregate_metric_valid",
@@ -396,8 +306,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					AggregationMethod: AggregationMethodCount,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "aggregate_metric_invalid_no_dimension_key",
@@ -408,7 +317,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					AggregationMethod: AggregationMethodCount,
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: "fields \"metric_name\", \"without_dimensions\", and \"aggregation_method\" " +
 				"are required for \"aggregate_metric\" translation rule",
 		},
@@ -422,8 +330,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					AggregationMethod: AggregationMethod("invalid"),
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "invalid \"aggregation_method\": \"invalid\" provided for \"aggregate_metric\" translation rule",
+			wantError: "invalid \"aggregation_method\": \"invalid\" provided for \"aggregate_metric\" translation rule",
 		},
 		{
 			name: "calculate_new_metric_valid",
@@ -436,8 +343,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Operator:       MetricOperatorDivision,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "divide_metrics_invalid_missing_metric_name",
@@ -449,7 +355,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					Operator:       MetricOperatorDivision,
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: `fields "metric_name", "operand1_metric", "operand2_metric", and "operator" ` +
 				`are required for "calculate_new_metric" translation rule`,
 		},
@@ -463,7 +368,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					Operator:       MetricOperatorDivision,
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: `fields "metric_name", "operand1_metric", "operand2_metric", and "operator" ` +
 				`are required for "calculate_new_metric" translation rule`,
 		},
@@ -477,7 +381,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					Operator:       MetricOperatorDivision,
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: `fields "metric_name", "operand1_metric", "operand2_metric", and "operator" ` +
 				`are required for "calculate_new_metric" translation rule`,
 		},
@@ -491,7 +394,6 @@ func TestNewMetricTranslator(t *testing.T) {
 					Operand2Metric: "op2_metric",
 				},
 			},
-			wantDimensionsMap: nil,
 			wantError: `fields "metric_name", "operand1_metric", "operand2_metric", and "operator" ` +
 				`are required for "calculate_new_metric" translation rule`,
 		},
@@ -503,8 +405,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					MetricNames: map[string]bool{"metric": true},
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         "",
+			wantError: "",
 		},
 		{
 			name: "drop_metrics_invalid",
@@ -513,8 +414,7 @@ func TestNewMetricTranslator(t *testing.T) {
 					Action: ActionDropMetrics,
 				},
 			},
-			wantDimensionsMap: nil,
-			wantError:         `field "metric_names" is required for "drop_metrics" translation rule`,
+			wantError: `field "metric_names" is required for "drop_metrics" translation rule`,
 		},
 		{
 			name: "delta_metric_invalid",
@@ -543,7 +443,6 @@ func TestNewMetricTranslator(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, mt)
 				assert.Equal(t, tt.trs, mt.rules)
-				assert.Equal(t, tt.wantDimensionsMap, mt.dimensionsMap)
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, tt.wantError, err.Error())
@@ -565,141 +464,6 @@ func TestTranslateDataPoints(t *testing.T) {
 		dps  []*sfxpb.DataPoint
 		want []*sfxpb.DataPoint
 	}{
-		{
-			name: "rename_dimension_keys",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"old_dimension": "new_dimension",
-						"old.dimension": "new.dimension",
-					},
-				},
-			},
-			dps: []*sfxpb.DataPoint{
-				{
-					Metric:    "single",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "old_dimension",
-							Value: "value1",
-						},
-						{
-							Key:   "old.dimension",
-							Value: "value2",
-						},
-						{
-							Key:   "dimension",
-							Value: "value3",
-						},
-					},
-				},
-			},
-			want: []*sfxpb.DataPoint{
-				{
-					Metric:    "single",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "new_dimension",
-							Value: "value1",
-						},
-						{
-							Key:   "new.dimension",
-							Value: "value2",
-						},
-						{
-							Key:   "dimension",
-							Value: "value3",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "rename_dimension_keys_filtered_metric",
-			trs: []Rule{
-				{
-					Action: ActionRenameDimensionKeys,
-					Mapping: map[string]string{
-						"old.dimension": "new.dimension",
-					},
-					MetricNames: map[string]bool{
-						"metric1": true,
-					},
-				},
-			},
-			dps: []*sfxpb.DataPoint{
-				{
-					Metric:    "metric1",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "old.dimension",
-							Value: "value1",
-						},
-					},
-				},
-				{
-					Metric:    "metric2",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "old.dimension",
-							Value: "value1",
-						},
-					},
-				},
-			},
-			want: []*sfxpb.DataPoint{
-				{
-					Metric:    "metric1",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "new.dimension",
-							Value: "value1",
-						},
-					},
-				},
-				// This metric doesn't match provided metric_name filter, so dimension key is not changed
-				{
-					Metric:    "metric2",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(13),
-					},
-					MetricType: &gaugeType,
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "old.dimension",
-							Value: "value1",
-						},
-					},
-				},
-			},
-		},
 		{
 			name: "rename_metric",
 			trs: []Rule{
@@ -1916,28 +1680,6 @@ func assertEqualPoints(t *testing.T, got, want []*sfxpb.DataPoint, action Action
 	}
 
 	assert.Equal(t, want, got)
-}
-
-func TestTestTranslateDimension(t *testing.T) {
-	mt, err := NewMetricTranslator([]Rule{
-		{
-			Action: ActionRenameDimensionKeys,
-			Mapping: map[string]string{
-				"old_dimension": "new_dimension",
-				"old.dimension": "new.dimension",
-			},
-		},
-	}, 1, make(chan struct{}))
-	require.NoError(t, err)
-
-	assert.Equal(t, "new_dimension", mt.translateDimension("old_dimension"))
-	assert.Equal(t, "new.dimension", mt.translateDimension("old.dimension"))
-	assert.Equal(t, "another_dimension", mt.translateDimension("another_dimension"))
-
-	// Test no rename_dimension_keys translation rule
-	mt, err = NewMetricTranslator([]Rule{}, 1, make(chan struct{}))
-	require.NoError(t, err)
-	assert.Equal(t, "old_dimension", mt.translateDimension("old_dimension"))
 }
 
 func TestNewCalculateNewMetricErrors(t *testing.T) {


### PR DESCRIPTION
Remove the `rename_dimension_keys` translation rule action and related code from the signalfx exporter, as it is no longer used.

The `rename_dimension_keys` action was the first translation rule added in #477 to translate OpenTelemetry dimension names to SignalFx-compatible names. However:

1. All dimension renames were removed from default rules (#2672, #2889) as the Splunk O11y backend started handling these translations automatically
2. Custom translation rules configuration was removed entirely (#35332)

Since `rename_dimension_keys` has not been used in default translation rules and users can no longer configure custom translation rules, this code is now unreachable and can be safely removed.