### PR TITLE
[chore] [exporter/signalfx] Remove MetricsConverter from events handler

### DIFF
--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -161,17 +161,17 @@ func (se *signalfxExporter) startDimensionClient(ctx context.Context) error {
 			LogUpdates:   se.config.LogDimensionUpdates,
 			Logger:       se.logger,
 			// Duration to wait between property updates.
-			SendDelay:           se.config.DimensionClient.SendDelay,
-			MaxBuffered:         se.config.DimensionClient.MaxBuffered,
-			MetricsConverter:    *se.converter,
-			DefaultProperties:   se.config.DefaultProperties,
-			ExcludeProperties:   se.config.ExcludeProperties,
-			MaxConnsPerHost:     se.config.DimensionClient.MaxConnsPerHost,
-			MaxIdleConns:        se.config.DimensionClient.MaxIdleConns,
-			MaxIdleConnsPerHost: se.config.DimensionClient.MaxIdleConnsPerHost,
-			IdleConnTimeout:     se.config.DimensionClient.IdleConnTimeout,
-			Timeout:             se.config.DimensionClient.Timeout,
-			DropTags:            se.config.DimensionClient.DropTags,
+			SendDelay:               se.config.DimensionClient.SendDelay,
+			MaxBuffered:             se.config.DimensionClient.MaxBuffered,
+			NonAlphanumericDimChars: se.config.NonAlphanumericDimensionChars,
+			DefaultProperties:       se.config.DefaultProperties,
+			ExcludeProperties:       se.config.ExcludeProperties,
+			MaxConnsPerHost:         se.config.DimensionClient.MaxConnsPerHost,
+			MaxIdleConns:            se.config.DimensionClient.MaxIdleConns,
+			MaxIdleConnsPerHost:     se.config.DimensionClient.MaxIdleConnsPerHost,
+			IdleConnTimeout:         se.config.DimensionClient.IdleConnTimeout,
+			Timeout:                 se.config.DimensionClient.Timeout,
+			DropTags:                se.config.DimensionClient.DropTags,
 		})
 	dimClient.Start()
 	se.dimClient = dimClient
@@ -189,27 +189,11 @@ func newEventExporter(config *Config, createSettings exporter.Settings) (*signal
 		return nil, errors.New("nil config")
 	}
 
