### PR TITLE
[exporter/signalfx] Add stateful deduplication for dimension updates

### DIFF
--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -155,23 +155,23 @@ func (se *signalfxExporter) startDimensionClient(ctx context.Context) error {
 
 	dimClient := dimensions.NewDimensionClient(
 		dimensions.DimensionClientOptions{
-			Token:        se.config.AccessToken,
-			APIURL:       apiURL,
-			APITLSConfig: apiTLSCfg,
-			LogUpdates:   se.config.LogDimensionUpdates,
-			Logger:       se.logger,
-			// Duration to wait between property updates.
-			SendDelay:               se.config.DimensionClient.SendDelay,
-			MaxBuffered:             se.config.DimensionClient.MaxBuffered,
-			NonAlphanumericDimChars: se.config.NonAlphanumericDimensionChars,
-			DefaultProperties:       se.config.DefaultProperties,
-			ExcludeProperties:       se.config.ExcludeProperties,
-			MaxConnsPerHost:         se.config.DimensionClient.MaxConnsPerHost,
-			MaxIdleConns:            se.config.DimensionClient.MaxIdleConns,
-			MaxIdleConnsPerHost:     se.config.DimensionClient.MaxIdleConnsPerHost,
-			IdleConnTimeout:         se.config.DimensionClient.IdleConnTimeout,
-			Timeout:                 se.config.DimensionClient.Timeout,
-			DropTags:                se.config.DimensionClient.DropTags,
+			Token:                       se.config.AccessToken,
+			APIURL:                      apiURL,
+			APITLSConfig:                apiTLSCfg,
+			LogUpdates:                  se.config.LogDimensionUpdates,
+			Logger:                      se.logger,
+			SendDelay:                   se.config.DimensionClient.SendDelay,
+			MaxBuffered:                 se.config.DimensionClient.MaxBuffered,
+			NonAlphanumericDimChars:     se.config.NonAlphanumericDimensionChars,
+			DefaultProperties:           se.config.DefaultProperties,
+			ExcludeProperties:           se.config.ExcludeProperties,
+			MaxConnsPerHost:             se.config.DimensionClient.MaxConnsPerHost,
+			MaxIdleConns:                se.config.DimensionClient.MaxIdleConns,
+			MaxIdleConnsPerHost:         se.config.DimensionClient.MaxIdleConnsPerHost,
+			IdleConnTimeout:             se.config.DimensionClient.IdleConnTimeout,
+			Timeout:                     se.config.DimensionClient.Timeout,
+			DropTags:                    se.config.DimensionClient.DropTags,
+			EnableStatefulDeduplication: statefulDeduplicationFeatureGate.IsEnabled(),
 		})
 	dimClient.Start()
 	se.dimClient = dimClient
@@ -296,9 +296,10 @@ func (se *signalfxExporter) processEntityEvents(logs plog.LogRecordSlice) error 
 			continue
 		}
 
-		// Failure to accept dimension likely means exceeded buffer. Reject all further
-		// dimension updates for this export cycle.
-		if err := se.dimClient.AcceptDimension(dimUpdate); err != nil {
+		// Apply filters and deduplication, then queue
+		if err := se.dimClient.AcceptDimensionWithDedup(dimUpdate); err != nil {
+			// Failure to accept dimension likely means exceeded buffer. Reject all further
+			// dimension updates for this export cycle.
 			return fmt.Errorf("failed to accept dimension update: %w", err)
 		}
 	}

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -43,6 +43,12 @@ var entityEventsFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	featuregate.WithRegisterDescription("Process entity events from logs pipeline and convert to dimension property updates"),
 	featuregate.WithRegisterFromVersion("v0.145.0"))
 
+var statefulDeduplicationFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.signalfx.dimensionStatefulDeduplication",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("Enable stateful deduplication for dimension updates to prevent sending duplicate property updates"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27890"))
+
 // NewFactory creates a factory for SignalFx exporter.
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.145.0
@@ -44,7 +45,6 @@ require (
 )
 
 require (
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/elastic/lunes v0.2.0 // indirect

--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -26,10 +26,33 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/sanitize"
 )
 
