### PR TITLE
[pkg/ottl] support slice paths in Concat

### DIFF
--- a/.chloggen/pkg-ottl-concat-slice-paths.yaml
+++ b/.chloggen/pkg-ottl-concat-slice-paths.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Extend `Concat` to accept slice-valued paths and converter outputs (e.g. `Concat(Split(...), ";")`) in addition to literal lists
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38690, 27821]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -614,6 +614,18 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Concat(attributes["primitiveValuesSlice"], ";"))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "value1;42;true")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Concat(Split(attributes["flags"], "|"), ";"))`,
+			want: func(tCtx *ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "A;B;C")
+			},
+		},
+		{
 			statement: `set(attributes["test"], ConvertCase(attributes["http.method"], "upper"))`,
 			want: func(tCtx *ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", http.MethodGet)

--- a/pkg/ottl/e2e/profiles/e2e_test.go
+++ b/pkg/ottl/e2e/profiles/e2e_test.go
@@ -568,6 +568,18 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Concat(attributes["primitiveValuesSlice"], ";"))`,
+			want: func(_ *testing.T, tCtx *ottlprofile.TransformContext) {
+				putProfileAttribute(t, tCtx, "test", "value1;42;true")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Concat(Split(attributes["flags"], "|"), ";"))`,
+			want: func(_ *testing.T, tCtx *ottlprofile.TransformContext) {
+				putProfileAttribute(t, tCtx, "test", "A;B;C")
+			},
+		},
+		{
 			statement: `set(attributes["test"], ConvertCase(attributes["http.method"], "upper"))`,
 			want: func(_ *testing.T, tCtx *ottlprofile.TransformContext) {
 				putProfileAttribute(t, tCtx, "test", http.MethodGet)
@@ -1636,6 +1648,7 @@ func constructProfileTransformContext() *ottlprofile.TransformContext {
 				map[string]any{"name": "foo", "value": 2},
 				map[string]any{"name": "bar", "value": 5},
 			}},
+			{Key: "primitiveValuesSlice", Value: []any{"value1", 42, true}},
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -649,11 +649,14 @@ Examples:
 
 ### Concat
 
-`Concat(values[], delimiter)`
+`Concat(values, delimiter)`
 
-The `Concat` Converter takes a sequence of values and a delimiter and concatenates their string representation. Unsupported values, such as lists or maps that may substantially increase payload size, are not added to the resulting string.
+The `Concat` Converter takes a sequence of values and a delimiter and concatenates their string representation.
 
-`values` is a list of values. It supports paths, primitive values, and byte slices (such as trace IDs or span IDs).
+`values` is either:
+
+- a list of values, which supports paths, primitive values, and byte slices (such as trace IDs or span IDs)
+- a path expression or converter result resolving to a slice
 
 `delimiter` is a string value that is placed between strings during concatenation. If no delimiter is desired, then simply pass an empty string.
 
@@ -666,6 +669,9 @@ Examples:
 
 
 - `Concat(["HTTP method is: ", span.attributes["http.method"]], "")`
+
+
+- `Concat(log.attributes["tags"], ",")`
 
 ### ContainsValue
 

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -5,15 +5,18 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
-	"fmt"
+	"strconv"
 	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type ConcatArguments[K any] struct {
-	Vals      []ottl.StringLikeGetter[K]
+	Vals      ottl.PSliceGetter[K]
 	Delimiter ottl.StringGetter[K]
 }
 
@@ -31,27 +34,51 @@ func createConcatFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (
 	return concat(args.Vals, args.Delimiter), nil
 }
 
-func concat[K any](vals []ottl.StringLikeGetter[K], delimiter ottl.StringGetter[K]) ottl.ExprFunc[K] {
+func concat[K any](vals ottl.PSliceGetter[K], delimiter ottl.StringGetter[K]) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (any, error) {
 		builder := strings.Builder{}
 		delimiterVal, err := delimiter.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		for i, rv := range vals {
-			val, err := rv.Get(ctx, tCtx)
-			if err != nil {
-				return nil, err
-			}
-			if val == nil {
-				builder.WriteString(fmt.Sprint(val))
-			} else {
-				builder.WriteString(*val)
-			}
-			if i != len(vals)-1 {
+
+		sliceVals, err := vals.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		wroteValue := false
+		for i := 0; i < sliceVals.Len(); i++ {
+			val := sliceVals.At(i)
+			valString := concatValueString(val)
+
+			if wroteValue {
 				builder.WriteString(delimiterVal)
 			}
+			builder.WriteString(valString)
+			wroteValue = true
 		}
 		return builder.String(), nil
+	}
+}
+
+func concatValueString(v pcommon.Value) string {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return v.Str()
+	case pcommon.ValueTypeInt:
+		return strconv.FormatInt(v.Int(), 10)
+	case pcommon.ValueTypeDouble:
+		return strconv.FormatFloat(v.Double(), 'g', -1, 64)
+	case pcommon.ValueTypeBool:
+		return strconv.FormatBool(v.Bool())
+	case pcommon.ValueTypeBytes:
+		return hex.EncodeToString(v.Bytes().AsRaw())
+	case pcommon.ValueTypeEmpty:
+		return "<nil>"
+	case pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
+		return v.AsString()
+	default:
+		return v.AsString()
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -17,210 +17,118 @@ import (
 func Test_concat(t *testing.T) {
 	tests := []struct {
 		name      string
-		vals      []ottl.StandardStringLikeGetter[any]
+		vals      any
 		delimiter ottl.StringGetter[any]
 		expected  string
 	}{
 		{
-			name: "concat strings",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "world", nil
-					},
-				},
-			},
+			name:      "concat strings",
+			vals:      []any{"hello", "world"},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return " ", nil }},
 			expected:  "hello world",
 		},
 		{
-			name: "nil",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return nil, nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "world", nil
-					},
-				},
-			},
+			name:      "nil",
+			vals:      []any{"hello", nil, "world"},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "", nil }},
 			expected:  "hello<nil>world",
 		},
 		{
-			name: "integers",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return int64(1), nil
-					},
-				},
-			},
+			name:      "integers",
+			vals:      []any{"hello", int64(1)},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "", nil }},
 			expected:  "hello1",
 		},
 		{
-			name: "floats",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return 3.14159, nil
-					},
-				},
-			},
+			name:      "floats",
+			vals:      []any{"hello", 3.14159},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "", nil }},
 			expected:  "hello3.14159",
 		},
 		{
-			name: "booleans",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return true, nil
-					},
-				},
-			},
+			name:      "booleans",
+			vals:      []any{"hello", true},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return " ", nil }},
 			expected:  "hello true",
 		},
 		{
-			name: "byte slices",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}, nil
-					},
-				},
-			},
+			name:      "byte slices",
+			vals:      []any{[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "", nil }},
 			expected:  "00000000000000000ed2e63cbe71f5a8",
 		},
 		{
 			name: "pcommon.Slice",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						s := pcommon.NewSlice()
-						_ = s.FromRaw([]any{1, 2})
-						return s, nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						s := pcommon.NewSlice()
-						_ = s.FromRaw([]any{3, 4})
-						return s, nil
-					},
-				},
-			},
+			vals: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				_ = s.FromRaw([]any{[]any{1, 2}, []any{3, 4}})
+				return s
+			}(),
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return ",", nil }},
 			expected:  "[1,2],[3,4]",
 		},
 		{
 			name: "maps",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						m := pcommon.NewMap()
-						m.PutStr("a", "b")
-						return m, nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						m := pcommon.NewMap()
-						m.PutStr("c", "d")
-						return m, nil
-					},
-				},
-			},
+			vals: func() pcommon.Slice {
+				s := pcommon.NewSlice()
+				s.EnsureCapacity(2)
+				s.AppendEmpty().SetEmptyMap().PutStr("a", "b")
+				s.AppendEmpty().SetEmptyMap().PutStr("c", "d")
+				return s
+			}(),
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return ",", nil }},
 			expected:  `{"a":"b"},{"c":"d"}`,
 		},
 		{
-			name: "empty string values",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "", nil
-					},
-				},
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "", nil
-					},
-				},
-			},
+			name:      "empty string values",
+			vals:      []any{"", "", ""},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "__", nil }},
 			expected:  "____",
 		},
 		{
-			name: "single argument",
-			vals: []ottl.StandardStringLikeGetter[any]{
-				{
-					Getter: func(context.Context, any) (any, error) {
-						return "hello", nil
-					},
-				},
-			},
+			name:      "single argument",
+			vals:      []any{"hello"},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "-", nil }},
 			expected:  "hello",
 		},
 		{
 			name:      "no arguments",
-			vals:      []ottl.StandardStringLikeGetter[any]{},
+			vals:      []any{},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "-", nil }},
 			expected:  "",
 		},
 		{
 			name:      "no arguments with an empty delimiter",
-			vals:      []ottl.StandardStringLikeGetter[any]{},
+			vals:      []any{},
 			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "", nil }},
 			expected:  "",
+		},
+		{
+			name:      "native string slice",
+			vals:      []string{"hello", "world"},
+			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return ":", nil }},
+			expected:  "hello:world",
+		},
+		{
+			name: "pcommon.Value slice",
+			vals: func() pcommon.Value {
+				v := pcommon.NewValueSlice()
+				v.Slice().AppendEmpty().SetStr("hello")
+				v.Slice().AppendEmpty().SetInt(7)
+				return v
+			}(),
+			delimiter: ottl.StandardStringGetter[any]{Getter: func(context.Context, any) (any, error) { return "-", nil }},
+			expected:  "hello-7",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			getters := make([]ottl.StringLikeGetter[any], len(tt.vals))
-
-			for i, val := range tt.vals {
-				getters[i] = val
+			valsGetter := ottl.StandardPSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return tt.vals, nil
+				},
 			}
-
-			exprFunc := concat(getters, tt.delimiter)
+			exprFunc := concat(valsGetter, tt.delimiter)
 			result, err := exprFunc(nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -229,7 +137,7 @@ func Test_concat(t *testing.T) {
 }
 
 func Test_concat_error(t *testing.T) {
-	target := &ottl.StandardStringLikeGetter[any]{
+	target := &ottl.StandardPSliceGetter[any]{
 		Getter: func(context.Context, any) (any, error) {
 			return make(chan int), nil
 		},
@@ -239,15 +147,15 @@ func Test_concat_error(t *testing.T) {
 			return "test", nil
 		},
 	}
-	exprFunc := concat[any]([]ottl.StringLikeGetter[any]{target}, delimiter)
+	exprFunc := concat[any](target, delimiter)
 	_, err := exprFunc(t.Context(), nil)
-	assert.Error(t, err)
+	assert.EqualError(t, err, "expected pcommon.Slice but got chan int")
 }
 
 func Test_concat_error_delimiter(t *testing.T) {
-	target := &ottl.StandardStringLikeGetter[any]{
+	target := &ottl.StandardPSliceGetter[any]{
 		Getter: func(context.Context, any) (any, error) {
-			return make(chan int), nil
+			return []any{"a"}, nil
 		},
 	}
 	delimiter := &ottl.StandardStringGetter[any]{
@@ -255,7 +163,7 @@ func Test_concat_error_delimiter(t *testing.T) {
 			return 3, nil
 		},
 	}
-	exprFunc := concat[any]([]ottl.StringLikeGetter[any]{target}, delimiter)
+	exprFunc := concat[any](target, delimiter)
 	_, err := exprFunc(t.Context(), nil)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This updates Concat to accept a single slice input (`PSliceGetter`) instead of only a literal list of `StringLikeGetters`.
It allows statements like:
`Concat(attributes["primitiveValuesSlice"], ";")`
`Concat(Split(attributes["flags"], "|"), ";")`
 while preserving the existing literal-list behavior like `Concat(["A","B"], ":")`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #27821
Fixes #38690



<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit tests for Concat with slice inputs `([]any, []string, pcommon.Value slice, maps, nested slices)`
e2e converter coverage for: `Concat(attributes["primitiveValuesSlice"], ";")` amd `Concat(Split(attributes["flags"], "|"), ";")`


[benchmarks run gist](https://gist.github.com/ShaanveerS/a871f06144f8f0259ae04b853c9b0fae)
<!--Describe the documentation added.-->
#### Documentation
Updated `pkg/ottl/ottlfuncs/README.md`.