### PR TITLE
Fix rebatching when the id is in the current batch

### DIFF
--- a/.chloggen/fix-rebatching-from-current-batch.yaml
+++ b/.chloggen/fix-rebatching-from-current-batch.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/tail_sampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Properly remove trace id from its original batch when using `decision_wait_after_root_received`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46004]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The bug only causes the traces dropped too early metric to be incorrectly incremented. There is no functional change to what is sampled.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -766,7 +766,7 @@ func (tsp *tailSamplingSpanProcessor) processTrace(id pcommon.TraceID, rss ptrac
 		actualData.SpanCount += spanCount
 	}
 	if containsRootSpan && tsp.cfg.DecisionWaitAfterRootReceived > 0 {
-		tsp.decisionBatcher.MoveToEarlierBatch(id, actualData.batchID, uint64(tsp.cfg.DecisionWaitAfterRootReceived.Seconds()))
+		actualData.batchID = tsp.decisionBatcher.MoveToEarlierBatch(id, actualData.batchID, uint64(tsp.cfg.DecisionWaitAfterRootReceived.Seconds()))
 	}
 
 	finalDecision := actualData.finalDecision


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
There is a bug in `(*batcher).MoveToEarlierBatch` where if the trace id is still in the current batch it will not be properly removed from the current batch causing a decision to be made for the trace twice. This does not break any functionality but will cause the trace dropped too early metric to be improperly incremented if a decision cache is used while also using the new `decision_wait_after_root_received` option.

I also noticed that we aren't updating the batch id on `actualData` after moving a trace so fixed that too. It shouldn't make too much of a difference as it shouldn't be possible to receive two root spans, but better to be safe.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
New tests added that reproduce the failure and cover 100% of code paths in `id_batcher.go`. I have also deployed this to a couple of internal environments and verified that traces dropped too early metric is no longer incremented.
