### PR TITLE
[extension/awscloudwatchmetricstreams_encoding] Add percentile statistics support for JSON format

### DIFF
--- a/.chloggen/awscloudwatchmetricstreams-percentile-support.yaml
+++ b/.chloggen/awscloudwatchmetricstreams-percentile-support.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awscloudwatchmetricstreams_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for extracting percentile statistics (p50, p90, p99, etc.) from CloudWatch Metric Streams JSON format
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45855]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The JSON unmarshaler now extracts percentile fields from CloudWatch Metric Streams data and converts them to OpenTelemetry Summary quantiles.
+  This enables feature parity with the embedded cwmetricstream unmarshaler in awsfirehosereceiver.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
@@ -31,3 +31,26 @@ extensions:
   awscloudwatchmetricstreams_encoding:
     format: json
 ```
+
+## Supported Statistics (JSON format)
+
+When using the JSON format, the extension extracts the following statistics from CloudWatch Metric Streams and converts them to OpenTelemetry Summary metrics:
+
+**Always extracted:**
+- `min` - Minimum value (converted to quantile 0)
+- `max` - Maximum value (converted to quantile 1)
+- `sum` - Sum of values
+- `count` - Sample count
+
+**Percentiles (extracted as quantile values):**
+- `p50`, `p90`, `p95`, `p99`, `p99.9`, etc. - Percentile values are converted to quantiles by dividing by 100 (e.g., `p99` becomes quantile `0.99`)
+
+**Not supported (silently ignored):**
+
+The following [additional statistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-statistics.html) that can be configured in CloudWatch Metric Streams are not extracted, as they do not map well to OpenTelemetry Summary quantiles:
+
+- Trimmed Mean (`TM(X%:Y%)`, `tm99`, `IQM`)
+- Winsorized Mean (`WM(X%:Y%)`, `wm98`)
+- Trimmed Count (`TC(X%:Y%)`, `tc90`)
+- Trimmed Sum (`TS(X%:Y%)`, `ts90`)
+- Percentile Rank (`PR(:X)`, `PR(X:Y)`)

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -75,13 +76,15 @@ type cloudwatchMetricValue struct {
 	isSet bool
 
 	// Max is the highest value observed.
-	Max float64 `json:"max"`
+	Max float64
 	// Min is the lowest value observed.
-	Min float64 `json:"min"`
+	Min float64
 	// Sum is the sum of data points collected.
-	Sum float64 `json:"sum"`
+	Sum float64
 	// Count is the number of data points.
-	Count float64 `json:"count"`
+	Count float64
+	// Percentiles contains percentile fields (e.g., p50, p99, p99.9).
+	Percentiles map[string]float64
 }
 
 // validateMetric validates that the cloudwatch metric has been unmarshalled correctly
@@ -101,13 +104,28 @@ func validateMetric(metric cloudwatchMetric) error {
 	return nil
 }
 
-// UnmarshalJSON unmarshalls the data to a cloudwatchMetricValue,
-// and sets isSet to true upon a successful execution
 func (v *cloudwatchMetricValue) UnmarshalJSON(data []byte) error {
-	type valueType cloudwatchMetricValue
-	if err := gojson.Unmarshal(data, (*valueType)(v)); err != nil {
+	// All CloudWatch metric values are float64, so use a typed map
+	rawFields := make(map[string]float64)
+	if err := gojson.Unmarshal(data, &rawFields); err != nil {
 		return err
 	}
+
+	v.Max = rawFields["max"]
+	v.Min = rawFields["min"]
+	v.Sum = rawFields["sum"]
+	v.Count = rawFields["count"]
+
+	// Other statistics (TM, WM, TC, TS, PR, IQM) are silently ignored.
+	v.Percentiles = make(map[string]float64)
+	for key, value := range rawFields {
+		if len(key) > 1 && key[0] == 'p' {
+			if _, err := strconv.ParseFloat(key[1:], 64); err == nil {
+				v.Percentiles[key] = value
+			}
+		}
+	}
+
 	v.isSet = true
 	return nil
 }
@@ -210,6 +228,14 @@ func (*formatJSONUnmarshaler) addMetricToResource(
 	maxQ := dp.QuantileValues().AppendEmpty()
 	maxQ.SetQuantile(1)
 	maxQ.SetValue(cwMetric.Value.Max)
+
+	for key, value := range cwMetric.Value.Percentiles {
+		percentileFloat, _ := strconv.ParseFloat(key[1:], 64)
+		q := dp.QuantileValues().AppendEmpty()
+		q.SetQuantile(percentileFloat / 100) // Convert percentile to quantile
+		q.SetValue(value)
+	}
+
 }
 
 // createMetrics creates pmetric.Metrics based on

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
@@ -235,7 +235,6 @@ func (*formatJSONUnmarshaler) addMetricToResource(
 		q.SetQuantile(percentileFloat / 100) // Convert percentile to quantile
 		q.SetValue(value)
 	}
-
 }
 
 // createMetrics creates pmetric.Metrics based on

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_metric_with_percentiles.json
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_metric_with_percentiles.json
@@ -1,0 +1,21 @@
+{
+    "metric_stream_name": "MyMetricStream",
+    "account_id": "1234567890",
+    "region": "us-east-1",
+    "namespace": "AWS/EC2",
+    "metric_name": "DiskWriteOps",
+    "dimensions": {
+        "InstanceId": "i-123456789012"
+    },
+    "timestamp": 1611929698000,
+    "value": {
+        "count": 3.0,
+        "sum": 20.0,
+        "max": 18.0,
+        "min": 0.0,
+        "p50": 10.0,
+        "p90": 16.0,
+        "p99": 17.0
+    },
+    "unit": "Seconds"
+}

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_metric_with_unsupported_stats.json
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_metric_with_unsupported_stats.json
@@ -1,0 +1,27 @@
+{
+    "metric_stream_name": "MyMetricStream",
+    "account_id": "1234567890",
+    "region": "us-east-1",
+    "namespace": "AWS/EC2",
+    "metric_name": "DiskWriteOps",
+    "dimensions": {
+        "InstanceId": "i-123456789012"
+    },
+    "timestamp": 1611929698000,
+    "value": {
+        "count": 3.0,
+        "sum": 20.0,
+        "max": 18.0,
+        "min": 0.0,
+        "p99": 17.0,
+        "TM(25%:75%)": 16.43,
+        "WM(10%:90%)": 15.5,
+        "TC(0.005:0.030)": 2.5,
+        "TS(80%:)": 19.0,
+        "PR(:300)": 85.0,
+        "IQM": 16.0,
+        "tm99": 15.8,
+        "wm98": 16.2
+    },
+    "unit": "Seconds"
+}

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_record_with_percentiles_expected.yaml
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_record_with_percentiles_expected.yaml
@@ -1,0 +1,46 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: aws.cloudwatch.metric_stream_name
+          value:
+            stringValue: MyMetricStream
+        - key: cloud.account.id
+          value:
+            stringValue: "1234567890"
+        - key: cloud.provider
+          value:
+            stringValue: aws
+        - key: cloud.region
+          value:
+            stringValue: us-east-1
+        - key: service.name
+          value:
+            stringValue: EC2
+        - key: service.namespace
+          value:
+            stringValue: AWS
+    scopeMetrics:
+      - metrics:
+          - name: DiskWriteOps
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: service.instance.id
+                      value:
+                        stringValue: i-123456789012
+                  count: "3"
+                  quantileValues:
+                    - {}
+                    - quantile: 0.5
+                      value: 10
+                    - quantile: 0.9
+                      value: 16
+                    - quantile: 0.99
+                      value: 17
+                    - quantile: 1
+                      value: 18
+                  sum: 20
+                  timeUnixNano: "1611929698000000000"
+            unit: Seconds
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_record_with_unsupported_stats_expected.yaml
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/testdata/json/valid_record_with_unsupported_stats_expected.yaml
@@ -1,0 +1,42 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: aws.cloudwatch.metric_stream_name
+          value:
+            stringValue: MyMetricStream
+        - key: cloud.account.id
+          value:
+            stringValue: "1234567890"
+        - key: cloud.provider
+          value:
+            stringValue: aws
+        - key: cloud.region
+          value:
+            stringValue: us-east-1
+        - key: service.name
+          value:
+            stringValue: EC2
+        - key: service.namespace
+          value:
+            stringValue: AWS
+    scopeMetrics:
+      - metrics:
+          - name: DiskWriteOps
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: service.instance.id
+                      value:
+                        stringValue: i-123456789012
+                  count: "3"
+                  quantileValues:
+                    - {}
+                    - quantile: 0.99
+                      value: 17
+                    - quantile: 1
+                      value: 18
+                  sum: 20
+                  timeUnixNano: "1611929698000000000"
+            unit: Seconds
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension


### PR DESCRIPTION
## Summary

- Add support for extracting percentile statistics (p50, p90, p99, p99.9, etc.) from CloudWatch Metric Streams JSON format
- Convert percentiles to OpenTelemetry Summary quantiles (e.g., p99 → quantile 0.99)
- Document supported and unsupported statistics in README

## Context

This change enables feature parity with the embedded `cwmetricstream` unmarshaler in `awsfirehosereceiver`. This is a prerequisite for removing the embedded unmarshalers as discussed in #45830.

## Changes

- Modified `UnmarshalJSON` to extract percentile fields from CloudWatch metric values
- Added percentile-to-quantile conversion in `addMetricToResource`
- Added test cases for metrics with percentiles and unsupported statistics
- Updated README with documentation on supported/unsupported statistics

## Unsupported Statistics

The following CloudWatch additional statistics are intentionally not supported as they don't map well to OpenTelemetry Summary quantiles:
- Trimmed Mean (TM, IQM)
- Winsorized Mean (WM)
- Trimmed Count (TC)
- Trimmed Sum (TS)
- Percentile Rank (PR)

## Link to tracking issue

Resolves part of #45830