### PR TITLE
[chore] introduce and use mdatagen Make target

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -251,13 +251,19 @@ fmt: $(GOFUMPT) $(GOIMPORTS)
 	$(GOIMPORTS) -w -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
 .PHONY: generate-tools
-generate-tools: $(MDATAGEN) $(GENQLIENT)
+generate-tools: $(GENQLIENT)
 ifeq ($(GOOS),windows)
 	@echo Adding "exe" extensions to generate tools
 	@for f in $^; do \
 		cp -u "$$f" "$$f.exe"; \
 	done
 endif
+
+MDATAGEN_METADATA_YAML?= metadata.yaml
+
+.PHONY: mdatagen
+mdatagen: $(MDATAGEN)
+	@$(MDATAGEN) $(MDATAGEN_METADATA_YAML)
 
 # On Windows changing path with absolute path includes ':' even escaping it is not enough to get it to correctly
 # update PATH, so use a relative path when pre-pending to PATH on Windows. Unfortunately, realpath is not portable

--- a/cmd/golden/doc.go
+++ b/cmd/golden/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package main // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/golden"

--- a/cmd/opampsupervisor/doc.go
+++ b/cmd/opampsupervisor/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package main // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor"

--- a/cmd/telemetrygen/config.go
+++ b/cmd/telemetrygen/config.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 The Jaeger Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package main // import "github.com/open-telemetry/opentelemetry-collector-contrib/telemetrygen/internal/telemetrygen"
 

--- a/confmap/provider/aesprovider/provider.go
+++ b/confmap/provider/aesprovider/provider.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package aesprovider // import "github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider"
 

--- a/confmap/provider/googlesecretmanagerprovider/provider.go
+++ b/confmap/provider/googlesecretmanagerprovider/provider.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlesecretmanagerprovider // import "github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider"
 

--- a/confmap/provider/s3provider/provider.go
+++ b/confmap/provider/s3provider/provider.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package s3provider // import "github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider"
 

--- a/confmap/provider/secretsmanagerprovider/provider.go
+++ b/confmap/provider/secretsmanagerprovider/provider.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package secretsmanagerprovider // import "github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider"
 

--- a/connector/countconnector/factory.go
+++ b/connector/countconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package countconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 

--- a/connector/datadogconnector/doc.go
+++ b/connector/datadogconnector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package datadogconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector"

--- a/connector/datadogconnector/factory.go
+++ b/connector/datadogconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package datadogconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector"
 

--- a/connector/exceptionsconnector/factory.go
+++ b/connector/exceptionsconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package exceptionsconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector"
 

--- a/connector/failoverconnector/doc.go
+++ b/connector/failoverconnector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package failoverconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector"

--- a/connector/grafanacloudconnector/doc.go
+++ b/connector/grafanacloudconnector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package grafanacloudconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector"

--- a/connector/metricsaslogsconnector/doc.go
+++ b/connector/metricsaslogsconnector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package metricsaslogsconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector"

--- a/connector/otlpjsonconnector/doc.go
+++ b/connector/otlpjsonconnector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package otlpjsonconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector"

--- a/connector/roundrobinconnector/factory.go
+++ b/connector/roundrobinconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package roundrobinconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector"
 

--- a/connector/routingconnector/factory.go
+++ b/connector/routingconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package routingconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
 

--- a/connector/servicegraphconnector/factory.go
+++ b/connector/servicegraphconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package servicegraphconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector"
 

--- a/connector/signaltometricsconnector/doc.go
+++ b/connector/signaltometricsconnector/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package signaltometricsconnector provides a stateless connector for generating metrics from raw signals.
 package signaltometricsconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector"

--- a/connector/slowsqlconnector/factory.go
+++ b/connector/slowsqlconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package slowsqlconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector"
 

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package spanmetricsconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 

--- a/connector/sumconnector/factory.go
+++ b/connector/sumconnector/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sumconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector"
 

--- a/docs/new-components.md
+++ b/docs/new-components.md
@@ -176,7 +176,7 @@ status:
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package fooreceiver bars.
 package fooreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fooreceiver"

--- a/docs/new-components.md
+++ b/docs/new-components.md
@@ -143,7 +143,7 @@ To donate your component to this repository, follow these steps:
 - Run `make crosslink` to update intra-repository dependencies. It will add a `replace` directive to `go.mod` file of every intra-repository dependant. This is necessary for your component to be included in the contrib executable.
 - Add your component to `versions.yaml`.
 - All components included in the distribution must be included in
-  [`cmd/otelcontribcol/builder-config.yaml`](./cmd/otelcontribcol/builder-config.yaml)
+  [`cmd/otelcontribcol/builder-config.yaml`](../cmd/otelcontribcol/builder-config.yaml)
   and in the respective testing harnesses. To align with the test goal of the
   project, components must be testable within the framework defined within the
   folder. If a component can not be properly tested within the existing

--- a/exporter/alertmanagerexporter/doc.go
+++ b/exporter/alertmanagerexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package alertmanagerexporter exports spanevents as alerts to Prometheus Alertmanager
 package alertmanagerexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter"

--- a/exporter/alibabacloudlogserviceexporter/factory.go
+++ b/exporter/alibabacloudlogserviceexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package alibabacloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter"
 

--- a/exporter/awscloudwatchlogsexporter/factory.go
+++ b/exporter/awscloudwatchlogsexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awscloudwatchlogsexporter provides a logging exporter for the OpenTelemetry collector.
 // This package is subject to change and may break configuration settings and behavior.

