### PR TITLE
[extension/bearertokenauth] Fix token file refresh for Kubernetes projected volumes

### DIFF
--- a/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
+++ b/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
@@ -2,12 +2,21 @@ change_type: bug_fix
 
 component: extension/bearertokenauth
 
-note: "Revert to workaround for watching Kubernetes mounted token files"
+note: Reintroduces file watcher workaround for symlinked token files.
 
-# TODO Need PR number
-# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: []
 
-subtext: "Fixes regression introduced in #44104."
+# TODO
+subtext: |
+  In #44104, the token file watcher was rewritten to watch the parent dir of the file rather than the file itself.
+  This change was made in an effort to avoid a race condition under which fsnotify would remove the watcher before the 
+  event handler got to it, causing an error log.
+  This unintentionally broke the behaviour of the token file watcher under certain circumstances - most notably for 
+  mounted ConfigMaps, Secrets and serviceAccountToken projected volumes on Kubernetes.
+  The implementation is now close to the previous one, which includes a workaround specifically to support the 
+  aforementioned scenario: watching the file itself for the Remove and Chmod events, as well as Write.
+  Additionally, `fsnotify.ErrNonExistentWatch`, which indicates the double removal condition on the file watcher, is now 
+  silently ignored. 
+  
 
 change_logs: [user]

--- a/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
+++ b/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
@@ -4,9 +4,8 @@ component: extension/bearertokenauth
 
 note: Reintroduces file watcher workaround for symlinked token files.
 
-issues: []
+issues: [45953]
 
-# TODO
 subtext: |
   In #44104, the token file watcher was rewritten to watch the parent dir of the file rather than the file itself.
   This change was made in an effort to avoid a race condition under which fsnotify would remove the watcher before the 

