### PR TITLE
[pkg/ottl] Add function to check if IP belongs to given CIDR

### DIFF
--- a/.chloggen/add-IsInCIDR-ottl-func.yaml
+++ b/.chloggen/add-IsInCIDR-ottl-func.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `IsInCIDR` function to check if IP belongs to given list of CIDR
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42215]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -1531,6 +1531,12 @@ func Test_e2e_converters(t *testing.T) {
 				tCtx.GetLogRecord().Attributes().PutBool("test", true)
 			},
 		},
+		{
+			statement: `set(attributes["in_cidr"], IsInCIDR(attributes["server.ip"], ["192.168.0.0/16"]))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutBool("in_cidr", true)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2175,6 +2181,7 @@ func constructLogTransformContext() *ottllog.TransformContext {
 	logRecord.Attributes().PutStr("val", "val2")
 	logRecord.Attributes().PutInt("int_value", 0)
 	logRecord.Attributes().PutStr("nil_string", "nil")
+	logRecord.Attributes().PutStr("server.ip", "192.168.0.1")
 	arr := logRecord.Attributes().PutEmptySlice("array")
 	arr0 := arr.AppendEmpty()
 	arr0.SetStr("looong")

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -498,6 +498,7 @@ Available Converters:
 - [Int](#int)
 - [IsBool](#isbool)
 - [IsDouble](#isdouble)
+- [IsInCIDR](#isincidr)
 - [IsInt](#isint)
 - [IsRootSpan](#isrootspan)
 - [IsMap](#ismap)
@@ -1265,6 +1266,20 @@ Examples:
 - `IsDouble(log.body)`
 
 - `IsDouble(log.attributes["maybe a double"])`
+
+### IsInCIDR
+
+`IsInCIDR(target, networks[])`
+
+The `IsInCIDR` Converter returns true if the given target IP address falls within any of the specified network ranges.
+
+The `target` is either a path expression to a telemetry field to retrieve, or a literal. The `networks` is a list of CIDR addresses.
+
+Examples:
+
+- `IsInCIDR(resource.attributes["server.ip"], ["192.168.0.0/16"])`
+
+- `IsInCIDR(resource.attributes["server.ip"], ["192.168.0.0/16", "10.0.0.0/8"])`
 
 ### IsInt
 

--- a/pkg/ottl/ottlfuncs/func_is_in_cidr.go
+++ b/pkg/ottl/ottlfuncs/func_is_in_cidr.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type IsInCIDRArguments[K any] struct {
+	Target   ottl.StringGetter[K]
+	Networks []ottl.StringGetter[K]
+}
+
+func NewIsInCIDRFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("IsInCIDR", &IsInCIDRArguments[K]{}, createIsInCIDRFunction[K])
+}
+
+func createIsInCIDRFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*IsInCIDRArguments[K])
+	if !ok {
+		return nil, errors.New("IsInCIDRFactory args must be of type *IsInCIDRArguments[K]")
+	}
+
+	return isInCIDR(args.Target, args.Networks)
+}
+
+func isInCIDR[K any](target ottl.StringGetter[K], networks []ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+	// Check if all networks are literals and pre-parse them if so.
+	literalNetworks := make([]*net.IPNet, 0, len(networks))
+	for _, network := range networks {
+		literal, isLiteral := ottl.GetLiteralValue[K, string](network)
+		if !isLiteral {
+			literalNetworks = nil
+			break
+		}
+		_, subnet, err := net.ParseCIDR(literal)
+		if err != nil {
+			return nil, err
+		}
+		literalNetworks = append(literalNetworks, subnet)
+	}
+
+	return func(ctx context.Context, tCtx K) (any, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		ip := net.ParseIP(val)
+		if ip == nil {
+			return false, nil
+		}
+
+		if literalNetworks != nil {
+			// Use pre-parsed networks for literal values.
+			for _, subnet := range literalNetworks {
+				if subnet.Contains(ip) {
+					return true, nil
+				}
+			}
+		} else {
+			// Parse networks at runtime for dynamic values.
+			for _, network := range networks {
+				networkValue, err := network.Get(ctx, tCtx)
+				if err != nil {
+					return nil, err
+				}
+
+				_, subnet, err := net.ParseCIDR(networkValue)
+				if err != nil {
+					return nil, err
+				}
+				if subnet.Contains(ip) {
+					return true, nil
+				}
+			}
+		}
+
+		return false, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_is_in_cidr_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_in_cidr_test.go
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_isInCIDR(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   any
+		networks []ottl.StringGetter[any]
+		result   any
+	}{
+		{
+			name:   "an included IP string",
+			target: "192.0.2.1",
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.24.0/24", nil },
+				},
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			result: true,
+		},
+		{
+			name:   "a not included IP string",
+			target: "195.0.2.1",
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			result: false,
+		},
+		{
+			name:   "non IP string",
+			target: "hello world",
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			result: false,
+		},
+		{
+			name:   "empty string",
+			target: "",
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			result: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := isInCIDR[any](ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) { return tt.target, nil },
+			}, tt.networks)
+			require.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tt.result, result)
+		})
+	}
+}
+
+func Test_isInCIDR_Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		target        any
+		networks      []ottl.StringGetter[any]
+		result        any
+		err           bool
+		expectedError string
+	}{
+		{
+			name:   "non-string",
+			target: 10,
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			expectedError: "expected string but got int",
+		},
+		{
+			name:   "dynamic network is not a valid CIDR",
+			target: "192.0.0.1",
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2/24", nil },
+				},
+			},
+			expectedError: "invalid CIDR address: 192.0.2/24",
+		},
+		{
+			name:   "nil",
+			target: nil,
+			networks: []ottl.StringGetter[any]{
+				ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "192.0.2.0/24", nil },
+				},
+			},
+			expectedError: "expected string but got nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := isInCIDR[any](ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) { return tt.target, nil },
+			}, tt.networks)
+			require.NoError(t, err)
+			_, err = exprFunc(nil, nil)
+			assert.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}
+
+func Test_isInCIDR_literalNetworks(t *testing.T) {
+	literalOne, err := ottl.NewTestingLiteralGetter(true, ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) { return "10.0.0.0/8", nil },
+	})
+	require.NoError(t, err)
+	literalTwo, err := ottl.NewTestingLiteralGetter(true, ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, any) (any, error) { return "192.168.0.0/16", nil },
+	})
+	require.NoError(t, err)
+
+	t.Run("single literal network", func(t *testing.T) {
+		exprFunc, err := isInCIDR[any](ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return "10.1.2.3", nil },
+		}, []ottl.StringGetter[any]{literalOne})
+		require.NoError(t, err)
+		result, err := exprFunc(nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("multiple literals networks", func(t *testing.T) {
+		exprFunc, err := isInCIDR[any](ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return "192.168.0.1", nil },
+		}, []ottl.StringGetter[any]{literalOne, literalTwo})
+		require.NoError(t, err)
+		result, err := exprFunc(nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("invalid literal network", func(t *testing.T) {
+		invalidLiteral, err := ottl.NewTestingLiteralGetter(true, ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return "192.0.2/24", nil },
+		})
+		require.NoError(t, err)
+
+		_, err = isInCIDR[any](ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return "192.0.0.1", nil },
+		}, []ottl.StringGetter[any]{invalidLiteral})
+		assert.ErrorContains(t, err, "invalid CIDR address")
+	})
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -133,5 +133,6 @@ func converters[K any]() []ottl.Factory[K] {
 		NewKeysFactory[K](),
 		NewXXH3Factory[K](),
 		NewXXH128Factory[K](),
+		NewIsInCIDRFactory[K](),
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add a function to check if IP belongs to given CIDR.
Revives #43620 and addresses maintainer comments. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #42215

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests for `IsInCIDR` and e2e coverage.

<!--Describe the documentation added.-->
#### Documentation
Updated the OTTL functions README with `IsInCIDR` docs.

