### PR TITLE
bump minimum version to go 1.25

### DIFF
--- a/.chloggen/codeboten_update-go-126.yaml
+++ b/.chloggen/codeboten_update-go-126.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Increase minimum Go version to 1.25
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46000]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/codecovgen/go.mod
+++ b/cmd/codecovgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/codecovgen
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/cmd/golden/go.mod
+++ b/cmd/golden/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/golden
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -375,17 +375,13 @@ func (s *Supervisor) Start(ctx context.Context) error {
 		return err
 	}
 
-	s.agentWG.Add(1)
-	go func() {
-		defer s.agentWG.Done()
+	s.agentWG.Go(func() {
 		s.runAgentProcess()
-	}()
+	})
 
-	s.customMessageWG.Add(1)
-	go func() {
-		defer s.customMessageWG.Done()
+	s.customMessageWG.Go(func() {
 		s.forwardCustomMessagesToServerLoop()
-	}()
+	})
 
 	return nil
 }
@@ -778,14 +774,12 @@ func (s *Supervisor) startHealthCheckServer() error {
 		return fmt.Errorf("failed to listen on port %d: %w", healthCheckServerPort, err)
 	}
 
-	s.healthCheckServerWG.Add(1)
-	go func() {
-		defer s.healthCheckServerWG.Done()
+	s.healthCheckServerWG.Go(func() {
 		s.telemetrySettings.Logger.Debug("Starting health check server", zap.Int64("port", healthCheckServerPort))
 		if err := s.healthCheckServer.Serve(listener); err != nil && err != http.ErrServerClosed {
 			s.telemetrySettings.Logger.Error("Health check server failed", zap.Error(err))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -2260,9 +2260,7 @@ func TestRemoteConfigConcurrentAccess(t *testing.T) {
 	startSignal := make(chan struct{})
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-startSignal
 		for i := range 1000 {
 			if i%2 == 0 {
@@ -2271,11 +2269,9 @@ func TestRemoteConfigConcurrentAccess(t *testing.T) {
 				s.remoteConfig.Store(config2)
 			}
 		}
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-startSignal
 		for range 1000 {
 			cfg := s.remoteConfig.Load()
@@ -2283,7 +2279,7 @@ func TestRemoteConfigConcurrentAccess(t *testing.T) {
 				_ = cfg.GetConfigHash()
 			}
 		}
-	}()
+	})
 
 	close(startSignal)
 	wg.Wait()

--- a/cmd/schemagen/go.mod
+++ b/cmd/schemagen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/schemagen
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/iancoleman/strcase v0.3.0

--- a/cmd/telemetrygen/go.mod
+++ b/cmd/telemetrygen/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/cmd/telemetrygen/internal/e2etest/go.mod
+++ b/cmd/telemetrygen/internal/e2etest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/e2etest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen v0.145.0

--- a/confmap/provider/aesprovider/go.mod
+++ b/confmap/provider/aesprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/aesprovider
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/confmap/provider/googlesecretmanagerprovider/go.mod
+++ b/confmap/provider/googlesecretmanagerprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/googlesecretmanagerprovider
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0

--- a/confmap/provider/s3provider/go.mod
+++ b/confmap/provider/s3provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/confmap/provider/secretsmanagerprovider/go.mod
+++ b/confmap/provider/secretsmanagerprovider/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/secretsmanagerprovider
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7

--- a/connector/countconnector/go.mod
+++ b/connector/countconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.145.0

--- a/connector/exceptionsconnector/go.mod
+++ b/connector/exceptionsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/exceptionsconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/connector/failoverconnector/go.mod
+++ b/connector/failoverconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/grafanacloudconnector/go.mod
+++ b/connector/grafanacloudconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/metricsaslogsconnector/go.mod
+++ b/connector/metricsaslogsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/metricsaslogsconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/otlpjsonconnector/go.mod
+++ b/connector/otlpjsonconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/connector/roundrobinconnector/go.mod
+++ b/connector/roundrobinconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/roundrobinconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.145.0

--- a/connector/servicegraphconnector/go.mod
+++ b/connector/servicegraphconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/signaltometricsconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/connector/slowsqlconnector/go.mod
+++ b/connector/slowsqlconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/slowsqlconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/connector/spanmetricsconnector/go.mod
+++ b/connector/spanmetricsconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/connector/sumconnector/go.mod
+++ b/connector/sumconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0

--- a/exporter/alertmanagerexporter/go.mod
+++ b/exporter/alertmanagerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.83

--- a/exporter/awscloudwatchlogsexporter/go.mod
+++ b/exporter/awscloudwatchlogsexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/smithy-go v1.24.0

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/exporter/awss3exporter/go.mod
+++ b/exporter/awss3exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/exporter/azureblobexporter/go.mod
+++ b/exporter/azureblobexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azureblobexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/exporter/azuredataexplorerexporter/go.mod
+++ b/exporter/azuredataexplorerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuredataexplorerexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.0

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/microsoft/ApplicationInsights-Go v0.4.4

--- a/exporter/bmchelixexporter/go.mod
+++ b/exporter/bmchelixexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/bmchelixexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/exporter/cassandraexporter/go.mod
+++ b/exporter/cassandraexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/cassandraexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/apache/cassandra-gocql-driver/v2 v2.0.0

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.42.0

--- a/exporter/coralogixexporter/go.mod
+++ b/exporter/coralogixexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -222,7 +222,7 @@ func (*factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, sta
 					statsWriter.Write(sp)
 				}
 			}
-		}()
+		})
 	}
 }
 

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -164,11 +164,9 @@ func (*factory) TraceAgent(ctx context.Context, wg *sync.WaitGroup, params expor
 	if err != nil {
 		return nil, err
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		agnt.Run()
-	}()
+	})
 	return agnt, nil
 }
 
@@ -201,9 +199,7 @@ func (*factory) createDefaultConfig() component.Config {
 
 func (*factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, statsIn <-chan []byte, statsWriter *writer.DatadogStatsWriter, tracerVersion, agentVersion string, logger *zap.Logger) {
 	for i := 0; i < runtime.NumCPU(); i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-ctx.Done():

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.180

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/integrationtest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.180

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -88,11 +88,9 @@ func TestIntegration(t *testing.T) {
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()
@@ -287,11 +285,9 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_toplevel_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()
@@ -480,11 +476,9 @@ func TestIntegrationLogs(t *testing.T) {
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_logs_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()
@@ -637,11 +631,9 @@ func testIntegrationHostMetrics(t *testing.T, expectedMetrics map[string]struct{
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_host_metrics_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()
@@ -787,11 +779,9 @@ func testIntegrationInternalMetrics(t *testing.T, expectedMetrics map[string]str
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_internal_metrics_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()
@@ -842,11 +832,9 @@ func TestIntegrationLogsHostMetadata(t *testing.T) {
 	factories := getIntegrationTestComponents(t)
 	app := getIntegrationTestCollector(t, "integration_test_logs_only_host_metadata_config.yaml", factories)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		_ = app.Run(t.Context()) // ignore shutdown error, core collector has race in shutdown: https://github.com/open-telemetry/opentelemetry-collector/issues/12944
-		wg.Done()
-	}()
+	})
 	defer func() {
 		app.Shutdown()
 		wg.Wait()

--- a/exporter/datasetexporter/go.mod
+++ b/exporter/datasetexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datasetexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/dorisexporter/go.mod
+++ b/exporter/dorisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	// https://github.com/go-sql-driver/mysql/issues/1602; https://github.com/apache/doris/pull/32177

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/exporter/elasticsearchexporter/integrationtest/go.mod
+++ b/exporter/elasticsearchexporter/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/integrationtest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/elastic/go-docappender/v2 v2.12.1

--- a/exporter/faroexporter/go.mod
+++ b/exporter/faroexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/faroexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DeRuina/timberjack v1.3.9

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.55.0

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.4.0

--- a/exporter/googlecloudstorageexporter/go.mod
+++ b/exporter/googlecloudstorageexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudstorageexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.55.0

--- a/exporter/honeycombmarkerexporter/go.mod
+++ b/exporter/honeycombmarkerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombmarkerexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0

--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.7

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -560,11 +560,9 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 				consumeCh <- struct{}{}
 				return
 			case <-ticker.C:
-				waitWG.Add(1)
-				go func() {
+				waitWG.Go(func() {
 					assert.NoError(t, p.ConsumeLogs(ctx, randomLogs()))
-					waitWG.Done()
-				}()
+				})
 			}
 		}
 	}(ctx)

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -698,11 +698,9 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 				consumeCh <- struct{}{}
 				return
 			case <-ticker.C:
-				waitWG.Add(1)
-				go func() {
+				waitWG.Go(func() {
 					assert.NoError(t, p.ConsumeTraces(ctx, randomTraces()))
-					waitWG.Done()
-				}()
+				})
 			}
 		}
 	}(ctx)

