### PR TITLE
[extension/awslogs_encoding] Support CloudWatch Logs extracted fields for centralized logging

### DIFF
--- a/.chloggen/awslogsencodingextension-extracted-fields.yaml
+++ b/.chloggen/awslogsencodingextension-extracted-fields.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awslogsencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support CloudWatch Logs extracted fields (`@aws.account`, `@aws.region`) for centralized logging
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45631]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  CloudWatch Logs subscription filter unmarshaler now supports extracted fields (`@aws.account` and `@aws.region`)
+  that are automatically added when using CloudWatch Logs centralization and enabling `emitSystemFields` in
+  subscription filters. This enhancement enables proper resource attribution in OpenTelemetry when processing
+  logs from multiple AWS accounts and regions. Logs with different extracted field values are automatically
+  grouped into separate ResourceLogs for proper semantic convention mapping:
+  - `@aws.account` maps to `cloud.account.id`
+  - `@aws.region` maps to `cloud.region`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/awslogsencodingextension-extracted-fields.yaml
+++ b/.chloggen/awslogsencodingextension-extracted-fields.yaml
@@ -10,7 +10,7 @@ component: extension/awslogsencodingextension
 note: Support CloudWatch Logs extracted fields (`@aws.account`, `@aws.region`) for centralized logging
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [45631]
+issues: [45792]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/awslogsencodingextension-extracted-fields.yaml
+++ b/.chloggen/awslogsencodingextension-extracted-fields.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogsencodingextension
+component: extension/awslogs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Support CloudWatch Logs extracted fields (`@aws.account`, `@aws.region`) for centralized logging

--- a/.chloggen/awslogsencodingextension-fix-duplicate-attrs.yaml
+++ b/.chloggen/awslogsencodingextension-fix-duplicate-attrs.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/awslogsencodingextension
+component: extension/awslogs_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix duplicate resource attributes in subscription filter unmarshaler

--- a/.chloggen/awslogsencodingextension-fix-duplicate-attrs.yaml
+++ b/.chloggen/awslogsencodingextension-fix-duplicate-attrs.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awslogsencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicate resource attributes in subscription filter unmarshaler
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45792]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `aws.log.group.names` and `aws.log.stream.names` resource attributes were incorrectly
+  being set twice: first as array values, then immediately overwritten as string values.
+  This fix removes the duplicate string assignments, ensuring the attributes are correctly
+  set only as arrays per OpenTelemetry semantic conventions.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/awslogsencodingextension/README.md
+++ b/extension/encoding/awslogsencodingextension/README.md
@@ -556,3 +556,30 @@ The following fields are common across all log types:
 | `event.http.http_user_agent`   | `user_agent.original`              |
 | `event.http.http_content_type` | `http.request.header.content-type` |
 | `event.http.cookie`            | `http.request.header.cookie`       |