--- a/exporter/awsemfexporter/doc.go
+++ b/exporter/awsemfexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awsemfexporter implements an OpenTelemetry Collector exporter that sends EmbeddedMetricFormat to
 // AWS CloudWatch Logs in the region the collector is running in using the PutLogEvents API.

--- a/exporter/awskinesisexporter/factory.go
+++ b/exporter/awskinesisexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awskinesisexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter"
 

--- a/exporter/awss3exporter/doc.go
+++ b/exporter/awss3exporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awss3exporter stores OpenTelemetry data as an AWS S3 exporter.
 package awss3exporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"

--- a/exporter/awsxrayexporter/doc.go
+++ b/exporter/awsxrayexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awsxrayexporter implements an OpenTelemetry Collector exporter that sends trace data to
 // AWS X-Ray in the region the collector is running in using the PutTraceSegments API.

--- a/exporter/azureblobexporter/doc.go
+++ b/exporter/azureblobexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package azureblobexporter stores OpenTelemetry data as an Azure Storage Blob exporter.
 package azureblobexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter"

--- a/exporter/azuredataexplorerexporter/doc.go
+++ b/exporter/azuredataexplorerexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package azuredataexplorerexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter"

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package azuremonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 

--- a/exporter/bmchelixexporter/doc.go
+++ b/exporter/bmchelixexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package bmchelixexporter implements an exporter that sends data to BMC Helix.
 package bmchelixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter"

--- a/exporter/cassandraexporter/doc.go
+++ b/exporter/cassandraexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package cassandraexporter exports trace and log data to an Apache Cassandra instance.
 package cassandraexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter"

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
 

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package coralogixexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter"
 

--- a/exporter/datadogexporter/doc.go
+++ b/exporter/datadogexporter/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package datadogexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"

--- a/exporter/datasetexporter/doc.go
+++ b/exporter/datasetexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package datasetexporter implements an exporter that sends data to DataSet.
 package datasetexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter"

--- a/exporter/datasetexporter/factory.go
+++ b/exporter/datasetexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package datasetexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter"
 

--- a/exporter/dorisexporter/doc.go
+++ b/exporter/dorisexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package dorisexporter exports trace, metric and log data to an Apache Doris instance.
 package dorisexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter"

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 

--- a/exporter/faroexporter/doc.go
+++ b/exporter/faroexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package faroexporter implements an exporter that sends data to Grafana Faro.
 package faroexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter"

--- a/exporter/fileexporter/doc.go
+++ b/exporter/fileexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package fileexporter exports data to files.
 package fileexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter"
 

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudpubsubexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter"
 

--- a/exporter/googlecloudstorageexporter/doc.go
+++ b/exporter/googlecloudstorageexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudstorageexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter"

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlemanagedprometheusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter"
 

--- a/exporter/honeycombmarkerexporter/doc.go
+++ b/exporter/honeycombmarkerexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package honeycombmarkerexporter exports Marker data to Honeycomb.
 package honeycombmarkerexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter"

--- a/exporter/influxdbexporter/factory.go
+++ b/exporter/influxdbexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package influxdbexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter"
 

--- a/exporter/kafkaexporter/doc.go
+++ b/exporter/kafkaexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package kafkaexporter exports traces, logs, metrics and profiles data to Kafka.
 package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 

--- a/exporter/logicmonitorexporter/factory.go
+++ b/exporter/logicmonitorexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package logicmonitorexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter"
 

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package logzioexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
 

--- a/exporter/mezmoexporter/doc.go
+++ b/exporter/mezmoexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package mezmoexporter implements an exporter that sends data to Mezmo.
 package mezmoexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter"

--- a/exporter/opensearchexporter/factory.go
+++ b/exporter/opensearchexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package opensearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter"
 

--- a/exporter/otelarrowexporter/doc.go
+++ b/exporter/otelarrowexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package otelarrowexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter"

--- a/exporter/prometheusexporter/doc.go
+++ b/exporter/prometheusexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package prometheusexporter exports metrics data as a Prometheus pull handler.
 package prometheusexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"

--- a/exporter/prometheusremotewriteexporter/doc.go
+++ b/exporter/prometheusremotewriteexporter/doc.go
@@ -3,5 +3,5 @@
 
 // Package prometheusremotewriteexporter sends metrics data to Prometheus Remote Write (PRW) endpoints.
 //
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package prometheusremotewriteexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"

--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package pulsarexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter"
 

--- a/exporter/rabbitmqexporter/doc.go
+++ b/exporter/rabbitmqexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package rabbitmqexporter exports telemetry to RabbitMQ using the AMQP 0.9.1 protocol
 package rabbitmqexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter"

--- a/exporter/sapmexporter/doc.go
+++ b/exporter/sapmexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package sapmexporter sends traces to a SAPM endpoint.
 //

--- a/exporter/sematextexporter/doc.go
+++ b/exporter/sematextexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package sematextexporter sends metrics and logs to sematext cloud.
 package sematextexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter"

--- a/exporter/sematextexporter/factory.go
+++ b/exporter/sematextexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sematextexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter"
 

--- a/exporter/sentryexporter/factory.go
+++ b/exporter/sentryexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sentryexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter"
 

--- a/exporter/signalfxexporter/doc.go
+++ b/exporter/signalfxexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package signalfxexporter implements an exporter that sends data to SignalFx.
 package signalfxexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"

--- a/exporter/splunkhecexporter/doc.go
+++ b/exporter/splunkhecexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package splunkhecexporter implements an exporter that sends data to Splunk.
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"

