### PR TITLE
[chore] remove Kubernetes v1.35.0 from e2e test matrix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,7 +96,6 @@ jobs:
         k8s-version:
           - "v1.32.8"
           - "v1.34.0"
-          - "v1.35.0"
         component:
           - receiver/k8sclusterreceiver
           - processor/k8sattributesprocessor

--- a/extension/observer/k8sobserver/README.md
+++ b/extension/observer/k8sobserver/README.md
@@ -67,7 +67,7 @@ This spec-determined value would then be available via the `${env:K8S_NODE_NAME}
 
 ### Kubernetes Versions
 
-This extension is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L99)
+This extension is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L98)
 workflow. These tested versions represent the officially supported Kubernetes versions for this component.
 
 ## Config

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -965,7 +965,7 @@ as tags.
 
 ### Kubernetes Versions
 
-This processor is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L99)
+This processor is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L98)
 workflow. These tested versions represent the officially supported Kubernetes versions for this component.
 
 ## Production Deployment Guide

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -156,7 +156,7 @@ for the format of emitted log records.
 
 ### Kubernetes Versions
 
-This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L99)
+This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L98)
 workflow. These tested versions represent the officially supported Kubernetes versions for this component.
 
 ## Example

--- a/receiver/k8sobjectsreceiver/README.md
+++ b/receiver/k8sobjectsreceiver/README.md
@@ -249,7 +249,7 @@ EOF
 
 ### Kubernetes Versions
 
-This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L99)
+This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L98)
 workflow. These tested versions represent the officially supported Kubernetes versions for this component.
 
 ## Troubleshooting

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -25,7 +25,7 @@ Details about the metrics produced by this receiver can be found in [metadata.ya
 
 ### Kubernetes Versions
 
-This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L99)
+This receiver is tested against the Kubernetes versions specified in the [e2e-tests.yml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/e2e-tests.yml#L97-L98)
 workflow. These tested versions represent the officially supported Kubernetes versions for this component.
 
 ## Configuration


### PR DESCRIPTION
#### Description
http://github.com/open-telemetry/opentelemetry-collector-contrib/commit/482448c34c3a1feda7e156f34323fa0dc851c46e added 1.35.0 to the test matrix, that seems to introduce more flakiness to k8s tests. Remove 1.35.0 and keep 2 versions in the matrix for now. We can drop 1.32.8 and add back 1.35.0 in ~2 weeks (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46054)