### PR TITLE
[exporter/elasticsearch] Update the ECS mode metrics data point hasher to exclude the `elasticsearch.mapping.hints` attribute

### DIFF
--- a/.chloggen/es-exporter-ecs-hasher-exclude-mapping-hint.yaml
+++ b/.chloggen/es-exporter-ecs-hasher-exclude-mapping-hint.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/elasticsearch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the ECS mode metrics data point hasher to exclude the `elasticsearch.mapping.hints` attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Excluding the `elasticsearch.mapping.hints` attribute will allow similar metric data points to be grouped together and indexed to the same document.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/es-exporter-ecs-hasher-exclude-mapping-hint.yaml
+++ b/.chloggen/es-exporter-ecs-hasher-exclude-mapping-hint.yaml
@@ -10,7 +10,7 @@ component: exporter/elasticsearch
 note: Update the ECS mode metrics data point hasher to exclude the `elasticsearch.mapping.hints` attribute
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [45887]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
+++ b/exporter/elasticsearchexporter/internal/metricgroup/hasher.go
@@ -70,7 +70,7 @@ func (h *ECSDataPointHasher) HashKey() HashKey {
 	binary.LittleEndian.PutUint64(timestampBuf, uint64(h.dp.Timestamp()))
 	_, _ = hasher.Write(timestampBuf)
 
-	mapHashSortedExcludeReservedAttrs(hasher, merged)
+	mapHashSortedExcludeReservedAttrs(hasher, merged, elasticsearch.MappingHintsAttrKey)
 
 	return HashKey{
 		dpHash: hasher.Sum64(),


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR updates the ECS mode metrics data point hasher to exclude the `elasticsearch.mapping.hints` attribute. 
This is helpful for aggregated metrics generated by the https://github.com/elastic/opentelemetry-collector-components/tree/main/connector/elasticapmconnector, since it generates metrics where the only difference is the `elasticsearch.mapping.hints` attribute value. 

This also aligns with the OTEL mode metrics data point hasher.

Assisted-by: Claude Opus 4.5

<!--Describe what testing was performed and which tests were added.-->
#### Testing
1. Add test cases to assert metrics with different `elasticsearch.mapping.hints` values are grouped correctly