### PR TITLE
[extension/oauth2clientauth] fix client-credentials grant type

### DIFF
--- a/.chloggen/oauth2clientauthextension-clientcredentials-jwt.yaml
+++ b/.chloggen/oauth2clientauthextension-clientcredentials-jwt.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/oauth2client
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix oauth2clientauth client-credentials grant type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45786]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -70,10 +70,7 @@ func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticat
 			return nil, err
 		}
 	case grantTypeClientCredentials, "":
-		credentials, err = newJwtGrantTypeConfig(cfg)
-		if err != nil {
-			return nil, err
-		}
+		credentials = newClientCredentialsGrantTypeConfig(cfg)
 	default:
 		return nil, fmt.Errorf("unknown grant type %q", cfg.GrantType)
 	}


### PR DESCRIPTION
#### Description

Fix a regression introduced by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/44318, which led to the extension using the JWT bearer auth flow even when client-credentials is configured.

#### Link to tracking issue

Fixes #45786

#### Testing

Added a unit test that failed with the bug.

#### Documentation

N/A