### PR TITLE
[chore] [receiver/prometheusreceiver] Replace busy-wait loop with require.Eventually in staleness test

### DIFF
--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -177,15 +177,10 @@ service:
 	defer app.Shutdown()
 
 	// Wait until the collector has actually started.
-	for notYetStarted := true; notYetStarted; {
+	require.Eventually(t, func() bool {
 		state := app.GetState()
-		switch state {
-		case otelcol.StateRunning, otelcol.StateClosed, otelcol.StateClosing:
-			notYetStarted = false
-		case otelcol.StateStarting:
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		return state == otelcol.StateRunning || state == otelcol.StateClosed || state == otelcol.StateClosing
+	}, 30*time.Second, 10*time.Millisecond, "collector did not start")
 
 	// 5. Let's wait on 10 fetches.
 	var wReqL []*prompb.WriteRequest


### PR DESCRIPTION
#### Description

Replace the `time.Sleep` busy-wait polling loop for collector startup in `TestStalenessMarkersEndToEnd` with `require.Eventually`. The previous loop had no timeout and would hang forever if the collector failed to start; `require.Eventually` adds a 30s safety timeout while remaining idiomatic.

#### Link to tracking issue
Related to #44319

#### Testing

- `TestStalenessMarkersEndToEnd` passes
- All existing tests in `internal` package pass

#### Documentation

N/A