--- a/exporter/stefexporter/doc.go
+++ b/exporter/stefexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package stefexporter implements an exporter that sends data Otel/STEF format.
 package stefexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter"

--- a/exporter/sumologicexporter/factory.go
+++ b/exporter/sumologicexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sumologicexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter"
 

--- a/exporter/syslogexporter/doc.go
+++ b/exporter/syslogexporter/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package syslogexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter"

--- a/exporter/tencentcloudlogserviceexporter/doc.go
+++ b/exporter/tencentcloudlogserviceexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package tencentcloudlogserviceexporter exports data to TenCent Log Service.
 package tencentcloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter"

--- a/exporter/tencentcloudlogserviceexporter/factory.go
+++ b/exporter/tencentcloudlogserviceexporter/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package tencentcloudlogserviceexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter"
 

--- a/exporter/tinybirdexporter/doc.go
+++ b/exporter/tinybirdexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package tinybirdexporter defines the Tinybird exporter.
 // which enables sending metrics and traces to Tinybird.

--- a/exporter/zipkinexporter/doc.go
+++ b/exporter/zipkinexporter/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package zipkinexporter exports trace data to Zipkin.
 package zipkinexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"

--- a/extension/ackextension/doc.go
+++ b/extension/ackextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package ackextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension"

--- a/extension/asapauthextension/doc.go
+++ b/extension/asapauthextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package asapauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension"

--- a/extension/awsproxy/doc.go
+++ b/extension/awsproxy/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awsproxy defines an extension that accepts requests without any authentication of AWS signatures
 // applied and forwards them to the AWS API, applying authentication and signing.

--- a/extension/azureauthextension/doc.go
+++ b/extension/azureauthextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package azureauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension"

--- a/extension/basicauthextension/doc.go
+++ b/extension/basicauthextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package basicauthextension implements an extension offering basic auth authentication over HTTP.
 package basicauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension"

--- a/extension/bearertokenauthextension/doc.go
+++ b/extension/bearertokenauthextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package bearertokenauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"

--- a/extension/cgroupruntimeextension/doc.go
+++ b/extension/cgroupruntimeextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package cgroupruntimeextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension"

--- a/extension/datadogextension/doc.go
+++ b/extension/datadogextension/doc.go
@@ -5,6 +5,6 @@
 // which enables OpenTelemetry Collectors to report component status in Datadog App
 //  User Interface.
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package datadogextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension"

--- a/extension/encoding/avrologencodingextension/doc.go
+++ b/extension/encoding/avrologencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package avrologencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension"

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/doc.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awscloudwatchmetricstreamsencodingextension provides an encoding extension
 // capable of unmarshalling metrics produced by CloudWatch Metric Streams.

--- a/extension/encoding/awslogsencodingextension/doc.go
+++ b/extension/encoding/awslogsencodingextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awslogsencodingextension provides an encoding extension
 // for unmarshalling logs produced by various AWS services.

--- a/extension/encoding/azureencodingextension/doc.go
+++ b/extension/encoding/azureencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package azureencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension"

--- a/extension/encoding/googlecloudlogentryencodingextension/doc.go
+++ b/extension/encoding/googlecloudlogentryencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package googlecloudlogentryencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension"

--- a/extension/encoding/jaegerencodingextension/doc.go
+++ b/extension/encoding/jaegerencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package jaegerencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension"

--- a/extension/encoding/jsonlogencodingextension/doc.go
+++ b/extension/encoding/jsonlogencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package jsonlogencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension"

--- a/extension/encoding/otlpencodingextension/doc.go
+++ b/extension/encoding/otlpencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package otlpencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension"

--- a/extension/encoding/textencodingextension/doc.go
+++ b/extension/encoding/textencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package textencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension"

--- a/extension/encoding/zipkinencodingextension/doc.go
+++ b/extension/encoding/zipkinencodingextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package zipkinencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension"

--- a/extension/googleclientauthextension/doc.go
+++ b/extension/googleclientauthextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package googleclientauthextension implements an extension that provides authentication with Google Cloud.
 package googleclientauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"

--- a/extension/googleclientauthextension/factory.go
+++ b/extension/googleclientauthextension/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googleclientauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension"
 

--- a/extension/headerssetterextension/doc.go
+++ b/extension/headerssetterextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package headerssetterextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension"

--- a/extension/healthcheckextension/doc.go
+++ b/extension/healthcheckextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package healthcheckextension implements an extension that enables an HTTP
 // endpoint that can be used to check the overall health and status of the

--- a/extension/healthcheckv2extension/doc.go
+++ b/extension/healthcheckv2extension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package healthcheckv2extension implements an extension that enables HTTP
 // and or GRPC health checks for a collector.

--- a/extension/healthcheckv2extension/factory.go
+++ b/extension/healthcheckv2extension/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package healthcheckv2extension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension"
 

--- a/extension/httpforwarderextension/doc.go
+++ b/extension/httpforwarderextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package httpforwarderextension accepts HTTP requests, optionally adds headers to them and forwards them.
 package httpforwarderextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension"

--- a/extension/jaegerremotesampling/doc.go
+++ b/extension/jaegerremotesampling/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package jaegerremotesampling // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling"

--- a/extension/k8sleaderelector/doc.go
+++ b/extension/k8sleaderelector/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8sleaderelector // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector"

--- a/extension/oauth2clientauthextension/doc.go
+++ b/extension/oauth2clientauthextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package oauth2clientauthextension implements `cauth.Client`
 // This extension provides OAuth2 Client Credentials flow authenticator for HTTP and gRPC based exporters.

