### PR TITLE
[processor/resourcedetection] Add OIDC issuer and token path checks for EKS detection

### DIFF
--- a/.chloggen/fix_isEKSDetection.yaml
+++ b/.chloggen/fix_isEKSDetection.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetection
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: IRSA and Pod Identity tokens are checked to determine if running within an EKS cluster
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45866]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
EKS changed the `gitVersion` format in Kubernetes 1.35 (platform version eks.3), removing the `-eks-` identifier that the detector relied on. This adds multiple fallback detection methods before the `gitVersion` check:

1. IRSA token path - `AWS_WEB_IDENTITY_TOKEN_FILE` contains "eks.amazonaws.com"
2. Pod Identity token path - `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` contains "eks-pod-identity"
3. OIDC issuer - API server `/.well-known/openid-configuration` issuer contains "oidc.eks."
4. Fallback: `gitVersion` contains "-eks-" (existing check)

Each positive signal is reasonably conclusive. Errors in earlier checks gracefully fall through to subsequent checks.

Fixes #45866

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
