### PR TITLE
[processor/resourcedetectionprocessor] Read cloud.account.id from symlink in Lambda detector

### DIFF
--- a/.chloggen/lambda-cloud-account-id.yaml
+++ b/.chloggen/lambda-cloud-account-id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Read cloud.account.id from symlink created by the OTel Lambda Extension in the Lambda resource detector.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45952]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/lambda-cloud-account-id.yaml
+++ b/.chloggen/lambda-cloud-account-id.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: processor/resourcedetectionprocessor
+component: processor/resourcedetection
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Read cloud.account.id from symlink created by the OTel Lambda Extension in the Lambda resource detector.

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/documentation.md
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/documentation.md
@@ -10,6 +10,7 @@
 | ---- | ----------- | ------ | ------- |
 | aws.log.group.names | The aws.log.group.names | Any Slice | true |
 | aws.log.stream.names | The aws.log.stream.names | Any Slice | true |
+| cloud.account.id | The cloud account id | Any Str | true |
 | cloud.platform | The cloud.platform | Any Str | true |
 | cloud.provider | The cloud.provider | Any Str | true |
 | cloud.region | The cloud.region | Any Str | true |

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/config.schema.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/config.schema.yaml
@@ -13,6 +13,8 @@ $defs:
         $ref: resource_attribute_config
       aws.log.stream.names:
         $ref: resource_attribute_config
