### PR TITLE
[processor/resourcedetection] Promote `processor.resourcedetection.removeGCPFaasID` feature gate to Stable 

### DIFF
--- a/.chloggen/feat_resourcedetection_fg_faasid_stable.yaml
+++ b/.chloggen/feat_resourcedetection_fg_faasid_stable.yaml
@@ -10,7 +10,7 @@ component: processor/resourcedetection
 note: "Promote `processor.resourcedetection.removeGCPFaasID` feature gate to Stable and is now always enabled"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [44565]
+issues: [45797]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/feat_resourcedetection_fg_faasid_stable.yaml
+++ b/.chloggen/feat_resourcedetection_fg_faasid_stable.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Promote `processor.resourcedetection.removeGCPFaasID` feature gate to Stable and is now always enabled"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44565]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The faas.id attribute is replaced by the faas.instance attribute.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -218,7 +218,7 @@ able to determine `host.name`. In that case, users are encouraged to set `host.n
     * cloud.platform ("gcp_cloud_run")
     * cloud.account.id (project id)
     * cloud.region (e.g. "us-central1")
-    * faas.id (instance id)
+    * faas.instance (instance id)
     * faas.name (service name)
     * faas.version (service revision)
 
@@ -228,7 +228,7 @@ able to determine `host.name`. In that case, users are encouraged to set `host.n
     * cloud.platform ("gcp_cloud_run")
     * cloud.account.id (project id)
     * cloud.region (e.g. "us-central1")
-    * faas.id (instance id)
+    * faas.instance (instance id)
     * faas.name (service name)
     * gcp.cloud_run.job.execution ("my-service-ajg89")
     * gcp.cloud_run.job.task_index ("0")
@@ -239,7 +239,7 @@ able to determine `host.name`. In that case, users are encouraged to set `host.n
     * cloud.platform ("gcp_cloud_functions")
     * cloud.account.id (project id)
     * cloud.region (e.g. "us-central1")
-    * faas.id (instance id)
+    * faas.instance (instance id)
     * faas.name (function name)
     * faas.version (function version)
 
