### PR TITLE
[receiver/windowsservice] bug fix for scrape error crash

### DIFF
--- a/.chloggen/46008-regenerate-component.yaml
+++ b/.chloggen/46008-regenerate-component.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/windowsservice
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: regenerated component with mdatagen to fix a bug causing crash on repeated scrape cycles
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46008]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/windowsservicereceiver/generated_package_test.go
+++ b/receiver/windowsservicereceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package windowsservicereceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/windowsservicereceiver/internal/metadata/generated_config_test.go
+++ b/receiver/windowsservicereceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )


### PR DESCRIPTION
#### Description
Fixes a bug with the new mdatagen tool which was causing the receiver to crash after multiple scrape cycles.

#### Link to tracking issue
Fixes [46008](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46008)