--- a/extension/observer/cfgardenobserver/doc.go
+++ b/extension/observer/cfgardenobserver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package cfgardenobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver"

--- a/extension/observer/dockerobserver/doc.go
+++ b/extension/observer/dockerobserver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package dockerobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver"

--- a/extension/observer/ecsobserver/doc.go
+++ b/extension/observer/ecsobserver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package ecsobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver"

--- a/extension/observer/hostobserver/doc.go
+++ b/extension/observer/hostobserver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package hostobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver"

--- a/extension/observer/k8sobserver/doc.go
+++ b/extension/observer/k8sobserver/doc.go
@@ -3,6 +3,6 @@
 
 // Package k8sobserver implements a k8s observer extension for monitoring pods.
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"

--- a/extension/observer/kafkatopicsobserver/doc.go
+++ b/extension/observer/kafkatopicsobserver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package kafkatopicsobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver"

--- a/extension/oidcauthextension/doc.go
+++ b/extension/oidcauthextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package oidcauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension"

--- a/extension/opampextension/doc.go
+++ b/extension/opampextension/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package opampextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension"

--- a/extension/pprofextension/doc.go
+++ b/extension/pprofextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package pprofextension implements an extension that exposes the golang
 // net/http/pprof (Performance Profiler) in a HTTP endpoint.

--- a/extension/remotetapextension/doc.go
+++ b/extension/remotetapextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package remotetapextension implements an extension that exposes the golang
 // remoteobserver processor websockets through a Web interface.

--- a/extension/sigv4authextension/doc.go
+++ b/extension/sigv4authextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package sigv4authextension implements the `extensionauth.HTTPClient` interface.
 // This extension provides the Sigv4 process of adding authentication information to AWS API requests sent by HTTP.

--- a/extension/solarwindsapmsettingsextension/doc.go
+++ b/extension/solarwindsapmsettingsextension/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package solarwindsapmsettingsextension
 package solarwindsapmsettingsextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension"

--- a/extension/storage/dbstorage/doc.go
+++ b/extension/storage/dbstorage/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package dbstorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage"

--- a/extension/storage/dbstorage/factory.go
+++ b/extension/storage/dbstorage/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package dbstorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage"
 

--- a/extension/storage/filestorage/doc.go
+++ b/extension/storage/filestorage/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package filestorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"

--- a/extension/storage/filestorage/factory.go
+++ b/extension/storage/filestorage/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package filestorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 

--- a/extension/storage/redisstorageextension/doc.go
+++ b/extension/storage/redisstorageextension/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package redisstorageextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension"

--- a/extension/sumologicextension/factory.go
+++ b/extension/sumologicextension/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 //
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sumologicextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension"
 

--- a/internal/otelarrow/doc.go
+++ b/internal/otelarrow/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package otelarrow // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow"

--- a/pkg/golden/doc.go
+++ b/pkg/golden/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package golden // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"

--- a/pkg/ottl/doc.go
+++ b/pkg/ottl/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"

--- a/pkg/stanza/fileconsumer/Makefile
+++ b/pkg/stanza/fileconsumer/Makefile
@@ -1,0 +1,1 @@
+include ../../../Makefile.Common

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 

--- a/pkg/status/doc.go
+++ b/pkg/status/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package status // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"

--- a/pkg/translator/faro/doc.go
+++ b/pkg/translator/faro/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package faro // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/faro"

--- a/processor/attributesprocessor/doc.go
+++ b/processor/attributesprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package attributesprocessor contains the logic to modify attributes of a span.
 // It supports insert, update, upsert and delete as actions.

--- a/processor/coralogixprocessor/doc.go
+++ b/processor/coralogixprocessor/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package coralogixprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor"

--- a/processor/cumulativetodeltaprocessor/doc.go
+++ b/processor/cumulativetodeltaprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // package cumulativetodeltaprocessor implements a processor which
 // converts cumulative sum metrics to cumulative delta.

--- a/processor/datadogsemanticsprocessor/doc.go
+++ b/processor/datadogsemanticsprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package datadogsemanticsprocessor contains the logic to transform OpenTelemetry semantic conventions to Datadog semantic conventions.
 package datadogsemanticsprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor"

--- a/processor/deltatocumulativeprocessor/doc.go
+++ b/processor/deltatocumulativeprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // package deltatocumulativeprocessor implements a processor which
 // converts metrics from delta temporality to cumulative.

--- a/processor/deltatorateprocessor/doc.go
+++ b/processor/deltatorateprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // package deltatorateprocessor implements a processor which
 // converts delta sum metrics to rates.

--- a/processor/dnslookupprocessor/doc.go
+++ b/processor/dnslookupprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package dnslookupprocessor
 package dnslookupprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor"

--- a/processor/filterprocessor/doc.go
+++ b/processor/filterprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package filterprocessor implements a processor for filtering
 // (dropping) metrics and/or spans by various properties.

--- a/processor/geoipprocessor/doc.go
+++ b/processor/geoipprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package geoipprocessor.
 package geoipprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor"

--- a/processor/groupbyattrsprocessor/doc.go
+++ b/processor/groupbyattrsprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package groupbyattrsprocessor creates Resources based on specified
 // attributes, and groups metrics, log records and spans with matching

--- a/processor/groupbytraceprocessor/doc.go
+++ b/processor/groupbytraceprocessor/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package groupbytraceprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"

--- a/processor/intervalprocessor/doc.go
+++ b/processor/intervalprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // package intervalprocessor implements a processor which aggregates cumulative
 // metrics over time, and periodically exports the latest values

