### PR TITLE
feat(k8sinventory): use pagination in pull mode

### DIFF
--- a/.chloggen/k8sinventory-pull-pagination.yaml
+++ b/.chloggen/k8sinventory-pull-pagination.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: k8sinventory
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use pagination in k8sinventory pull mode to reduce load on the API server"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: '[user]'

--- a/internal/k8sinventory/pull/observer.go
+++ b/internal/k8sinventory/pull/observer.go
@@ -11,14 +11,19 @@ import (
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory"
 )
 
+const defaultPageSize = 500
+
 type Config struct {
 	k8sinventory.Config
 	Interval time.Duration
+	PageSize int
 }
 
 type Observer struct {
@@ -31,6 +36,9 @@ type Observer struct {
 }
 
 func New(client dynamic.Interface, config Config, logger *zap.Logger, handlePullObjectsFunc func(objects *unstructured.UnstructuredList)) (*Observer, error) {
+	if config.PageSize <= 0 {
+		config.PageSize = defaultPageSize
+	}
 	o := &Observer{
 		client:                client,
 		config:                config,
@@ -76,16 +84,29 @@ func (o *Observer) startPull(ctx context.Context, resource dynamic.ResourceInter
 		listOption.ResourceVersionMatch = metav1.ResourceVersionMatchExact
 	}
 
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return resource.List(ctx, opts)
+	})
+	p.PageSize = int64(o.config.PageSize)
+
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			objects, err := resource.List(ctx, listOption)
+			obj, _, err := p.List(ctx, listOption)
 			if err != nil {
 				o.logger.Error("error in pulling object",
 					zap.String("resource", o.config.Gvr.String()),
 					zap.Error(err))
-			} else if len(objects.Items) > 0 {
+			}
+			objects, ok := obj.(*unstructured.UnstructuredList)
+			if !ok {
+				o.logger.Error("unexpected object type",
+					zap.String("resource", o.config.Gvr.String()),
+					zap.Any("object", obj))
+				continue
+			}
+			if len(objects.Items) > 0 {
 				if o.handlePullObjectsFunc != nil {
 					o.handlePullObjectsFunc(objects)
 				}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This adds paginated LIST calls to k8sinventory's `pull` mode, with a default page size of 500 (configurable if needed).

This reduces load on the API server when high-cardinality resources (e.g. `pods`) are retrieved.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
