### PR TITLE
Azure Eventhub Receiver supports Server & Client Spans

### DIFF
--- a/.chloggen/az-eventhub-receiver-updates.yaml
+++ b/.chloggen/az-eventhub-receiver-updates.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/translator/azure
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Client Server span kinds added and updated OpenTelemetry HTTP semantic conversion to the latest version 1.39.0 for azure Logs, Metrics & Traces
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46028]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/pkg/translator/azure/resourcelogs_to_logs.go
+++ b/pkg/translator/azure/resourcelogs_to_logs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/relvacode/iso8601"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 )

--- a/pkg/translator/azure/resources_to_traces.go
+++ b/pkg/translator/azure/resources_to_traces.go
@@ -133,11 +133,11 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 
 		// Common attributes for both AppRequests and AppDependencies
 		span.SetName(azureTrace.Name)
-		span.Attributes().PutStr("OperationName", azureTrace.OperationName)
-		span.Attributes().PutStr("AppRoleName", azureTrace.AppRoleName)
-		span.Attributes().PutStr("AppRoleInstance", azureTrace.AppRoleInstance)
-		span.Attributes().PutStr("Type", azureTrace.Type)
-		span.Attributes().PutStr("SDKVersion", azureTrace.SDKVersion)
+		span.Attributes().PutStr("operation.name", azureTrace.OperationName)
+		span.Attributes().PutStr("cloud.app.name", azureTrace.AppRoleName)
+		span.Attributes().PutStr("cloud.app.instance", azureTrace.AppRoleInstance)
+		span.Attributes().PutStr("cloud.span.type", azureTrace.Type)
+		span.Attributes().PutStr("azure.client.sdk.version", azureTrace.SDKVersion)
 		switch azureTrace.Success {
 		case true:
 			span.Status().SetCode(ptrace.StatusCodeOk)
@@ -162,10 +162,10 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 			span.Attributes().PutStr(string(conventions.URLPathKey), hostpath)
 			span.Attributes().PutStr(string(conventions.URLSchemeKey), scheme)
 			span.Attributes().PutStr(string(conventions.ClientAddressKey), azureTrace.ClientIP)
-			span.Attributes().PutStr("geo.locality.name", azureTrace.ClientCity)
+			span.Attributes().PutStr("client.geo.locality.name", azureTrace.ClientCity)
 			span.Attributes().PutStr("client.type", azureTrace.ClientType)
-			span.Attributes().PutStr("client.state", azureTrace.ClientStateOrProvince)
-			span.Attributes().PutStr("client.country", azureTrace.ClientCountryOrRegion)
+			span.Attributes().PutStr("client.geo.region.iso_code", azureTrace.ClientStateOrProvince)
+			span.Attributes().PutStr("client.geo.country.iso_code", azureTrace.ClientCountryOrRegion)
 			span.Attributes().PutStr(string(conventions.HTTPResponseStatusCodeKey), azureTrace.ResultCode)
 			span.Attributes().PutDouble(string(conventions.HTTPResponseBodySizeKey), azureTrace.Measurements["Response Size"])
 			span.Attributes().PutDouble(string(conventions.HTTPRequestBodySizeKey), azureTrace.Measurements["Request Size"])

--- a/pkg/translator/azure/resources_to_traces.go
+++ b/pkg/translator/azure/resources_to_traces.go
@@ -138,7 +138,14 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 		span.Attributes().PutStr("AppRoleInstance", azureTrace.AppRoleInstance)
 		span.Attributes().PutStr("Type", azureTrace.Type)
 		span.Attributes().PutStr("SDKVersion", azureTrace.SDKVersion)
-		span.Attributes().PutBool("Success", azureTrace.Success)
+		switch azureTrace.Success {
+		case true:
+			span.Status().SetCode(ptrace.StatusCodeOk)
+		case false:
+			span.Status().SetCode(ptrace.StatusCodeError)
+		default:
+			span.Status().SetCode(ptrace.StatusCodeUnset)
+		}
 		span.Attributes().PutStr(string(conventions.UserAgentOriginalKey), azureTrace.Properties["Request-User-Agent"])
 
 		switch azureTrace.Type {
@@ -155,7 +162,7 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 			span.Attributes().PutStr(string(conventions.URLPathKey), hostpath)
 			span.Attributes().PutStr(string(conventions.URLSchemeKey), scheme)
 			span.Attributes().PutStr(string(conventions.ClientAddressKey), azureTrace.ClientIP)
-			span.Attributes().PutStr("client.city", azureTrace.ClientCity)
+			span.Attributes().PutStr("geo.locality.name", azureTrace.ClientCity)
 			span.Attributes().PutStr("client.type", azureTrace.ClientType)
 			span.Attributes().PutStr("client.state", azureTrace.ClientStateOrProvince)
 			span.Attributes().PutStr("client.country", azureTrace.ClientCountryOrRegion)
@@ -170,9 +177,9 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 
 			switch azureTrace.DependencyType {
 			case "Backend":
-				span.Attributes().PutStr("http.request.method", azureTrace.Properties["Backend Method"])
+				span.Attributes().PutStr(string(conventions.HTTPRequestMethodKey), azureTrace.Properties["Backend Method"])
 			case "HTTP":
-				span.Attributes().PutStr("http.request.method", azureTrace.Properties["HTTP Method"])
+				span.Attributes().PutStr(string(conventions.HTTPRequestMethodKey), azureTrace.Properties["HTTP Method"])
 			}
 
 			urlObj, _ := url.Parse(azureTrace.Target)

--- a/pkg/translator/azure/resources_to_traces.go
+++ b/pkg/translator/azure/resources_to_traces.go
@@ -133,10 +133,10 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 
 		// Common attributes for both AppRequests and AppDependencies
 		span.SetName(azureTrace.Name)
-		span.Attributes().PutStr("operation.name", azureTrace.OperationName)
-		span.Attributes().PutStr("cloud.app.name", azureTrace.AppRoleName)
-		span.Attributes().PutStr("cloud.app.instance", azureTrace.AppRoleInstance)
-		span.Attributes().PutStr("cloud.span.type", azureTrace.Type)
+		span.Attributes().PutStr("azure.operation.name", azureTrace.OperationName)
+		span.Attributes().PutStr("azure.app.name", azureTrace.AppRoleName)
+		span.Attributes().PutStr("azure.app.instance", azureTrace.AppRoleInstance)
+		span.Attributes().PutStr("azure.category", azureTrace.Type)
 		span.Attributes().PutStr("azure.client.sdk.version", azureTrace.SDKVersion)
 		switch azureTrace.Success {
 		case true:

--- a/pkg/translator/azure/resources_to_traces.go
+++ b/pkg/translator/azure/resources_to_traces.go
@@ -114,12 +114,12 @@ func (r TracesUnmarshaler) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 		traceID, traceErr := TraceIDFromHex(azureTrace.OperationID)
 		if traceErr != nil {
 			r.Logger.Warn("Invalid TraceID", zap.String("traceID", azureTrace.OperationID))
-			return t, traceErr
+			return t, err
 		}
 		spanID, spanErr := SpanIDFromHex(azureTrace.SpanID)
 		if spanErr != nil {
 			r.Logger.Warn("Invalid SpanID", zap.String("spanID", azureTrace.SpanID))
-			return t, spanErr
+			return t, err
 		}
 		parentID, parentErr := SpanIDFromHex(azureTrace.ParentID)
 		if parentErr != nil {

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -247,6 +247,8 @@ See: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/appm
 
 Traces based on Azure Application Insights array of records from `AppRequests` & `AppDependencies` with the following fields.
 
+Basic mapping
+
 | Azure       | Open Telemetry                                        |
 |-------------|-------------------------------------------------------|
 | Time        | start_time(time_unix_nano(time))                      |
@@ -256,5 +258,7 @@ Traces based on Azure Application Insights array of records from `AppRequests` &
 | ParentId    | span.parentId                                         |
 | Id          | span.id                                               |
 | AppRoleName | service.name                                          |
+| Type        | `AppRequests` => SpanKind `Server`                    |
+|             | `AppDependencies` => SpanKind `Client`                |
 
 [storage extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+	conventions "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver/internal/metadata"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Azure Eventhub Recevier supports Server & Client Spans
- Updated OpenTelemetry HTTP semantic conversion to the latest version 1.39.0

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