--- a/processor/isolationforestprocessor/doc.go
+++ b/processor/isolationforestprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package isolationforestprocessor provides an OpenTelemetry Collector processor
 // that uses the isolation forest machine learning algorithm for anomaly detection

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"

--- a/processor/logstransformprocessor/doc.go
+++ b/processor/logstransformprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package logstransformprocessor implements a processor
 // to apply log operators to logs coming from any receiver.

--- a/processor/metricsgenerationprocessor/doc.go
+++ b/processor/metricsgenerationprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // package metricsgenerationprocessor implements a processor which calculates
 // a new metric from existing metrics.

--- a/processor/metricstarttimeprocessor/doc.go
+++ b/processor/metricstarttimeprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package metricstarttimeprocessor sets the start time of cumulative metric points when the start time is unknown.
 package metricstarttimeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor"

--- a/processor/metricstransformprocessor/doc.go
+++ b/processor/metricstransformprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package metricstransformprocessor implements a processor for transforming metrics.
 // The supported transformations are included in the README

--- a/processor/probabilisticsamplerprocessor/factory.go
+++ b/processor/probabilisticsamplerprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package probabilisticsamplerprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 

--- a/processor/redactionprocessor/factory.go
+++ b/processor/redactionprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package redactionprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
 

--- a/processor/remotetapprocessor/doc.go
+++ b/processor/remotetapprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package remotetapprocessor can be positioned anywhere in a pipeline, allowing
 // data to pass through to the next component. Simultaneously, it makes a portion

--- a/processor/resourcedetectionprocessor/doc.go
+++ b/processor/resourcedetectionprocessor/doc.go
@@ -1,29 +1,29 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
-//go:generate mdatagen internal/aws/ec2/metadata.yaml
-//go:generate mdatagen internal/aws/ecs/metadata.yaml
-//go:generate mdatagen internal/aws/eks/metadata.yaml
-//go:generate mdatagen internal/aws/elasticbeanstalk/metadata.yaml
-//go:generate mdatagen internal/aws/lambda/metadata.yaml
-//go:generate mdatagen internal/azure/aks/metadata.yaml
-//go:generate mdatagen internal/azure/metadata.yaml
-//go:generate mdatagen internal/consul/metadata.yaml
-//go:generate mdatagen internal/digitalocean/metadata.yaml
-//go:generate mdatagen internal/docker/metadata.yaml
-//go:generate mdatagen internal/gcp/metadata.yaml
-//go:generate mdatagen internal/heroku/metadata.yaml
-//go:generate mdatagen internal/hetzner/metadata.yaml
-//go:generate mdatagen internal/openshift/metadata.yaml
-//go:generate mdatagen internal/system/metadata.yaml
-//go:generate mdatagen internal/k8snode/metadata.yaml
-//go:generate mdatagen internal/kubeadm/metadata.yaml
-//go:generate mdatagen internal/dynatrace/metadata.yaml
-//go:generate mdatagen internal/akamai/metadata.yaml
-//go:generate mdatagen internal/scaleway/metadata.yaml
-//go:generate mdatagen internal/upcloud/metadata.yaml
-//go:generate mdatagen internal/vultr/metadata.yaml
+//go:generate make mdatagen
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/aws/ec2/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/aws/ecs/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/aws/eks/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/aws/elasticbeanstalk/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/aws/lambda/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/azure/aks/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/azure/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/consul/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/digitalocean/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/docker/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/gcp/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/heroku/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/hetzner/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/openshift/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/system/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/k8snode/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/kubeadm/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/dynatrace/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/akamai/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/scaleway/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/upcloud/metadata.yaml
+//go:generate make mdatagen MDATAGEN_METADATA_YAML=internal/vultr/metadata.yaml
 
 // package resourcedetectionprocessor implements a processor
 // which can be used to detect resource information from the host,

--- a/processor/resourceprocessor/doc.go
+++ b/processor/resourceprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package resourceprocessor implements a processor for
 // applying changes on resource attributes.

--- a/processor/schemaprocessor/factory.go
+++ b/processor/schemaprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package schemaprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor"
 

--- a/processor/spanprocessor/doc.go
+++ b/processor/spanprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package spanprocessor contains logic to modify top level settings of a span, such
 // as its name.

--- a/processor/sumologicprocessor/factory.go
+++ b/processor/sumologicprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 //
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sumologicprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor"
 

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 

--- a/processor/transformprocessor/doc.go
+++ b/processor/transformprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package transformprocessor contains the logic to execute telemetry transform based
 // on the OpenTelemetry Transformation Language.

--- a/processor/unrollprocessor/doc.go
+++ b/processor/unrollprocessor/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package unrollprocessor contains the logic to unroll log based telemetry.
 package unrollprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor"

--- a/receiver/activedirectorydsreceiver/doc.go
+++ b/receiver/activedirectorydsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package activedirectorydsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"

--- a/receiver/aerospikereceiver/doc.go
+++ b/receiver/aerospikereceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package aerospikereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver"

--- a/receiver/apachereceiver/doc.go
+++ b/receiver/apachereceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package apachereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver"

--- a/receiver/apachesparkreceiver/doc.go
+++ b/receiver/apachesparkreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package apachesparkreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver"

--- a/receiver/awscloudwatchreceiver/docs.go
+++ b/receiver/awscloudwatchreceiver/docs.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awscloudwatchreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver"

--- a/receiver/awscontainerinsightreceiver/doc.go
+++ b/receiver/awscontainerinsightreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awscontainerinsightreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver"

