### PR TITLE
[receiver/prometheusreceiver] Fix counter metrics typed as Gauge with…

### DIFF
--- a/.chloggen/fix-prometheus-counter-metadata.yaml
+++ b/.chloggen/fix-prometheus-counter-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix counter metrics incorrectly typed as Gauge when metadata unavailable with Target Allocator
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34263]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusreceiver/internal/grouped_counter_test.go
+++ b/receiver/prometheusreceiver/internal/grouped_counter_test.go
@@ -1,0 +1,184 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/scrape"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// TestGroupedCounterMetrics tests that grouped counter metrics with multiple time series
+// are not silently dropped, as reported in issue #34263
+func TestGroupedCounterMetrics(t *testing.T) {
+	// Create a metadata store that knows about the counter metric
+	metadataStore := newFakeMetadataStore(map[string]scrape.MetricMetadata{
+		"cnpg_pg_stat_database_blks_read": {
+			MetricFamily: "cnpg_pg_stat_database_blks_read",
+			Type:         model.MetricTypeCounter,
+			Help:         "Number of disk blocks read in this database",
+		},
+		"cnpg_pg_stat_replication_flush_diff_bytes": {
+			MetricFamily: "cnpg_pg_stat_replication_flush_diff_bytes",
+			Type:         model.MetricTypeGauge,
+			Help:         "Difference in bytes from the last write-ahead log location flushed to disk by this standby server",
+		},
+	})
+
+	testGroupedCounterMetricsWithMetadata(t, metadataStore, "with metadata")
+}
+
+// TestGroupedCounterMetricsWithoutMetadata tests the case when metadata is not available
+// This reproduces the actual bug from issue #34263
+func TestGroupedCounterMetricsWithoutMetadata(t *testing.T) {
+	// Create an EMPTY metadata store to simulate the Target Allocator scenario
+	// where metadata may not be properly propagated
+	metadataStore := newFakeMetadataStore(map[string]scrape.MetricMetadata{})
+
+	testGroupedCounterMetricsWithMetadata(t, metadataStore, "without metadata")
+}
+
+func testGroupedCounterMetricsWithMetadata(t *testing.T, metadataStore *fakeMetadataStore, testName string) {
+	// Add scrape target to context (using the same pattern as transaction_test.go)
+	target := scrape.NewTarget(
+		labels.FromMap(map[string]string{
+			model.InstanceLabel: "localhost:8080",
+		}),
+		&config.ScrapeConfig{},
+		map[model.LabelName]model.LabelValue{
+			model.AddressLabel: "address:8080",
+			model.SchemeLabel:  "http",
+		},
+		nil,
+	)
+
+	ctx := scrape.ContextWithMetricMetadataStore(
+		scrape.ContextWithTarget(context.Background(), target),
+		metadataStore)
+
+	sink := new(consumertest.MetricsSink)
+
+	tr := newTransaction(
+		ctx,
+		sink,
+		labels.EmptyLabels(),
+		receivertest.NewNopSettings(receivertest.NopType),
+		nopObsRecv(t),
+		false, // trimSuffixes
+		true,  // useMetadata
+	)
+
+	// Simulate scraping grouped counter metrics (issue #34263)
+	// These should NOT be dropped
+	counterSamples := []struct {
+		name   string
+		labels labels.Labels
+		value  float64
+	}{
+		{
+			name:   "cnpg_pg_stat_database_blks_read",
+			labels: labels.FromStrings(model.MetricNameLabel, "cnpg_pg_stat_database_blks_read", "datname", "", model.JobLabel, "test-job", model.InstanceLabel, "test-instance"),
+			value:  122,
+		},
+		{
+			name:   "cnpg_pg_stat_database_blks_read",
+			labels: labels.FromStrings(model.MetricNameLabel, "cnpg_pg_stat_database_blks_read", "datname", "my-database", model.JobLabel, "test-job", model.InstanceLabel, "test-instance"),
+			value:  426,
+		},
+		{
+			name:   "cnpg_pg_stat_database_blks_read",
+			labels: labels.FromStrings(model.MetricNameLabel, "cnpg_pg_stat_database_blks_read", "datname", "postgres", model.JobLabel, "test-job", model.InstanceLabel, "test-instance"),
+			value:  359,
+		},
+	}
+
+	// Simulate scraping grouped gauge metrics (these work fine according to the issue)
+	gaugeSamples := []struct {
+		name   string
+		labels labels.Labels
+		value  float64
+	}{
+		{
+			name:   "cnpg_pg_stat_replication_flush_diff_bytes",
+			labels: labels.FromStrings(model.MetricNameLabel, "cnpg_pg_stat_replication_flush_diff_bytes", "application_name", "my-cnpg-cluster-2", "client_addr", "10.244.0.99/32", model.JobLabel, "test-job", model.InstanceLabel, "test-instance"),
+			value:  0,
+		},
+		{
+			name:   "cnpg_pg_stat_replication_flush_diff_bytes",
+			labels: labels.FromStrings(model.MetricNameLabel, "cnpg_pg_stat_replication_flush_diff_bytes", "application_name", "my-cnpg-cluster-3", "client_addr", "10.244.3.70/32", model.JobLabel, "test-job", model.InstanceLabel, "test-instance"),
+			value:  0,
+		},
+	}
+
+	// Append counter samples
+	for _, sample := range counterSamples {
+		_, err := tr.Append(0, sample.labels, 1000, sample.value)
+		require.NoError(t, err, "Failed to append counter sample %s", sample.name)
+	}
+
+	// Append gauge samples
+	for _, sample := range gaugeSamples {
+		_, err := tr.Append(0, sample.labels, 1000, sample.value)
+		require.NoError(t, err, "Failed to append gauge sample %s", sample.name)
+	}
+
+	// Commit the transaction
+	require.NoError(t, tr.Commit())
+
+	// Verify that metrics were created
+	require.Equal(t, 1, len(sink.AllMetrics()), "Expected 1 metrics batch")
+	md := sink.AllMetrics()[0]
+	require.Equal(t, 1, md.ResourceMetrics().Len(), "Expected 1 resource")
+
+	rm := md.ResourceMetrics().At(0)
+	require.Equal(t, 1, rm.ScopeMetrics().Len(), "Expected 1 scope")
+
+	sm := rm.ScopeMetrics().At(0)
+	metrics := sm.Metrics()
+
+	// Debug: print all metrics
+	t.Logf("%s: Found %d metrics", testName, metrics.Len())
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		t.Logf("%s: Metric %d: name=%s, type=%s", testName, i, m.Name(), m.Type())
+	}
+
+	// Find counter and gauge metrics
+	var counterMetric, gaugeMetric pmetric.Metric
+	for i := 0; i < metrics.Len(); i++ {
+		m := metrics.At(i)
+		if m.Name() == "cnpg_pg_stat_database_blks_read" {
+			counterMetric = m
+		}
+		if m.Name() == "cnpg_pg_stat_replication_flush_diff_bytes" {
+			gaugeMetric = m
+		}
+	}
+
+	// Verify gauge metric (should work)
+	require.NotEmpty(t, gaugeMetric.Name(), "Gauge metric should be present")
+	require.Equal(t, pmetric.MetricTypeGauge, gaugeMetric.Type(), "Expected gauge type")
+	require.Equal(t, 2, gaugeMetric.Gauge().DataPoints().Len(), "Expected 2 gauge data points")
+
+	// Verify counter metric (this is where the bug happens in issue #34263)
+	require.NotEmpty(t, counterMetric.Name(), "Counter metric should be present")
+
+	// Debug: check what type it actually is
+	t.Logf("%s: Counter metric type: %s", testName, counterMetric.Type())
+
+	// With the heuristic fix, counters should now be correctly typed as Sum even without metadata
+	require.Equal(t, pmetric.MetricTypeSum, counterMetric.Type(), "Expected sum type for counter")
+	require.Equal(t, 3, counterMetric.Sum().DataPoints().Len(), "Expected 3 counter data points")
+
+	// Verify that the counter is monotonic
+	require.True(t, counterMetric.Sum().IsMonotonic(), "Counter should be monotonic")
+}

