### PR TITLE
[reciever/azureeventhub] Azure eventhub continue after error

### DIFF
--- a/.chloggen/azure-eventhub-continue-after-error.yaml
+++ b/.chloggen/azure-eventhub-continue-after-error.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/azureeventhub
+component: receiver/azure_event_hub
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fixes a bug where the receiver would stop receiving messages after a parsing error.

--- a/.chloggen/azure-eventhub-continue-after-error.yaml
+++ b/.chloggen/azure-eventhub-continue-after-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azureeventhub
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where the receiver would stop receiving messages after a parsing error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45898]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -18,7 +18,7 @@ import (
 
 type hubWrapper interface {
 	GetRuntimeInformation(ctx context.Context) (*hubRuntimeInfo, error)
-	Receive(ctx context.Context, partitionID string, handler hubHandler, applyOffset bool) (listenerHandleWrapper, error)
+	Receive(ctx context.Context, partitionID string, handler hubHandler, applyOffset bool, logger *zap.Logger) (listenerHandleWrapper, error)
 	Close(ctx context.Context) error
 }
 
@@ -98,7 +98,7 @@ func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 }
 
 func (h *eventhubHandler) setUpOnePartition(ctx context.Context, partitionID string, applyOffset bool) error {
-	handle, err := h.hub.Receive(ctx, partitionID, h.newMessageHandler, applyOffset)
+	handle, err := h.hub.Receive(ctx, partitionID, h.newMessageHandler, applyOffset, h.settings.Logger)
 	if err != nil {
 		return err
 	}

--- a/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_azeventhub_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 type mockPartitionClient struct {
@@ -171,6 +172,7 @@ func TestHubWrapperAzeventhubImpl_Receive(t *testing.T) {
 					return nil
 				},
 				test.applyOffset,
+				zaptest.NewLogger(t),
 			)
 			if test.expectErr {
 				require.Error(t, err)

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -35,7 +35,7 @@ func (mockHubWrapper) GetRuntimeInformation(context.Context) (*hubRuntimeInfo, e
 	}, nil
 }
 
-func (mockHubWrapper) Receive(ctx context.Context, _ string, _ hubHandler, _ bool) (listenerHandleWrapper, error) {
+func (mockHubWrapper) Receive(ctx context.Context, _ string, _ hubHandler, _ bool, _ *zap.Logger) (listenerHandleWrapper, error) {
 	return &mockListenerHandleWrapper{
 		ctx: ctx,
 	}, nil


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Previously, the receiver would throw an error when parsing failed, and silently sit around and not collect any more events. This change keeps processing events even if an event was not parsed correctly.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45898

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a test case and did manual testing to validate that the receiver continues to collect events even after a parsing error
