### PR TITLE
[chore][processor/resourcedetection] run make generate-schemas

### DIFF
--- a/processor/resourcedetectionprocessor/config.schema.yaml
+++ b/processor/resourcedetectionprocessor/config.schema.yaml
@@ -9,6 +9,9 @@ $defs:
       aks:
         description: Aks contains user-specified configurations for the aks detector
         $ref: ./internal/azure/aks.config
+      alibaba_ecs:
+        description: AlibabaECSConfig contains user-specified configurations for the Alibaba Cloud ECS detector
+        $ref: ./internal/alibaba/ecs.config
       azure:
         description: Azure contains user-specified configurations for the azure detector
         $ref: ./internal/azure.config


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Run `make generate-schemas`, which was not run against a branch synced with `main`.

Was introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45758