+
+### CloudWatch Logs Subscription Filter record fields
+
+[CloudWatch Logs Subscription Filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html) events are mapped to OpenTelemetry logs with the following resource attributes:
+
+| CloudWatch Logs field | Attribute in OpenTelemetry log |
+|-----------------------|--------------------------------|
+| `owner`               | `cloud.account.id`             |
+| `logGroup`            | `aws.log.group.names` (array)  |
+| `logStream`           | `aws.log.stream.names` (array) |
+
+Each log event's `timestamp` is converted to the OpenTelemetry log timestamp, and the `message` is set as the log body.
+
+#### Extracted Fields for Centralized Logging
+
+When using [CloudWatch Logs centralization](https://aws.amazon.com/blogs/mt/simplifying-log-management-using-amazon-cloudwatch-logs-centralization/) to consolidate logs from multiple AWS accounts and regions into a central account, you can enable `emitSystemFields` in your CloudWatch Logs subscription filter to include the original account ID and region in each log event.
+
+To enable extracted fields, set the `emitSystemFields` parameter when creating or updating your CloudWatch Logs subscription filter:
+
+When `emitSystemFields` is enabled, the following fields are extracted and mapped to OpenTelemetry semantic conventions:
+
+| Extracted field  | Attribute in OpenTelemetry log |
+|------------------|--------------------------------|
+| `@aws.account`   | `cloud.account.id`             |
+| `@aws.region`    | `cloud.region`                 |
+
+**Note:** When extracted fields are present, they take precedence over the `owner` field for `cloud.account.id`. Logs with different extracted field values (different account IDs or regions) are automatically grouped into separate `ResourceLogs` to ensure proper resource attribution in OpenTelemetry.

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_account_id.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_account_id.json
@@ -1,0 +1,17 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789012",
+    "logGroup": "test-log-group",
+    "logStream": "test-log-stream",
+    "subscriptionFilters": ["test-filter"],
+    "logEvents": [
+        {
+            "id": "38480917865042697267627490045603633139480491071049695232",
+            "timestamp": 1725544035523,
+            "message": "Hello world, here is our first log message!",
+            "extractedFields": {
+                "@aws.account": "999888777666"
+            }
+        }
+    ]
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_account_id_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_account_id_expected.yaml
@@ -6,28 +6,22 @@ resourceLogs:
             stringValue: aws
         - key: cloud.account.id
           value:
-            stringValue: "123456789012"
+            stringValue: "999888777666"
         - key: aws.log.group.names
           value:
             arrayValue:
               values:
-                - stringValue: CloudTrail
+                - stringValue: test-log-group
         - key: aws.log.stream.names
           value:
             arrayValue:
               values:
-                - stringValue: 123456789012_CloudTrail_us-east-1
+                - stringValue: test-log-stream
     scopeLogs:
       - logRecords:
           - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
-          - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
-          - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
+              stringValue: "Hello world, here is our first log message!"
+            timeUnixNano: "1725544035523000000"
         scope:
           attributes:
             - key: encoding.format

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_both.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_both.json
@@ -1,0 +1,18 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789012",
+    "logGroup": "test-log-group",
+    "logStream": "test-log-stream",
+    "subscriptionFilters": ["test-filter"],
+    "logEvents": [
+        {
+            "id": "38480917865042697267627490045603633139480491071049695232",
+            "timestamp": 1725544035523,
+            "message": "Hello world, here is our first log message!",
+            "extractedFields": {
+                "@aws.account": "999888777666",
+                "@aws.region": "us-west-2"
+            }
+        }
+    ]
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_both_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/extracted_fields_both_expected.yaml
@@ -6,28 +6,25 @@ resourceLogs:
             stringValue: aws
         - key: cloud.account.id
           value:
-            stringValue: "123456789012"
+            stringValue: "999888777666"
+        - key: cloud.region
+          value:
+            stringValue: us-west-2
         - key: aws.log.group.names
           value:
             arrayValue:
               values:
-                - stringValue: CloudTrail
+                - stringValue: test-log-group
         - key: aws.log.stream.names
           value:
             arrayValue:
               values:
-                - stringValue: 123456789012_CloudTrail_us-east-1
+                - stringValue: test-log-stream
     scopeLogs:
       - logRecords:
           - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
-          - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
-          - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
+              stringValue: "Hello world, here is our first log message!"
+            timeUnixNano: "1725544035523000000"
         scope:
           attributes:
             - key: encoding.format

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_different_extracted_fields.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_different_extracted_fields.json
@@ -1,0 +1,27 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789012",
+    "logGroup": "test-log-group",
+    "logStream": "test-log-stream",
+    "subscriptionFilters": ["test-filter"],
+    "logEvents": [
+        {
+            "id": "38480917865042697267627490045603633139480491071049695232",
+            "timestamp": 1725544035523,
+            "message": "First log from account 111",
+            "extractedFields": {
+                "@aws.account": "111111111111",
+                "@aws.region": "us-east-1"
+            }
+        },
+        {
+            "id": "38480917865042697267627490045603633139480491071049695233",
+            "timestamp": 1725544035524,
+            "message": "Second log from account 222",
+            "extractedFields": {
+                "@aws.account": "222222222222",
+                "@aws.region": "us-west-2"
+            }
+        }
+    ]
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_different_extracted_fields_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_different_extracted_fields_expected.yaml
@@ -1,0 +1,65 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: aws
+        - key: cloud.account.id
+          value:
+            stringValue: "111111111111"
+        - key: cloud.region
+          value:
+            stringValue: us-east-1
+        - key: aws.log.group.names
+          value:
+            arrayValue:
+              values:
+                - stringValue: test-log-group
+        - key: aws.log.stream.names
+          value:
+            arrayValue:
+              values:
+                - stringValue: test-log-stream
+    scopeLogs:
+      - logRecords:
+          - body:
+              stringValue: "First log from account 111"
+            timeUnixNano: "1725544035523000000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: aws.cloudwatch
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
+  - resource:
+      attributes:
+        - key: cloud.provider
+          value:
+            stringValue: aws
+        - key: cloud.account.id
+          value:
+            stringValue: "222222222222"
+        - key: cloud.region
+          value:
+            stringValue: us-west-2
+        - key: aws.log.group.names
+          value:
+            arrayValue:
+              values:
+                - stringValue: test-log-group
+        - key: aws.log.stream.names
+          value:
+            arrayValue:
+              values:
+                - stringValue: test-log-stream
+    scopeLogs:
+      - logRecords:
+          - body:
+              stringValue: "Second log from account 222"
+            timeUnixNano: "1725544035524000000"
+        scope:
+          attributes:
+            - key: encoding.format
+              value:
+                stringValue: aws.cloudwatch
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_same_extracted_fields.json
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_same_extracted_fields.json
@@ -1,0 +1,27 @@
+{
+    "messageType": "DATA_MESSAGE",
+    "owner": "123456789012",
+    "logGroup": "test-log-group",
+    "logStream": "test-log-stream",
+    "subscriptionFilters": ["test-filter"],
+    "logEvents": [
+        {
+            "id": "38480917865042697267627490045603633139480491071049695232",
+            "timestamp": 1725544035523,
+            "message": "First log with extracted fields",
+            "extractedFields": {
+                "@aws.account": "999888777666",
+                "@aws.region": "us-west-2"
+            }
+        },
+        {
+            "id": "38480917865042697267627490045603633139480491071049695233",
+            "timestamp": 1725544035524,
+            "message": "Second log with same extracted fields",
+            "extractedFields": {
+                "@aws.account": "999888777666",
+                "@aws.region": "us-west-2"
+            }
+        }
+    ]
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_same_extracted_fields_expected.yaml
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/testdata/two_records_same_extracted_fields_expected.yaml
@@ -6,28 +6,28 @@ resourceLogs:
             stringValue: aws
         - key: cloud.account.id
           value:
-            stringValue: "123456789012"
+            stringValue: "999888777666"
+        - key: cloud.region
+          value:
+            stringValue: us-west-2
         - key: aws.log.group.names
           value:
             arrayValue:
               values:
-                - stringValue: CloudTrail
+                - stringValue: test-log-group
         - key: aws.log.stream.names
           value:
             arrayValue:
               values:
-                - stringValue: 123456789012_CloudTrail_us-east-1
+                - stringValue: test-log-stream
     scopeLogs:
       - logRecords:
           - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
+              stringValue: "First log with extracted fields"
+            timeUnixNano: "1725544035523000000"
           - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
-          - body:
-              stringValue: '{"eventVersion":"1.03","userIdentity":{"type":"Root"}'
-            timeUnixNano: "1432826855000000000"
+              stringValue: "Second log with same extracted fields"
+            timeUnixNano: "1725544035524000000"
         scope:
           attributes:
             - key: encoding.format

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/types.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/types.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package subscriptionfilter // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter"
+
+// extractedFields contains the extracted fields from CloudWatch Logs events.
+// These fields are present when emitSystemFields is enabled in the CloudWatch Logs
+// subscription filter, which is useful for centralized logging scenarios where logs
+// from multiple AWS accounts and regions are consolidated.
+type extractedFields struct {
+	AccountID string `json:"@aws.account,omitempty"`
+	Region    string `json:"@aws.region,omitempty"`
+}
+
+// cloudwatchLogsLogEvent represents a single log event from CloudWatch Logs.
+// This is a custom type that extends the AWS SDK's CloudwatchLogsLogEvent
+// to include extractedFields support.
+type cloudwatchLogsLogEvent struct {
+	ID              string           `json:"id"`
+	Timestamp       int64            `json:"timestamp"`
+	Message         string           `json:"message"`
+	ExtractedFields *extractedFields `json:"extractedFields,omitempty"`
+}
+
+// cloudwatchLogsData represents the CloudWatch Logs data structure.
+// This is a custom type that replaces the AWS SDK's CloudwatchLogsData
+// to support extractedFields in log events.
+type cloudwatchLogsData struct {
+	Owner               string                   `json:"owner"`
+	LogGroup            string                   `json:"logGroup"`
+	LogStream           string                   `json:"logStream"`
+	SubscriptionFilters []string                 `json:"subscriptionFilters"`
+	MessageType         string                   `json:"messageType"`
+	LogEvents           []cloudwatchLogsLogEvent `json:"logEvents"`
+}
+
+// resourceGroupKey represents the combination of account ID and region
+// used for grouping log events into separate ResourceLogs.
+type resourceGroupKey struct {
+	accountID string
+	region    string
+}

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/subscription-filter/unmarshaler.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/aws/aws-lambda-go/events"
 	gojson "github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -27,7 +26,7 @@ var (
 	errEmptyLogStream = errors.New("cloudwatch log with message type 'DATA_MESSAGE' has empty log stream field")
 )
 
-func validateLog(log events.CloudwatchLogsData) error {
+func validateLog(log cloudwatchLogsData) error {
 	switch log.MessageType {
 	case "DATA_MESSAGE":
 		if log.Owner == "" {
@@ -58,10 +57,12 @@ func NewSubscriptionFilterUnmarshaler(buildInfo component.BuildInfo) unmarshaler
 
 // UnmarshalAWSLogs deserializes the given reader as CloudWatch Logs events
 // into a plog.Logs, grouping logs by owner (account ID), log group, and
-// log stream. Logs are assumed to be gzip-compressed as specified at
+// log stream. When extracted fields are present (from centralized logging),
+// logs are further grouped by their extracted account ID and region.
+// Logs are assumed to be gzip-compressed as specified at
 // https://docs.aws.amazon.com/firehose/latest/dev/writing-with-cloudwatch-logs.html.
 func (f *subscriptionFilterUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error) {
-	var cwLog events.CloudwatchLogsData
+	var cwLog cloudwatchLogsData
 	decoder := gojson.NewDecoder(reader)
 	if err := decoder.Decode(&cwLog); err != nil {
 		return plog.Logs{}, fmt.Errorf("failed to decode decompressed reader: %w", err)
@@ -78,30 +79,63 @@ func (f *subscriptionFilterUnmarshaler) UnmarshalAWSLogs(reader io.Reader) (plog
 	return f.createLogs(cwLog), nil
 }
 
-// createLogs create plog.Logs from the cloudwatchLog
-func (f *subscriptionFilterUnmarshaler) createLogs(
-	cwLog events.CloudwatchLogsData,
-) plog.Logs {
+// createLogs creates plog.Logs from the cloudwatchLogsData.
+// Events are grouped by their extracted fields (account ID + region).
+// Events with different extracted fields are placed in separate ResourceLogs,
+// while events with identical extracted fields are grouped together.
+// When extracted fields are absent, the Owner field is used as the account ID.
+func (f *subscriptionFilterUnmarshaler) createLogs(cwLog cloudwatchLogsData) plog.Logs {
 	logs := plog.NewLogs()
-	rl := logs.ResourceLogs().AppendEmpty()
-	resourceAttrs := rl.Resource().Attributes()
-	resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
-	resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), cwLog.Owner)
-	resourceAttrs.PutEmptySlice(string(conventions.AWSLogGroupNamesKey)).AppendEmpty().SetStr(cwLog.LogGroup)
-	resourceAttrs.PutEmptySlice(string(conventions.AWSLogStreamNamesKey)).AppendEmpty().SetStr(cwLog.LogStream)
-	resourceAttrs.PutStr(string(conventions.AWSLogGroupNamesKey), cwLog.LogGroup)
-	resourceAttrs.PutStr(string(conventions.AWSLogStreamNamesKey), cwLog.LogStream)
 
-	sl := rl.ScopeLogs().AppendEmpty()
-	sl.Scope().SetName(metadata.ScopeName)
-	sl.Scope().SetVersion(f.buildInfo.Version)
-	sl.Scope().Attributes().PutStr(constants.FormatIdentificationTag, "aws."+constants.FormatCloudWatchLogsSubscriptionFilter)
-	for _, event := range cwLog.LogEvents {
-		logRecord := sl.LogRecords().AppendEmpty()
-		// pcommon.Timestamp is a time specified as UNIX Epoch time in nanoseconds
-		// but timestamp in cloudwatch logs are in milliseconds.
-		logRecord.SetTimestamp(pcommon.Timestamp(event.Timestamp * int64(time.Millisecond)))
-		logRecord.Body().SetStr(event.Message)
+	// Group event indices by key to get the indices of events that belong to the same resource group.
+	// This allows us to append all log records for a given resource group at once.
+	eventsByKey := make(map[resourceGroupKey][]int)
+	for i, event := range cwLog.LogEvents {
+		var key resourceGroupKey
+		if event.ExtractedFields != nil {
+			if event.ExtractedFields.AccountID != "" {
+				key.accountID = event.ExtractedFields.AccountID
+			} else {
+				key.accountID = cwLog.Owner
+			}
+			key.region = event.ExtractedFields.Region
+		} else {
+			key.accountID = cwLog.Owner
+		}
+		eventsByKey[key] = append(eventsByKey[key], i)
 	}
+
+	// Create ResourceLogs and populate log records with pre-allocation.
+	for key, eventIndices := range eventsByKey {
+		rl := logs.ResourceLogs().AppendEmpty()
+		resourceAttrs := rl.Resource().Attributes()
+		resourceAttrs.PutStr(string(conventions.CloudProviderKey), conventions.CloudProviderAWS.Value.AsString())
+		resourceAttrs.PutStr(string(conventions.CloudAccountIDKey), key.accountID)
+		if key.region != "" {
+			resourceAttrs.PutStr(string(conventions.CloudRegionKey), key.region)
+		}
+		resourceAttrs.PutEmptySlice(string(conventions.AWSLogGroupNamesKey)).AppendEmpty().SetStr(cwLog.LogGroup)
+		resourceAttrs.PutEmptySlice(string(conventions.AWSLogStreamNamesKey)).AppendEmpty().SetStr(cwLog.LogStream)
+
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.Scope().SetName(metadata.ScopeName)
+		sl.Scope().SetVersion(f.buildInfo.Version)
+		sl.Scope().Attributes().PutStr(constants.FormatIdentificationTag, "aws."+constants.FormatCloudWatchLogsSubscriptionFilter)
+
+		// Pre-allocate LogRecords capacity to avoid reallocations.
+		logRecords := sl.LogRecords()
+		logRecords.EnsureCapacity(len(eventIndices))
+
+		// Append log records using indices to access original events.
+		for _, idx := range eventIndices {
+			event := cwLog.LogEvents[idx]
+			logRecord := logRecords.AppendEmpty()
+			// pcommon.Timestamp is a time specified as UNIX Epoch time in nanoseconds
+			// but timestamp in cloudwatch logs are in milliseconds.
+			logRecord.SetTimestamp(pcommon.Timestamp(event.Timestamp * int64(time.Millisecond)))
+			logRecord.Body().SetStr(event.Message)
+		}
+	}
+
 	return logs
 }


### PR DESCRIPTION
## Summary

Add support for CloudWatch Logs extracted fields (`@aws.account`, `@aws.region`) in the `awslogsencodingextension`'s subscription-filter unmarshaler.

This enhancement enables proper resource attribution in OpenTelemetry when processing logs from centralized logging setups where logs from multiple AWS accounts and regions are consolidated into a single destination.

## Changes

- **Custom types**: Replace AWS SDK types (`events.CloudwatchLogsData`) with custom types that include `ExtractedFields` support
- **Resource grouping**: Implement logic to create separate `ResourceLogs` for logs with different account ID and region combinations
- **Semantic mapping**: 
  - `@aws.account` → `cloud.account.id`
  - `@aws.region` → `cloud.region`
- **Tests**: Add comprehensive test coverage for extracted fields scenarios
- **Documentation**: Update README with centralized logging documentation

## How to enable extracted fields in AWS

Set the `emitSystemFields` parameter when creating a CloudWatch Logs subscription filter:

```bash
aws logs put-subscription-filter \
    --log-group-name "your-log-group" \
    --filter-name "your-filter" \
    --filter-pattern "" \
    --destination-arn "arn:aws:firehose:region:account:deliverystream/your-stream" \
    --emit-system-fields
```

## Related

- Related to #45631 (Firehose receiver implementation)
- Addresses reviewer feedback suggesting implementation in the encoding extension

## Testing

All tests pass:
```
go test ./internal/unmarshaler/subscription-filter/... -v
```