### PR TITLE
pkg/sampling: apply optimization to OTel tracestate parsing

### DIFF
--- a/.chloggen/pkg-sampling-otel-tracestate-optimization.yaml
+++ b/.chloggen/pkg-sampling-otel-tracestate-optimization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Optimize OTel tracestate parsing by replacing regex validation with hand-written validator (10-21x faster).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45539]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/sampling/common.go
+++ b/pkg/sampling/common.go
@@ -121,3 +121,35 @@ func (ser *serializer) write(str string) {
 func (ser *serializer) check(err error) {
 	ser.err = multierr.Append(ser.err, err)
 }
+
+// =============================================================================
+// Character validation functions shared by W3C and OTel tracestate parsers.
+// These hand-written validators are significantly faster than regex-based
+// validation (30-60x speedup).
+// =============================================================================
+
+// isLcAlpha returns true if c is a lowercase ASCII letter (a-z).
+func isLcAlpha(c byte) bool {
+	return c >= 'a' && c <= 'z'
+}
+
+// isLcAlphaNum returns true if c is a lowercase ASCII letter or digit.
+func isLcAlphaNum(c byte) bool {
+	return isLcAlpha(c) || (c >= '0' && c <= '9')
+}
+
+// isValidKeyChar returns true if c is valid in a W3C tracestate key
+// (lowercase alphanumeric or one of: _ - * /).
+func isValidKeyChar(c byte) bool {
+	return isLcAlphaNum(c) || c == '_' || c == '-' || c == '*' || c == '/'
+}
+
+// isValidKeyChars returns true if all characters in s are valid W3C key characters.
+func isValidKeyChars(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isValidKeyChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sampling/oteltracestate_benchmark_test.go
+++ b/pkg/sampling/oteltracestate_benchmark_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sampling
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Regex patterns for OTel tracestate validation.
+// Kept here for benchmark comparison purposes.
+//
+// OTel tracestate syntax:
+// chr        = ucalpha / lcalpha / DIGIT / "." / "_" / "-"
+// ucalpha    = %x41-5A ; A-Z
+// lcalpha    = %x61-7A ; a-z
+// key        = lcalpha *(lcalpha / DIGIT )
+// value      = *(chr)
+// list-member = key ":" value
+// list        = list-member *( ";" list-member )
+const (
+	otelKeyRegexp             = lcAlphaRegexp + lcAlphanumRegexp + `*`
+	otelValueRegexp           = `[a-zA-Z0-9._\-]*`
+	otelMemberRegexp          = `(?:` + otelKeyRegexp + `:` + otelValueRegexp + `)`
+	otelSemicolonMemberRegexp = `(?:` + `;` + otelMemberRegexp + `)`
+	otelTracestateRegexp      = `^` + otelMemberRegexp + otelSemicolonMemberRegexp + `*$`
+)
+
+var otelTracestateRe = regexp.MustCompile(otelTracestateRegexp)
+
+func BenchmarkNewOpenTelemetryTraceState(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "Simple",
+			input: "th:c",
+		},
+		{
+			name:  "WithRValue",
+			input: "th:c;rv:d29d6a7215ced0",
+		},
+		{
+			name:  "WithExtraFields",
+			input: "th:c;rv:d29d6a7215ced0;pn:abc",
+		},
+		{
+			name:  "MultipleExtras",
+			input: "th:c;rv:d29d6a7215ced0;pn:abc;extra1:value1;extra2:value2",
+		},
+		{
+			name:  "LongValue",
+			input: "th:c;extra:" + strings.Repeat("x", 200),
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = NewOpenTelemetryTraceState(bm.input)
+			}
+		})
+	}
+}
+
+func BenchmarkNewOpenTelemetryTraceStateParallel(b *testing.B) {
+	input := "th:c;rv:d29d6a7215ced0;pn:abc"
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = NewOpenTelemetryTraceState(input)
+		}
+	})
+}
+
+// =============================================================================
+// Benchmark: Hand-written Validator vs Regex
+// =============================================================================
+
+func BenchmarkOTelTracestateValidation(b *testing.B) {
+	benchmarks := []struct {
+		name  string
+		input string
+	}{
+		{"Simple", "th:c"},
+		{"WithRValue", "th:c;rv:d29d6a7215ced0"},
+		{"Complex", "th:c;rv:d29d6a7215ced0;pn:abc;extra1:value1;extra2:value2"},
+		{"LongValue", "th:c;extra:" + strings.Repeat("x", 200)},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run("Regex/"+bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = otelTracestateRe.MatchString(bm.input)
+			}
+		})
+
+		b.Run("NoRegex/"+bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = isValidOTelTraceState(bm.input)
+			}
+		})
+	}
+}

--- a/pkg/sampling/w3ctracestate.go
+++ b/pkg/sampling/w3ctracestate.go
@@ -286,27 +286,6 @@ func isValidW3CValue(value string) bool {
 	return true
 }
 
-func isLcAlpha(c byte) bool {
-	return c >= 'a' && c <= 'z'
-}
-
-func isLcAlphaNum(c byte) bool {
-	return isLcAlpha(c) || (c >= '0' && c <= '9')
-}
-
-func isValidKeyChar(c byte) bool {
-	return isLcAlphaNum(c) || c == '_' || c == '-' || c == '*' || c == '/'
-}
-
-func isValidKeyChars(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if !isValidKeyChar(s[i]) {
-			return false
-		}
-	}
-	return true
-}
-
 // isNonBlankValueChar: %x21-2B / %x2D-3C / %x3E-7E
 func isNonBlankValueChar(c byte) bool {
 	return (c >= 0x21 && c <= 0x2B) || (c >= 0x2D && c <= 0x3C) || (c >= 0x3E && c <= 0x7E)


### PR DESCRIPTION
### Description

This PR applies the same optimization that was done for W3C tracestate parsing to the OTel tracestate parsing. It replaces regex-based validation with a hand-written character validator, providing significant performance improvements.

### Link to tracking issue

This will be used by issue #45539

### Changes

- Add `isValidOTelTraceState()` hand-written validator in `oteltracestate.go`
- Add OTel-specific validation functions: `isValidOTelKey()`, `isValidOTelValue()`, `isOTelValueChar()`
- Keep original regex constants and compiled regex for documentation and benchmark comparison
- Add benchmark tests comparing regex vs hand-written validation

### Benchmark Results

All benchmarks run on Apple M1 Max with zero allocations for both approaches.

#### OTel Tracestate Validation

| Test Case | Regex | Hand-written | Speedup |
|-----------|------:|-------------:|--------:|
| Simple | 90 ns/op | 8 ns/op | **11x** |
| WithRValue | 300 ns/op | 28 ns/op | **11x** |
| Complex | 733 ns/op | 67 ns/op | **11x** |
| LongValue | 2,455 ns/op | 118 ns/op | **21x** |

#### W3C Tracestate Validation (for reference)

| Test Case | Regex | Hand-written | Speedup |
|-----------|------:|-------------:|--------:|
| Simple | 535 ns/op | 19 ns/op | **29x** |
| Complex | 4,687 ns/op | 106 ns/op | **44x** |
| LongValue | 14,103 ns/op | 215 ns/op | **66x** |
| MaxPairs (32) | 19,805 ns/op | 624 ns/op | **32x** |

### Testing

- All existing unit tests pass
- Added benchmark tests for performance comparison