### PR TITLE
[receiver/httpcheck] Always emit httpcheck.error metric on successful checks

### DIFF
--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -76,6 +76,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 				h.mb.RecordHttpcheckErrorDataPoint(now, int64(1), h.cfg.Targets[targetIndex].Endpoint, err.Error())
 			} else {
 				statusCode = resp.StatusCode
+				h.mb.RecordHttpcheckErrorDataPoint(now, int64(0), h.cfg.Targets[targetIndex].Endpoint, "")
 			}
 
 			for class, intVal := range httpResponseClasses {

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
@@ -12,6 +12,20 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
             name: httpcheck.duration
             unit: ms
+          - description: Records errors occurring during HTTP check.
+            name: httpcheck.error
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: error.message
+                      value:
+                        stringValue: ""
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+            unit: '{error}'
           - description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
             name: httpcheck.status
             sum:

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -12,6 +12,20 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
             name: httpcheck.duration
             unit: ms
+          - description: Records errors occurring during HTTP check.
+            name: httpcheck.error
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: error.message
+                      value:
+                        stringValue: ""
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+            unit: '{error}'
           - description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
             name: httpcheck.status
             sum:

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
@@ -17,6 +17,28 @@ resourceMetrics:
                         stringValue: http://127.0.0.1:8000
             name: httpcheck.duration
             unit: ms
+          - description: Records errors occurring during HTTP check.
+            name: httpcheck.error
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: error.message
+                      value:
+                        stringValue: ""
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                - asInt: "0"
+                  attributes:
+                    - key: error.message
+                      value:
+                        stringValue: ""
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+            unit: '{error}'
           - description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
             name: httpcheck.status
             sum:


### PR DESCRIPTION
#### Description

Record httpcheck.error=0 with an empty error.message on successful HTTP checks so that the metric is consistently present regardless of outcome.

Otherwise it's hard to create alerts based on this metric because you can't differentiate between missing data and a healthy state