--- a/exporter/logicmonitorexporter/go.mod
+++ b/exporter/logicmonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/logicmonitor/lm-data-sdk-go v1.3.4

--- a/exporter/logzioexporter/go.mod
+++ b/exporter/logzioexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3

--- a/exporter/mezmoexporter/go.mod
+++ b/exporter/mezmoexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/mezmoexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/opensearchexporter/go.mod
+++ b/exporter/opensearchexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.145.0

--- a/exporter/otelarrowexporter/internal/arrow/stream.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream.go
@@ -187,14 +187,12 @@ func (s *Stream) run(ctx context.Context, dc doneCancel, streamClient StreamClie
 	var ww sync.WaitGroup
 
 	var writeErr error
-	ww.Add(1)
-	go func() {
-		defer ww.Done()
+	ww.Go(func() {
 		writeErr = s.write(ctx)
 		if writeErr != nil {
 			dc.cancel()
 		}
-	}()
+	})
 
 	// the result from read() is processed after cancel and wait,
 	// so we can set s.client = nil in case of a delayed Unimplemented.

--- a/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -77,12 +77,9 @@ func newStreamTestCase(t *testing.T, pname PrioritizerName) *streamTestCase {
 func (tc *streamTestCase) start(channel testChannel) {
 	tc.traceCall.Times(1).DoAndReturn(tc.connectTestStream(channel))
 
-	tc.wait.Add(1)
-
-	go func() {
-		defer tc.wait.Done()
+	tc.wait.Go(func() {
 		tc.stream.run(tc.bgctx, tc.doneCancel, tc.traceClient, nil)
-	}()
+	})
 }
 
 // cancelAndWait cancels the context and waits for the runner to return.

--- a/exporter/prometheusexporter/accumulator_bench_test.go
+++ b/exporter/prometheusexporter/accumulator_bench_test.go
@@ -112,13 +112,11 @@ func BenchmarkAccumulatorConcurrent(b *testing.B) {
 			iterations := max(b.N/concurrency, 1)
 
 			for range concurrency {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					for range iterations {
 						accumulator.Accumulate(resourceMetrics)
 					}
-				}()
+				})
 			}
 
 			wg.Wait()

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -241,11 +241,9 @@ func Test_Shutdown(t *testing.T) {
 	require.NoError(t, err)
 	errChan := make(chan error, 5)
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errChan <- prwe.PushMetrics(t.Context(), pmetric.NewMetrics())
-		}()
+		})
 	}
 	wg.Wait()
 	close(errChan)

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/pulsarexporter/go.mod
+++ b/exporter/pulsarexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/pulsarexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0

--- a/exporter/rabbitmqexporter/go.mod
+++ b/exporter/rabbitmqexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/rabbitmqexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -1,7 +1,7 @@
 // Deprecated: [v0.143.0] Use OTLP exporter instead
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/sematextexporter/go.mod
+++ b/exporter/sematextexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sematextexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/sentryexporter/go.mod
+++ b/exporter/sentryexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/getsentry/sentry-go v0.42.0

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/stefexporter/go.mod
+++ b/exporter/stefexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/stefexporter/internal/connmanager_test.go
+++ b/exporter/stefexporter/internal/connmanager_test.go
@@ -194,15 +194,13 @@ func TestConnManagerAcquireReleaseConcurrent(t *testing.T) {
 			test: func(cm *ConnManager) {
 				var wg sync.WaitGroup
 				for range 100 {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						conn, err := cm.Acquire(t.Context())
 						if err != nil {
 							return
 						}
 						cm.Release(t.Context(), conn)
-					}()
+					})
 				}
 				wg.Wait()
 			},
