### PR TITLE
[processor/cumulativetodelta] Fix exponential histogram diff zero padding

### DIFF
--- a/.chloggen/cumulativetodelta-exp-hist-diff.yaml
+++ b/.chloggen/cumulativetodelta-exp-hist-diff.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/cumulativetodelta
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory blowup in exponential histogram delta conversion
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45927]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/cumulativetodeltaprocessor/internal/tracking/value.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/value.go
@@ -90,7 +90,8 @@ func (buckets *ExponentialBuckets) Diff(old *ExponentialBuckets) (out Exponentia
 		if out.BucketCounts == nil {
 			out.Offset = int32(bucket)
 		} else {
-			zeros := bucket - int(out.Offset) + len(out.BucketCounts)
+			nextBucket := int(out.Offset) + len(out.BucketCounts)
+			zeros := bucket - nextBucket
 			out.BucketCounts = append(out.BucketCounts, make([]uint64, zeros)...)
 		}
 		out.BucketCounts = append(out.BucketCounts, diff)

--- a/processor/cumulativetodeltaprocessor/internal/tracking/value_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/value_test.go
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracking
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialBuckets_Diff(t *testing.T) {
+	tests := []struct {
+		name    string
+		current ExponentialBuckets
+		old     ExponentialBuckets
+		want    ExponentialBuckets
+	}{
+		{
+			name: "sparse buckets without previous",
+			current: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: []uint64{1, 0, 2, 0, 3},
+			},
+			old: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: nil,
+			},
+			want: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: []uint64{1, 0, 2, 0, 3},
+			},
+		},
+		{
+			name: "leading zeros and non-zero offset",
+			current: ExponentialBuckets{
+				Offset:       5,
+				BucketCounts: []uint64{0, 4, 0, 2},
+			},
+			old: ExponentialBuckets{
+				Offset:       5,
+				BucketCounts: nil,
+			},
+			want: ExponentialBuckets{
+				Offset:       6,
+				BucketCounts: []uint64{4, 0, 2},
+			},
+		},
+		{
+			name: "subtract previous counts on overlapping buckets",
+			current: ExponentialBuckets{
+				Offset:       2,
+				BucketCounts: []uint64{5, 0, 9, 1},
+			},
+			old: ExponentialBuckets{
+				Offset:       1,
+				BucketCounts: []uint64{3, 0, 6, 1, 1},
+			},
+			want: ExponentialBuckets{
+				Offset:       2,
+				BucketCounts: []uint64{5, 0, 8},
+			},
+		},
+		{
+			name: "monotonicity fallback keeps later valid bucket",
+			current: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: []uint64{1, 2, 1, 5},
+			},
+			old: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: []uint64{1, 3, 2, 3},
+			},
+			want: ExponentialBuckets{
+				Offset:       3,
+				BucketCounts: []uint64{2},
+			},
+		},
+		{
+			name: "empty when all buckets are non-increasing",
+			current: ExponentialBuckets{
+				Offset:       10,
+				BucketCounts: []uint64{0, 1},
+			},
+			old: ExponentialBuckets{
+				Offset:       10,
+				BucketCounts: []uint64{0, 2},
+			},
+			want: ExponentialBuckets{},
+		},
+		{
+			name: "negative offsets",
+			current: ExponentialBuckets{
+				Offset:       -3,
+				BucketCounts: []uint64{2, 0, 4},
+			},
+			old: ExponentialBuckets{
+				Offset:       -4,
+				BucketCounts: []uint64{1, 1, 3, 1},
+			},
+			want: ExponentialBuckets{
+				Offset:       -3,
+				BucketCounts: []uint64{1, 0, 3},
+			},
+		},
+		{
+			name: "first non-zero bucket sets output offset",
+			current: ExponentialBuckets{
+				Offset:       100,
+				BucketCounts: []uint64{0, 0, 9},
+			},
+			old: ExponentialBuckets{
+				Offset:       0,
+				BucketCounts: nil,
+			},
+			want: ExponentialBuckets{
+				Offset:       102,
+				BucketCounts: []uint64{9},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.current.Diff(&tc.old)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixes exponential histogram memory blowup in `ExponentialBuckets.Diff` by fixing the zero-gap math.
The old math added too many empty buckets for sparse data, so memory usage kept growing and could lead to OOM.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45927

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added tests in `internal/tracking/value_test.go` to check gaps, offsets, subtraction against previous data and reset/non-increasing cases.
<!--Describe the documentation added.-->