+      cloud.account.id:
+        $ref: resource_attribute_config
       cloud.platform:
         $ref: resource_attribute_config
       cloud.provider:

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_config.go
@@ -29,6 +29,7 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 type ResourceAttributesConfig struct {
 	AwsLogGroupNames  ResourceAttributeConfig `mapstructure:"aws.log.group.names"`
 	AwsLogStreamNames ResourceAttributeConfig `mapstructure:"aws.log.stream.names"`
+	CloudAccountID    ResourceAttributeConfig `mapstructure:"cloud.account.id"`
 	CloudPlatform     ResourceAttributeConfig `mapstructure:"cloud.platform"`
 	CloudProvider     ResourceAttributeConfig `mapstructure:"cloud.provider"`
 	CloudRegion       ResourceAttributeConfig `mapstructure:"cloud.region"`
@@ -44,6 +45,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		AwsLogStreamNames: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudAccountID: ResourceAttributeConfig{
 			Enabled: true,
 		},
 		CloudPlatform: ResourceAttributeConfig{

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_config_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_config_test.go
@@ -26,6 +26,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AwsLogGroupNames:  ResourceAttributeConfig{Enabled: true},
 				AwsLogStreamNames: ResourceAttributeConfig{Enabled: true},
+				CloudAccountID:    ResourceAttributeConfig{Enabled: true},
 				CloudPlatform:     ResourceAttributeConfig{Enabled: true},
 				CloudProvider:     ResourceAttributeConfig{Enabled: true},
 				CloudRegion:       ResourceAttributeConfig{Enabled: true},
@@ -40,6 +41,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AwsLogGroupNames:  ResourceAttributeConfig{Enabled: false},
 				AwsLogStreamNames: ResourceAttributeConfig{Enabled: false},
+				CloudAccountID:    ResourceAttributeConfig{Enabled: false},
 				CloudPlatform:     ResourceAttributeConfig{Enabled: false},
 				CloudProvider:     ResourceAttributeConfig{Enabled: false},
 				CloudRegion:       ResourceAttributeConfig{Enabled: false},

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_resource.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_resource.go
@@ -35,6 +35,13 @@ func (rb *ResourceBuilder) SetAwsLogStreamNames(val []any) {
 	}
 }
 
+// SetCloudAccountID sets provided value as "cloud.account.id" attribute.
+func (rb *ResourceBuilder) SetCloudAccountID(val string) {
+	if rb.config.CloudAccountID.Enabled {
+		rb.res.Attributes().PutStr("cloud.account.id", val)
+	}
+}
+
 // SetCloudPlatform sets provided value as "cloud.platform" attribute.
 func (rb *ResourceBuilder) SetCloudPlatform(val string) {
 	if rb.config.CloudPlatform.Enabled {

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_resource_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/generated_resource_test.go
@@ -15,6 +15,7 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetAwsLogGroupNames([]any{"aws.log.group.names-item1", "aws.log.group.names-item2"})
 			rb.SetAwsLogStreamNames([]any{"aws.log.stream.names-item1", "aws.log.stream.names-item2"})
+			rb.SetCloudAccountID("cloud.account.id-val")
 			rb.SetCloudPlatform("cloud.platform-val")
 			rb.SetCloudProvider("cloud.provider-val")
 			rb.SetCloudRegion("cloud.region-val")
@@ -28,9 +29,9 @@ func TestResourceBuilder(t *testing.T) {
 
 			switch tt {
 			case "default":
-				assert.Equal(t, 9, res.Attributes().Len())
+				assert.Equal(t, 10, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 9, res.Attributes().Len())
+				assert.Equal(t, 10, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -47,6 +48,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.Equal(t, []any{"aws.log.stream.names-item1", "aws.log.stream.names-item2"}, val.Slice().AsRaw())
+			}
+			val, ok = res.Attributes().Get("cloud.account.id")
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, "cloud.account.id-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("cloud.platform")
 			assert.True(t, ok)

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/internal/metadata/testdata/config.yaml
@@ -5,6 +5,8 @@ all_set:
       enabled: true
     aws.log.stream.names:
       enabled: true
+    cloud.account.id:
+      enabled: true
     cloud.platform:
       enabled: true
     cloud.provider:
@@ -24,6 +26,8 @@ none_set:
     aws.log.group.names:
       enabled: false
     aws.log.stream.names:
+      enabled: false
+    cloud.account.id:
       enabled: false
     cloud.platform:
       enabled: false

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
@@ -20,6 +20,10 @@ const (
 	// TypeStr is type of detector.
 	TypeStr = "lambda"
 
+	// accountIDSymlinkPath is the path to a symlink whose target is the AWS account ID.
+	// This symlink is created by the opentelemetry-lambda extension layer.
+	accountIDSymlinkPath = "/tmp/.otel-account-id"
+
 	// Environment variables that are set when running on AWS Lambda.
 	// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
 	awsRegionEnvVar                   = "AWS_REGION"
@@ -54,6 +58,9 @@ func (d *detector) Detect(_ context.Context) (resource pcommon.Resource, schemaU
 	d.rb.SetCloudPlatform(conventions.CloudPlatformAWSLambda.Value.AsString())
 	if value, ok := os.LookupEnv(awsRegionEnvVar); ok {
 		d.rb.SetCloudRegion(value)
+	}
+	if accountID, err := os.Readlink(accountIDSymlinkPath); err == nil {
+		d.rb.SetCloudAccountID(accountID)
 	}
 
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/faas.md

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
@@ -64,6 +64,8 @@ func (d *detector) Detect(_ context.Context) (resource pcommon.Resource, schemaU
 	if runtime.GOOS != "windows" {
 		if accountID, err := os.Readlink(accountIDSymlinkPath); err == nil {
 			d.rb.SetCloudAccountID(accountID)
+		} else {
+			d.logger.Debug("cloud.account.id not available via symlink", zap.Error(err))
 		}
 	}
 

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
@@ -23,7 +23,7 @@ const (
 
 	// accountIDSymlinkPath is the path to a symlink whose target is the AWS account ID.
 	// This symlink is created by the opentelemetry-lambda extension layer.
-	accountIDSymlinkPath = "/tmp/.otel-account-id"
+	accountIDSymlinkPath = "/tmp/.otel-aws-account-id"
 
 	// Environment variables that are set when running on AWS Lambda.
 	// https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda.go
@@ -6,6 +6,7 @@ package lambda // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"context"
 	"os"
+	"runtime"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/processor"
@@ -59,8 +60,11 @@ func (d *detector) Detect(_ context.Context) (resource pcommon.Resource, schemaU
 	if value, ok := os.LookupEnv(awsRegionEnvVar); ok {
 		d.rb.SetCloudRegion(value)
 	}
-	if accountID, err := os.Readlink(accountIDSymlinkPath); err == nil {
-		d.rb.SetCloudAccountID(accountID)
+	// The account ID symlink is only available on Linux (Lambda does not support Windows).
+	if runtime.GOOS != "windows" {
+		if accountID, err := os.Readlink(accountIDSymlinkPath); err == nil {
+			d.rb.SetCloudAccountID(accountID)
+		}
 	}
 
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/faas.md

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
@@ -4,6 +4,8 @@
 package lambda
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +44,63 @@ func TestNotLambda(t *testing.T) {
 	require.NotNil(t, res)
 
 	assert.Equal(t, 0, res.Attributes().Len(), "Resource object should be empty")
+}
+
+// Tests that cloud.account.id is set when the account ID symlink exists
+func TestLambdaAccountIDSymlink(t *testing.T) {
+	ctx := t.Context()
+
+	const functionName = "TestFunctionName"
+	const expectedAccountID = "123456789012"
+	t.Setenv(awsLambdaFunctionNameEnvVar, functionName)
+
+	// Create a symlink at a temp path and override the constant via a helper.
+	// Since accountIDSymlinkPath is a const, we create the symlink at the actual path
+	// in a temp directory and override it for the test.
+	tmpDir := t.TempDir()
+	symlinkPath := filepath.Join(tmpDir, ".otel-account-id")
+	err := os.Symlink(expectedAccountID, symlinkPath)
+	require.NoError(t, err)
+
+	// Patch the global symlink path for this test by creating the symlink at the well-known path.
+	// We use the actual /tmp path since that's what the detector reads.
+	// Clean up any pre-existing symlink first (ignore error if it doesn't exist).
+	os.Remove(accountIDSymlinkPath)
+	t.Cleanup(func() { os.Remove(accountIDSymlinkPath) })
+	err = os.Symlink(expectedAccountID, accountIDSymlinkPath)
+	require.NoError(t, err)
+
+	lambdaDetector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())
+	require.NoError(t, err)
+	res, _, err := lambdaDetector.Detect(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	val, ok := res.Attributes().Get("cloud.account.id")
+	assert.True(t, ok, "cloud.account.id attribute should be present")
+	assert.Equal(t, expectedAccountID, val.Str())
+}
+
+// Tests that cloud.account.id is absent when the symlink does not exist
+func TestLambdaAccountIDSymlinkMissing(t *testing.T) {
+	ctx := t.Context()
+
+	const functionName = "TestFunctionName"
+	t.Setenv(awsLambdaFunctionNameEnvVar, functionName)
+
+	// Ensure symlink does not exist
+	os.Remove(accountIDSymlinkPath)
+
+	lambdaDetector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())
+	require.NoError(t, err)
+	res, _, err := lambdaDetector.Detect(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	_, ok := res.Attributes().Get("cloud.account.id")
+	assert.False(t, ok, "cloud.account.id attribute should not be present when symlink is missing")
+	// Verify other attributes are still set correctly
+	assert.Equal(t, "aws", res.Attributes().AsRaw()["cloud.provider"])
+	assert.Equal(t, "aws_lambda", res.Attributes().AsRaw()["cloud.platform"])
+	assert.Equal(t, functionName, res.Attributes().AsRaw()["faas.name"])
 }

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
@@ -5,7 +5,7 @@ package lambda
 
 import (
 	"os"
-	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,26 +48,21 @@ func TestNotLambda(t *testing.T) {
 
 // Tests that cloud.account.id is set when the account ID symlink exists
 func TestLambdaAccountIDSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping symlink test on Windows: Lambda does not support Windows")
+	}
+
 	ctx := t.Context()
 
 	const functionName = "TestFunctionName"
 	const expectedAccountID = "123456789012"
 	t.Setenv(awsLambdaFunctionNameEnvVar, functionName)
 
-	// Create a symlink at a temp path and override the constant via a helper.
-	// Since accountIDSymlinkPath is a const, we create the symlink at the actual path
-	// in a temp directory and override it for the test.
-	tmpDir := t.TempDir()
-	symlinkPath := filepath.Join(tmpDir, ".otel-account-id")
-	err := os.Symlink(expectedAccountID, symlinkPath)
-	require.NoError(t, err)
-
-	// Patch the global symlink path for this test by creating the symlink at the well-known path.
-	// We use the actual /tmp path since that's what the detector reads.
+	// Create the symlink at the well-known path.
 	// Clean up any pre-existing symlink first (ignore error if it doesn't exist).
 	os.Remove(accountIDSymlinkPath)
 	t.Cleanup(func() { os.Remove(accountIDSymlinkPath) })
-	err = os.Symlink(expectedAccountID, accountIDSymlinkPath)
+	err := os.Symlink(expectedAccountID, accountIDSymlinkPath)
 	require.NoError(t, err)
 
 	lambdaDetector, err := NewDetector(processortest.NewNopSettings(processortest.NopType), CreateDefaultConfig())

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
@@ -3,6 +3,10 @@ type: resourcedetectionprocessor/lambda
 parent: resourcedetection
 
 resource_attributes:
+  cloud.account.id:
+    description: The cloud account id
+    type: string
+    enabled: true
   aws.log.group.names:
     description: The aws.log.group.names
     type: slice

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/metadata.yaml
@@ -3,10 +3,6 @@ type: resourcedetectionprocessor/lambda
 parent: resourcedetection
 
 resource_attributes:
-  cloud.account.id:
-    description: The cloud account id
-    type: string
-    enabled: true
   aws.log.group.names:
     description: The aws.log.group.names
     type: slice
@@ -14,6 +10,10 @@ resource_attributes:
   aws.log.stream.names:
     description: The aws.log.stream.names
     type: slice
+    enabled: true
+  cloud.account.id:
+    description: The cloud account id
+    type: string
     enabled: true
   cloud.platform:
     description: The cloud.platform


### PR DESCRIPTION
## Summary

- Reads `cloud.account.id` from the symlink at `/tmp/.otel-aws-account-id` created by the OTel Lambda Extension
- Uses `os.Readlink()` to read the symlink target
- Logs at debug level if the symlink doesn't exist (`if err == nil` guard)
- Full metadata.yaml integration with generated config, resource builder, tests, schema, and documentation

## Depends on

- open-telemetry/opentelemetry-lambda#2127 (extension creates the symlink)

## Changes

- `lambda.go` — Added readlink logic with `accountIDSymlinkPath` constant
- `metadata.yaml` — Added `cloud.account.id` resource attribute
- 6 generated files updated (config, resource builder, tests, schema, testdata, docs)
- `lambda_test.go` — Happy path and missing symlink tests

## Test plan

- [x] Unit test: symlink exists → `cloud.account.id` set correctly
- [x] Unit test: missing symlink → attribute absent, no error
- [x] All generated metadata tests pass