### PR TITLE
[chore] receiver/kubeletstats: update readme

### DIFF
--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -226,9 +226,13 @@ receivers:
       auth_type: serviceAccount
 ```
 
-If `k8s_api_config` set, the receiver will attempt to collect metadata from underlying storage resources for
+If `k8s_api_config` is set, the receiver will attempt to collect metadata from underlying storage resources for
 Persistent Volume Claims. For example, if a Pod is using a PVC backed by an EBS instance on AWS, the receiver
 would set the `k8s.volume.type` label to be `awsElasticBlockStore` rather than `persistentVolumeClaim`.
+
+**Important**: When using `k8s_api_config`, the service account must have `get` permissions for
+`persistentvolumeclaims` and `persistentvolumes` resources. See [Role-based access control](#role-based-access-control)
+for the required RBAC configuration.
 
 ### Metric Groups
 
@@ -316,7 +320,9 @@ with detailed sample configurations in [testdata/config.yaml](./testdata/config.
 
 ### Role-based access control
 
-The Kubelet Stats Receiver needs `get` permissions on the `nodes/stats` resources. Additionally, when using `extra_metadata_labels` or any of the `{request|limit}_utilization` metrics the processor also needs `get` permissions for `nodes/proxy` resources.
+The Kubelet Stats Receiver needs `get` permissions on the `nodes/stats` resources. Additionally, when using `extra_metadata_labels` or any of the `{request|limit}_utilization` metrics the receiver also needs `get` permissions for `nodes/proxy` resources.
+
+When using `k8s_api_config` to collect detailed volume metadata from PersistentVolumeClaims (as described in [Collecting Additional Volume Metadata](#collecting-additional-volume-metadata)), the receiver also needs `get` permissions for `persistentvolumeclaims` and `persistentvolumes` resources.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -332,5 +338,14 @@ rules:
   # are collecting the request/limit utilization metrics
   - apiGroups: [""]
     resources: ["nodes/proxy"]
+    verbs: ["get"]
+
+  # Only needed if you are using k8s_api_config to collect
+  # detailed volume metadata from PersistentVolumeClaims
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
     verbs: ["get"]
 ```


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Adds documentation for the RBAC permissions required when using `k8s_api_config` to collect detailed volume metadata from PVCs. When using `k8s_api_config` with `extra_metadata_labels: [k8s.volume.type]`, the receiver makes direct K8s API calls to fetch [PVC](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.145.0/receiver/kubeletstatsreceiver/scraper.go#L143) and [PV](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.145.0/receiver/kubeletstatsreceiver/scraper.go#L153) details. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45510
<!--Please delete paragraphs that you did not use before submitting.-->