--- a/receiver/awsecscontainermetricsreceiver/doc.go
+++ b/receiver/awsecscontainermetricsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awsecscontainermetricsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"

--- a/receiver/awsfirehosereceiver/doc.go
+++ b/receiver/awsfirehosereceiver/doc.go
@@ -11,6 +11,6 @@
 // More details can be found at:
 // https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awsfirehosereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"

--- a/receiver/awslambdareceiver/doc.go
+++ b/receiver/awslambdareceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package awslambdareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver"

--- a/receiver/awss3receiver/doc.go
+++ b/receiver/awss3receiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awss3receiver implements a receiver that can be used by the
 // OpenTelemetry collector to retrieve traces previously stored in S3 by the

--- a/receiver/awsxrayreceiver/doc.go
+++ b/receiver/awsxrayreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package awsxrayreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive traces in the AWS X-Ray segment format.

--- a/receiver/azureblobreceiver/doc.go
+++ b/receiver/azureblobreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"

--- a/receiver/azureeventhubreceiver/doc.go
+++ b/receiver/azureeventhubreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package azureeventhubreceiver listens to logs emitted by Azure Event hubs.
 package azureeventhubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver"

--- a/receiver/azuremonitorreceiver/doc.go
+++ b/receiver/azuremonitorreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package azuremonitorreceiver scrapes Azure Monitor API for available metrics.
 package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"

--- a/receiver/bigipreceiver/doc.go
+++ b/receiver/bigipreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package bigipreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver"

--- a/receiver/carbonreceiver/doc.go
+++ b/receiver/carbonreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package carbonreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive data in the Carbon supported formats.

--- a/receiver/chronyreceiver/doc.go
+++ b/receiver/chronyreceiver/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package chronyreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver"

--- a/receiver/ciscoosreceiver/doc.go
+++ b/receiver/ciscoosreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package ciscoosreceiver provides a receiver for collecting metrics from Cisco network devices via SSH.
 package ciscoosreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver"

--- a/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/Makefile
+++ b/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/doc.go
+++ b/receiver/ciscoosreceiver/internal/scraper/interfacesscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package interfacesscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver/internal/scraper/interfacesscraper"

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/Makefile
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/ciscoosreceiver/internal/scraper/systemscraper/doc.go
+++ b/receiver/ciscoosreceiver/internal/scraper/systemscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package systemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver/internal/scraper/systemscraper"

--- a/receiver/cloudflarereceiver/docs.go
+++ b/receiver/cloudflarereceiver/docs.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package cloudflarereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver"

--- a/receiver/cloudfoundryreceiver/doc.go
+++ b/receiver/cloudfoundryreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package cloudfoundryreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive Cloud Foundry metrics and logs via its Reverse

--- a/receiver/collectdreceiver/doc.go
+++ b/receiver/collectdreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package collectdreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive traces from CollectD http_write plugin

--- a/receiver/couchdbreceiver/doc.go
+++ b/receiver/couchdbreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package couchdbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver"

--- a/receiver/datadogreceiver/doc.go
+++ b/receiver/datadogreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package datadogreceiver ingests traces in the Datadog APM format and translates them OpenTelemetry for collector usage
 package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"

--- a/receiver/dockerstatsreceiver/doc.go
+++ b/receiver/dockerstatsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package dockerstatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"

--- a/receiver/elasticsearchreceiver/doc.go
+++ b/receiver/elasticsearchreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package elasticsearchreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver"

--- a/receiver/envoyalsreceiver/doc.go
+++ b/receiver/envoyalsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package envoyalsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver"

--- a/receiver/expvarreceiver/doc.go
+++ b/receiver/expvarreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package expvarreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver"

--- a/receiver/faroreceiver/doc.go
+++ b/receiver/faroreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package faroreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver"

--- a/receiver/filelogreceiver/doc.go
+++ b/receiver/filelogreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package filelogreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive logs using the stanza log agent

--- a/receiver/filestatsreceiver/doc.go
+++ b/receiver/filestatsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package filestatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"

--- a/receiver/flinkmetricsreceiver/doc.go
+++ b/receiver/flinkmetricsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package flinkmetricsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver"

--- a/receiver/fluentforwardreceiver/doc.go
+++ b/receiver/fluentforwardreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package fluentforwardreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"

--- a/receiver/githubreceiver/doc.go
+++ b/receiver/githubreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package githubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver"

--- a/receiver/gitlabreceiver/doc.go
+++ b/receiver/gitlabreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package gitlabreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver"

--- a/receiver/googlecloudmonitoringreceiver/doc.go
+++ b/receiver/googlecloudmonitoringreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudmonitoringreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver"

--- a/receiver/googlecloudpubsubpushreceiver/doc.go
+++ b/receiver/googlecloudpubsubpushreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudpubsubpushreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver"

--- a/receiver/googlecloudpubsubreceiver/doc.go
+++ b/receiver/googlecloudpubsubreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudpubsubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver"

--- a/receiver/googlecloudspannerreceiver/doc.go
+++ b/receiver/googlecloudspannerreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package googlecloudspannerreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver"

--- a/receiver/haproxyreceiver/doc.go
+++ b/receiver/haproxyreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package haproxyreceiver implements a receiver collecting metrics from HAProxy.
 package haproxyreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver"

--- a/receiver/hostmetricsreceiver/doc.go
+++ b/receiver/hostmetricsreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package hostmetricsreceiver reads metrics like CPU usage, disk usage, and network usage from the host.
 package hostmetricsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package cpuscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package diskscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package filesystemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package loadscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package memoryscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package networkscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/nfsscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package nfsscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/nfsscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package processesscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processesscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/Makefile
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/Makefile
@@ -1,0 +1,1 @@
+include ../../../../../Makefile.Common

