### PR TITLE
[exporter/googlecloudstorage] Add use_existing config to skip bucket creation

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -10,7 +10,7 @@ component: exporter/googlecloudstorage
 note: Add `use_existing` config option to skip bucket creation when bucket is externally managed
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [0000]
+issues: [45968]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,24 +1,23 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/fluentforward
+component: exporter/googlecloudstorage
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: handle uint64 to int64 overflow by changing to string
+note: Add `use_existing` config option to skip bucket creation when bucket is externally managed
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [45252]
+issues: [0000]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  FluentD supports record entries with uint64 types. OpenTelemetry log attributes only support int64 and no uint64.
-  The old solution would overflow with uint64 values greater than `math.MaxInt64` and result in negative attribute values.
-  This fix changes that behaviour by storing only those large values as string attributes instead.
+  When `use_existing` is set to true, the exporter assumes the bucket exists and skips creation entirely.
+  This is useful when bucket creation is managed externally or when the service account lacks bucket creation permissions.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/googlecloudstorageexporter/README.md
+++ b/exporter/googlecloudstorageexporter/README.md
@@ -25,7 +25,8 @@ This exporter writes received OpenTelemetry data to a cloud storage bucket.
 | `bucket.name`            | Name for the bucket storage.                                                                                                                                                                                             | Yes      |         |
 | `bucket.file_prefix`     | Prefix for the created filename. This prefix is applied after the partition path (if any).                                                                                                                               | No       | `logs`  |
 | `bucket.partition`       | Configuration for time-based partitioning. See below for details.                                                                                                                                                        | No       |         |
-| `bucket.reuse_if_exists` | If true, use the existing bucket if it already exists; if false, error if bucket exists.                                                                                                                                 | No       | `false` |
+| `bucket.use_existing`    | If true, skip bucket creation and assume the bucket already exists. Useful when bucket is managed externally or service account lacks creation permissions. Takes precedence over `reuse_if_exists`.                      | No       | `false` |
+| `bucket.reuse_if_exists` | If true, use the existing bucket if it already exists; if false, error if bucket exists. Ignored if `use_existing` is true.                                                                                              | No       | `false` |
 | `bucket.region`          | Region where the bucket will be created or where it exists. If left empty, it will query the metadata endpoint. It requires the collector to be running in a Google Cloud environment.                                   | Yes      |         |
 | `bucket.compression`     | Compression algorithm used to compress data before uploading. Valid values are `gzip`, `zstd`, or no value set for no compression.                                                                                        | No       |         |
 
@@ -74,4 +75,19 @@ exporters:
       file_prefix: logs
       partition:
         format: "year=%Y/month=%m/day=%d"