@@ -228,15 +226,13 @@ func TestConnManagerAcquireDiscardConcurrent(t *testing.T) {
 			test: func(cm *ConnManager) {
 				var wg sync.WaitGroup
 				for range 100 {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						conn, err := cm.Acquire(t.Context())
 						if err != nil {
 							return
 						}
 						cm.DiscardAndClose(conn)
-					}()
+					})
 				}
 				wg.Wait()
 			},

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -520,16 +520,14 @@ func Benchmark_ExporterPushLogs(b *testing.B) {
 	for b.Loop() {
 		wg := sync.WaitGroup{}
 		for range 10 {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				logs := logRecordsToLogs(exampleNLogs(128))
 				logs.MarkReadOnly()
 				err := exp.pushLogsData(b.Context(), logs)
 				if err != nil {
 					b.Logf("Failed pushing logs: %v", err)
 				}
-				wg.Done()
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/klauspost/compress v1.18.4

--- a/exporter/syslogexporter/go.mod
+++ b/exporter/syslogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/syslogexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/exporter/tencentcloudlogserviceexporter/go.mod
+++ b/exporter/tencentcloudlogserviceexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/exporter/tinybirdexporter/go.mod
+++ b/exporter/tinybirdexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tinybirdexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/exporter/zipkinexporter/go.mod
+++ b/exporter/zipkinexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/extension/ackextension/go.mod
+++ b/extension/ackextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/extension/asapauthextension/go.mod
+++ b/extension/asapauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.14.3

--- a/extension/awsproxy/go.mod
+++ b/extension/awsproxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy v0.145.0

--- a/extension/azureauthextension/go.mod
+++ b/extension/azureauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/azureauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/extension/basicauthextension/go.mod
+++ b/extension/basicauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/extension/cgroupruntimeextension/go.mod
+++ b/extension/cgroupruntimeextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/cgroupruntimeextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.76.0-rc.4

--- a/extension/encoding/avrologencodingextension/go.mod
+++ b/extension/encoding/avrologencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/linkedin/goavro/v2 v2.15.0

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/json_unmarshaler.go
@@ -274,9 +274,9 @@ func setResourceAttributes(rKey resourceKey, resource pcommon.Resource) {
 // if prepended by AWS/. Otherwise, it returns the CloudWatch namespace as the
 // service name with an empty service namespace
 func toServiceAttributes(namespace string) (serviceNamespace, serviceName string) {
-	index := strings.Index(namespace, namespaceDelimiter)
-	if index != -1 && strings.EqualFold(namespace[:index], conventions.CloudProviderAWS.Value.AsString()) {
-		return namespace[:index], namespace[index+1:]
+	before, after, ok := strings.Cut(namespace, namespaceDelimiter)
+	if ok && strings.EqualFold(before, conventions.CloudProviderAWS.Value.AsString()) {
+		return before, after
 	}
 	return "", namespace
 }

--- a/extension/encoding/awslogsencodingextension/extension_test.go
+++ b/extension/encoding/awslogsencodingextension/extension_test.go
@@ -206,11 +206,9 @@ func TestConcurrentGzipReaderUsage(t *testing.T) {
 	concurrent := 20
 	wg := sync.WaitGroup{}
 	for range concurrent {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			testUnmarshall()
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/extension/encoding/awslogsencodingextension/go.mod
+++ b/extension/encoding/awslogsencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awslogsencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-lambda-go v1.52.0

--- a/extension/encoding/azureencodingextension/go.mod
+++ b/extension/encoding/azureencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/azureencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/go.mod
+++ b/extension/encoding/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding
 
-go 1.24.0
+go 1.25.0
 
 require (
 	go.opentelemetry.io/collector/extension v1.51.1-0.20260205185216-81bc641f26c0

--- a/extension/encoding/googlecloudlogentryencodingextension/go.mod
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/googlecloudlogentryencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/jaegerencodingextension/go.mod
+++ b/extension/encoding/jaegerencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jaegerencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/extension/encoding/otlpencodingextension/go.mod
+++ b/extension/encoding/otlpencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.145.0

--- a/extension/encoding/skywalkingencodingextension/go.mod
+++ b/extension/encoding/skywalkingencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/skywalkingencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking v0.145.0

--- a/extension/encoding/textencodingextension/go.mod
+++ b/extension/encoding/textencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.145.0

--- a/extension/encoding/zipkinencodingextension/go.mod
+++ b/extension/encoding/zipkinencodingextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.145.0

--- a/extension/googleclientauthextension/go.mod
+++ b/extension/googleclientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/googleclientauthextension
 
-go 1.24.0
+go 1.25.0
 
 exclude github.com/knadh/koanf v1.5.0
 

--- a/extension/headerssetterextension/go.mod
+++ b/extension/headerssetterextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/extension/healthcheckv2extension/go.mod
+++ b/extension/healthcheckv2extension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckv2extension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/extension/httpforwarderextension/extension.go
+++ b/extension/httpforwarderextension/extension.go
@@ -49,13 +49,11 @@ func (h *httpForwarder) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("failed to create HTTP Client: %w", err)
 	}
 
-	h.shutdownWG.Add(1)
-	go func() {
-		defer h.shutdownWG.Done()
+	h.shutdownWG.Go(func() {
 		if errHTTP := h.server.Serve(listener); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/extension/httpforwarderextension/go.mod
+++ b/extension/httpforwarderextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarderextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/fortytw2/leaktest v1.3.0

--- a/extension/jaegerremotesampling/internal/server/http/http.go
+++ b/extension/jaegerremotesampling/internal/server/http/http.go
@@ -67,14 +67,11 @@ func (h *SamplingHTTPServer) Start(ctx context.Context, host component.Host) err
 		return err
 	}
 
-	h.shutdownWG.Add(1)
-	go func() {
-		defer h.shutdownWG.Done()
-
+	h.shutdownWG.Go(func() {
 		if err := h.srv.Serve(hln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/extension/k8sleaderelector/extension.go
+++ b/extension/k8sleaderelector/extension.go
@@ -101,11 +101,9 @@ func (lee *leaderElectionExtension) Start(_ context.Context, _ component.Host) e
 		lee.logger.Error("Failed to create k8s leader elector", zap.Error(err))
 		return err
 	}
-	lee.waitGroup.Add(1)
-	go func() {
+	lee.waitGroup.Go(func() {
 		// Leader election loop stops if context is canceled or the leader elector loses the lease.
 		// The loop allows continued participation in leader election, even if the lease is lost.
-		defer lee.waitGroup.Done()
 		for {
 			leaderElector.Run(ctx)
 			if ctx.Err() != nil {
@@ -114,7 +112,7 @@ func (lee *leaderElectionExtension) Start(_ context.Context, _ component.Host) e
 
 			lee.logger.Info("Leader lease lost. Returning to standby mode...")
 		}
-	}()
+	})
 
 	return nil
 }

--- a/extension/k8sleaderelector/go.mod
+++ b/extension/k8sleaderelector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/oauth2clientauthextension/go.mod
+++ b/extension/oauth2clientauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/extension/observer/cfgardenobserver/go.mod
+++ b/extension/observer/cfgardenobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/cfgardenobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	code.cloudfoundry.org/garden v0.0.0-20241023020423-a21e43a17f84

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/extension/observer/go.mod
+++ b/extension/observer/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/observer/hostobserver/go.mod
+++ b/extension/observer/hostobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.145.0

--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/observer/kafkatopicsobserver/go.mod
+++ b/extension/observer/kafkatopicsobserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/kafkatopicsobserver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0

--- a/extension/opampcustommessages/go.mod
+++ b/extension/opampcustommessages/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages
 
-go 1.24.0
+go 1.25.0
 
 require github.com/open-telemetry/opamp-go v0.22.0
 

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/pprofextension/go.mod
+++ b/extension/pprofextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/extension/remotetapextension/go.mod
+++ b/extension/remotetapextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/remotetapextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/extension/solarwindsapmsettingsextension/go.mod
+++ b/extension/solarwindsapmsettingsextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/storage/dbstorage/go.mod
+++ b/extension/storage/dbstorage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -253,9 +253,7 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 
 // startCompactionLoop provides asynchronous compaction function
 func (c *fileStorageClient) startCompactionLoop() {
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	c.wg.Go(func() {
 		c.logger.Debug("starting compaction loop",
 			zap.Duration("compaction_check_interval", c.compactionCfg.CheckInterval))
 
@@ -278,7 +276,7 @@ func (c *fileStorageClient) startCompactionLoop() {
 				return
 			}
 		}
-	}()
+	})
 }
 
 // shouldCompact checks whether the conditions for online compaction are met

--- a/extension/storage/filestorage/go.mod
+++ b/extension/storage/filestorage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/extension/storage/go.mod
+++ b/extension/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/extension/storage/redisstorageextension/go.mod
+++ b/extension/storage/redisstorageextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-redis/redismock/v9 v9.2.0

--- a/extension/sumologicextension/go.mod
+++ b/extension/sumologicextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib
 // For the OpenTelemetry Collector Contrib distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 
-go 1.24.0
+go 1.25.0
 
 retract (
 	v0.76.2

--- a/internal/aws/awsutil/go.mod
+++ b/internal/aws/awsutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/internal/aws/containerinsight/go.mod
+++ b/internal/aws/containerinsight/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/aws/cwlogs/go.mod
+++ b/internal/aws/cwlogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/internal/aws/ecsutil/go.mod
+++ b/internal/aws/ecsutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/internal/aws/k8s/go.mod
+++ b/internal/aws/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/internal/aws/metrics/go.mod
+++ b/internal/aws/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/aws/proxy/go.mod
+++ b/internal/aws/proxy/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.8

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/internal/aws/xray/telemetry/sender.go
+++ b/internal/aws/xray/telemetry/sender.go
@@ -221,11 +221,9 @@ func newSender(client awsxray.XRayClient, opts ...Option) *telemetrySender {
 // Start starts the loop to send the records.
 func (ts *telemetrySender) Start(ctx context.Context) {
 	ts.startOnce.Do(func() {
-		ts.stopWait.Add(1)
-		go func() {
-			defer ts.stopWait.Done()
+		ts.stopWait.Go(func() {
 			ts.run(ctx)
-		}()
+		})
 	})
 }
 

--- a/internal/aws/xray/testdata/sampleapp/go.mod
+++ b/internal/aws/xray/testdata/sampleapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/internal/aws/xray/testdata/sampleserver/go.mod
+++ b/internal/aws/xray/testdata/sampleserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleserver
 
-go 1.24.0
+go 1.25.0
 
 require github.com/aws/aws-xray-sdk-go/v2 v2.0.0
 

--- a/internal/collectd/go.mod
+++ b/internal/collectd/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd
 
-go 1.24.0
+go 1.25.0

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/common
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/datadog/e2e/go.mod
+++ b/internal/datadog/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog/e2e
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.145.0

--- a/internal/datadog/go.mod
+++ b/internal/datadog/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.76.0-rc.4

--- a/internal/docker/go.mod
+++ b/internal/docker/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/internal/exp/metrics/go.mod
+++ b/internal/exp/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/expr-lang/expr v1.17.7

--- a/internal/gopsutilenv/go.mod
+++ b/internal/gopsutilenv/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/gopsutilenv
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/shirou/gopsutil/v4 v4.26.1

--- a/internal/grpcutil/go.mod
+++ b/internal/grpcutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/internal/healthcheck/go.mod
+++ b/internal/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/healthcheck
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/internal/healthcheck/internal/http/server.go
+++ b/internal/healthcheck/internal/http/server.go
@@ -101,15 +101,13 @@ func (s *Server) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("failed to bind to address %s: %w", s.httpConfig.NetAddr.Endpoint, err)
 	}
 
-	s.doneWg.Add(1)
-	go func() {
-		defer s.doneWg.Done()
+	s.doneWg.Go(func() {
 		defer s.doneOnce.Do(func() { close(s.doneCh) })
 
 		if err = s.httpServer.Serve(ln); !errors.Is(err, http.ErrServerClosed) && err != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewPermanentErrorEvent(err))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235

--- a/internal/k8sinventory/go.mod
+++ b/internal/k8sinventory/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sinventory
 
-go 1.24.4
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/k8sleaderelectortest/go.mod
+++ b/internal/k8sleaderelectortest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sleaderelectortest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.145.0

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/internal/kubelet/go.mod
+++ b/internal/kubelet/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/internal/metadataproviders/go.mod
+++ b/internal/metadataproviders/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/internal/otelarrow/go.mod
+++ b/internal/otelarrow/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/klauspost/compress v1.18.4

--- a/internal/pdatautil/go.mod
+++ b/internal/pdatautil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/internal/rabbitmq/go.mod
+++ b/internal/rabbitmq/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/rabbitmq
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/rabbitmq/amqp091-go v1.10.0

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/sqlquery/go.mod
+++ b/internal/sqlquery/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
 
-go 1.24.4
+go 1.25.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/batchpersignal/go.mod
+++ b/pkg/batchpersignal/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/core/xidutils/go.mod
+++ b/pkg/core/xidutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/datadog/go.mod
+++ b/pkg/datadog/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.76.0-rc.4

--- a/pkg/experimentalmetricmetadata/go.mod
+++ b/pkg/experimentalmetricmetadata/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/golden/go.mod
+++ b/pkg/golden/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.145.0

--- a/pkg/kafka/configkafka/go.mod
+++ b/pkg/kafka/configkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/configkafka
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/pkg/kafka/topic/go.mod
+++ b/pkg/kafka/topic/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic
 
-go 1.24.0
+go 1.25.0

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/alecthomas/participle/v2 v2.1.4

--- a/pkg/pdatatest/go.mod
+++ b/pkg/pdatatest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/pkg/pdatautil/go.mod
+++ b/pkg/pdatautil/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/resourcetotelemetry/go.mod
+++ b/pkg/resourcetotelemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/pkg/sampling/go.mod
+++ b/pkg/sampling/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/sampling/w3ctracestate.go
+++ b/pkg/sampling/w3ctracestate.go
@@ -233,11 +233,11 @@ func isValidW3CKey(key string) bool {
 		return false
 	}
 
-	atIdx := strings.IndexByte(key, '@')
-	if atIdx >= 0 {
+	before, after, ok := strings.Cut(key, "@")
+	if ok {
 		// Multi-tenant key
-		tenant := key[:atIdx]
-		system := key[atIdx+1:]
+		tenant := before
+		system := after
 
 		if tenant == "" || system == "" {
 			return false

--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -181,9 +181,7 @@ func (b *Input) Start(_ operator.Persister) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	b.cancel = cancel
 
-	b.wg.Add(1)
-	go func() {
-		defer b.wg.Done()
+	b.wg.Go(func() {
 		for n := 0; n < len(b.entries); n++ {
 			select {
 			case <-ctx.Done():
@@ -195,7 +193,7 @@ func (b *Input) Start(_ operator.Persister) error {
 				b.Logger().Error("failed to write entry", zap.Error(err))
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -107,9 +107,7 @@ func (m *Manager) Stop() error {
 // startPoller kicks off a goroutine that will poll the filesystem periodically,
 // checking if there are new files or new logs in the watched files
 func (m *Manager) startPoller(ctx context.Context) {
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
+	m.wg.Go(func() {
 		globTicker := time.NewTicker(m.pollInterval)
 		defer globTicker.Stop()
 
@@ -122,7 +120,7 @@ func (m *Manager) startPoller(ctx context.Context) {
 
 			m.poll(ctx)
 		}
-	}()
+	})
 }
 
 // poll checks all the watched paths for new entries

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1242,11 +1242,9 @@ func TestDeleteAfterRead_SkipPartials(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		operator.poll(ctx)
-	}()
+	})
 
 	for !shortOne || !longOne {
 		if token := sink.NextToken(t); string(token) == shortFileLine {

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/pkg/stanza/operator/input/generate/input.go
+++ b/pkg/stanza/operator/input/generate/input.go
@@ -31,9 +31,7 @@ func (i *Input) Start(_ operator.Persister) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	i.cancel = cancel
 
-	i.wg.Add(1)
-	go func() {
-		defer i.wg.Done()
+	i.wg.Go(func() {
 		n := 0
 		for {
 			select {
@@ -57,7 +55,7 @@ func (i *Input) Start(_ operator.Persister) error {
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/pkg/stanza/operator/input/stdin/input.go
+++ b/pkg/stanza/operator/input/stdin/input.go
@@ -42,9 +42,7 @@ func (i *Input) Start(_ operator.Persister) error {
 
 	scanner := bufio.NewScanner(i.stdin)
 
-	i.wg.Add(1)
-	go func() {
-		defer i.wg.Done()
+	i.wg.Go(func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -68,7 +66,7 @@ func (i *Input) Start(_ operator.Persister) error {
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/pkg/status/go.mod
+++ b/pkg/status/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/translator/azure/go.mod
+++ b/pkg/translator/azure/go.mod
@@ -1,6 +1,6 @@
 //module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/pkg/translator/azurelogs/go.mod
+++ b/pkg/translator/azurelogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azurelogs
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/pkg/translator/faro/go.mod
+++ b/pkg/translator/faro/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/faro
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-logfmt/logfmt v0.6.1

--- a/pkg/translator/jaeger/go.mod
+++ b/pkg/translator/jaeger/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-logfmt/logfmt v0.6.1

--- a/pkg/translator/pprof/go.mod
+++ b/pkg/translator/pprof/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/pprof
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/translator/prometheus/go.mod
+++ b/pkg/translator/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/pkg/translator/signalfx/go.mod
+++ b/pkg/translator/signalfx/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/pkg/translator/skywalking/go.mod
+++ b/pkg/translator/skywalking/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/pkg/translator/splunk/go.mod
+++ b/pkg/translator/splunk/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/splunk
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/pkg/translator/zipkin/go.mod
+++ b/pkg/translator/zipkin/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/pkg/winperfcounters/go.mod
+++ b/pkg/winperfcounters/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/pkg/xk8stest/go.mod
+++ b/pkg/xk8stest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/coralogixprocessor/go.mod
+++ b/processor/coralogixprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/coralogixprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/cumulativetodeltaprocessor/go.mod
+++ b/processor/cumulativetodeltaprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0

--- a/processor/datadogsemanticsprocessor/go.mod
+++ b/processor/datadogsemanticsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/datadogsemanticsprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.76.0-rc.4

--- a/processor/deltatocumulativeprocessor/go.mod
+++ b/processor/deltatocumulativeprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/processor/deltatocumulativeprocessor/internal/maps/map_test.go
+++ b/processor/deltatocumulativeprocessor/internal/maps/map_test.go
@@ -28,8 +28,7 @@ func TestLimit(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			for i := range 110 {
 				o, loaded := m.LoadOrStore(i, v)
 				switch {
@@ -41,8 +40,7 @@ func TestLimit(t *testing.T) {
 					stores.Add(1)
 				}
 			}
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/processor/deltatorateprocessor/go.mod
+++ b/processor/deltatorateprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/dnslookupprocessor/go.mod
+++ b/processor/dnslookupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/dnslookupprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/geoipprocessor/go.mod
+++ b/processor/geoipprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/geoipprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/maxmind/MaxMind-DB v0.0.0-20240605211347-880f6b4b5eb6

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.145.0

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -345,13 +345,11 @@ func TestEventConsumeConsistency(t *testing.T) {
 			realTraceID := workerIndexForTraceID(pcommon.TraceID(tt.traceID), 100)
 			var wg sync.WaitGroup
 			for range 50 {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					for range 30 {
 						assert.Equal(t, realTraceID, workerIndexForTraceID(pcommon.TraceID(tt.traceID), 100))
 					}
-				}()
+				})
 			}
 			wg.Wait()
 		})
@@ -403,11 +401,9 @@ func TestEventShutdown(t *testing.T) {
 	assert.Equal(t, 1, em.numEvents())
 
 	shutdownWg := sync.WaitGroup{}
-	shutdownWg.Add(1)
-	go func() {
+	shutdownWg.Go(func() {
 		em.shutdown()
-		shutdownWg.Done()
-	}()
+	})
 
 	wg.Done() // the pending event should be processed
 	// wait for shutdown to process remaining events
@@ -468,11 +464,9 @@ func TestEventShutdownMultipleWorkers(t *testing.T) {
 	}, 1*time.Second, 10*time.Millisecond)
 
 	shutdownWg := sync.WaitGroup{}
-	shutdownWg.Add(1)
-	go func() {
+	shutdownWg.Go(func() {
 		em.shutdown()
-		shutdownWg.Done()
-	}()
+	})
 
 	shutdownWg.Wait()
 

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.145.0

--- a/processor/intervalprocessor/go.mod
+++ b/processor/intervalprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/intervalprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.145.0

--- a/processor/isolationforestprocessor/go.mod
+++ b/processor/isolationforestprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/isolationforestprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/isolationforestprocessor/processor.go
+++ b/processor/isolationforestprocessor/processor.go
@@ -138,11 +138,9 @@ func (p *isolationForestProcessor) Start(_ context.Context, _ component.Host) er
 	// Any additional initialization logic can go here
 
 	// Start the background model update loop
-	p.shutdownWG.Add(1)
-	go func() {
-		defer p.shutdownWG.Done()
+	p.shutdownWG.Go(func() {
 		p.modelUpdateLoop()
-	}()
+	})
 
 	return nil
 }

--- a/processor/k8sattributesprocessor/client_test.go
+++ b/processor/k8sattributesprocessor/client_test.go
@@ -108,11 +108,9 @@ func (f *fakeClient) GetJob(jobUID string) (*kube.Job, bool) {
 func (f *fakeClient) Start() error {
 	startInformer := func(informer cache.SharedInformer) {
 		if informer != nil {
-			f.stopWg.Add(1)
-			go func() {
-				defer f.stopWg.Done()
+			f.stopWg.Go(func() {
 				informer.Run(f.StopCh)
-			}()
+			})
 		}
 	}
 

--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/distribution/reference v0.6.0

--- a/processor/logdedupprocessor/go.mod
+++ b/processor/logdedupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logdedupprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.145.0

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/lookupprocessor/go.mod
+++ b/processor/lookupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/lookupprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/processor/metricstarttimeprocessor/go.mod
+++ b/processor/metricstarttimeprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstarttimeprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.145.0

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/probabilisticsamplerprocessor/go.mod
+++ b/processor/probabilisticsamplerprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.145.0

--- a/processor/redactionprocessor/go.mod
+++ b/processor/redactionprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.76.0-rc.4

--- a/processor/remotetapprocessor/go.mod
+++ b/processor/remotetapprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/remotetapprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.145.0

--- a/processor/remotetapprocessor/processor.go
+++ b/processor/remotetapprocessor/processor.go
@@ -58,13 +58,11 @@ func (w *wsprocessor) Start(ctx context.Context, host component.Host) error {
 	if err != nil {
 		return err
 	}
-	w.shutdownWG.Add(1)
-	go func() {
-		defer w.shutdownWG.Done()
+	w.shutdownWG.Go(func() {
 		if errHTTP := w.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/processor/remotetapprocessor/processor_test.go
+++ b/processor/remotetapprocessor/processor_test.go
@@ -47,13 +47,11 @@ func TestConsumeMetrics(t *testing.T) {
 			idx := processor.cs.add(ch)
 			receiveNum := 0
 			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for range ch {
 					receiveNum++
 				}
-			}()
+			})
 
 			for i := 0; i < c.limit*2; i++ {
 				// send metric to chan c.limit*2 per sec.
@@ -98,13 +96,11 @@ func TestConsumeLogs(t *testing.T) {
 			idx := processor.cs.add(ch)
 			receiveNum := 0
 			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for range ch {
 					receiveNum++
 				}
-			}()
+			})
 
 			// send log to chan c.limit*2 per sec.
 			for i := 0; i < c.limit*2; i++ {
@@ -151,13 +147,11 @@ func TestConsumeTraces(t *testing.T) {
 			idx := processor.cs.add(ch)
 			receiveNum := 0
 			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for range ch {
 					receiveNum++
 				}
-			}()
+			})
 
 			for i := 0; i < c.limit*2; i++ {
 				// send trace to chan c.limit*2 per sec.

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/compute v1.54.0

--- a/processor/resourceprocessor/go.mod
+++ b/processor/resourceprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/schemaprocessor/go.mod
+++ b/processor/schemaprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/processor/schemaprocessor/internal/fixture/parallel.go
+++ b/processor/schemaprocessor/internal/fixture/parallel.go
@@ -35,13 +35,10 @@ func ParallelRaceCompute(tb testing.TB, count int, fn func() error) {
 		wg    sync.WaitGroup
 	)
 	for range count {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			<-start
 			assert.NoError(tb, fn(), "Must not error when executing function")
-		}()
+		})
 	}
 	close(start)
 

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/sumologicprocessor/go.mod
+++ b/processor/sumologicprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da

--- a/processor/tailsamplingprocessor/internal/idbatcher/id_batcher_test.go
+++ b/processor/tailsamplingprocessor/internal/idbatcher/id_batcher_test.go
@@ -57,9 +57,7 @@ func BenchmarkConcurrentEnqueue(b *testing.B) {
 	}()
 	ticked := &atomic.Int64{}
 	received := &atomic.Int64{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range ticker.C {
 			batch, more := batcher.CloseCurrentAndTakeFirstBatch()
 			ticked.Add(1)
@@ -68,7 +66,7 @@ func BenchmarkConcurrentEnqueue(b *testing.B) {
 				return
 			}
 		}
-	}()
+	})
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -524,8 +524,7 @@ func TestConsumptionDuringPolicyEvaluation(t *testing.T) {
 	// For each batch, we consume the same trace repeatedly for at least 2x the decision wait time
 	// this ensures that batches are being consumed concurrently with policy evaluation.
 	for _, batch := range batches {
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			start := time.Now()
 			// The important thing here is that we are writing as close as
 			// possible to the moment when the policy is evaluated. We can't
@@ -538,8 +537,7 @@ func TestConsumptionDuringPolicyEvaluation(t *testing.T) {
 					errCh <- err
 				}
 			}
-			wg.Done()
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/processor/unrollprocessor/go.mod
+++ b/processor/unrollprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/unrollprocessor
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/receiver/activedirectorydsreceiver/go.mod
+++ b/receiver/activedirectorydsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/aerospikereceiver/go.mod
+++ b/receiver/aerospikereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.5.1

--- a/receiver/apachereceiver/go.mod
+++ b/receiver/apachereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/apachesparkreceiver/go.mod
+++ b/receiver/apachesparkreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/receiver/awscontainerinsightreceiver/go.mod
+++ b/receiver/awscontainerinsightreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -94,10 +94,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 		}
 	}
 
-	acir.cancelWg.Add(1)
-	go func() {
-		defer acir.cancelWg.Done()
-
+	acir.cancelWg.Go(func() {
 		// cadvisor collects data at dynamical intervals (from 1 to 15 seconds). If the ticker happens
 		// at beginning of a minute, it might read the data collected at end of last minute. To avoid this,
 		// we want to wait until at least two cadvisor collection intervals happens before collecting the metrics
@@ -116,7 +113,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
@@ -199,9 +199,9 @@ func setResourceAttributes(key resourceKey, resource pcommon.Resource) {
 // if prepended by AWS/. Otherwise, it returns the CloudWatch namespace as the
 // service name with an empty service namespace
 func toServiceAttributes(namespace string) (serviceNamespace, serviceName string) {
-	index := strings.Index(namespace, namespaceDelimiter)
-	if index != -1 && strings.EqualFold(namespace[:index], conventions.CloudProviderAWS.Value.AsString()) {
-		return namespace[:index], namespace[index+1:]
+	before, after, ok := strings.Cut(namespace, namespaceDelimiter)
+	if ok && strings.EqualFold(before, conventions.CloudProviderAWS.Value.AsString()) {
+		return before, after
 	}
 	return "", namespace
 }

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -132,14 +132,11 @@ func (fmr *firehoseReceiver) Start(ctx context.Context, host component.Host) err
 	if err != nil {
 		return fmt.Errorf("failed to start listening for HTTP requests: %w", err)
 	}
-	fmr.shutdownWG.Add(1)
-	go func() {
-		defer fmr.shutdownWG.Done()
-
+	fmr.shutdownWG.Go(func() {
 		if errHTTP := fmr.server.Serve(listener); errHTTP != nil && !errors.Is(errHTTP, http.ErrServerClosed) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awslambdareceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-lambda-go v1.52.0

--- a/receiver/awss3receiver/go.mod
+++ b/receiver/awss3receiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/receiver/awsxrayreceiver/internal/translator/sdk.go
+++ b/receiver/awsxrayreceiver/internal/translator/sdk.go
@@ -27,9 +27,9 @@ func addSdkToResource(seg *awsxray.Segment, attrs pcommon.Map) {
 				// sample *xr.SDK: "X-Ray for Go"
 				sep := "for "
 				sdkStr := *xr.SDK
-				i := strings.Index(sdkStr, sep)
-				if i != -1 {
-					attrs.PutStr(string(conventions.TelemetrySDKLanguageKey), sdkStr[i+len(sep):])
+				_, after, ok := strings.Cut(sdkStr, sep)
+				if ok {
+					attrs.PutStr(string(conventions.TelemetrySDKLanguageKey), after)
 				}
 			}
 		}

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/receiver/bigipreceiver/go.mod
+++ b/receiver/bigipreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/receiver/carbonreceiver/internal/transport/server_test.go
+++ b/receiver/carbonreceiver/internal/transport/server_test.go
@@ -57,11 +57,9 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			mr.wgMetricsProcessed.Add(1)
 
 			wgListenAndServe := sync.WaitGroup{}
-			wgListenAndServe.Add(1)
-			go func() {
-				defer wgListenAndServe.Done()
+			wgListenAndServe.Go(func() {
 				assert.Error(t, svr.ListenAndServe(p, mc, mr))
-			}()
+			})
 
 			runtime.Gosched()
 

--- a/receiver/chronyreceiver/go.mod
+++ b/receiver/chronyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/facebook/time v0.0.0-20240510113249-fa89cc575891

--- a/receiver/ciscoosreceiver/go.mod
+++ b/receiver/ciscoosreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ciscoosreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/cloudflarereceiver/go.mod
+++ b/receiver/cloudflarereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -106,10 +106,7 @@ func (l *logsReceiver) startListening(ctx context.Context, host component.Host) 
 		return err
 	}
 
-	l.wg.Add(1)
-	go func() {
-		defer l.wg.Done()
-
+	l.wg.Go(func() {
 		if l.cfg.TLS != nil {
 			l.logger.Debug("Starting ServeTLS",
 				zap.String("address", l.cfg.Endpoint),
@@ -137,7 +134,7 @@ func (l *logsReceiver) startListening(ctx context.Context, host component.Host) 
 				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/cloudfoundryreceiver/go.mod
+++ b/receiver/cloudfoundryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	code.cloudfoundry.org/go-loggregator v7.4.0+incompatible

--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -118,10 +118,7 @@ func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host)
 
 	innerCtx, cancel := context.WithCancel(ctx)
 	cfr.cancel = cancel
-	cfr.goroutines.Add(1)
-
-	go func() {
-		defer cfr.goroutines.Done()
+	cfr.goroutines.Go(func() {
 		cfr.settings.Logger.Debug("cloudfoundry receiver starting")
 		_, tokenErr = tokenProvider.ProvideToken()
 		if tokenErr != nil {
@@ -139,7 +136,7 @@ func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host)
 			cfr.streamMetrics(innerCtx, streamFactory.CreateMetricsStream(innerCtx, cfr.config.RLPGateway.ShardID), host)
 		}
 		cfr.settings.Logger.Debug("cloudfoundry receiver stopped")
-	}()
+	})
 	return nil
 }
 

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.145.0

--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -76,13 +76,11 @@ func (cdr *collectdReceiver) Start(ctx context.Context, host component.Host) err
 	if err != nil {
 		return err
 	}
-	cdr.shutdownWG.Add(1)
-	go func() {
-		defer cdr.shutdownWG.Done()
+	cdr.shutdownWG.Go(func() {
 		if err := cdr.server.Serve(l); !errors.Is(err, http.ErrServerClosed) && err != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/couchdbreceiver/go.mod
+++ b/receiver/couchdbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.180

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/docker v28.5.2+incompatible

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/envoyalsreceiver/go.mod
+++ b/receiver/envoyalsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/envoyalsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0

--- a/receiver/expvarreceiver/go.mod
+++ b/receiver/expvarreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/faroreceiver/go.mod
+++ b/receiver/faroreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/faroreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/grafana/faro/pkg/go v0.0.0-20250314155512-06a06da3b8bc

--- a/receiver/faroreceiver/receiver.go
+++ b/receiver/faroreceiver/receiver.go
@@ -126,14 +126,12 @@ func (r *faroReceiver) startHTTPServer(ctx context.Context, host component.Host)
 		return err
 	}
 
-	r.shutdownWg.Add(1)
-	go func() {
-		defer r.shutdownWg.Done()
+	r.shutdownWg.Go(func() {
 		if err := r.serverHTTP.Serve(listener); !errors.Is(err, http.ErrServerClosed) && err != nil {
 			r.settings.Logger.Error("Failed to start HTTP server", zap.Error(err))
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-	}()
+	})
 
 	r.settings.Logger.Info("HTTP server started", zap.String("address", r.serverHTTP.Addr))
 	return nil

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.145.0

--- a/receiver/filestatsreceiver/go.mod
+++ b/receiver/filestatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/receiver/flinkmetricsreceiver/go.mod
+++ b/receiver/flinkmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.145.0

--- a/receiver/githubreceiver/go.mod
+++ b/receiver/githubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Khan/genqlient v0.8.1

--- a/receiver/githubreceiver/trace_receiver.go
+++ b/receiver/githubreceiver/trace_receiver.go
@@ -106,14 +106,11 @@ func (gtr *githubTracesReceiver) Start(ctx context.Context, host component.Host)
 
 	gtr.logger.Info("Health check now listening at", zap.String("health_path", gtr.cfg.WebHook.HealthPath))
 
-	gtr.shutdownWG.Add(1)
-	go func() {
-		defer gtr.shutdownWG.Done()
-
+	gtr.shutdownWG.Go(func() {
 		if errHTTP := gtr.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/gitlabreceiver/go.mod
+++ b/receiver/gitlabreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitlabreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/gitlabreceiver/traces_receiver.go
+++ b/receiver/gitlabreceiver/traces_receiver.go
@@ -138,13 +138,11 @@ func (gtr *gitlabTracesReceiver) Start(ctx context.Context, host component.Host)
 		),
 	)
 
-	gtr.shutdownWG.Add(1)
-	go func() {
-		defer gtr.shutdownWG.Done()
+	gtr.shutdownWG.Go(func() {
 		if errHTTP := gtr.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/googlecloudmonitoringreceiver/go.mod
+++ b/receiver/googlecloudmonitoringreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/receiver/googlecloudpubsubpushreceiver/go.mod
+++ b/receiver/googlecloudpubsubpushreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubpushreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.60.0

--- a/receiver/googlecloudpubsubpushreceiver/receiver.go
+++ b/receiver/googlecloudpubsubpushreceiver/receiver.go
@@ -171,13 +171,11 @@ func (p *pubSubPushReceiver) Start(ctx context.Context, host component.Host) err
 		return err
 	}
 
-	p.shutdownWG.Add(1)
-	go func() {
-		defer p.shutdownWG.Done()
+	p.shutdownWG.Go(func() {
 		if errHTTP := p.server.Serve(lis); errHTTP != nil && !errors.Is(err, http.ErrServerClosed) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/googlecloudpubsubpushreceiver/receiver_test.go
+++ b/receiver/googlecloudpubsubpushreceiver/receiver_test.go
@@ -254,9 +254,7 @@ func TestTelemetry(t *testing.T) {
 
 	var wg sync.WaitGroup
 	makeRequest := func() {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			resp, err := http.Post(
 				server.URL,
 				"application/json",
@@ -268,7 +266,7 @@ func TestTelemetry(t *testing.T) {
 				assert.NoError(t, errBody)
 			}()
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
-		}()
+		})
 	}
 	pauseRequest := func() {
 		<-started

--- a/receiver/googlecloudpubsubreceiver/go.mod
+++ b/receiver/googlecloudpubsubreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/pubsub/v2 v2.4.0

--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/spanner v1.87.0

--- a/receiver/haproxyreceiver/go.mod
+++ b/receiver/haproxyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/huaweicloudcesreceiver/go.mod
+++ b/receiver/huaweicloudcesreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/huaweicloudcesreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/icmpcheckreceiver/go.mod
+++ b/receiver/icmpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/icmpcheckreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/iisreceiver/go.mod
+++ b/receiver/iisreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/apache/thrift v0.22.0

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -342,13 +342,11 @@ func (jr *jReceiver) startCollector(ctx context.Context, host component.Host) er
 			zap.String("endpoint", httpConfig.NetAddr.Endpoint),
 		)
 
-		jr.goroutines.Add(1)
-		go func() {
-			defer jr.goroutines.Done()
+		jr.goroutines.Go(func() {
 			if errHTTP := jr.collectorServer.Serve(cln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 			}
-		}()
+		})
 	}
 
 	if jr.config.GRPC.HasValue() {
@@ -368,13 +366,11 @@ func (jr *jReceiver) startCollector(ctx context.Context, host component.Host) er
 
 		jr.settings.Logger.Info("Starting gRPC server for Jaeger Protobuf", zap.String("endpoint", grpcConfig.NetAddr.Endpoint))
 
-		jr.goroutines.Add(1)
-		go func() {
-			defer jr.goroutines.Done()
+		jr.goroutines.Go(func() {
 			if errGrpc := jr.grpc.Serve(ln); !errors.Is(errGrpc, grpc.ErrServerStopped) && errGrpc != nil {
 				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errGrpc))
 			}
-		}()
+		})
 	}
 
 	return nil

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.145.0

--- a/receiver/k8slogreceiver/go.mod
+++ b/receiver/k8slogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8slogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.145.0

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/IBM/sarama v1.46.3

--- a/receiver/kafkareceiver/consumer_franz.go
+++ b/receiver/kafkareceiver/consumer_franz.go
@@ -485,11 +485,9 @@ func (c *franzConsumer) lost(ctx context.Context, _ *kgo.Client,
 				pc.cancelContext(errors.New(
 					"stopping processing: partition reassigned or lost",
 				))
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					pc.wait()
-				}()
+				})
 				c.telemetryBuilder.KafkaReceiverPartitionClose.Add(context.Background(), 1)
 			}
 		}

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/libhoneyreceiver/go.mod
+++ b/receiver/libhoneyreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/klauspost/compress v1.18.4

--- a/receiver/libhoneyreceiver/receiver.go
+++ b/receiver/libhoneyreceiver/receiver.go
@@ -96,14 +96,11 @@ func (r *libhoneyReceiver) startHTTPServer(ctx context.Context, host component.H
 		return err
 	}
 
-	r.shutdownWG.Add(1)
-	go func() {
-		defer r.shutdownWG.Done()
-
+	r.shutdownWG.Go(func() {
 		if err := r.server.Serve(hln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/lokireceiver/go.mod
+++ b/receiver/lokireceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/receiver/lokireceiver/loki.go
+++ b/receiver/lokireceiver/loki.go
@@ -128,14 +128,11 @@ func (r *lokiReceiver) startHTTPServer(ctx context.Context, host component.Host)
 	if err != nil {
 		return err
 	}
-	r.shutdownWG.Add(1)
-
-	go func() {
-		defer r.shutdownWG.Done()
+	r.shutdownWG.Go(func() {
 		if errHTTP := r.serverHTTP.Serve(listener); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 	return nil
 }
 
@@ -145,14 +142,11 @@ func (r *lokiReceiver) startGRPCServer(ctx context.Context, host component.Host)
 	if err != nil {
 		return err
 	}
-	r.shutdownWG.Add(1)
-
-	go func() {
-		defer r.shutdownWG.Done()
+	r.shutdownWG.Go(func() {
 		if errGRPC := r.serverGRPC.Serve(listener); !errors.Is(errGRPC, grpc.ErrServerStopped) && errGRPC != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errGRPC))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/macosunifiedloggingreceiver/go.mod
+++ b/receiver/macosunifiedloggingreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/macosunifiedloggingreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/receiver/macosunifiedloggingreceiver/receiver_darwin.go
+++ b/receiver/macosunifiedloggingreceiver/receiver_darwin.go
@@ -132,11 +132,7 @@ func (r *unifiedLoggingReceiver) readFromLive(ctx context.Context) {
 				currentInterval = minInterval
 			} else {
 				nextInterval := currentInterval * 2
-				if nextInterval > maxInterval {
-					currentInterval = maxInterval
-				} else {
-					currentInterval = nextInterval
-				}
+				currentInterval = min(nextInterval, maxInterval)
 			}
 		}
 	}

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -111,9 +111,7 @@ func (alr *accessLogsReceiver) startPolling(ctx context.Context) error {
 		}
 
 		t := time.NewTicker(pc.AccessLogs.PollInterval)
-		alr.wg.Add(1)
-		go func() {
-			defer alr.wg.Done()
+		alr.wg.Go(func() {
 			for {
 				select {
 				case <-t.C:
@@ -124,7 +122,7 @@ func (alr *accessLogsReceiver) startPolling(ctx context.Context) error {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	return nil

--- a/receiver/mongodbatlasreceiver/events.go
+++ b/receiver/mongodbatlasreceiver/events.go
@@ -113,9 +113,7 @@ func (er *eventsReceiver) Shutdown(ctx context.Context) error {
 
 func (er *eventsReceiver) startPolling(ctx context.Context) error {
 	t := time.NewTicker(er.pollInterval)
-	er.wg.Add(1)
-	go func() {
-		defer er.wg.Done()
+	er.wg.Go(func() {
 		for {
 			select {
 			case <-t.C:
@@ -126,7 +124,7 @@ func (er *eventsReceiver) startPolling(ctx context.Context) error {
 				return
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -65,9 +65,7 @@ func newMongoDBAtlasLogsReceiver(settings rcvr.Settings, cfg *Config, consumer c
 
 // Log receiver logic
 func (s *logsReceiver) Start(ctx context.Context, _ component.Host) error {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
+	s.wg.Go(func() {
 		s.start = time.Now().Add(-collectionInterval)
 		s.end = time.Now()
 		for {
@@ -83,7 +81,7 @@ func (s *logsReceiver) Start(ctx context.Context, _ component.Host) error {
 				s.end = time.Now()
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/mongodbreceiver/go.mod
+++ b/receiver/mongodbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.76.0-rc.4

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/receiver/netflowreceiver/go.mod
+++ b/receiver/netflowreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/netflowreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/netsampler/goflow2/v2 v2.2.6

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/nsxtreceiver/go.mod
+++ b/receiver/nsxtreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/ntpreceiver/go.mod
+++ b/receiver/ntpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/ntpreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/beevik/ntp v1.5.0

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.76.0-rc.4

--- a/receiver/osqueryreceiver/go.mod
+++ b/receiver/osqueryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/osqueryreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.145.0

--- a/receiver/otelarrowreceiver/otelarrow.go
+++ b/receiver/otelarrowreceiver/otelarrow.go
@@ -105,14 +105,11 @@ func (r *otelArrowReceiver) startGRPCServer(cfg configgrpc.ServerConfig, host co
 	if err != nil {
 		return err
 	}
-	r.shutdownWG.Add(1)
-	go func() {
-		defer r.shutdownWG.Done()
-
+	r.shutdownWG.Go(func() {
 		if errGrpc := r.serverGRPC.Serve(gln); errGrpc != nil && !errors.Is(errGrpc, grpc.ErrServerStopped) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errGrpc))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -408,22 +408,20 @@ func TestOTelArrowShutdown(t *testing.T) {
 			}()
 
 			var recvWG sync.WaitGroup
-			recvWG.Add(1)
 
 			// Receive batch responses. See the comment on
 			// https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream
 			// to explain why this must be done.  We do not use the
 			// return value, this just avoids leaking the stream context,
 			// which can otherwise hang this test.
-			go func() {
-				defer recvWG.Done()
+			recvWG.Go(func() {
 				for {
 					if _, recvErr := stream.Recv(); recvErr == nil {
 						continue
 					}
 					break
 				}
-			}()
+			})
 
 			// Wait until the receiver outputs anything to the sink.
 			assert.Eventually(t, func() bool {

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.145.0

--- a/receiver/podmanreceiver/go.mod
+++ b/receiver/podmanreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/receiver/pprofreceiver/go.mod
+++ b/receiver/pprofreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pprofreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/receiver/prometheusreceiver/internal/targetallocator/manager.go
+++ b/receiver/prometheusreceiver/internal/targetallocator/manager.go
@@ -95,9 +95,7 @@ func (m *Manager) Start(ctx context.Context, host component.Host, sm *scrape.Man
 	if err != nil {
 		return err
 	}
-	m.wg.Add(1)
-	go func() {
-		defer m.wg.Done()
+	m.wg.Go(func() {
 		targetAllocatorIntervalTicker := time.NewTicker(m.cfg.Interval)
 		for {
 			select {
@@ -114,7 +112,7 @@ func (m *Manager) Start(ctx context.Context, host component.Host, sm *scrape.Man
 				return
 			}
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -134,13 +134,11 @@ func (prw *prometheusRemoteWriteReceiver) Start(ctx context.Context, host compon
 		return fmt.Errorf("failed to create prometheus remote-write listener: %w", err)
 	}
 
-	prw.wg.Add(1)
-	go func() {
-		defer prw.wg.Done()
+	prw.wg.Go(func() {
 		if err := prw.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(fmt.Errorf("error starting prometheus remote-write receiver: %w", err)))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/pulsarreceiver/go.mod
+++ b/receiver/pulsarreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/pulsarreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/apache/pulsar-client-go v0.18.0

--- a/receiver/purefareceiver/go.mod
+++ b/receiver/purefareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefareceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.145.0

--- a/receiver/purefbreceiver/go.mod
+++ b/receiver/purefbreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.145.0

--- a/receiver/rabbitmqreceiver/go.mod
+++ b/receiver/rabbitmqreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/expr-lang/expr v1.17.7

--- a/receiver/redfishreceiver/go.mod
+++ b/receiver/redfishreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redfishreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/riakreceiver/go.mod
+++ b/receiver/riakreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/saphanareceiver/go.mod
+++ b/receiver/saphanareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/SAP/go-hdb v1.14.22

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -147,13 +147,11 @@ func (r *sfxReceiver) Start(ctx context.Context, host component.Host) error {
 	r.server.ReadHeaderTimeout = defaultServerTimeout
 	r.server.WriteTimeout = defaultServerTimeout
 
-	r.shutdownWG.Add(1)
-	go func() {
-		defer r.shutdownWG.Done()
+	r.shutdownWG.Go(func() {
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 	return nil
 }
 

--- a/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
+++ b/receiver/simpleprometheusreceiver/examples/federation/prom-counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.145.0

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/receiver/skywalkingreceiver/skywalking_receiver.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver.go
@@ -146,13 +146,11 @@ func (sr *swReceiver) startCollector(host component.Host) error {
 			return cerr
 		}
 
-		sr.goroutines.Add(1)
-		go func() {
-			defer sr.goroutines.Done()
+		sr.goroutines.Go(func() {
 			if errHTTP := sr.collectorServer.Serve(cln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 			}
-		}()
+		})
 	}
 
 	if sr.collectorGRPCEnabled() {
@@ -181,13 +179,11 @@ func (sr *swReceiver) startCollector(host component.Host) error {
 		v3.RegisterCLRMetricReportServiceServer(sr.grpc, &clrService{})
 		v3.RegisterBrowserPerfServiceServer(sr.grpc, sr.dummyReportService)
 
-		sr.goroutines.Add(1)
-		go func() {
-			defer sr.goroutines.Done()
+		sr.goroutines.Go(func() {
 			if errGrpc := sr.grpc.Serve(gln); !errors.Is(errGrpc, grpc.ErrServerStopped) && errGrpc != nil {
 				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errGrpc))
 			}
-		}()
+		})
 	}
 
 	return nil

--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gosnmp/gosnmp v1.43.2

--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/receiver/solacereceiver/go.mod
+++ b/receiver/solacereceiver/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Azure/go-amqp v1.5.1

--- a/receiver/splunkenterprisereceiver/go.mod
+++ b/receiver/splunkenterprisereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkenterprisereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -177,13 +177,11 @@ func (r *splunkReceiver) Start(ctx context.Context, host component.Host) error {
 	r.server.ReadHeaderTimeout = defaultServerTimeout
 	r.server.WriteTimeout = defaultServerTimeout
 
-	r.shutdownWG.Add(1)
-	go func() {
-		defer r.shutdownWG.Done()
+	r.shutdownWG.Go(func() {
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return err
 }

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/docker/go-connections v0.6.0

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.76.0-rc.4

--- a/receiver/sshcheckreceiver/go.mod
+++ b/receiver/sshcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/lightstep/go-expohisto v1.0.0

--- a/receiver/statsdreceiver/internal/transport/server_test.go
+++ b/receiver/statsdreceiver/internal/transport/server_test.go
@@ -59,11 +59,9 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			transferChan := make(chan Metric, 10)
 
 			wgListenAndServe := sync.WaitGroup{}
-			wgListenAndServe.Add(1)
-			go func() {
-				defer wgListenAndServe.Done()
+			wgListenAndServe.Go(func() {
 				assert.Error(t, srv.ListenAndServe(mc, mr, transferChan))
-			}()
+			})
 
 			runtime.Gosched()
 

--- a/receiver/statsdreceiver/internal/transport/tcp_server.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server.go
@@ -60,11 +60,9 @@ func (t *tcpServer) ListenAndServe(nextConsumer consumer.Metrics, reporter Repor
 			continue
 		}
 
-		t.wg.Add(1)
-		go func() {
-			defer t.wg.Done()
+		t.wg.Go(func() {
 			handleTCPConn(conn, reporter, transferChan)
-		}()
+		})
 	}
 }
 

--- a/receiver/stefreceiver/go.mod
+++ b/receiver/stefreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stefreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stefexporter v0.145.0

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/receiver/systemdreceiver/go.mod
+++ b/receiver/systemdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/systemdreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/containerd/cgroups/v3 v3.1.2

--- a/receiver/tcpcheckreceiver/go.mod
+++ b/receiver/tcpcheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcpcheckreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.145.0

--- a/receiver/tlscheckreceiver/go.mod
+++ b/receiver/tlscheckreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tlscheckreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.145.0

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -605,9 +605,9 @@ func (vc *vcenterClient) convertVSANValueToMetricDetails(
 
 // uuidFromEntityRefID returns the UUID portion of the EntityRefId
 func (*vcenterClient) uuidFromEntityRefID(id string) (string, error) {
-	colonIndex := strings.Index(id, ":")
-	if colonIndex != -1 {
-		uuid := id[colonIndex+1:]
+	_, after, ok := strings.Cut(id, ":")
+	if ok {
+		uuid := after
 		return uuid, nil
 	}
 

--- a/receiver/vcenterreceiver/go.mod
+++ b/receiver/vcenterreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/basgys/goxml2json v1.1.0

--- a/receiver/vcrreceiver/go.mod
+++ b/receiver/vcrreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcrreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/collectd v0.145.0

--- a/receiver/webhookeventreceiver/go.mod
+++ b/receiver/webhookeventreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/goccy/go-json v0.10.5

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -131,13 +131,11 @@ func (er *eventReceiver) Start(ctx context.Context, host component.Host) error {
 	er.server.WriteTimeout = writeTimeout
 
 	// shutdown
-	er.shutdownWG.Add(1)
-	go func() {
-		defer er.shutdownWG.Done()
+	er.shutdownWG.Go(func() {
 		if errHTTP := er.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.145.0

--- a/receiver/windowsservicereceiver/go.mod
+++ b/receiver/windowsservicereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsservicereceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/yanggrpcreceiver/go.mod
+++ b/receiver/yanggrpcreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/yanggrpcreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/receiver/yanggrpcreceiver/grpc_service.go
+++ b/receiver/yanggrpcreceiver/grpc_service.go
@@ -174,8 +174,8 @@ func (s *grpcService) processTelemetryData(req *pb.MdtDialoutArgs) error {
 // extractYANGModule extracts the YANG module name from encoding path
 func (*grpcService) extractYANGModule(encodingPath string) string {
 	// Example: "Cisco-IOS-XE-interfaces-oper:interfaces/interface/statistics"
-	if idx := strings.Index(encodingPath, ":"); idx != -1 {
-		return encodingPath[:idx]
+	if before, _, ok := strings.Cut(encodingPath, ":"); ok {
+		return before
 	}
 	return "unknown"
 }

--- a/receiver/yanggrpcreceiver/receiver.go
+++ b/receiver/yanggrpcreceiver/receiver.go
@@ -80,13 +80,11 @@ func (y *yangReceiver) Start(ctx context.Context, host component.Host) error {
 	}
 	pb.RegisterGRPCMdtDialoutServer(y.server, service)
 
-	y.wg.Add(1)
-	go func() {
-		defer y.wg.Done()
+	y.wg.Go(func() {
 		if err := y.server.Serve(listener); err != nil {
 			y.settings.Logger.Error("gRPC server error", zap.Error(err))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/jaegertracing/jaeger-idl v0.6.0

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -105,14 +105,11 @@ func (zr *zipkinReceiver) Start(ctx context.Context, host component.Host) error 
 	if err != nil {
 		return err
 	}
-	zr.shutdownWG.Add(1)
-	go func() {
-		defer zr.shutdownWG.Done()
-
+	zr.shutdownWG.Go(func() {
 		if errHTTP := zr.server.Serve(listener); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errHTTP))
 		}
-	}()
+	})
 
 	return nil
 }

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.145.0

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "dependencies"
   ],
   "constraints": {
-    "go": "1.24"
+    "go": "1.25"
   },
   "schedule": [
     "on tuesday"

--- a/scraper/zookeeperscraper/go.mod
+++ b/scraper/zookeeperscraper/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/scraper/zookeeperscraper
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/fluent/fluent-logger-golang v1.10.1

--- a/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatasenders/mockdatadogagentexporter
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -80,14 +80,12 @@ func (ipp *inProcessCollector) Start(StartParams) error {
 		return err
 	}
 
-	ipp.wg.Add(1)
-	go func() {
-		defer ipp.wg.Done()
+	ipp.wg.Go(func() {
 		if appErr := ipp.svc.Run(context.Background()); appErr != nil {
 			// TODO: Pass this to the error handler.
 			panic(appErr)
 		}
-	}()
+	})
 
 	for {
 		switch state := ipp.svc.GetState(); state {

--- a/testbed/testbed/load_generator.go
+++ b/testbed/testbed/load_generator.go
@@ -217,10 +217,7 @@ func (ps *ProviderSender) generate() {
 	tickDuration := ps.perWorkerTickDuration(numWorkers)
 
 	for i := 0; i < numWorkers; i++ {
-		workers.Add(1)
-
-		go func() {
-			defer workers.Done()
+		workers.Go(func() {
 			t := time.NewTicker(tickDuration)
 			defer t.Stop()
 
@@ -238,7 +235,7 @@ func (ps *ProviderSender) generate() {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	workers.Wait()


### PR DESCRIPTION
Follows the normal procedure with the release of [go 1.26](https://go.dev/doc/devel/release#go1.26.0)