--- a/receiver/hostmetricsreceiver/internal/scraper/systemscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/systemscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package systemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/systemscraper"

--- a/receiver/httpcheckreceiver/doc.go
+++ b/receiver/httpcheckreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package httpcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver"

--- a/receiver/huaweicloudcesreceiver/doc.go
+++ b/receiver/huaweicloudcesreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package huaweicloudcesreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver"

--- a/receiver/icmpcheckreceiver/doc.go
+++ b/receiver/icmpcheckreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package icmpcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver"

--- a/receiver/iisreceiver/doc.go
+++ b/receiver/iisreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"

--- a/receiver/influxdbreceiver/doc.go
+++ b/receiver/influxdbreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package influxdbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver"

--- a/receiver/jaegerreceiver/doc.go
+++ b/receiver/jaegerreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package jaegerreceiver receives Jaeger traces.
 package jaegerreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"

--- a/receiver/jmxreceiver/doc.go
+++ b/receiver/jmxreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package jmxreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"

--- a/receiver/journaldreceiver/doc.go
+++ b/receiver/journaldreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package journaldreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"

--- a/receiver/k8sclusterreceiver/doc.go
+++ b/receiver/k8sclusterreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8sclusterreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"

--- a/receiver/k8seventsreceiver/doc.go
+++ b/receiver/k8seventsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8seventsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver"

--- a/receiver/k8slogreceiver/doc.go
+++ b/receiver/k8slogreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8slogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver"

--- a/receiver/k8sobjectsreceiver/doc.go
+++ b/receiver/k8sobjectsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package k8sobjectsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver"

--- a/receiver/kafkametricsreceiver/doc.go
+++ b/receiver/kafkametricsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package kafkametricsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver"

--- a/receiver/kafkareceiver/doc.go
+++ b/receiver/kafkareceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package kafkareceiver receives traces from Kafka.
 package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"

--- a/receiver/kubeletstatsreceiver/doc.go
+++ b/receiver/kubeletstatsreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package kubeletstatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"

--- a/receiver/libhoneyreceiver/doc.go
+++ b/receiver/libhoneyreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package libhoneyreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver"

--- a/receiver/lokireceiver/factory.go
+++ b/receiver/lokireceiver/factory.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package lokireceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver"
 

--- a/receiver/macosunifiedloggingreceiver/doc.go
+++ b/receiver/macosunifiedloggingreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package macosunifiedloggingreceiver implements a receiver that uses the native
 // macOS `log` command to retrieve and parse unified logging data.

--- a/receiver/memcachedreceiver/doc.go
+++ b/receiver/memcachedreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package memcachedreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver"

--- a/receiver/mongodbatlasreceiver/doc.go
+++ b/receiver/mongodbatlasreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package mongodbatlasreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"

--- a/receiver/mongodbreceiver/doc.go
+++ b/receiver/mongodbreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package mongodbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver"

--- a/receiver/mysqlreceiver/doc.go
+++ b/receiver/mysqlreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package mysqlreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver"

--- a/receiver/namedpipereceiver/doc.go
+++ b/receiver/namedpipereceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package namedpipereceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive logs using the stanza log agent

--- a/receiver/netflowreceiver/doc.go
+++ b/receiver/netflowreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package netflowreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver"

--- a/receiver/nginxreceiver/doc.go
+++ b/receiver/nginxreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package nginxreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver"

--- a/receiver/nsxtreceiver/doc.go
+++ b/receiver/nsxtreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package nsxtreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver"

--- a/receiver/ntpreceiver/doc.go
+++ b/receiver/ntpreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package ntpreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver"

--- a/receiver/oracledbreceiver/doc.go
+++ b/receiver/oracledbreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package oracledbreceiver implements a receiver collecting metrics from an Oracle datase.
 package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver"

--- a/receiver/osqueryreceiver/doc.go
+++ b/receiver/osqueryreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package osqueryreceiver emits osquery results as logs
 package osqueryreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver"

--- a/receiver/otelarrowreceiver/doc.go
+++ b/receiver/otelarrowreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package otelarrowreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver"

--- a/receiver/otlpjsonfilereceiver/doc.go
+++ b/receiver/otlpjsonfilereceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package otlpjsonfilereceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive logs, traces and metrics from files

--- a/receiver/podmanreceiver/doc.go
+++ b/receiver/podmanreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"

--- a/receiver/postgresqlreceiver/doc.go
+++ b/receiver/postgresqlreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package postgresqlreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"

--- a/receiver/pprofreceiver/doc.go
+++ b/receiver/pprofreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package pprofreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver"

--- a/receiver/prometheusreceiver/doc.go
+++ b/receiver/prometheusreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package prometheusreceiver autodiscovers and scrapes Prometheus metrics handlers, often served at /metrics.
 package prometheusreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"

--- a/receiver/prometheusremotewritereceiver/doc.go
+++ b/receiver/prometheusremotewritereceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package prometheusremotewritereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver"

--- a/receiver/pulsarreceiver/doc.go
+++ b/receiver/pulsarreceiver/doc.go
@@ -1,5 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 package pulsarreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver"

--- a/receiver/purefareceiver/doc.go
+++ b/receiver/purefareceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package purefareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver"

--- a/receiver/purefbreceiver/doc.go
+++ b/receiver/purefbreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package purefbreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver"