+// hashCache stores dimension update hashes for deduplication.
+type hashCache struct {
+	sync.Mutex
+	hashes map[DimensionKey]uint64
+}
+
+func newHashCache() *hashCache {
+	return &hashCache{
+		hashes: make(map[DimensionKey]uint64),
+	}
+}
+
+// checkAndUpdate atomically checks if the stored hash matches and updates it.
+// Returns true if the hash matches the stored value, false otherwise.
+func (hc *hashCache) checkAndUpdate(key DimensionKey, hash uint64) bool {
+	hc.Lock()
+	defer hc.Unlock()
+
+	lastHash, exists := hc.hashes[key]
+	if exists && lastHash == hash {
+		return true
+	}
+	hc.hashes[key] = hash
+	return false
+}
+
 // DimensionClient sends updates to dimensions to the SignalFx API
-// This is a port of https://github.com/signalfx/signalfx-agent/blob/main/pkg/core/writer/dimensions/client.go
-// with the only major difference being deduplication of dimension
-// updates are currently not done by this port.
 type DimensionClient struct {
 	sync.RWMutex
 	cancel        context.CancelFunc
@@ -61,6 +84,9 @@ type DimensionClient struct {
 	ExcludeProperties []dpfilters.PropertyFilter
 	// dropTags specifies whether tags should be omitted or not. Default value is false.
 	dropTags bool
+	// lastSeenCache stores dimension update hashes for deduplication.
+	// If nil, deduplication is disabled.
+	lastSeenCache *hashCache
 }
 
 type queuedDimension struct {
@@ -87,6 +113,9 @@ type DimensionClientOptions struct {
 	IdleConnTimeout         time.Duration
 	Timeout                 time.Duration
 	DropTags                bool
+	// EnableStatefulDeduplication controls whether to track last sent state
+	// and skip sending updates when dimension properties haven't changed.
+	EnableStatefulDeduplication bool
 }
 
 // NewDimensionClient returns a new client
@@ -110,6 +139,11 @@ func NewDimensionClient(options DimensionClientOptions) *DimensionClient {
 	}
 	sender := NewReqSender(client, 20, map[string]string{"client": "dimension"})
 
+	var lastSeenCache *hashCache
+	if options.EnableStatefulDeduplication {
+		lastSeenCache = newHashCache()
+	}
+
 	return &DimensionClient{
 		Token:                   options.Token,
 		APIURL:                  options.APIURL,
@@ -125,6 +159,7 @@ func NewDimensionClient(options DimensionClientOptions) *DimensionClient {
 		DefaultProperties:       options.DefaultProperties,
 		ExcludeProperties:       options.ExcludeProperties,
 		dropTags:                options.DropTags,
+		lastSeenCache:           lastSeenCache,
 	}
 }
 
@@ -144,13 +179,27 @@ func (dc *DimensionClient) Shutdown() {
 	}
 }
 
-// AcceptDimension to be sent to the API.  This will return fairly quickly and
-// won't block. If the buffer is full, the dim update will be dropped.
-func (dc *DimensionClient) AcceptDimension(dimUpdate *DimensionUpdate) error {
-	if dimUpdate = dc.filterDimensionUpdate(dimUpdate); dimUpdate == nil {
+// AcceptDimensionWithDedup applies filtering and deduplication before queuing the dimension update.
+func (dc *DimensionClient) AcceptDimensionWithDedup(dimUpdate *DimensionUpdate) error {
+	dimUpdate = dc.filterDimensionUpdate(dimUpdate)
+	if dimUpdate == nil {
 		return nil
 	}
 
+	if dc.lastSeenCache != nil {
+		if dc.lastSeenCache.checkAndUpdate(dimUpdate.Key(), dimUpdate.Hash()) {
+			return nil
+		}
+	}
+
+	return dc.AcceptDimension(dimUpdate)
+}
+
+// AcceptDimension queues a dimension update to be sent to the API.
+// This will return fairly quickly and won't block.
+// If the buffer is full, the dim update will be dropped.
+// Note: This does NOT apply filtering or deduplication. Use AcceptDimensionWithDedup for that.
+func (dc *DimensionClient) AcceptDimension(dimUpdate *DimensionUpdate) error {
 	dc.Lock()
 	defer dc.Unlock()
 

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -128,7 +128,7 @@ func TestDimensionClient(t *testing.T) {
 
 	t.Run("send dimension update with properties and tags", func(t *testing.T) {
 		server.reset()
-		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimensionWithDedup(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -161,7 +161,7 @@ func TestDimensionClient(t *testing.T) {
 
 	t.Run("same dimension with different values", func(t *testing.T) {
 		server.reset()
-		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimensionWithDedup(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -192,7 +192,7 @@ func TestDimensionClient(t *testing.T) {
 		client.dropTags = true
 		defer func() { client.dropTags = false }()
 
-		require.NoError(t, client.AcceptDimension(&DimensionUpdate{
+		require.NoError(t, client.AcceptDimensionWithDedup(&DimensionUpdate{
 			Name:  "host",
 			Value: "test-box",
 			Properties: map[string]*string{
@@ -503,4 +503,147 @@ func TestInvalidUpdatesNotSent(t *testing.T) {
 func newString(s string) *string {
 	out := s
 	return &out
+}
+
+func TestStatefulDeduplication(t *testing.T) {
+	ts := &testServer{
+		startCh:      make(chan struct{}),
+		finishCh:     make(chan struct{}),
+		respCode:     http.StatusOK,
+		requestCount: new(atomic.Int32),
+	}
+	ts.server = httptest.NewServer(ts)
+	defer ts.server.Close()
+
+	url, err := url.Parse(ts.server.URL)
+	require.NoError(t, err)
+
+	client := NewDimensionClient(DimensionClientOptions{
+		Token:                       "test",
+		APIURL:                      url,
+		Logger:                      zap.NewNop(),
+		SendDelay:                   1 * time.Millisecond,
+		MaxBuffered:                 10,
+		EnableStatefulDeduplication: true,
+	})
+	client.Start()
+	defer client.Shutdown()
+
+	propVal1 := "value1"
+	propVal2 := "value2"
+
+	// Send first update
+	dimUpdate1 := &DimensionUpdate{
+		Name:  "host",
+		Value: "test-host",
+		Properties: map[string]*string{
+			"prop1": &propVal1,
+		},
+		Tags: map[string]bool{
+			"tag1": true,
+		},
+	}
+
+	err = client.AcceptDimensionWithDedup(dimUpdate1)
+	require.NoError(t, err)
+
+	ts.handleRequest()
+
+	// Send identical update - should be deduplicated
+	dimUpdate2 := &DimensionUpdate{
+		Name:  "host",
+		Value: "test-host",
+		Properties: map[string]*string{
+			"prop1": &propVal1,
+		},
+		Tags: map[string]bool{
+			"tag1": true,
+		},
+	}
+
+	err = client.AcceptDimensionWithDedup(dimUpdate2)
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	require.EqualValues(t, 1, ts.requestCount.Load())
+	require.Len(t, ts.acceptedDims, 1)
+
+	// Send different update - should NOT be deduplicated
+	dimUpdate3 := &DimensionUpdate{
+		Name:  "host",
+		Value: "test-host",
+		Properties: map[string]*string{
+			"prop1": &propVal2,
+		},
+		Tags: map[string]bool{
+			"tag1": true,
+		},
+	}
+
+	err = client.AcceptDimensionWithDedup(dimUpdate3)
+	require.NoError(t, err)
+
+	ts.handleRequest()
+
+	require.EqualValues(t, 2, ts.requestCount.Load())
+	require.Len(t, ts.acceptedDims, 2)
+}
+
+func TestStatefulDeduplicationDisabled(t *testing.T) {
+	ts := &testServer{
+		startCh:      make(chan struct{}),
+		finishCh:     make(chan struct{}),
+		respCode:     http.StatusOK,
+		requestCount: new(atomic.Int32),
+	}
+	ts.server = httptest.NewServer(ts)
+	defer ts.server.Close()
+
+	url, err := url.Parse(ts.server.URL)
+	require.NoError(t, err)
+
+	client := NewDimensionClient(DimensionClientOptions{
+		Token:                       "test",
+		APIURL:                      url,
+		Logger:                      zap.NewNop(),
+		SendDelay:                   1 * time.Millisecond,
+		MaxBuffered:                 10,
+		EnableStatefulDeduplication: false,
+	})
+	client.Start()
+	defer client.Shutdown()
+
+	propVal := "value1"
+
+	// Send first update
+	dimUpdate1 := &DimensionUpdate{
+		Name:  "host",
+		Value: "test-host",
+		Properties: map[string]*string{
+			"prop1": &propVal,
+		},
+	}
+
+	err = client.AcceptDimension(dimUpdate1)
+	require.NoError(t, err)
+
+	ts.handleRequest()
+
+	// Send identical update - should NOT be deduplicated (feature disabled)
+	dimUpdate2 := &DimensionUpdate{
+		Name:  "host",
+		Value: "test-host",
+		Properties: map[string]*string{
+			"prop1": &propVal,
+		},
+	}
+
+	err = client.AcceptDimension(dimUpdate2)
+	require.NoError(t, err)
+
+	ts.handleRequest()
+
+	require.EqualValues(t, 2, ts.requestCount.Load())
+	require.Len(t, ts.acceptedDims, 2)
 }

--- a/exporter/signalfxexporter/internal/dimensions/dimensionupdate.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimensionupdate.go
@@ -5,7 +5,19 @@ package dimensions // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+const (
+	hashSeparator     = byte(0)
+	hashNilMarker     = "<nil>"
+	hashPropMarker    = "P:"
+	hashTagMarker     = "T:"
+	hashTagTrueValue  = byte(1)
+	hashTagFalseValue = byte(0)
 )
 
 type DimensionUpdate struct {
@@ -44,4 +56,52 @@ type DimensionKey struct {
 
 func (dk DimensionKey) String() string {
 	return fmt.Sprintf("[%s/%s]", dk.Name, dk.Value)
+}
+
+// Hash computes a deterministic hash of the dimension update's properties and tags.
+func (d *DimensionUpdate) Hash() uint64 {
+	h := xxhash.New()
+
+	if len(d.Properties) > 0 {
+		_, _ = h.WriteString(hashPropMarker)
+		propKeys := make([]string, 0, len(d.Properties))
+		for k := range d.Properties {
+			propKeys = append(propKeys, k)
+		}
+		sort.Strings(propKeys)
+
+		for _, k := range propKeys {
+			_, _ = h.WriteString(k)
+			_, _ = h.Write([]byte{hashSeparator})
+			v := d.Properties[k]
+			if v != nil {
+				_, _ = h.WriteString(*v)
+			} else {
+				_, _ = h.WriteString(hashNilMarker)
+			}
+			_, _ = h.Write([]byte{hashSeparator})
+		}
+	}
+
+	if len(d.Tags) > 0 {
+		_, _ = h.WriteString(hashTagMarker)
+		tagKeys := make([]string, 0, len(d.Tags))
+		for k := range d.Tags {
+			tagKeys = append(tagKeys, k)
+		}
+		sort.Strings(tagKeys)
+
+		for _, k := range tagKeys {
+			_, _ = h.WriteString(k)
+			_, _ = h.Write([]byte{hashSeparator})
+			if d.Tags[k] {
+				_, _ = h.Write([]byte{hashTagTrueValue})
+			} else {
+				_, _ = h.Write([]byte{hashTagFalseValue})
+			}
+			_, _ = h.Write([]byte{hashSeparator})
+		}
+	}
+
+	return h.Sum64()
 }

--- a/exporter/signalfxexporter/internal/dimensions/dimensionupdate_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimensionupdate_test.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dimensions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDimensionUpdate_Hash(t *testing.T) {
+	tests := []struct {
+		name    string
+		update1 *DimensionUpdate
+		update2 *DimensionUpdate
+		equal   bool
+	}{
+		{
+			name: "identical_properties",
+			update1: &DimensionUpdate{
+				Properties: map[string]*string{
+					"a": strPtr("1"),
+					"b": strPtr("2"),
+					"c": strPtr("3"),
+				},
+			},
+			update2: &DimensionUpdate{
+				Properties: map[string]*string{
+					"c": strPtr("3"),
+					"a": strPtr("1"),
+					"b": strPtr("2"),
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "different_property_values",
+			update1: &DimensionUpdate{
+				Properties: map[string]*string{"prop": strPtr("val1")},
+			},
+			update2: &DimensionUpdate{
+				Properties: map[string]*string{"prop": strPtr("val2")},
+			},
+			equal: false,
+		},
+		{
+			name: "nil_vs_non_nil_property",
+			update1: &DimensionUpdate{
+				Properties: map[string]*string{"prop": nil},
+			},
+			update2: &DimensionUpdate{
+				Properties: map[string]*string{"prop": strPtr("value")},
+			},
+			equal: false,
+		},
+		{
+			name: "identical_tags",
+			update1: &DimensionUpdate{
+				Tags: map[string]bool{"tag1": true, "tag2": false, "tag3": true},
+			},
+			update2: &DimensionUpdate{
+				Tags: map[string]bool{"tag3": true, "tag1": true, "tag2": false},
+			},
+			equal: true,
+		},
+		{
+			name: "different_tag_values",
+			update1: &DimensionUpdate{
+				Tags: map[string]bool{"tag": true},
+			},
+			update2: &DimensionUpdate{
+				Tags: map[string]bool{"tag": false},
+			},
+			equal: false,
+		},
+		{
+			name: "property_vs_tag_collision_resistance",
+			update1: &DimensionUpdate{
+				Properties: map[string]*string{"key": strPtr("value")},
+			},
+			update2: &DimensionUpdate{
+				Tags: map[string]bool{"key": true},
+			},
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash1 := tt.update1.Hash()
+			hash2 := tt.update2.Hash()
+			if tt.equal {
+				assert.Equal(t, hash1, hash2)
+			} else {
+				assert.NotEqual(t, hash1, hash2)
+			}
+		})
+	}
+}

--- a/exporter/signalfxexporter/internal/dimensions/metadata.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata.go
@@ -108,7 +108,8 @@ func (dc *DimensionClient) PushMetadata(metadata []*metadata.MetadataUpdate) err
 			return fmt.Errorf("dimensionUpdate %v is missing Name or value, cannot send", dimensionUpdate)
 		}
 
-		errs = multierr.Append(errs, dc.AcceptDimension(dimensionUpdate))
+		// Apply filters and deduplication, then queue
+		errs = multierr.Append(errs, dc.AcceptDimensionWithDedup(dimensionUpdate))
 	}
 
 	return errs


### PR DESCRIPTION
Follow-up to open-telemetry/opentelemetry-collector-contrib#45595.

This change adds hash-based, stateful deduplication for dimension property updates to prevent duplicate API calls.

It addresses the issue where the `k8s_cluster` receiver periodically resends entity events every `metadata_collection_interval` (default: 5 minutes), which can trigger redundant dimension property updates. Even if periodic events are disabled with `metadata_collection_interval: 0` on the `k8s_cluster` receiver side, identical entity events can still be sent because the entity payload is only a subset of the full Kubernetes object. Other parts of the Kubernetes object may change in ways that do not affect the captured entity payload, but still cause the event to be re-emitted.

For now, this is behind the feature gate `exporter.signalfx.dimensionStatefulDeduplication` and is disabled by default.

A follow-up PR will add an adaptive TTL for the hash cache to manage memory usage over time and evict keys for dimensions that are no longer active.
