### PR TITLE
fix[extension/encoding/textencoding]: Text encoding extension with nil separator splitting

### DIFF
--- a/.chloggen/fix-text-encoding-extension-splitting.yaml
+++ b/.chloggen/fix-text-encoding-extension-splitting.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/encoding/textencodingextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix text encoding extension to not split large messages when no separator is configured.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45845]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/fix-text-encoding-extension-splitting.yaml
+++ b/.chloggen/fix-text-encoding-extension-splitting.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: extension/encoding/textencodingextension
+component: extension/text_encoding
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix text encoding extension to not split large messages when no separator is configured.

--- a/extension/encoding/textencodingextension/text.go
+++ b/extension/encoding/textencodingextension/text.go
@@ -45,7 +45,10 @@ func (r *textLogCodec) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 			if atEOF && len(data) == 0 {
 				return 0, nil, nil
 			}
-			return len(data), data, nil
+			if atEOF {
+				return len(data), data, nil
+			}
+			return 0, nil, nil // Request more data until EOF
 		})
 	}
 	for s.Scan() {

--- a/extension/encoding/textencodingextension/text_test.go
+++ b/extension/encoding/textencodingextension/text_test.go
@@ -53,3 +53,26 @@ func TestNoSeparator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "foo\r\nbar\n", string(b))
 }
+
+func TestNoSeparatorLargeMessage(t *testing.T) {
+	// Test that large messages (> bufio.Scanner's default 4096 buffer) are not split
+	// when no separator is configured. This verifies the fix for the bug where the
+	// split function would return immediately without waiting for EOF.
+	enc, err := textutils.LookupEncoding("utf8")
+	require.NoError(t, err)
+	codec := &textLogCodec{decoder: enc.NewDecoder()}
+
+	// Create a message larger than bufio.Scanner's default 4096 byte buffer
+	largeMessage := make([]byte, 16384)
+	for i := range largeMessage {
+		largeMessage[i] = byte('a' + (i % 26))
+	}
+
+	ld, err := codec.UnmarshalLogs(largeMessage)
+	require.NoError(t, err)
+	assert.Equal(t, 1, ld.LogRecordCount(), "large message should not be split into multiple records")
+
+	b, err := codec.MarshalLogs(ld)
+	require.NoError(t, err)
+	require.Equal(t, largeMessage, b)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes an issue with the text encoding extension where if configured without an unmarshaling separator, the extension splits large payloads into multiple logs.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45845

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added a unit test that reproduces the bug.

Manual testing with a distribution of the OTel collector.