--- a/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
+++ b/.chloggen/fix-bearertokenauthextension-refresh-regression.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+
+component: extension/bearertokenauth
+
+note: "Revert to workaround for watching Kubernetes mounted token files"
+
+# TODO Need PR number
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+subtext: "Fixes regression introduced in #44104."
+
+change_logs: [user]

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 
@@ -107,10 +106,7 @@ func (b *bearerTokenAuth) Start(ctx context.Context, _ component.Host) error {
 	// start file watcher
 	go b.startWatcher(ctx, watcher)
 
-	// Watch the parent directory instead of the file directly to handle atomic replacements
-	// This eliminates race conditions with fsnotify when files are atomically replaced
-	watchDir := filepath.Dir(b.filename)
-	return watcher.Add(watchDir)
+	return watcher.Add(b.filename)
 }
 
 func (b *bearerTokenAuth) startWatcher(ctx context.Context, watcher *fsnotify.Watcher) {
@@ -126,20 +122,22 @@ func (b *bearerTokenAuth) startWatcher(ctx context.Context, watcher *fsnotify.Wa
 			if !ok {
 				continue
 			}
-
-			// Only process events for our target file by filtering events
-			// Since we're watching the parent directory, we get events for all files in it
-			if event.Name != b.filename {
-				continue
+			// NOTE: k8s configmaps uses symlinks, we need this workaround.
+			// original configmap file is removed.
+			// SEE: https://martensson.io/go-fsnotify-and-kubernetes-configmaps/
+			if event.Op&fsnotify.Remove == fsnotify.Remove || event.Op&fsnotify.Chmod == fsnotify.Chmod {
+				// The watch may already have been removed by fsnotify when the file (or symlink target) was deleted.
+				// This is expected during atomic replacements via symlink renaming (e.g. Kubernetes ConfigMap mount updates).
+				if err := watcher.Remove(event.Name); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
+					b.logger.Error("removing watcher failed", zap.Error(err))
+				}
+				if err := watcher.Add(b.filename); err != nil {
+					b.logger.Error("adding watcher failed", zap.Error(err))
+				}
+				b.refreshToken()
 			}
-
-			// Handle file events for our target file
-			// Since we're watching the directory, we don't need to manage watch add/remove
-			// The directory watch persists even when files are atomically replaced
-			if event.Op&fsnotify.Write == fsnotify.Write ||
-				event.Op&fsnotify.Create == fsnotify.Create ||
-				event.Op&fsnotify.Remove == fsnotify.Remove ||
-				event.Op&fsnotify.Chmod == fsnotify.Chmod {
+			// also allow normal files to be modified and reloaded.
+			if event.Op&fsnotify.Write == fsnotify.Write {
 				b.refreshToken()
 			}
 		}

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -450,7 +451,13 @@ func TestCustomHeaderAuthenticate(t *testing.T) {
 
 // TestBearerTokenFileTokenRotationWithSymlink verifies that a token is refreshed when the backing file is rotated
 // using the Kubernetes-style atomic symlink swap.
+// This test is not applicable to Windows as atomic symlink swaps are not supported and the kubelet falls
+// back to a non-atomic Remove+Symlink strategy.
 func TestBearerTokenFileTokenRotationWithSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Atomic symlink swaps with rename(2) are not supported on Windows")
+	}
+
 	mountDir := t.TempDir()
 
 	// Initial timestamped directory with token file

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -449,11 +449,11 @@ func TestCustomHeaderAuthenticate(t *testing.T) {
 	assert.NoError(t, bauth.Shutdown(t.Context()))
 }
 
-// TestBearerTokenFileTokenRotationWithSymlink verifies that a token is refreshed when the backing file is rotated
+// TestBearerTokenFileRefreshWithAtomicSymlinkSwap verifies that a token is refreshed when the backing file is rotated
 // using the Kubernetes-style atomic symlink swap.
 // This test is not applicable to Windows as atomic symlink swaps are not supported and the kubelet falls
 // back to a non-atomic Remove+Symlink strategy.
-func TestBearerTokenFileTokenRotationWithSymlink(t *testing.T) {
+func TestBearerTokenFileRefreshWithAtomicSymlinkSwap(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Atomic symlink swaps with rename(2) are not supported on Windows")
 	}


### PR DESCRIPTION
#### Description
Fixes a bug which caused token file refresh to break completely for files backed by Kubernetes projected volumes (ConfigMaps, Secrets, serviceAccountTokens).
The bug is a regression introduced in #44104, which removed a crucial and very specifically documented workaround for this particular case. This has resulted in token files backed by projected volumes ("double symlinks") not refreshing at all.

I have encountered this issue in production (`v0.144.0`), and am also able to reproduce it consistently. The last well-behaving version seems to be `v0.138.0`. Applying this PR fixes the issue for my reproduction.

The fix is mostly a revert to the previous code, but with a couple of notable changes:
* The event handler now uses bit masking to decode the fs events (this was also done in the buggy changeset)
* The error indicating the double removal of the watcher is now ignored in the event handler

Note: as with the previous implementation, on some systems there is the potential for receiving two discrete events in quick succession. This causes the token to be refreshed twice.
Even if this is not-so-nice, it's really just a tiny read and store operation and should have negligible impact. One could perhaps introduce a simple debounce mechanism (with, say, 1s delay) to smooth it over, but I consider that out-of-scope for this PR.

#### Testing
Added `TestBearerTokenFileTokenRotationWithSymlink` which simulates the "atomic swap" behaviour of Kubernetes projected volumes on Linux. The test failed before, and passes after the fix is applied. Notably this test is only really applicable on Linux, and will pass in _both_ cases on MacOS (don't know about Windows) due to difference in behaviours between `kqueue` and `inotify`.

The bug itself was easily reproducible by running the latest version of `otelcollector-contrib` in a local `kind` cluster, configured with reading the token from a ConfigMap-backed volume. On the pre-fix collector the changes to the ConfigMap are not picked up and the token is thus never updated, whilst it works as expected with the fix applied.
