### PR TITLE
loadbalancingexporter: add exemplarTraceID routing key for metrics

### DIFF
--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -22,15 +22,17 @@ const (
 	resourceRouting
 	streamIDRouting
 	attrRouting
+	exemplarTraceIDRouting
 )
 
 const (
-	svcRoutingStr        = "service"
-	traceIDRoutingStr    = "traceID"
-	metricNameRoutingStr = "metric"
-	resourceRoutingStr   = "resource"
-	streamIDRoutingStr   = "streamID"
-	attrRoutingStr       = "attributes"
+	svcRoutingStr             = "service"
+	traceIDRoutingStr         = "traceID"
+	metricNameRoutingStr      = "metric"
+	resourceRoutingStr        = "resource"
+	streamIDRoutingStr        = "streamID"
+	attrRoutingStr            = "attributes"
+	exemplarTraceIDRoutingStr = "exemplarTraceID"
 )
 
 // Config defines configuration for the exporter.

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/exemplar_trace_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/exemplar_trace_id/input.yaml
@@ -1,0 +1,27 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+        metrics:
+          - name: test.sum.metric
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 100
+                  exemplars:
+                    - timeUnixNano: 50
+                      asDouble: 10
+                      traceId: "0102030405060708090a0b0c0d0e0f10"
+                    - timeUnixNano: 51
+                      asDouble: 20
+                      traceId: "0102030405060708090a0b0c0d0e0f10"

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/exemplar_trace_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/exemplar_trace_id/output.yaml
@@ -1,0 +1,27 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+        metrics:
+          - name: test.sum.metric
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 30
+                  exemplars:
+                    - timeUnixNano: 50
+                      asDouble: 10
+                      traceId: "0102030405060708090a0b0c0d0e0f10"
+                    - timeUnixNano: 51
+                      asDouble: 20
+                      traceId: "0102030405060708090a0b0c0d0e0f10"

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_exemplar_trace_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_exemplar_trace_id/input.yaml
@@ -1,0 +1,30 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+        metrics:
+          - name: test.sum.metric
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 100
+                  exemplars:
+                    - timeUnixNano: 50
+                      asDouble: 10
+                      traceId: "0102030405060708090a0b0c0d0e0f10"
+                    - timeUnixNano: 51
+                      asDouble: 20
+                      traceId: "0102030405060708090a0b0c0d0e0f10"
+                    - timeUnixNano: 52
+                      asDouble: 30
+                      traceId: "100f0e0d0c0b0a090807060504030201"

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_exemplar_trace_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_exemplar_trace_id/output.yaml
@@ -1,0 +1,53 @@
+"\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10":
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: test-service
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+          metrics:
+            - name: test.sum.metric
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 30
+                    exemplars:
+                      - timeUnixNano: 50
+                        asDouble: 10
+                        traceId: "0102030405060708090a0b0c0d0e0f10"
+                      - timeUnixNano: 51
+                        asDouble: 20
+                        traceId: "0102030405060708090a0b0c0d0e0f10"
+"\x10\x0f\x0e\r\x0c\x0b\n\t\x08\x07\x06\x05\x04\x03\x02\x01":
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: test-service
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+          metrics:
+            - name: test.sum.metric
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 30
+                    exemplars:
+                      - timeUnixNano: 52
+                        asDouble: 30
+                        traceId: "100f0e0d0c0b0a090807060504030201"


### PR DESCRIPTION
#### Description

Adds a new `exemplarTraceID` routing key for metrics that routes based on trace IDs found in exemplars. This enables co-location of metrics with their corresponding traces on the same backend, which is useful for trace-metric correlation scenarios.

Key behaviors:
- Routes metrics based on the trace ID found in their exemplars
- Metrics are split by exemplar trace ID, with values recomputed from the exemplar values
- Metrics without exemplars (or without valid trace IDs in exemplars) are dropped
- Uses the same consistent hashing as `traceID` routing for traces, ensuring metrics and traces with the same trace ID land on the same backend

Use case: When running both metrics and traces through loadbalancing exporters to the same backends, using `exemplarTraceID` for metrics and `traceID` for traces ensures correlated data lands together for analysis.

#### Link to tracking issue
Fixes #44597

#### Testing

- Added unit tests for `splitMetricsByExemplarTraceID` covering Sum, Gauge, Histogram, and ExponentialHistogram metric types
- Added golden file tests in `testdata/metrics/split_metrics/basic_exemplar_trace_id/`
- Added integration test in `TestConsumeMetrics_SingleEndpoint` for the new routing key
- Verified with existing benchmarks: `go test -bench='BenchmarkConsumeMetrics/exemplarTraceID' -benchmem`

#### Documentation

- Updated README.md with `exemplarTraceID` in the routing key table (with warning note)
- Added detailed documentation for `exemplarTraceID` behavior including warnings about:
  - Value recomputation from exemplars
  - Metrics without exemplars being dropped
  - Intended use case (trace-metric correlation, not general aggregation)