+```
+
+### Using Externally Managed Bucket
+
+When the bucket is managed outside of the collector (e.g., via Terraform, CloudFormation) or the service account lacks bucket creation permissions:
+
+```yaml
+exporters:
+  googlecloudstorage:
+    bucket:
+      name: existing-bucket
+      project_id: my-project
+      region: us-central1
+      use_existing: true
+      file_prefix: collector-logs
 ```

--- a/exporter/googlecloudstorageexporter/config.go
+++ b/exporter/googlecloudstorageexporter/config.go
@@ -44,10 +44,17 @@ type bucketConfig struct {
 	// Partition configures the time-based partition format and file prefix.
 	Partition partitionConfig `mapstructure:"partition"`
 
+	// UseExisting skips bucket creation and uses an existing bucket.
+	// When set to true, the exporter assumes the bucket already exists
+	// and will not attempt to create it. This is useful when bucket
+	// creation is managed externally or the service account lacks
+	// bucket creation permissions.
+	UseExisting bool `mapstructure:"use_existing"`
+
 	// ReuseIfExists decides if the bucket should be used if it already
 	// exists. If it is set to false, an error will be thrown if the
 	// bucket already exists. Otherwise, the existent bucket will be
-	// used.
+	// used. This flag is ignored if UseExisting is true.
 	ReuseIfExists bool `mapstructure:"reuse_if_exists"`
 
 	// Region where bucket will be created or where it exists. If it is left

--- a/exporter/googlecloudstorageexporter/config.schema.yaml
+++ b/exporter/googlecloudstorageexporter/config.schema.yaml
@@ -29,7 +29,10 @@ properties:
         description: Region where bucket will be created or where it exists. If it is left empty, it will query the metadata endpoint. It requires the collector to be running in a Google Cloud environment.
         type: string
       reuse_if_exists:
-        description: ReuseIfExists decides if the bucket should be used if it already exists. If it is set to false, an error will be thrown if the bucket already exists. Otherwise, the existent bucket will be used.
+        description: ReuseIfExists decides if the bucket should be used if it already exists. If it is set to false, an error will be thrown if the bucket already exists. Otherwise, the existent bucket will be used. This flag is ignored if UseExisting is true.
+        type: boolean
+      use_existing:
+        description: UseExisting skips bucket creation and uses an existing bucket. When set to true, the exporter assumes the bucket already exists and will not attempt to create it. This is useful when bucket creation is managed externally or the service account lacks bucket creation permissions.
         type: boolean
   encoding:
     x-pointer: true

--- a/exporter/googlecloudstorageexporter/exporter.go
+++ b/exporter/googlecloudstorageexporter/exporter.go
@@ -193,21 +193,27 @@ func (s *storageExporter) Start(ctx context.Context, host component.Host) error 
 	if err != nil {
 		return fmt.Errorf("failed to create storage client: %w", err)
 	}
-	err = client.Bucket(s.cfg.Bucket.Name).Create(ctx, s.cfg.Bucket.ProjectID, &storage.BucketAttrs{
-		Location: s.cfg.Bucket.Region,
-	})
-	if err != nil {
-		if !s.cfg.Bucket.ReuseIfExists {
-			return fmt.Errorf("failed to create storage bucket %q: %w", s.cfg.Bucket.Name, err)
-		}
-		if !isBucketConflictError(err) {
-			return fmt.Errorf("unexpected error creating the storage bucket %q: %w", s.cfg.Bucket.Name, err)
-		}
-		// otherwise bucket exists and will be reused
-		s.logger.Info("Existing bucket will be used", zap.String("bucket", s.cfg.Bucket.Name))
+
+	if s.cfg.Bucket.UseExisting {
+		s.logger.Info("Using existing bucket", zap.String("bucket", s.cfg.Bucket.Name))
 	} else {
-		s.logger.Info("Created bucket", zap.String("bucket", s.cfg.Bucket.Name))
+		err = client.Bucket(s.cfg.Bucket.Name).Create(ctx, s.cfg.Bucket.ProjectID, &storage.BucketAttrs{
+			Location: s.cfg.Bucket.Region,
+		})
+		if err != nil {
+			if !s.cfg.Bucket.ReuseIfExists {
+				return fmt.Errorf("failed to create storage bucket %q: %w", s.cfg.Bucket.Name, err)
+			}
+			if !isBucketConflictError(err) {
+				return fmt.Errorf("unexpected error creating the storage bucket %q: %w", s.cfg.Bucket.Name, err)
+			}
+			// otherwise bucket exists and will be reused
+			s.logger.Info("Existing bucket will be used", zap.String("bucket", s.cfg.Bucket.Name))
+		} else {
+			s.logger.Info("Created bucket", zap.String("bucket", s.cfg.Bucket.Name))
+		}
 	}
+
 	s.bucketHandle = client.Bucket(s.cfg.Bucket.Name)
 	s.storageClient = client
 	return nil

--- a/exporter/googlecloudstorageexporter/exporter_test.go
+++ b/exporter/googlecloudstorageexporter/exporter_test.go
@@ -224,6 +224,14 @@ func TestStart(t *testing.T) {
 		err := gcsExporter.Start(t.Context(), mHost)
 		require.NoError(t, err)
 	})
+
+	t.Run("use existing bucket without creation", func(t *testing.T) {
+		gcsExporter.cfg.Bucket.Name = bucketExistsName
+		gcsExporter.cfg.Bucket.UseExisting = true
+		gcsExporter.cfg.Bucket.ReuseIfExists = false
+		err := gcsExporter.Start(t.Context(), mHost)
+		require.NoError(t, err)
+	})
 }
 
 func TestUploadFile(t *testing.T) {


### PR DESCRIPTION
## Description

Adds a new `use_existing` configuration option to the Google Cloud Storage exporter that allows it to skip bucket creation entirely and assume the bucket already exists.

## Motivation

This is useful when:
- Bucket creation is managed externally (Terraform, CloudFormation, etc.)
- Service account lacks bucket creation permissions
- Organization policy requires bucket creation through separate processes

## Changes

- Added `use_existing` boolean field to bucket configuration
- Implemented two distinct code paths:
  - If `use_existing=true`: Skip creation entirely
  - If `use_existing=false`: Attempt creation with existing `reuse_if_exists` fallback behavior
- Updated documentation with configuration details and example
- Added test case for the new behavior
- Created changelog entry

## Backward Compatibility

The existing `reuse_if_exists` behavior is preserved for backward compatibility. When `use_existing` is true, it takes precedence and skips creation entirely.

## Testing

- All existing tests pass
- New test case added: `use_existing_bucket_without_creation`
- Linting passes

## Link to tracking Issue

Fixes #45968 