--- a/receiver/prometheusreceiver/internal/metadata.go
+++ b/receiver/prometheusreceiver/internal/metadata.go
@@ -66,11 +66,74 @@ func metadataForMetric(metricName string, mc scrape.MetricMetadataStore) (*scrap
 		}
 		return &metadata, normalizedName
 	}
-	// Otherwise, the metric is unknown
+	// Otherwise, the metric is unknown.
+	// As a fallback, try to infer the type from the metric name to handle
+	// cases where metadata is not available (e.g., issue #34263).
+	// Use Prometheus naming conventions to detect counters.
+	if isLikelyCounter(metricName) {
+		return &scrape.MetricMetadata{
+			MetricFamily: normalizedName,
+			Type:         model.MetricTypeCounter,
+		}, metricName
+	}
+
 	return &scrape.MetricMetadata{
 		MetricFamily: metricName,
 		Type:         model.MetricTypeUnknown,
 	}, metricName
+}
+
+// isLikelyCounter uses heuristics to determine if a metric name likely represents a counter
+// when metadata is not available. This follows Prometheus naming conventions and common patterns.
+func isLikelyCounter(metricName string) bool {
+	// Explicit counter suffixes (Prometheus conventions)
+	// Note: _count is NOT included here because it's ambiguous - it could be part of
+	// histogram metrics (foo_count) or just a poorly named metric (some_count)
+	counterSuffixes := []string{
+		metricSuffixTotal,  // "_total" - most common and reliable counter suffix
+		"_created",         // timestamp when counter was created
+		"_bytes_total",     // total bytes
+		"_packets_total",   // total packets
+	}
+
+	for _, suffix := range counterSuffixes {
+		if strings.HasSuffix(metricName, suffix) {
+			return true
+		}
+	}
+
+	// Common counter patterns (operations that accumulate over time)
+	// These are substrings that indicate cumulative/monotonically increasing values
+	counterPatterns := []string{
+		"_read",      // bytes/blocks/records read (e.g., cnpg_pg_stat_database_blks_read)
+		"_written",   // bytes/blocks/records written
+		"_sent",      // messages/bytes sent
+		"_received",  // messages/bytes received
+		"_requests",  // number of requests
+		"_errors",    // number of errors
+		"_failures",  // number of failures
+		"_success",   // number of successes
+		"_hits",      // cache hits, etc.
+		"_misses",    // cache misses, etc.
+		"_packets",   // network packets
+		"_dropped",   // dropped packets/messages
+		"_processed", // processed items
+		"_completed", // completed operations
+		"_failed",    // failed operations
+		"_retries",   // retry attempts
+	}
+
+	for _, pattern := range counterPatterns {
+		if strings.Contains(metricName, pattern) {
+			// Avoid false positives: if it ends with "_ratio" or "_percent", it's likely a gauge
+			if strings.HasSuffix(metricName, "_ratio") || strings.HasSuffix(metricName, "_percent") {
+				continue
+			}
+			return true
+		}
+	}
+
+	return false
 }
 
 // isCounterCreatedLine determines whether a metric is a _created line for a counter appended by an om-text parser

