### PR TITLE
[processor/k8sattributes] Fix fallback for deployment name extraction from ReplicaSet when regex extraction fails

### DIFF
--- a/.chloggen/k8attr-deployment-name-fallback.yaml
+++ b/.chloggen/k8attr-deployment-name-fallback.yaml
@@ -4,7 +4,7 @@
 change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: processors/k8sattributes
+component: processor/k8sattributes
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fix fallback for deployment name extraction from ReplicaSet when regex extraction fails."

--- a/.chloggen/k8attr-deployment-name-fallback.yaml
+++ b/.chloggen/k8attr-deployment-name-fallback.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processors/k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix fallback for deployment name extraction from ReplicaSet when regex extraction fails."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45724]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -832,8 +832,12 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 					var deploymentName string
 					if c.Rules.DeploymentNameFromReplicaSet {
 						deploymentName = extractDeploymentNameFromReplicaSet(ref.Name)
-					} else if replicaset, ok := c.GetReplicaSet(string(ref.UID)); ok {
-						deploymentName = replicaset.Deployment.Name
+					}
+					// If regex extraction failed or flag is disabled, try looking up the ReplicaSet
+					if deploymentName == "" {
+						if replicaset, ok := c.GetReplicaSet(string(ref.UID)); ok {
+							deploymentName = replicaset.Deployment.Name
+						}
 					}
 					if deploymentName != "" {
 						if c.Rules.DeploymentName {

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -3701,6 +3701,14 @@ func TestDeploymentNameFromReplicaSetFeature(t *testing.T) {
 			replicaSetName:                      "invalid-name",
 			expectedDeploymentName:              "",
 		},
+		{
+			name:                                "flag enabled - regex fails but falls back to cache (issue 45724)",
+			deploymentNameFromReplicaSetEnabled: true,
+			replicaSetInCache:                   true,
+			deploymentInRS:                      true,
+			replicaSetName:                      "my-app-weird-suffix",
+			expectedDeploymentName:              "real-deployment-name",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45724

