### PR TITLE
[chore] update auto assign users list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -12,17 +12,19 @@ assigneeGroups:
   approvers_maintainers:
     # Approvers
     - ArthurSens
+    - axw
     - braydonk
-    - ChrsMark
     - crobert-1
     - dashpole
     - dehaansa
-    - mwear
     - fatsheep9146
+    - pjanotti
+    - VihasMakwana
     # Maintainers
     - andrzej-stencel
     - atoulme
     - bogdandrutu
+    - ChrsMark
     - codeboten
     - dmitryax
     - edmocosta


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

I identified that this list was not updated after the merge of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45908. So, I take the initiative to update it.

If it does not make sense to match the users described in the README.md, please close this PR. 🙏 