--- a/receiver/prometheusreceiver/internal/metadata_test.go
+++ b/receiver/prometheusreceiver/internal/metadata_test.go
@@ -160,3 +160,53 @@ func (f fakeMetadataStore) SizeMetadata() int {
 func (f fakeMetadataStore) LengthMetadata() int {
 	return len(f.data)
 }
+
+func TestIsLikelyCounter(t *testing.T) {
+	testCases := []struct {
+		metricName string
+		expected   bool
+		reason     string
+	}{
+		// Explicit counter suffixes
+		{"http_requests_total", true, "has _total suffix"},
+		{"metric_created", true, "has _created suffix"},
+		{"data_bytes_total", true, "has _bytes_total suffix"},
+		{"network_packets_total", true, "has _packets_total suffix"},
+
+		// Common counter patterns (issue #34263)
+		{"cnpg_pg_stat_database_blks_read", true, "contains _read pattern"},
+		{"bytes_written", true, "contains _written pattern"},
+		{"messages_sent", true, "contains _sent pattern"},
+		{"messages_received", true, "contains _received pattern"},
+		{"http_requests", true, "contains _requests pattern"},
+		{"http_errors", true, "contains _errors pattern"},
+		{"operation_failures", true, "contains _failures pattern"},
+		{"cache_hits", true, "contains _hits pattern"},
+		{"cache_misses", true, "contains _misses pattern"},
+		{"packets_dropped", true, "contains _dropped pattern"},
+		{"items_processed", true, "contains _processed pattern"},
+		{"tasks_completed", true, "contains _completed pattern"},
+		{"operations_failed", true, "contains _failed pattern"},
+		{"request_retries", true, "contains _retries pattern"},
+
+		// Should NOT be detected as counters
+		{"cpu_usage", false, "gauge - current usage"},
+		{"memory_bytes", false, "gauge - current size"},
+		{"temperature_celsius", false, "gauge - current temperature"},
+		{"queue_length", false, "gauge - current queue length"},
+		{"active_connections", false, "gauge - current connections"},
+		{"some_count", false, "_count suffix is ambiguous without context"},
+		{"success_ratio", false, "ratio is a gauge even if contains success"},
+		{"error_percent", false, "percent is a gauge even if contains error"},
+		{"cache_hit_ratio", false, "ratio is a gauge even if contains hits"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.metricName, func(t *testing.T) {
+			result := isLikelyCounter(tc.metricName)
+			if result != tc.expected {
+				t.Errorf("Metric: %s - %s: expected %v, got %v", tc.metricName, tc.reason, tc.expected, result)
+			}
+		})
+	}
+}

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -70,6 +70,15 @@ func newMetricFamily(metricName string, mc scrape.MetricMetadataStore, logger *z
 		logger.Debug(fmt.Sprintf("Unknown-typed metric : %s %+v", metricName, metadata))
 	}
 
+	// Log a warning if metadata type is Unknown and being treated as Gauge
+	// This helps diagnose issues like #34263 where counter metrics are silently dropped
+	if metadata.Type == model.MetricTypeUnknown && mtype == pmetric.MetricTypeGauge {
+		logger.Debug("Metric has no type metadata, treating as gauge",
+			zap.String("metric_name", metricName),
+			zap.String("family_name", familyName),
+		)
+	}
+
 	return &metricFamily{
 		mtype:       mtype,
 		isMonotonic: isMonotonic,

--- a/receiver/prometheusreceiver/issue_34263_test.go
+++ b/receiver/prometheusreceiver/issue_34263_test.go
@@ -1,0 +1,151 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// TestIssue34263_GroupedCounterMetrics reproduces issue #34263 where grouped counter metrics
+// are silently dropped. This test uses the actual Prometheus scrape output from the issue.
+//
+// Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34263
+//
+// The problem occurs when:
+// 1. Multiple time series share the same counter metric name with different labels
+// 2. Metadata (# TYPE declarations) may not be properly propagated
+// 3. Counter metrics get treated as gauges and are dropped
+func TestIssue34263_GroupedCounterMetrics(t *testing.T) {
+	// This is the actual Prometheus scrape output from issue #34263
+	// It contains grouped counter metrics (cnpg_pg_stat_database_blks_read)
+	// and grouped gauge metrics (cnpg_pg_stat_replication_flush_diff_bytes)
+	promData := `
+# HELP cnpg_pg_stat_database_blks_read Number of disk blocks read in this database
+# TYPE cnpg_pg_stat_database_blks_read counter
+cnpg_pg_stat_database_blks_read{datname=""} 122
+cnpg_pg_stat_database_blks_read{datname="my-database"} 426
+cnpg_pg_stat_database_blks_read{datname="postgres"} 359
+cnpg_pg_stat_database_blks_read{datname="template0"} 0
+cnpg_pg_stat_database_blks_read{datname="template1"} 1379
+# HELP cnpg_pg_stat_replication_flush_diff_bytes Difference in bytes from the last write-ahead log location flushed to disk by this standby server
+# TYPE cnpg_pg_stat_replication_flush_diff_bytes gauge
+cnpg_pg_stat_replication_flush_diff_bytes{application_name="my-cnpg-cluster-2",client_addr="10.244.0.99/32",client_port="53160",usename="streaming_replica"} 0
+cnpg_pg_stat_replication_flush_diff_bytes{application_name="my-cnpg-cluster-3",client_addr="10.244.3.70/32",client_port="47804",usename="streaming_replica"} 0
+`
+
+	targets := []*testData{
+		{
+			name: "issue_34263_grouped_counters",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: promData},
+			},
+			validateFunc: func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+				require.NotEmpty(t, mds, "At least one resource metric should be present")
+
+				metrics := getMetrics(mds[0])
+
+				// Find the counter and gauge metrics
+				var counterMetric, gaugeMetric pmetric.Metric
+				var foundCounter, foundGauge bool
+
+				for _, m := range metrics {
+					switch m.Name() {
+					case "cnpg_pg_stat_database_blks_read":
+						counterMetric = m
+						foundCounter = true
+					case "cnpg_pg_stat_replication_flush_diff_bytes":
+						gaugeMetric = m
+						foundGauge = true
+					}
+				}
+
+				// Verify gauge metric is present (this should work)
+				require.True(t, foundGauge, "Gauge metric 'cnpg_pg_stat_replication_flush_diff_bytes' should be present")
+				require.Equal(t, pmetric.MetricTypeGauge, gaugeMetric.Type(), "Expected gauge type")
+				require.Equal(t, 2, gaugeMetric.Gauge().DataPoints().Len(), "Expected 2 gauge data points")
+
+				// Verify counter metric is present (THIS IS THE BUG - it gets dropped or mistyped)
+				require.True(t, foundCounter, "Counter metric 'cnpg_pg_stat_database_blks_read' should be present (BUG: gets dropped in issue #34263)")
+				require.Equal(t, pmetric.MetricTypeSum, counterMetric.Type(), "Expected sum type for counter metric")
+				require.Equal(t, 5, counterMetric.Sum().DataPoints().Len(), "Expected 5 counter data points")
+				require.True(t, counterMetric.Sum().IsMonotonic(), "Counter should be monotonic")
+
+				// Verify the actual values are present
+				// Note: We just verify we have the correct number of data points
+				// The label filtering behavior may vary, so we don't assert on specific attribute values
+				t.Logf("Counter metric has %d data points (expected 5)", counterMetric.Sum().DataPoints().Len())
+			},
+			validateScrapes: true,
+		},
+	}
+
+	testComponent(t, targets, nil)
+}
+
+// TestIssue34263_WithMoreCounterPatterns tests additional counter patterns
+// that should be recognized even without metadata
+func TestIssue34263_WithMoreCounterPatterns(t *testing.T) {
+	// Additional test with common counter patterns from real-world Prometheus exporters
+	promData := `
+# HELP http_requests_total Total HTTP requests
+# TYPE http_requests_total counter
+http_requests_total{method="GET",status="200"} 1234
+http_requests_total{method="POST",status="201"} 567
+# HELP bytes_written Total bytes written
+# TYPE bytes_written counter
+bytes_written{device="sda"} 10485760
+bytes_written{device="sdb"} 20971520
+# HELP packets_received Total packets received
+# TYPE packets_received counter
+packets_received{interface="eth0"} 5000
+packets_received{interface="eth1"} 3000
+# HELP cache_hits Cache hits
+# TYPE cache_hits counter
+cache_hits{cache="redis"} 9876
+cache_hits{cache="memcached"} 5432
+`
+
+	targets := []*testData{
+		{
+			name: "issue_34263_various_counter_patterns",
+			pages: []mockPrometheusResponse{
+				{code: 200, data: promData},
+			},
+			validateFunc: func(t *testing.T, td *testData, mds []pmetric.ResourceMetrics) {
+				require.NotEmpty(t, mds, "At least one resource metric should be present")
+
+				metrics := getMetrics(mds[0])
+
+				// All of these should be recognized as counters
+				counterNames := []string{
+					"http_requests_total",
+					"bytes_written",
+					"packets_received",
+					"cache_hits",
+				}
+
+				for _, name := range counterNames {
+					found := false
+					for _, m := range metrics {
+						if m.Name() == name {
+							found = true
+							require.Equal(t, pmetric.MetricTypeSum, m.Type(),
+								"Metric '%s' should be typed as Sum (counter)", name)
+							require.True(t, m.Sum().IsMonotonic(),
+								"Metric '%s' should be monotonic", name)
+							break
+						}
+					}
+					require.True(t, found, "Counter metric '%s' should be present", name)
+				}
+			},
+			validateScrapes: true,
+		},
+	}
+
+	testComponent(t, targets, nil)
+}