-	// The converter is needed only for dimension updates from entity events.
-	// TODO: Refactor it to extract only the dimension update logic from the metrics converter.
-	converter, err := translation.NewMetricsConverter(
-		createSettings.Logger,
-		nil,
-		config.ExcludeMetrics,
-		config.IncludeMetrics,
-		config.NonAlphanumericDimensionChars,
-		config.DropHistogramBuckets,
-		!config.SendOTLPHistograms,
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	return &signalfxExporter{
 		config:                 config,
 		version:                createSettings.BuildInfo.Version,
 		logger:                 createSettings.Logger,
 		telemetrySettings:      createSettings.TelemetrySettings,
-		converter:              converter,
 		entityEventTransformer: dimensions.NewEntityEventTransformer(config.DefaultProperties),
 	}, nil
 }

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1075,16 +1075,6 @@ func TestConsumeMetadataNotStarted(t *testing.T) {
 
 func TestConsumeMetadata(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	converter, err := translation.NewMetricsConverter(
-		zap.NewNop(),
-		nil,
-		cfg.ExcludeMetrics,
-		cfg.IncludeMetrics,
-		cfg.NonAlphanumericDimensionChars,
-		false,
-		true,
-	)
-	require.NoError(t, err)
 	type args struct {
 		metadata []*metadata.MetadataUpdate
 	}
@@ -1386,14 +1376,14 @@ func TestConsumeMetadata(t *testing.T) {
 
 			dimClient := dimensions.NewDimensionClient(
 				dimensions.DimensionClientOptions{
-					Token:             "foo",
-					APIURL:            serverURL,
-					LogUpdates:        true,
-					Logger:            logger,
-					SendDelay:         tt.sendDelay,
-					MaxBuffered:       10,
-					MetricsConverter:  *converter,
-					ExcludeProperties: tt.excludeProperties,
+					Token:                   "foo",
+					APIURL:                  serverURL,
+					LogUpdates:              true,
+					Logger:                  logger,
+					SendDelay:               tt.sendDelay,
+					MaxBuffered:             10,
+					NonAlphanumericDimChars: cfg.NonAlphanumericDimensionChars,
+					ExcludeProperties:       tt.excludeProperties,
 				})
 			dimClient.Start()
 
@@ -1737,26 +1727,16 @@ func TestTLSAPIConnection(t *testing.T) {
 			serverURL, err := url.Parse(tt.config.APIURL)
 			assert.NoError(t, err)
 
-			converter, err := translation.NewMetricsConverter(
-				zap.NewNop(),
-				nil,
-				nil,
-				nil,
-				"",
-				false,
-				true)
-			require.NoError(t, err)
-
 			dimClient := dimensions.NewDimensionClient(
 				dimensions.DimensionClientOptions{
-					Token:            "",
-					APIURL:           serverURL,
-					LogUpdates:       true,
-					Logger:           logger,
-					SendDelay:        1,
-					MaxBuffered:      10,
-					APITLSConfig:     apiTLSCfg,
-					MetricsConverter: *converter,
+					Token:                   "",
+					APIURL:                  serverURL,
+					LogUpdates:              true,
+					Logger:                  logger,
+					SendDelay:               1,
+					MaxBuffered:             10,
+					APITLSConfig:            apiTLSCfg,
+					NonAlphanumericDimChars: "",
 				})
 			dimClient.Start()
 			defer func() { dimClient.Shutdown() }()

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -5,14 +5,13 @@ package translation // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"fmt"
-	"strings"
-	"unicode"
 
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/dimensions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation/dpfilters"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx"
@@ -120,17 +119,6 @@ func (c *MetricsConverter) translateAndFilter(dps []*sfxpb.DataPoint) []*sfxpb.D
 	return dps
 }
 
-func filterKeyChars(str, nonAlphanumericDimChars string) string {
-	filterMap := func(r rune) rune {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune(nonAlphanumericDimChars, r) {
-			return r
-		}
-		return '_'
-	}
-
-	return strings.Map(filterMap, str)
-}
-
 // resourceToDimensions will return a set of dimension from the
 // resource attributes, including a cloud host id (AWSUniqueId, gcp_id, etc.)
 // if it can be constructed from the provided metadata.
@@ -157,10 +145,6 @@ func resourceToDimensions(res pcommon.Resource) []*sfxpb.Dimension {
 	}
 
 	return dims
-}
-
-func (c *MetricsConverter) ConvertDimension(dim string) string {
-	return filterKeyChars(dim, c.datapointValidator.nonAlphanumericDimChars)
 }
 
 func (c *MetricsConverter) Shutdown() {
@@ -219,20 +203,20 @@ func (dpv *datapointValidator) sanitizeDataPoints(dps []*sfxpb.DataPoint) []*sfx
 // sanitizeDimensions replaces all characters unsupported by SignalFx backend
 // in metric label keys and with "_" and drops dimensions when the key is greater
 // than 128 characters or when value is greater than 256 characters in length.
-func (dpv *datapointValidator) sanitizeDimensions(dimensions []*sfxpb.Dimension) []*sfxpb.Dimension {
+func (dpv *datapointValidator) sanitizeDimensions(dims []*sfxpb.Dimension) []*sfxpb.Dimension {
 	resultDimensionsLen := 0
-	for dimensionIndex, d := range dimensions {
+	for dimensionIndex, d := range dims {
 		if dpv.isValidDimension(d) {
-			d.Key = filterKeyChars(d.Key, dpv.nonAlphanumericDimChars)
+			d.Key = dimensions.FilterKeyChars(d.Key, dpv.nonAlphanumericDimChars)
 			if resultDimensionsLen < dimensionIndex {
-				dimensions[resultDimensionsLen] = d
+				dims[resultDimensionsLen] = d
 			}
 			resultDimensionsLen++
 		}
 	}
 
 	// Trim dimensions slice to account for any removed dimensions.
-	return dimensions[:resultDimensionsLen]
+	return dims[:resultDimensionsLen]
 }
 
 func (dpv *datapointValidator) isValidMetricName(name string) bool {

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1227,39 +1227,3 @@ func TestNewMetricsConverter(t *testing.T) {
 		})
 	}
 }
-
-func TestMetricsConverter_ConvertDimension(t *testing.T) {
-	type fields struct {
-		metricTranslator        *MetricTranslator
-		nonAlphanumericDimChars string
-	}
-	type args struct {
-		dim string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "No translations",
-			fields: fields{
-				metricTranslator:        nil,
-				nonAlphanumericDimChars: "_-",
-			},
-			args: args{
-				dim: "d.i.m",
-			},
-			want: "d_i_m",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewMetricsConverter(zap.NewNop(), tt.fields.metricTranslator, nil, nil, tt.fields.nonAlphanumericDimChars, false, true)
-			require.NoError(t, err)
-			got := c.ConvertDimension(tt.args.dim)
-			assert.Equal(t, tt.want, got, "ConvertDimension() = %v, want %v", got, tt.want)
-		})
-	}
-}


### PR DESCRIPTION
After merging https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45763, the dimension client and event exporter only need the `nonAlphanumericDimChars` configuration string, not the entire converter. So we can simplify dimension handling in the signalfx exporter by removing unnecessary dependency on `MetricsConverter`.