@@ -250,7 +250,7 @@ able to determine `host.name`. In that case, users are encouraged to set `host.n
     * cloud.account.id (project id)
     * cloud.region (e.g. "us-central1")
     * cloud.availability_zone (e.g. "us-central1-c")
-    * faas.id (instance id)
+    * faas.instance (instance id)
     * faas.name (service name)
     * faas.version (service version)
 

--- a/processor/resourcedetectionprocessor/documentation.md
+++ b/processor/resourcedetectionprocessor/documentation.md
@@ -9,6 +9,6 @@ This component has the following feature gates:
 | Feature Gate | Stage | Description | From Version | To Version | Reference |
 | ------------ | ----- | ----------- | ------------ | ---------- | --------- |
 | `processor.resourcedetection.propagateerrors` | beta | When enabled, allows errors returned from resource detectors to propagate in the Start() method and stop the collector. | v0.121.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37961) |
-| `processor.resourcedetection.removeGCPFaasID` | beta | Remove faas.id from the GCP detector. Use faas.instance instead. | v0.87.0 | N/A | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26486) |
+| `processor.resourcedetection.removeGCPFaasID` | stable | Remove faas.id from the GCP detector. Use faas.instance instead. | v0.87.0 | v0.145.0 | [Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26486) |
 
 For more information about feature gates, see the [Feature Gates](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md) documentation.

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/hetznercloud/hcloud-go/v2 v2.36.0
 	github.com/linode/go-metadata v0.2.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.144.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.144.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.144.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.144.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.144.0
@@ -128,6 +127,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.144.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.144.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	localMetadata "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp/internal/metadata"
-	processormetadata "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/metadata"
 )
 
 func TestDetect(t *testing.T) {
@@ -26,7 +24,6 @@ func TestDetect(t *testing.T) {
 		detector         internal.Detector
 		expectErr        bool
 		expectedResource map[string]any
-		addFaasID        bool
 	}{
 		{
 			desc: "zonal GKE cluster",
@@ -192,28 +189,6 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			desc: "Cloud Run with feature gate disabled",
-			detector: newTestDetector(&fakeGCPDetector{
-				projectID:       "my-project",
-				cloudPlatform:   gcp.CloudRun,
-				faaSID:          "1472385723456792345",
-				faaSCloudRegion: "us-central1",
-				faaSName:        "my-service",
-				faaSVersion:     "123456",
-			}),
-			expectedResource: map[string]any{
-				"cloud.provider":   "gcp",
-				"cloud.account.id": "my-project",
-				"cloud.platform":   "gcp_cloud_run",
-				"cloud.region":     "us-central1",
-				"faas.name":        "my-service",
-				"faas.version":     "123456",
-				"faas.instance":    "1472385723456792345",
-				"faas.id":          "1472385723456792345",
-			},
-			addFaasID: true,
-		},
-		{
 			desc: "Cloud Run Job",
 			detector: newTestDetector(&fakeGCPDetector{
 				projectID:               "my-project",
@@ -236,30 +211,6 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			desc: "Cloud Run Job with feature gate disabled",
-			detector: newTestDetector(&fakeGCPDetector{
-				projectID:               "my-project",
-				cloudPlatform:           gcp.CloudRunJob,
-				faaSID:                  "1472385723456792345",
-				faaSCloudRegion:         "us-central1",
-				faaSName:                "my-service",
-				gcpCloudRunJobExecution: "my-service-ajg89",
-				gcpCloudRunJobTaskIndex: "2",
-			}),
-			expectedResource: map[string]any{
-				"cloud.provider":               "gcp",
-				"cloud.account.id":             "my-project",
-				"cloud.platform":               "gcp_cloud_run",
-				"cloud.region":                 "us-central1",
-				"faas.name":                    "my-service",
-				"faas.instance":                "1472385723456792345",
-				"faas.id":                      "1472385723456792345",
-				"gcp.cloud_run.job.execution":  "my-service-ajg89",
-				"gcp.cloud_run.job.task_index": "2",
-			},
-			addFaasID: true,
-		},
-		{
 			desc: "Cloud Functions",
 			detector: newTestDetector(&fakeGCPDetector{
 				projectID:       "my-project",
@@ -278,28 +229,6 @@ func TestDetect(t *testing.T) {
 				"faas.version":     "123456",
 				"faas.instance":    "1472385723456792345",
 			},
-		},
-		{
-			desc: "Cloud Functions with feature gate disabled",
-			detector: newTestDetector(&fakeGCPDetector{
-				projectID:       "my-project",
-				cloudPlatform:   gcp.CloudFunctions,
-				faaSID:          "1472385723456792345",
-				faaSCloudRegion: "us-central1",
-				faaSName:        "my-service",
-				faaSVersion:     "123456",
-			}),
-			expectedResource: map[string]any{
-				"cloud.provider":   "gcp",
-				"cloud.account.id": "my-project",
-				"cloud.platform":   "gcp_cloud_functions",
-				"cloud.region":     "us-central1",
-				"faas.name":        "my-service",
-				"faas.version":     "123456",
-				"faas.instance":    "1472385723456792345",
-				"faas.id":          "1472385723456792345",
-			},
-			addFaasID: true,
 		},
 		{
 			desc: "App Engine Standard",
@@ -324,30 +253,6 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			desc: "App Engine Standard with feature gate disabled",
-			detector: newTestDetector(&fakeGCPDetector{
-				projectID:                 "my-project",
-				cloudPlatform:             gcp.AppEngineStandard,
-				appEngineServiceInstance:  "1472385723456792345",
-				appEngineAvailabilityZone: "us-central1-c",
-				appEngineRegion:           "us-central1",
-				appEngineServiceName:      "my-service",
-				appEngineServiceVersion:   "123456",
-			}),
-			expectedResource: map[string]any{
-				"cloud.provider":          "gcp",
-				"cloud.account.id":        "my-project",
-				"cloud.platform":          "gcp_app_engine",
-				"cloud.region":            "us-central1",
-				"cloud.availability_zone": "us-central1-c",
-				"faas.name":               "my-service",
-				"faas.version":            "123456",
-				"faas.instance":           "1472385723456792345",
-				"faas.id":                 "1472385723456792345",
-			},
-			addFaasID: true,
-		},
-		{
 			desc: "App Engine Flex",
 			detector: newTestDetector(&fakeGCPDetector{
 				projectID:                 "my-project",
@@ -368,30 +273,6 @@ func TestDetect(t *testing.T) {
 				"faas.version":            "123456",
 				"faas.instance":           "1472385723456792345",
 			},
-		},
-		{
-			desc: "App Engine Flex with feature gate disabled",
-			detector: newTestDetector(&fakeGCPDetector{
-				projectID:                 "my-project",
-				cloudPlatform:             gcp.AppEngineFlex,
-				appEngineServiceInstance:  "1472385723456792345",
-				appEngineAvailabilityZone: "us-central1-c",
-				appEngineRegion:           "us-central1",
-				appEngineServiceName:      "my-service",
-				appEngineServiceVersion:   "123456",
-			}),
-			expectedResource: map[string]any{
-				"cloud.provider":          "gcp",
-				"cloud.account.id":        "my-project",
-				"cloud.platform":          "gcp_app_engine",
-				"cloud.region":            "us-central1",
-				"cloud.availability_zone": "us-central1-c",
-				"faas.name":               "my-service",
-				"faas.version":            "123456",
-				"faas.instance":           "1472385723456792345",
-				"faas.id":                 "1472385723456792345",
-			},
-			addFaasID: true,
 		},
 		{
 			desc: "Bare Metal Solution",
@@ -433,7 +314,6 @@ func TestDetect(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			defer testutil.SetFeatureGateForTest(t, processormetadata.ProcessorResourcedetectionRemoveGCPFaasIDFeatureGate, !tc.addFaasID)()
 			res, schema, err := tc.detector.Detect(t.Context())
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/processor/resourcedetectionprocessor/internal/metadata/generated_feature_gates.go
+++ b/processor/resourcedetectionprocessor/internal/metadata/generated_feature_gates.go
@@ -16,8 +16,9 @@ var ProcessorResourcedetectionPropagateerrorsFeatureGate = featuregate.GlobalReg
 
 var ProcessorResourcedetectionRemoveGCPFaasIDFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"processor.resourcedetection.removeGCPFaasID",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("Remove faas.id from the GCP detector. Use faas.instance instead."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26486"),
 	featuregate.WithRegisterFromVersion("v0.87.0"),
+	featuregate.WithRegisterToVersion("v0.145.0"),
 )

--- a/processor/resourcedetectionprocessor/metadata.yaml
+++ b/processor/resourcedetectionprocessor/metadata.yaml
@@ -30,8 +30,9 @@ feature_gates:
     from_version: v0.121.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37961
   - id: processor.resourcedetection.removeGCPFaasID
-    stage: beta
+    stage: stable
     description: >-
       Remove faas.id from the GCP detector. Use faas.instance instead.
     from_version: v0.87.0
+    to_version: v0.145.0
     reference_url: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26486


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Promote `processor.resourcedetection.removeGCPFaasID` feature gate to Stable.

This feature gate has been in Beta since `v0.131.0` without any issues, so it is safe to promote it to Stable.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated and removed all the tests that validate the values with the feature gate disabled.

<!--Describe the documentation added.-->
#### Documentation

Updated docs to refer to `faas.instance` instead of `faas.id`.

<!--Please delete paragraphs that you did not use before submitting.-->