### PR DESCRIPTION
Summary

Fixes #34263 

Counter metrics are now correctly typed as Sum even when metadata is unavailable (e.g., when using Target Allocator).

## Problem

When using Target Allocator, counter metrics were being incorrectly typed as Gauge instead of Sum when the MetricMetadataStore doesn't contain TYPE information from `# TYPE` declarations. This caused grouped counter metrics like `cnpg_pg_stat_database_blks_read` to appear "silently dropped" since they were typed incorrectly.

## Solution

Implemented fallback heuristics to detect counter metrics from metric names using Prometheus naming conventions when metadata is unavailable:

**Explicit counter suffixes:**
- `_total` (most reliable)
- `_created` 
- `_bytes_total`
- `_packets_total`

**Common counter patterns:**
- Operations: `_read`, `_written`, `_sent`, `_received`, `_processed`, `_completed`
- Events: `_requests`, `_errors`, `_failures`, `_hits`, `_misses`, `_dropped`, `_retries`

**False positive protection:**
- Excludes metrics ending with `_ratio` or `_percent`
- Excludes ambiguous `_count` suffix (could be histogram or poorly named metric)

## Changes

- `metadata.go`: Added `isLikelyCounter()` heuristic function
- `metadata_test.go`: Added comprehensive tests for counter detection (20+ patterns)
- `metricfamily.go`: Added diagnostic logging when Unknown types default to Gauge
- `grouped_counter_test.go`: Test reproducing and verifying the fix for #34263

