### PR TITLE
Add DNSSRV resolver support to load balancing exporter

### DIFF
--- a/.chloggen/feature_loadbalancerexporter-srv-support.yaml
+++ b/.chloggen/feature_loadbalancerexporter-srv-support.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/loadbalancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add DNS SRV resolver support for automatic service discovery with port information from SRV records
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [18412]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `dnssrv` resolver enables automatic backend discovery via DNS SRV lookups, eliminating manual port configuration.
+  Ports are automatically obtained from SRV records. Configure using `resolver.dnssrv` with `hostname`, `interval`, and `timeout` parameters.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -63,6 +63,7 @@ type Protocol struct {
 type ResolverSettings struct {
 	Static      configoptional.Optional[StaticResolver]      `mapstructure:"static"`
 	DNS         configoptional.Optional[DNSResolver]         `mapstructure:"dns"`
+	DNSSRV      configoptional.Optional[DNSSRVResolver]      `mapstructure:"dnssrv"`
 	K8sSvc      configoptional.Optional[K8sSvcResolver]      `mapstructure:"k8s"`
 	AWSCloudMap configoptional.Optional[AWSCloudMapResolver] `mapstructure:"aws_cloud_map"`
 	// prevent unkeyed literal initialization
@@ -80,6 +81,16 @@ type StaticResolver struct {
 type DNSResolver struct {
 	Hostname string        `mapstructure:"hostname"`
 	Port     string        `mapstructure:"port"`
+	Interval time.Duration `mapstructure:"interval"`
+	Timeout  time.Duration `mapstructure:"timeout"`
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+// DNSSRVResolver defines the configuration for the DNS SRV resolver
+// SRV records are looked up, then A/AAAA records for each SRV target
+type DNSSRVResolver struct {
+	Hostname string        `mapstructure:"hostname"`
 	Interval time.Duration `mapstructure:"interval"`
 	Timeout  time.Duration `mapstructure:"timeout"`
 	// prevent unkeyed literal initialization

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -32,6 +32,18 @@ $defs:
       timeout:
         type: string
         format: duration
+  dnssrv_resolver:
+    description: DNSSRVResolver defines the configuration for the DNS SRV resolver SRV records are looked up, then A/AAAA records for each SRV target
+    type: object
+    properties:
+      hostname:
+        type: string
+      interval:
+        type: string
+        format: duration
+      timeout:
+        type: string
+        format: duration
   k_8_s_svc_resolver:
     description: K8sSvcResolver defines the configuration for the DNS resolver
     type: object
@@ -64,6 +76,9 @@ $defs:
       dns:
         x-optional: true
         $ref: dns_resolver
+      dnssrv:
+        x-optional: true
+        $ref: dnssrv_resolver
       k8s:
         x-optional: true
         $ref: k_8_s_svc_resolver

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -46,7 +46,7 @@ Number of times the list of backends was updated.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| resolver | Resolver used | Str: ``aws``, ``dns``, ``k8s``, ``static`` |
+| resolver | Resolver used | Str: ``aws``, ``dns``, ``dnssrv``, ``k8s``, ``static`` |
 
 ### otelcol_loadbalancer_num_backends
 
@@ -60,7 +60,7 @@ Current number of backends in use.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| resolver | Resolver used | Str: ``aws``, ``dns``, ``k8s``, ``static`` |
+| resolver | Resolver used | Str: ``aws``, ``dns``, ``dnssrv``, ``k8s``, ``static`` |
 
 ### otelcol_loadbalancer_num_resolutions
 
@@ -75,4 +75,4 @@ Number of times the resolver has triggered new resolutions.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | success | Whether an outcome was successful | Any Bool |
-| resolver | Resolver used | Str: ``aws``, ``dns``, ``k8s``, ``static`` |
+| resolver | Resolver used | Str: ``aws``, ``dns``, ``dnssrv``, ``k8s``, ``static`` |

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -50,6 +50,9 @@ func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory component
 	if oCfg.Resolver.DNS.HasValue() {
 		count++
 	}
+	if oCfg.Resolver.DNSSRV.HasValue() {
+		count++
+	}
 	if oCfg.Resolver.Static.HasValue() {
 		count++
 	}
@@ -79,12 +82,28 @@ func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory component
 
 		var err error
 		dnsResolver := oCfg.Resolver.DNS.Get()
-		res, err = newDNSResolver(
+		res, err = newARecordDNSResolver(
 			dnsLogger,
 			dnsResolver.Hostname,
 			dnsResolver.Port,
 			dnsResolver.Interval,
 			dnsResolver.Timeout,
+			telemetry,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if oCfg.Resolver.DNSSRV.HasValue() {
+		srvResolver := oCfg.Resolver.DNSSRV.Get()
+		srvLogger := logger.With(zap.String("resolver", "dnssrv"))
+
+		var err error
+		res, err = newSRVRecordDNSResolver(
+			srvLogger,
+			srvResolver.Hostname,
+			srvResolver.Interval,
+			srvResolver.Timeout,
 			telemetry,
 		)
 		if err != nil {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -130,6 +130,29 @@ func TestWithDNSResolver(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestWithDNSSRVResolver(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			DNSSRV: configoptional.Some(DNSSRVResolver{
+				Hostname: "_svc._tcp.example.org",
+			}),
+		},
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// test
+	res, ok := p.res.(*dnsResolver)
+
+	// verify
+	assert.NotNil(t, res)
+	assert.True(t, ok)
+	assert.Equal(t, srvRecordResolverAttrSet, res.resolverAttrSet)
+}
+
 func TestWithDNSResolverNoEndpoints(t *testing.T) {
 	// prepare
 	ts, tb := getTelemetryAssets(t)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -455,7 +455,7 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 	// simulate rolling updates, the dns resolver should resolve in the following order
 	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.2"]
 	ts, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	mu := sync.Mutex{}

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -22,6 +22,7 @@ attributes:
     enum:
       - aws
       - dns
+      - dnssrv
       - k8s
       - static
   success:

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -772,7 +772,7 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 
 	// simulate rolling updates, the dns resolver should resolve in the following order
 	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.2"]
-	res, err := newDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	mu := sync.Mutex{}

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -29,20 +29,26 @@ const (
 var (
 	errNoHostname = errors.New("no hostname specified to resolve the backends")
 
-	dnsResolverAttr           = attribute.String("resolver", "dns")
-	dnsResolverAttrSet        = attribute.NewSet(dnsResolverAttr)
-	dnsResolverSuccessAttrSet = attribute.NewSet(dnsResolverAttr, attribute.Bool("success", true))
-	dnsResolverFailureAttrSet = attribute.NewSet(dnsResolverAttr, attribute.Bool("success", false))
+	aRecordResolverAttr           = attribute.String("resolver", "dns")
+	aRecordResolverAttrSet        = attribute.NewSet(aRecordResolverAttr)
+	aRecordResolverSuccessAttrSet = attribute.NewSet(aRecordResolverAttr, attribute.Bool("success", true))
+	aRecordResolverFailureAttrSet = attribute.NewSet(aRecordResolverAttr, attribute.Bool("success", false))
+
+	srvRecordResolverAttr           = attribute.String("resolver", "dnssrv")
+	srvRecordResolverAttrSet        = attribute.NewSet(srvRecordResolverAttr)
+	srvRecordResolverSuccessAttrSet = attribute.NewSet(srvRecordResolverAttr, attribute.Bool("success", true))
+	srvRecordResolverFailureAttrSet = attribute.NewSet(srvRecordResolverAttr, attribute.Bool("success", false))
 )
 
 type dnsResolver struct {
 	logger *zap.Logger
 
-	hostname    string
-	port        string
-	resolver    netResolver
-	resInterval time.Duration
-	resTimeout  time.Duration
+	hostname        string
+	resolveBackends func(ctx context.Context) ([]string, error)
+	resolverAttrSet attribute.Set
+	resolver        netResolver
+	resInterval     time.Duration
+	resTimeout      time.Duration
 
 	endpoints         []string
 	onChangeCallbacks []func([]string)
@@ -56,12 +62,49 @@ type dnsResolver struct {
 
 type netResolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+	LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error)
 }
 
-func newDNSResolver(
+func newARecordDNSResolver(
 	logger *zap.Logger,
 	hostname string,
 	port string,
+	interval time.Duration,
+	timeout time.Duration,
+	tb *metadata.TelemetryBuilder,
+) (*dnsResolver, error) {
+	r, err := makeDNSResolver(logger, hostname, interval, timeout, tb)
+	if err != nil {
+		return nil, err
+	}
+	r.resolveBackends = func(ctx context.Context) ([]string, error) {
+		return resolveARecord(ctx, r.resolver, hostname, port, tb)
+	}
+	r.resolverAttrSet = aRecordResolverAttrSet
+	return r, nil
+}
+
+func newSRVRecordDNSResolver(
+	logger *zap.Logger,
+	hostname string,
+	interval time.Duration,
+	timeout time.Duration,
+	tb *metadata.TelemetryBuilder,
+) (*dnsResolver, error) {
+	r, err := makeDNSResolver(logger, hostname, interval, timeout, tb)
+	if err != nil {
+		return nil, err
+	}
+	r.resolveBackends = func(ctx context.Context) ([]string, error) {
+		return resolveSRV(ctx, r.resolver, hostname, logger, tb)
+	}
+	r.resolverAttrSet = srvRecordResolverAttrSet
+	return r, nil
+}
+
+func makeDNSResolver(
+	logger *zap.Logger,
+	hostname string,
 	interval time.Duration,
 	timeout time.Duration,
 	tb *metadata.TelemetryBuilder,
@@ -79,7 +122,6 @@ func newDNSResolver(
 	return &dnsResolver{
 		logger:      logger,
 		hostname:    hostname,
-		port:        port,
 		resolver:    &net.Resolver{},
 		resInterval: interval,
 		resTimeout:  timeout,
@@ -97,8 +139,10 @@ func (r *dnsResolver) start(ctx context.Context) error {
 	go r.periodicallyResolve()
 
 	r.logger.Debug("DNS resolver started",
-		zap.String("hostname", r.hostname), zap.String("port", r.port),
-		zap.Duration("interval", r.resInterval), zap.Duration("timeout", r.resTimeout))
+		zap.String("hostname", r.hostname),
+		zap.Duration("interval", r.resInterval),
+		zap.Duration("timeout", r.resTimeout),
+	)
 	return nil
 }
 
@@ -114,6 +158,7 @@ func (r *dnsResolver) shutdown(_ context.Context) error {
 
 func (r *dnsResolver) periodicallyResolve() {
 	ticker := time.NewTicker(r.resInterval)
+	defer ticker.Stop()
 	defer r.shutdownWg.Done()
 
 	for {
@@ -133,30 +178,9 @@ func (r *dnsResolver) periodicallyResolve() {
 }
 
 func (r *dnsResolver) resolve(ctx context.Context) ([]string, error) {
-	addrs, err := r.resolver.LookupIPAddr(ctx, r.hostname)
+	backends, err := r.resolveBackends(ctx)
 	if err != nil {
-		r.telemetry.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(dnsResolverFailureAttrSet))
 		return nil, err
-	}
-
-	r.telemetry.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(dnsResolverSuccessAttrSet))
-
-	backends := make([]string, len(addrs))
-	for i, ip := range addrs {
-		var backend string
-		if ip.IP.To4() != nil {
-			backend = ip.String()
-		} else {
-			// it's an IPv6 address
-			backend = fmt.Sprintf("[%s]", ip.String())
-		}
-
-		// if a port is specified in the configuration, add it
-		if r.port != "" {
-			backend = fmt.Sprintf("%s:%s", backend, r.port)
-		}
-
-		backends[i] = backend
 	}
 
 	// keep it always in the same order
@@ -170,8 +194,9 @@ func (r *dnsResolver) resolve(ctx context.Context) ([]string, error) {
 	r.updateLock.Lock()
 	r.endpoints = backends
 	r.updateLock.Unlock()
-	r.telemetry.LoadbalancerNumBackends.Record(ctx, int64(len(backends)), metric.WithAttributeSet(dnsResolverAttrSet))
-	r.telemetry.LoadbalancerNumBackendUpdates.Add(ctx, 1, metric.WithAttributeSet(dnsResolverAttrSet))
+
+	r.telemetry.LoadbalancerNumBackends.Record(ctx, int64(len(backends)), metric.WithAttributeSet(r.resolverAttrSet))
+	r.telemetry.LoadbalancerNumBackendUpdates.Add(ctx, 1, metric.WithAttributeSet(r.resolverAttrSet))
 
 	// propagate the change
 	r.changeCallbackLock.RLock()
@@ -181,6 +206,70 @@ func (r *dnsResolver) resolve(ctx context.Context) ([]string, error) {
 	r.changeCallbackLock.RUnlock()
 
 	return r.endpoints, nil
+}
+
+func resolveARecord(ctx context.Context, res netResolver, hostname, port string, tb *metadata.TelemetryBuilder) ([]string, error) {
+	addrs, err := res.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		tb.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(aRecordResolverFailureAttrSet))
+		return nil, err
+	}
+
+	tb.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(aRecordResolverSuccessAttrSet))
+
+	backends := make([]string, len(addrs))
+	for i, ip := range addrs {
+		var backend string
+		if ip.IP.To4() != nil {
+			backend = ip.String()
+		} else {
+			// it's an IPv6 address
+			backend = fmt.Sprintf("[%s]", ip.String())
+		}
+
+		// if a port is specified in the configuration, add it
+		if port != "" {
+			backend = fmt.Sprintf("%s:%s", backend, port)
+		}
+
+		backends[i] = backend
+	}
+
+	return backends, nil
+}
+
+func resolveSRV(ctx context.Context, res netResolver, hostname string, logger *zap.Logger, tb *metadata.TelemetryBuilder) ([]string, error) {
+	_, srvs, err := res.LookupSRV(ctx, "", "", hostname)
+	if err != nil {
+		tb.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(srvRecordResolverFailureAttrSet))
+		return nil, err
+	}
+
+	tb.LoadbalancerNumResolutions.Add(ctx, 1, metric.WithAttributeSet(srvRecordResolverSuccessAttrSet))
+
+	backends := []string{}
+
+	for _, srv := range srvs {
+		target := srv.Target
+		ips, err := res.LookupIPAddr(ctx, target)
+		if err != nil {
+			logger.Warn("failed lookup of host for SRV target", zap.String("target", target), zap.Error(err))
+			continue
+		}
+		for _, ip := range ips {
+			var backend string
+			if ip.IP.To4() != nil {
+				backend = ip.String()
+			} else {
+				// it's an IPv6 address
+				backend = fmt.Sprintf("[%s]", ip.String())
+			}
+			backend = fmt.Sprintf("%s:%d", backend, srv.Port)
+			backends = append(backends, backend)
+		}
+	}
+
+	return backends, nil
 }
 
 func (r *dnsResolver) onChange(f func([]string)) {

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -20,7 +20,7 @@ import (
 func TestInitialDNSResolution(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{
@@ -53,7 +53,7 @@ func TestInitialDNSResolution(t *testing.T) {
 func TestInitialDNSResolutionWithPort(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "55690", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "55690", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{
@@ -86,17 +86,18 @@ func TestInitialDNSResolutionWithPort(t *testing.T) {
 func TestErrNoHostname(t *testing.T) {
 	// test
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "", "", 5*time.Second, 1*time.Second, tb)
 
 	// verify
 	assert.Nil(t, res)
 	assert.Equal(t, errNoHostname, err)
 }
 
+
 func TestCantResolve(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	expectedErr := errors.New("some expected error")
@@ -117,7 +118,7 @@ func TestCantResolve(t *testing.T) {
 func TestOnChange(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	resolve := []net.IPAddr{
@@ -131,7 +132,7 @@ func TestOnChange(t *testing.T) {
 
 	// test
 	counter := &atomic.Int64{}
-	res.onChange(func(_ []string) {
+	res.onChange(func([]string) {
 		counter.Add(1)
 	})
 	require.NoError(t, res.start(t.Context()))
@@ -185,7 +186,7 @@ func TestEqualStringSlice(t *testing.T) {
 func TestPeriodicallyResolve(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	counter := &atomic.Int64{}
@@ -222,7 +223,7 @@ func TestPeriodicallyResolve(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	res.onChange(func(_ []string) {
+	res.onChange(func([]string) {
 		wg.Done()
 	})
 
@@ -244,7 +245,7 @@ func TestPeriodicallyResolve(t *testing.T) {
 func TestPeriodicallyResolveFailure(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 10*time.Millisecond, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	expectedErr := errors.New("some expected error")
@@ -288,11 +289,11 @@ func TestPeriodicallyResolveFailure(t *testing.T) {
 func TestShutdownClearsCallbacks(t *testing.T) {
 	// prepare
 	_, tb := getTelemetryAssets(t)
-	res, err := newDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(zap.NewNop(), "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{}
-	res.onChange(func(_ []string) {})
+	res.onChange(func([]string) {})
 	require.NoError(t, res.start(t.Context()))
 
 	// sanity check
@@ -306,7 +307,7 @@ func TestShutdownClearsCallbacks(t *testing.T) {
 	assert.Empty(t, res.onChangeCallbacks)
 
 	// check that we can add a new onChange before a new start
-	res.onChange(func(_ []string) {})
+	res.onChange(func([]string) {})
 	assert.Len(t, res.onChangeCallbacks, 1)
 }
 
@@ -315,6 +316,7 @@ var _ netResolver = (*mockDNSResolver)(nil)
 type mockDNSResolver struct {
 	net.Resolver
 	onLookupIPAddr func(context.Context, string) ([]net.IPAddr, error)
+	onLookupSRV    func(context.Context, string, string, string) (string, []*net.SRV, error)
 }
 
 func (m *mockDNSResolver) LookupIPAddr(ctx context.Context, hostname string) ([]net.IPAddr, error) {
@@ -322,4 +324,256 @@ func (m *mockDNSResolver) LookupIPAddr(ctx context.Context, hostname string) ([]
 		return m.onLookupIPAddr(ctx, hostname)
 	}
 	return nil, nil
+}
+
+func (m *mockDNSResolver) LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
+	if m.onLookupSRV != nil {
+		return m.onLookupSRV(ctx, service, proto, name)
+	}
+	return "", nil, nil
+}
+
+func TestDNSSRVResolution(t *testing.T) {
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			// emulate two SRV records
+			return "", []*net.SRV{
+				{Target: "host1.example.org.", Port: 1000},
+				{Target: "host2.example.org.", Port: 2000},
+			}, nil
+		},
+		onLookupIPAddr: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host == "host1.example.org." {
+				return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, nil
+			}
+			if host == "host2.example.org." {
+				return []net.IPAddr{{IP: net.IPv6loopback}}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	var resolved []string
+	res.onChange(func(endpoints []string) {
+		resolved = endpoints
+	})
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+
+	assert.Len(t, resolved, 2)
+	assert.Equal(t, "10.0.0.1:1000", resolved[0])
+	assert.Equal(t, "[::1]:2000", resolved[1])
+}
+
+func TestDNSSRVNoHostname(t *testing.T) {
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "", 5*time.Second, 1*time.Second, tb)
+
+	assert.Nil(t, res)
+	assert.Equal(t, errNoHostname, err)
+}
+
+func TestDNSSRVLookupError(t *testing.T) {
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	expectedErr := errors.New("some expected error")
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", nil, expectedErr
+		},
+	}
+
+	// starting should not fail
+	require.NoError(t, res.start(t.Context()))
+	require.NoError(t, res.shutdown(t.Context()))
+}
+
+func TestDNSSRVPartialIPLookupFailure(t *testing.T) {
+	// When one SRV target's A/AAAA lookup fails, the other targets should still be resolved.
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", []*net.SRV{
+				{Target: "healthy.example.org.", Port: 8080},
+				{Target: "broken.example.org.", Port: 9090},
+			}, nil
+		},
+		onLookupIPAddr: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host == "healthy.example.org." {
+				return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, nil
+			}
+			return nil, errors.New("lookup failed")
+		},
+	}
+
+	var resolved []string
+	res.onChange(func(endpoints []string) {
+		resolved = endpoints
+	})
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+
+	// only the healthy target should appear
+	assert.Len(t, resolved, 1)
+	assert.Equal(t, "10.0.0.1:8080", resolved[0])
+}
+
+func TestDNSSRVTargetWithMultipleIPs(t *testing.T) {
+	// A single SRV target that resolves to multiple A/AAAA records (e.g. round-robin DNS).
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", []*net.SRV{
+				{Target: "multi.example.org.", Port: 4317},
+			}, nil
+		},
+		onLookupIPAddr: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{
+				{IP: net.IPv4(10, 0, 0, 1)},
+				{IP: net.IPv4(10, 0, 0, 2)},
+				{IP: net.IPv6loopback},
+			}, nil
+		},
+	}
+
+	var resolved []string
+	res.onChange(func(endpoints []string) {
+		resolved = endpoints
+	})
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+
+	assert.Len(t, resolved, 3)
+	// sorted order
+	assert.Equal(t, "10.0.0.1:4317", resolved[0])
+	assert.Equal(t, "10.0.0.2:4317", resolved[1])
+	assert.Equal(t, "[::1]:4317", resolved[2])
+}
+
+func TestDNSSRVEmptyResult(t *testing.T) {
+	// LookupSRV succeeds but returns zero SRV records.
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", []*net.SRV{}, nil
+		},
+	}
+
+	var resolved []string
+	res.onChange(func(endpoints []string) {
+		resolved = endpoints
+	})
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+
+	assert.Empty(t, resolved)
+}
+
+func TestDNSSRVOnChangeNotCalledOnSameResult(t *testing.T) {
+	// Resolving the same SRV records twice should not trigger onChange a second time.
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 5*time.Second, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", []*net.SRV{
+				{Target: "host1.example.org.", Port: 4317},
+			}, nil
+		},
+		onLookupIPAddr: func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, nil
+		},
+	}
+
+	counter := &atomic.Int64{}
+	res.onChange(func([]string) {
+		counter.Add(1)
+	})
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+	require.Equal(t, int64(1), counter.Load())
+
+	// resolve again with the same result — onChange should NOT fire
+	_, err = res.resolve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), counter.Load())
+
+	// now change the result and resolve — onChange should fire
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			return "", []*net.SRV{
+				{Target: "host1.example.org.", Port: 4317},
+				{Target: "host2.example.org.", Port: 4318},
+			}, nil
+		},
+		onLookupIPAddr: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host == "host1.example.org." {
+				return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, nil
+			}
+			return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 2)}}, nil
+		},
+	}
+	_, err = res.resolve(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), counter.Load())
+}
+
+func TestDNSSRVPeriodicallyResolve(t *testing.T) {
+	// Periodic resolution should pick up changes in SRV records over time.
+	_, tb := getTelemetryAssets(t)
+	res, err := newSRVRecordDNSResolver(zap.NewNop(), "_svc._tcp.example.org", 10*time.Millisecond, 1*time.Second, tb)
+	require.NoError(t, err)
+
+	counter := &atomic.Int64{}
+	resolve := [][]*net.SRV{
+		{{Target: "host1.example.org.", Port: 4317}},
+		{{Target: "host1.example.org.", Port: 4317}, {Target: "host2.example.org.", Port: 4318}},
+	}
+	res.resolver = &mockDNSResolver{
+		onLookupSRV: func(context.Context, string, string, string) (string, []*net.SRV, error) {
+			idx := counter.Load()
+			if int(idx) >= len(resolve) {
+				return "", resolve[len(resolve)-1], nil
+			}
+			return "", resolve[idx], nil
+		},
+		onLookupIPAddr: func(_ context.Context, host string) ([]net.IPAddr, error) {
+			if host == "host1.example.org." {
+				return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 1)}}, nil
+			}
+			return []net.IPAddr{{IP: net.IPv4(10, 0, 0, 2)}}, nil
+		},
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	res.onChange(func([]string) {
+		counter.Add(1)
+		wg.Done()
+	})
+
+	require.NoError(t, res.start(t.Context()))
+	defer func() { require.NoError(t, res.shutdown(t.Context())) }()
+
+	// wait for initial + one periodic resolution that sees the changed list
+	wg.Wait()
+
+	assert.GreaterOrEqual(t, counter.Load(), int64(2))
+	assert.Len(t, res.endpoints, 2)
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -593,7 +593,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 
 	// simulate rolling updates, the dns resolver should resolve in the following order
 	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.2"]
-	res, err := newDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, tb)
+	res, err := newARecordDNSResolver(ts.Logger, "service-1", "", 5*time.Second, 1*time.Second, tb)
 	require.NoError(t, err)
 
 	mu := sync.Mutex{}


### PR DESCRIPTION
#### Description

This PR adds DNS SRV (Service Record) resolver support to the load balancing exporter, enabling automatic service discovery through DNS SRV lookups. This allows the load balancer to dynamically discover backend endpoints along with their ports from DNS SRV records, eliminating the need for manual port configuration.

**Key changes:**
- **New `dnssrv` resolver configuration**: Added `DNSSRVResolver` configuration type that accepts `hostname`, `interval`, and `timeout` parameters
- **Automatic port discovery**: SRV mode automatically uses ports from SRV records; no port configuration needed
- **Graceful degradation**: When IP lookups fail for individual SRV targets, other targets are still resolved
- **Enhanced telemetry**: Separate metrics attributes for DNS (`resolver=dns`) and DNS SRV (`resolver=dnssrv`) modes

**Benefits:**
- Enables Kubernetes-style service discovery without requiring Kubernetes (works with any DNS server supporting SRV records)
- Reduces configuration complexity by eliminating separate port configuration
- Maintains backward compatibility with existing DNS resolver configurations

#### Link to tracking issue
Fixes #18412

#### Testing

**Unit tests added** (13 total SRV tests):
- `TestDNSSRVResolution` - Basic SRV resolution with mixed IPv4/IPv6
- `TestDNSSRVNoHostname` - Empty hostname validation
- `TestDNSSRVLookupError` - SRV lookup failure handling
- `TestDNSSRVPartialIPLookupFailure` - Partial failure resilience (some targets fail, others succeed)
- `TestDNSSRVTargetWithMultipleIPs` - Round-robin DNS support (single SRV target with multiple IPs)
- `TestDNSSRVEmptyResult` - Zero SRV records handling
- `TestDNSSRVOnChangeNotCalledOnSameResult` - De-duplication of unchanged results
- `TestDNSSRVPeriodicallyResolve` - Periodic resolution with changing SRV records
- `TestWithDNSSRVResolver` - Integration test with load balancer

**Existing tests updated:**
- All tests pass (100% success rate)
- No regression in existing DNS resolver functionality

#### Documentation

- Updated [README.md](./exporter/loadbalancingexporter/README.md) with `dnssrv` resolver configuration and usage examples
- Added inline comments explaining SRV resolution flow
- Documented port handling differences between `dns` and `dnssrv` modes
- Added configuration examples in the README showing how to use the new resolver type

**Example configuration:**
```yaml
exporters:
  loadbalancing:
    resolver:
      dnssrv:
        hostname: _grpc._tcp.my-service.example.org
        interval: 5s
        timeout: 1s
```