--- a/receiver/rabbitmqreceiver/doc.go
+++ b/receiver/rabbitmqreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package rabbitmqreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver"

--- a/receiver/receivercreator/doc.go
+++ b/receiver/receivercreator/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package receivercreator implements receiver_creator that can instantiate other receivers at runtime.
 package receivercreator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator"

--- a/receiver/redfishreceiver/doc.go
+++ b/receiver/redfishreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package redfishreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver"

--- a/receiver/redisreceiver/doc.go
+++ b/receiver/redisreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package redisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"

--- a/receiver/riakreceiver/doc.go
+++ b/receiver/riakreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package riakreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver"

--- a/receiver/saphanareceiver/doc.go
+++ b/receiver/saphanareceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package saphanareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver"

--- a/receiver/signalfxreceiver/doc.go
+++ b/receiver/signalfxreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package signalfxreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive data in the SignalFx supported formats.

--- a/receiver/simpleprometheusreceiver/doc.go
+++ b/receiver/simpleprometheusreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package simpleprometheusreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver"

--- a/receiver/skywalkingreceiver/doc.go
+++ b/receiver/skywalkingreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package skywalkingreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver"

--- a/receiver/snmpreceiver/doc.go
+++ b/receiver/snmpreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package snmpreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver"

--- a/receiver/snowflakereceiver/doc.go
+++ b/receiver/snowflakereceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package snowflakereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver"

--- a/receiver/solacereceiver/doc.go
+++ b/receiver/solacereceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package solacereceiver receives traces from Solace broker using AMQP 1.0 protocol.
 package solacereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver"

--- a/receiver/splunkenterprisereceiver/doc.go
+++ b/receiver/splunkenterprisereceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package splunkenterprisereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver"

--- a/receiver/splunkhecreceiver/doc.go
+++ b/receiver/splunkhecreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package splunkhecreceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive data in the Splunk HEC supported formats.

--- a/receiver/sqlqueryreceiver/doc.go
+++ b/receiver/sqlqueryreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sqlqueryreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver"

--- a/receiver/sqlserverreceiver/doc.go
+++ b/receiver/sqlserverreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"

--- a/receiver/sshcheckreceiver/doc.go
+++ b/receiver/sshcheckreceiver/doc.go
@@ -3,4 +3,4 @@
 
 package sshcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver"
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen

--- a/receiver/statsdreceiver/doc.go
+++ b/receiver/statsdreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package statsdreceiver implements a collector receiver that listens
 // on UDP port 8125 by default for incoming StatsD messages and parses

--- a/receiver/stefreceiver/doc.go
+++ b/receiver/stefreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package stefreceiver
 package stefreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver"

--- a/receiver/syslogreceiver/doc.go
+++ b/receiver/syslogreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package syslogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver"

--- a/receiver/systemdreceiver/doc.go
+++ b/receiver/systemdreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package systemdreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver"

--- a/receiver/tcpcheckreceiver/doc.go
+++ b/receiver/tcpcheckreceiver/doc.go
@@ -3,4 +3,4 @@
 
 package tcpcheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver"
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen

--- a/receiver/tcplogreceiver/doc.go
+++ b/receiver/tcplogreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package tcplogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"

--- a/receiver/tlscheckreceiver/doc.go
+++ b/receiver/tlscheckreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package tlscheckreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver"

--- a/receiver/udplogreceiver/doc.go
+++ b/receiver/udplogreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package udplogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"

--- a/receiver/vcenterreceiver/doc.go
+++ b/receiver/vcenterreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package vcenterreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"

--- a/receiver/wavefrontreceiver/doc.go
+++ b/receiver/wavefrontreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package wavefrontreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver"

--- a/receiver/webhookeventreceiver/doc.go
+++ b/receiver/webhookeventreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package webhookeventreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver"

--- a/receiver/windowseventlogreceiver/doc.go
+++ b/receiver/windowseventlogreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package stanzareceiver implements a receiver that can be used by the
 // OpenTelemetry collector to receive logs using the stanza log agent

--- a/receiver/windowsperfcountersreceiver/doc.go
+++ b/receiver/windowsperfcountersreceiver/doc.go
@@ -7,7 +7,7 @@
 // representations.
 //
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // This receiver is only compatible with Windows.
 package windowsperfcountersreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver"

--- a/receiver/windowsservicereceiver/doc.go
+++ b/receiver/windowsservicereceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package windowsservice receiver.
 package windowsservicereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver"

--- a/receiver/yanggrpcreceiver/doc.go
+++ b/receiver/yanggrpcreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package yanggrpcreceiver.
 package yanggrpcreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver"

--- a/receiver/zipkinreceiver/doc.go
+++ b/receiver/zipkinreceiver/doc.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 // Package zipkinreceiver receives Zipkin traces.
 package zipkinreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"

--- a/receiver/zookeeperreceiver/doc.go
+++ b/receiver/zookeeperreceiver/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package zookeeperreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"

--- a/scraper/zookeeperscraper/doc.go
+++ b/scraper/zookeeperscraper/doc.go
@@ -1,6 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:generate mdatagen metadata.yaml
+//go:generate make mdatagen
 
 package zookeeperscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/scraper/zookeeperscraper"


### PR DESCRIPTION
#### Description

Introduce a `make mdatagen` target, which defaults to invoking the tool with metadata.yaml in the module directory. The metadata.yaml file path may be overridden by setting the env var MDATAGEN_METADATA_YAML.

This will simplify moving away from installing tools, and using "go tool". Offshoot of #45739

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

Updated docs/new-components.md