### PR TITLE
[receiver/mongodbreceiver] Skip database-level commands when all data…

### DIFF
--- a/.chloggen/fix-mongodb-skip-db-commands.yaml
+++ b/.chloggen/fix-mongodb-skip-db-commands.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip database-level commands when all database metrics are disabled to prevent unauthorized errors on sharded clusters with direct_connection
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45924]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -21,6 +21,65 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver/internal/metadata"
 )
 
+// databaseMetricNames lists the MetricsConfig field names that require database iteration
+// (ListDatabaseNames, DBStats, ListCollectionNames, or IndexStats commands).
+// This is the single source of truth used by requiresDatabaseIteration and tests.
+var databaseMetricNames = []string{
+	"MongodbCollectionCount",
+	"MongodbDataSize",
+	"MongodbExtentCount",
+	"MongodbIndexSize",
+	"MongodbIndexCount",
+	"MongodbObjectCount",
+	"MongodbStorageSize",
+	"MongodbIndexAccessCount",
+	"MongodbConnectionCount",
+	"MongodbDocumentOperationCount",
+	"MongodbMemoryUsage",
+	"MongodbLockAcquireCount",
+	"MongodbLockAcquireWaitCount",
+	"MongodbLockAcquireTime",
+	"MongodbLockDeadlockCount",
+}
+
+// serverMetricNames lists the MetricsConfig field names that only require admin-level
+// server commands and do not need database iteration.
+// This is the single source of truth used by requiresDatabaseIteration and tests.
+var serverMetricNames = []string{
+	"MongodbActiveReads",
+	"MongodbActiveWrites",
+	"MongodbCacheOperations",
+	"MongodbCommandsRate",
+	"MongodbCursorCount",
+	"MongodbCursorTimeoutCount",
+	"MongodbDatabaseCount",
+	"MongodbDeletesRate",
+	"MongodbFlushesRate",
+	"MongodbGetmoresRate",
+	"MongodbGlobalLockTime",
+	"MongodbHealth",
+	"MongodbInsertsRate",
+	"MongodbNetworkIoReceive",
+	"MongodbNetworkIoTransmit",
+	"MongodbNetworkRequestCount",
+	"MongodbOperationCount",
+	"MongodbOperationLatencyTime",
+	"MongodbOperationReplCount",
+	"MongodbOperationTime",
+	"MongodbPageFaults",
+	"MongodbQueriesRate",
+	"MongodbReplCommandsPerSec",
+	"MongodbReplDeletesPerSec",
+	"MongodbReplGetmoresPerSec",
+	"MongodbReplInsertsPerSec",
+	"MongodbReplQueriesPerSec",
+	"MongodbReplUpdatesPerSec",
+	"MongodbSessionCount",
+	"MongodbUpdatesRate",
+	"MongodbUptime",
+	"MongodbWtcacheBytesRead",
+}
+
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
 	configtls.ClientConfig         `mapstructure:"tls,omitempty"`

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -145,6 +145,37 @@ func (s *mongodbScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 }
 
 func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.ScrapeErrors) {
+	// Check if we need to iterate databases
+	if !s.requiresDatabaseIteration() {
+		s.logger.Debug("Skipping database iteration as all database-level metrics are disabled")
+
+		// Still collect admin-level server metrics
+		serverStatus, sErr := s.client.ServerStatus(ctx, "admin")
+		if sErr != nil {
+			errs.Add(fmt.Errorf("failed to fetch server status: %w", sErr))
+			return
+		}
+		serverAddress, serverPort, aErr := serverAddressAndPort(serverStatus)
+		if aErr != nil {
+			errs.Add(fmt.Errorf("failed to fetch server address and port: %w", aErr))
+			return
+		}
+
+		now := pcommon.NewTimestampFromTime(time.Now())
+
+		// Collect admin-level metrics (these don't require database iteration)
+		s.recordAdminStats(now, serverStatus, errs)
+		s.collectTopStats(ctx, now, errs)
+
+		rb := s.mb.NewResourceBuilder()
+		rb.SetServerAddress(serverAddress)
+		rb.SetServerPort(serverPort)
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+
+		return // Skip database iteration
+	}
+
+	// Original code path - database metrics are enabled
 	dbNames, err := s.client.ListDatabaseNames(ctx, bson.D{})
 	if err != nil {
 		errs.AddPartial(1, fmt.Errorf("failed to fetch database names: %w", err))
@@ -191,6 +222,39 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 		rb.SetDatabase(dbName)
 		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
+}
+
+// requiresDatabaseIteration checks if any metrics that require database iteration are enabled.
+// Returns true if we need to call ListDatabaseNames, DBStats, ListCollectionNames, or IndexStats.
+func (s *mongodbScraper) requiresDatabaseIteration() bool {
+	// Database-level metrics (require DBStats command)
+	if s.config.Metrics.MongodbCollectionCount.Enabled ||
+		s.config.Metrics.MongodbDataSize.Enabled ||
+		s.config.Metrics.MongodbExtentCount.Enabled ||
+		s.config.Metrics.MongodbIndexSize.Enabled ||
+		s.config.Metrics.MongodbIndexCount.Enabled ||
+		s.config.Metrics.MongodbObjectCount.Enabled ||
+		s.config.Metrics.MongodbStorageSize.Enabled {
+		return true
+	}
+
+	// Collection-level metrics (require ListCollectionNames + IndexStats commands)
+	if s.config.Metrics.MongodbIndexAccessCount.Enabled {
+		return true
+	}
+
+	// Per-database server metrics (require per-database ServerStatus command)
+	if s.config.Metrics.MongodbConnectionCount.Enabled ||
+		s.config.Metrics.MongodbDocumentOperationCount.Enabled ||
+		s.config.Metrics.MongodbMemoryUsage.Enabled ||
+		s.config.Metrics.MongodbLockAcquireCount.Enabled ||
+		s.config.Metrics.MongodbLockAcquireWaitCount.Enabled ||
+		s.config.Metrics.MongodbLockAcquireTime.Enabled ||
+		s.config.Metrics.MongodbLockDeadlockCount.Enabled {
+		return true
+	}
+
+	return false
 }
 
 func (s *mongodbScraper) collectDatabase(ctx context.Context, now pcommon.Timestamp, databaseName string, errs *scrapererror.ScrapeErrors) {

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -145,41 +145,18 @@ func (s *mongodbScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 }
 
 func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.ScrapeErrors) {
-	// Check if we need to iterate databases
-	if !s.requiresDatabaseIteration() {
+	var dbNames []string
+	var err error
+
+	// Skip database iteration if no database-level metrics are enabled
+	if s.requiresDatabaseIteration() {
+		dbNames, err = s.client.ListDatabaseNames(ctx, bson.D{})
+		if err != nil {
+			errs.AddPartial(1, fmt.Errorf("failed to fetch database names: %w", err))
+			return
+		}
+	} else {
 		s.logger.Debug("Skipping database iteration as all database-level metrics are disabled")
-
-		// Still collect admin-level server metrics
-		serverStatus, sErr := s.client.ServerStatus(ctx, "admin")
-		if sErr != nil {
-			errs.Add(fmt.Errorf("failed to fetch server status: %w", sErr))
-			return
-		}
-		serverAddress, serverPort, aErr := serverAddressAndPort(serverStatus)
-		if aErr != nil {
-			errs.Add(fmt.Errorf("failed to fetch server address and port: %w", aErr))
-			return
-		}
-
-		now := pcommon.NewTimestampFromTime(time.Now())
-
-		// Collect admin-level metrics (these don't require database iteration)
-		s.recordAdminStats(now, serverStatus, errs)
-		s.collectTopStats(ctx, now, errs)
-
-		rb := s.mb.NewResourceBuilder()
-		rb.SetServerAddress(serverAddress)
-		rb.SetServerPort(serverPort)
-		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
-
-		return // Skip database iteration
-	}
-
-	// Original code path - database metrics are enabled
-	dbNames, err := s.client.ListDatabaseNames(ctx, bson.D{})
-	if err != nil {
-		errs.AddPartial(1, fmt.Errorf("failed to fetch database names: %w", err))
-		return
 	}
 
 	serverStatus, sErr := s.client.ServerStatus(ctx, "admin")
@@ -195,7 +172,9 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
+	if len(dbNames) > 0 {
+		s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
+	}
 	s.recordAdminStats(now, serverStatus, errs)
 	s.collectTopStats(ctx, now, errs)
 

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -145,20 +146,6 @@ func (s *mongodbScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 }
 
 func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.ScrapeErrors) {
-	var dbNames []string
-	var err error
-
-	// Skip database iteration if no database-level metrics are enabled
-	if s.requiresDatabaseIteration() {
-		dbNames, err = s.client.ListDatabaseNames(ctx, bson.D{})
-		if err != nil {
-			errs.AddPartial(1, fmt.Errorf("failed to fetch database names: %w", err))
-			return
-		}
-	} else {
-		s.logger.Debug("Skipping database iteration as all database-level metrics are disabled")
-	}
-
 	serverStatus, sErr := s.client.ServerStatus(ctx, "admin")
 	if sErr != nil {
 		errs.Add(fmt.Errorf("failed to fetch server status: %w", sErr))
@@ -171,19 +158,30 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 	}
 
 	now := pcommon.NewTimestampFromTime(time.Now())
-
-	if len(dbNames) > 0 {
-		s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
-	}
 	s.recordAdminStats(now, serverStatus, errs)
 	s.collectTopStats(ctx, now, errs)
+
+	// Fetch database names and record the count before emitting the admin resource,
+	// so the database count metric lands on the admin resource alongside other server metrics.
+	// Database iteration is skipped entirely if no database-level metrics are enabled.
+	var dbNames []string
+	if s.requiresDatabaseIteration() {
+		var err error
+		dbNames, err = s.client.ListDatabaseNames(ctx, bson.D{})
+		if err != nil {
+			errs.AddPartial(1, fmt.Errorf("failed to fetch database names: %w", err))
+		} else {
+			s.mb.RecordMongodbDatabaseCountDataPoint(now, int64(len(dbNames)))
+		}
+	} else {
+		s.logger.Debug("Skipping database iteration as all database-level metrics are disabled")
+	}
 
 	rb := s.mb.NewResourceBuilder()
 	rb.SetServerAddress(serverAddress)
 	rb.SetServerPort(serverPort)
 	s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 
-	// Collect metrics for each database
 	for _, dbName := range dbNames {
 		s.collectDatabase(ctx, now, dbName, errs)
 		collectionNames, err := s.client.ListCollectionNames(ctx, dbName)
@@ -205,34 +203,17 @@ func (s *mongodbScraper) collectMetrics(ctx context.Context, errs *scrapererror.
 
 // requiresDatabaseIteration checks if any metrics that require database iteration are enabled.
 // Returns true if we need to call ListDatabaseNames, DBStats, ListCollectionNames, or IndexStats.
+// The authoritative list of database-level metrics is databaseMetricNames in config.go.
 func (s *mongodbScraper) requiresDatabaseIteration() bool {
-	// Database-level metrics (require DBStats command)
-	if s.config.Metrics.MongodbCollectionCount.Enabled ||
-		s.config.Metrics.MongodbDataSize.Enabled ||
-		s.config.Metrics.MongodbExtentCount.Enabled ||
-		s.config.Metrics.MongodbIndexSize.Enabled ||
-		s.config.Metrics.MongodbIndexCount.Enabled ||
-		s.config.Metrics.MongodbObjectCount.Enabled ||
-		s.config.Metrics.MongodbStorageSize.Enabled {
-		return true
+	metricsVal := reflect.ValueOf(s.config.Metrics)
+	for _, name := range databaseMetricNames {
+		field := metricsVal.FieldByName(name)
+		if field.IsValid() {
+			if enabled := field.FieldByName("Enabled"); enabled.IsValid() && enabled.Bool() {
+				return true
+			}
+		}
 	}
-
-	// Collection-level metrics (require ListCollectionNames + IndexStats commands)
-	if s.config.Metrics.MongodbIndexAccessCount.Enabled {
-		return true
-	}
-
-	// Per-database server metrics (require per-database ServerStatus command)
-	if s.config.Metrics.MongodbConnectionCount.Enabled ||
-		s.config.Metrics.MongodbDocumentOperationCount.Enabled ||
-		s.config.Metrics.MongodbMemoryUsage.Enabled ||
-		s.config.Metrics.MongodbLockAcquireCount.Enabled ||
-		s.config.Metrics.MongodbLockAcquireWaitCount.Enabled ||
-		s.config.Metrics.MongodbLockAcquireTime.Enabled ||
-		s.config.Metrics.MongodbLockDeadlockCount.Enabled {
-		return true
-	}
-
 	return false
 }
 

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -157,14 +157,21 @@ func TestScraperScrape(t *testing.T) {
 				fc := &fakeClient{}
 				mongo40, err := version.NewVersion("4.0")
 				require.NoError(t, err)
+				adminStatus, err := loadAdminStatusAsMap()
+				require.NoError(t, err)
 				fc.On("GetVersion", mock.Anything).Return(mongo40, nil)
+				fc.On("ServerStatus", mock.Anything, "admin").Return(adminStatus, nil)
+				fc.On("TopStats", mock.Anything).Return(bson.M{}, errors.New("some top stats error"))
 				fc.On("ListDatabaseNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{}, errors.New("some database names error"))
 				return fc
 			},
-			expectedMetricGen: func(*testing.T) pmetric.Metrics {
-				return pmetric.NewMetrics()
+			expectedMetricGen: func(t *testing.T) pmetric.Metrics {
+				goldenPath := filepath.Join("testdata", "scraper", "partial_scrape_no_db_count.yaml")
+				expectedMetrics, err := golden.ReadMetrics(goldenPath)
+				require.NoError(t, err)
+				return expectedMetrics
 			},
-			expectedErr: errors.New("failed to fetch database names: some database names error"),
+			expectedErr: errors.New("failed to fetch top stats metrics: some top stats error; failed to fetch database names: some database names error"),
 		},
 		{
 			desc:       "Failed to fetch collection names",
@@ -623,59 +630,14 @@ func TestCollectMetricsSkipsDatabaseIteration(t *testing.T) {
 }
 
 func TestAllMetricsCategorized(t *testing.T) {
-	// Metrics that require database iteration
-	databaseMetrics := map[string]bool{
-		"MongodbCollectionCount":        true,
-		"MongodbDataSize":               true,
-		"MongodbExtentCount":            true,
-		"MongodbIndexSize":              true,
-		"MongodbIndexCount":             true,
-		"MongodbObjectCount":            true,
-		"MongodbStorageSize":            true,
-		"MongodbIndexAccessCount":       true,
-		"MongodbConnectionCount":        true,
-		"MongodbDocumentOperationCount": true,
-		"MongodbMemoryUsage":            true,
-		"MongodbLockAcquireCount":       true,
-		"MongodbLockAcquireWaitCount":   true,
-		"MongodbLockAcquireTime":        true,
-		"MongodbLockDeadlockCount":      true,
+	// Build lookup maps from the authoritative lists in config.go
+	dbMetrics := make(map[string]bool, len(databaseMetricNames))
+	for _, name := range databaseMetricNames {
+		dbMetrics[name] = true
 	}
-
-	// Admin/server-level metrics that don't require database iteration
-	serverMetrics := map[string]bool{
-		"MongodbActiveReads":         true,
-		"MongodbActiveWrites":        true,
-		"MongodbCacheOperations":     true,
-		"MongodbCommandsRate":        true,
-		"MongodbCursorCount":         true,
-		"MongodbCursorTimeoutCount":  true,
-		"MongodbDatabaseCount":       true,
-		"MongodbDeletesRate":         true,
-		"MongodbFlushesRate":         true,
-		"MongodbGetmoresRate":        true,
-		"MongodbGlobalLockTime":      true,
-		"MongodbHealth":              true,
-		"MongodbInsertsRate":         true,
-		"MongodbNetworkIoReceive":    true,
-		"MongodbNetworkIoTransmit":   true,
-		"MongodbNetworkRequestCount": true,
-		"MongodbOperationCount":      true,
-		"MongodbOperationLatencyTime": true,
-		"MongodbOperationReplCount":  true,
-		"MongodbOperationTime":       true,
-		"MongodbPageFaults":          true,
-		"MongodbQueriesRate":         true,
-		"MongodbReplCommandsPerSec":  true,
-		"MongodbReplDeletesPerSec":   true,
-		"MongodbReplGetmoresPerSec":  true,
-		"MongodbReplInsertsPerSec":   true,
-		"MongodbReplQueriesPerSec":   true,
-		"MongodbReplUpdatesPerSec":   true,
-		"MongodbSessionCount":        true,
-		"MongodbUpdatesRate":         true,
-		"MongodbUptime":              true,
-		"MongodbWtcacheBytesRead":    true,
+	srvMetrics := make(map[string]bool, len(serverMetricNames))
+	for _, name := range serverMetricNames {
+		srvMetrics[name] = true
 	}
 
 	cfg := createDefaultConfig().(*Config)
@@ -685,13 +647,13 @@ func TestAllMetricsCategorized(t *testing.T) {
 		field := cfgType.Field(i)
 		metricName := field.Name
 
-		isDatabaseMetric := databaseMetrics[metricName]
-		isServerMetric := serverMetrics[metricName]
+		isDatabaseMetric := dbMetrics[metricName]
+		isServerMetric := srvMetrics[metricName]
 
 		require.True(t, isDatabaseMetric || isServerMetric,
 			"Metric %s is not categorized as either database or server metric. "+
-				"Please add it to either databaseMetrics or serverMetrics map in TestAllMetricsCategorized, "+
-				"and ensure requiresDatabaseIteration() checks it if it's a database metric.", metricName)
+				"Please add it to either databaseMetricNames or serverMetricNames in config.go, "+
+				"and ensure requiresDatabaseIteration() will pick it up if it's a database metric.", metricName)
 
 		require.False(t, isDatabaseMetric && isServerMetric,
 			"Metric %s is categorized as both database and server metric", metricName)

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -6,6 +6,7 @@ package mongodbreceiver
 import (
 	"errors"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -619,4 +620,80 @@ func TestCollectMetricsSkipsDatabaseIteration(t *testing.T) {
 	fc.AssertNotCalled(t, "DBStats", mock.Anything, mock.Anything)
 	fc.AssertNotCalled(t, "ListCollectionNames", mock.Anything, mock.Anything)
 	fc.AssertNotCalled(t, "IndexStats", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestAllMetricsCategorized(t *testing.T) {
+	// Metrics that require database iteration
+	databaseMetrics := map[string]bool{
+		"MongodbCollectionCount":        true,
+		"MongodbDataSize":               true,
+		"MongodbExtentCount":            true,
+		"MongodbIndexSize":              true,
+		"MongodbIndexCount":             true,
+		"MongodbObjectCount":            true,
+		"MongodbStorageSize":            true,
+		"MongodbIndexAccessCount":       true,
+		"MongodbConnectionCount":        true,
+		"MongodbDocumentOperationCount": true,
+		"MongodbMemoryUsage":            true,
+		"MongodbLockAcquireCount":       true,
+		"MongodbLockAcquireWaitCount":   true,
+		"MongodbLockAcquireTime":        true,
+		"MongodbLockDeadlockCount":      true,
+	}
+
+	// Admin/server-level metrics that don't require database iteration
+	serverMetrics := map[string]bool{
+		"MongodbActiveReads":         true,
+		"MongodbActiveWrites":        true,
+		"MongodbCacheOperations":     true,
+		"MongodbCommandsRate":        true,
+		"MongodbCursorCount":         true,
+		"MongodbCursorTimeoutCount":  true,
+		"MongodbDatabaseCount":       true,
+		"MongodbDeletesRate":         true,
+		"MongodbFlushesRate":         true,
+		"MongodbGetmoresRate":        true,
+		"MongodbGlobalLockTime":      true,
+		"MongodbHealth":              true,
+		"MongodbInsertsRate":         true,
+		"MongodbNetworkIoReceive":    true,
+		"MongodbNetworkIoTransmit":   true,
+		"MongodbNetworkRequestCount": true,
+		"MongodbOperationCount":      true,
+		"MongodbOperationLatencyTime": true,
+		"MongodbOperationReplCount":  true,
+		"MongodbOperationTime":       true,
+		"MongodbPageFaults":          true,
+		"MongodbQueriesRate":         true,
+		"MongodbReplCommandsPerSec":  true,
+		"MongodbReplDeletesPerSec":   true,
+		"MongodbReplGetmoresPerSec":  true,
+		"MongodbReplInsertsPerSec":   true,
+		"MongodbReplQueriesPerSec":   true,
+		"MongodbReplUpdatesPerSec":   true,
+		"MongodbSessionCount":        true,
+		"MongodbUpdatesRate":         true,
+		"MongodbUptime":              true,
+		"MongodbWtcacheBytesRead":    true,
+	}
+
+	cfg := createDefaultConfig().(*Config)
+	cfgType := reflect.TypeOf(cfg.Metrics)
+
+	for i := 0; i < cfgType.NumField(); i++ {
+		field := cfgType.Field(i)
+		metricName := field.Name
+
+		isDatabaseMetric := databaseMetrics[metricName]
+		isServerMetric := serverMetrics[metricName]
+
+		require.True(t, isDatabaseMetric || isServerMetric,
+			"Metric %s is not categorized as either database or server metric. "+
+				"Please add it to either databaseMetrics or serverMetrics map in TestAllMetricsCategorized, "+
+				"and ensure requiresDatabaseIteration() checks it if it's a database metric.", metricName)
+
+		require.False(t, isDatabaseMetric && isServerMetric,
+			"Metric %s is categorized as both database and server metric", metricName)
+	}
 }

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -457,3 +457,166 @@ func TestServerAddressAndPort(t *testing.T) {
 		})
 	}
 }
+
+func TestRequiresDatabaseIteration(t *testing.T) {
+	testCases := []struct {
+		desc              string
+		setupConfig       func(*Config)
+		expectedIteration bool
+	}{
+		{
+			desc: "All database metrics disabled",
+			setupConfig: func(cfg *Config) {
+				// Disable all database-level metrics
+				cfg.Metrics.MongodbCollectionCount.Enabled = false
+				cfg.Metrics.MongodbDataSize.Enabled = false
+				cfg.Metrics.MongodbExtentCount.Enabled = false
+				cfg.Metrics.MongodbIndexSize.Enabled = false
+				cfg.Metrics.MongodbIndexCount.Enabled = false
+				cfg.Metrics.MongodbObjectCount.Enabled = false
+				cfg.Metrics.MongodbStorageSize.Enabled = false
+				// Disable collection-level metrics
+				cfg.Metrics.MongodbIndexAccessCount.Enabled = false
+				// Disable per-database server metrics
+				cfg.Metrics.MongodbConnectionCount.Enabled = false
+				cfg.Metrics.MongodbDocumentOperationCount.Enabled = false
+				cfg.Metrics.MongodbMemoryUsage.Enabled = false
+				cfg.Metrics.MongodbLockAcquireCount.Enabled = false
+				cfg.Metrics.MongodbLockAcquireWaitCount.Enabled = false
+				cfg.Metrics.MongodbLockAcquireTime.Enabled = false
+				cfg.Metrics.MongodbLockDeadlockCount.Enabled = false
+			},
+			expectedIteration: false,
+		},
+		{
+			desc: "One database metric enabled (collection count)",
+			setupConfig: func(cfg *Config) {
+				cfg.Metrics.MongodbCollectionCount.Enabled = true
+			},
+			expectedIteration: true,
+		},
+		{
+			desc: "One database metric enabled (data size)",
+			setupConfig: func(cfg *Config) {
+				cfg.Metrics.MongodbDataSize.Enabled = true
+			},
+			expectedIteration: true,
+		},
+		{
+			desc: "Collection metric enabled (index access count)",
+			setupConfig: func(cfg *Config) {
+				cfg.Metrics.MongodbIndexAccessCount.Enabled = true
+			},
+			expectedIteration: true,
+		},
+		{
+			desc: "Per-database server metric enabled (connection count)",
+			setupConfig: func(cfg *Config) {
+				cfg.Metrics.MongodbConnectionCount.Enabled = true
+			},
+			expectedIteration: true,
+		},
+		{
+			desc: "Per-database server metric enabled (lock acquire count)",
+			setupConfig: func(cfg *Config) {
+				cfg.Metrics.MongodbLockAcquireCount.Enabled = true
+			},
+			expectedIteration: true,
+		},
+		{
+			desc: "Only admin-level metrics enabled",
+			setupConfig: func(cfg *Config) {
+				// Disable all database-level metrics
+				cfg.Metrics.MongodbCollectionCount.Enabled = false
+				cfg.Metrics.MongodbDataSize.Enabled = false
+				cfg.Metrics.MongodbExtentCount.Enabled = false
+				cfg.Metrics.MongodbIndexSize.Enabled = false
+				cfg.Metrics.MongodbIndexCount.Enabled = false
+				cfg.Metrics.MongodbObjectCount.Enabled = false
+				cfg.Metrics.MongodbStorageSize.Enabled = false
+				cfg.Metrics.MongodbIndexAccessCount.Enabled = false
+				cfg.Metrics.MongodbConnectionCount.Enabled = false
+				cfg.Metrics.MongodbDocumentOperationCount.Enabled = false
+				cfg.Metrics.MongodbMemoryUsage.Enabled = false
+				cfg.Metrics.MongodbLockAcquireCount.Enabled = false
+				cfg.Metrics.MongodbLockAcquireWaitCount.Enabled = false
+				cfg.Metrics.MongodbLockAcquireTime.Enabled = false
+				cfg.Metrics.MongodbLockDeadlockCount.Enabled = false
+				// Enable admin-level metrics (should not require database iteration)
+				cfg.Metrics.MongodbCacheOperations.Enabled = true
+				cfg.Metrics.MongodbCursorCount.Enabled = true
+				cfg.Metrics.MongodbGlobalLockTime.Enabled = true
+			},
+			expectedIteration: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			tc.setupConfig(cfg)
+			scraper := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+
+			actual := scraper.requiresDatabaseIteration()
+			require.Equal(t, tc.expectedIteration, actual)
+		})
+	}
+}
+
+func TestCollectMetricsSkipsDatabaseIteration(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+
+	// Disable all database-level metrics
+	cfg.Metrics.MongodbCollectionCount.Enabled = false
+	cfg.Metrics.MongodbDataSize.Enabled = false
+	cfg.Metrics.MongodbExtentCount.Enabled = false
+	cfg.Metrics.MongodbIndexSize.Enabled = false
+	cfg.Metrics.MongodbIndexCount.Enabled = false
+	cfg.Metrics.MongodbObjectCount.Enabled = false
+	cfg.Metrics.MongodbStorageSize.Enabled = false
+	cfg.Metrics.MongodbIndexAccessCount.Enabled = false
+	cfg.Metrics.MongodbConnectionCount.Enabled = false
+	cfg.Metrics.MongodbDocumentOperationCount.Enabled = false
+	cfg.Metrics.MongodbMemoryUsage.Enabled = false
+	cfg.Metrics.MongodbLockAcquireCount.Enabled = false
+	cfg.Metrics.MongodbLockAcquireWaitCount.Enabled = false
+	cfg.Metrics.MongodbLockAcquireTime.Enabled = false
+	cfg.Metrics.MongodbLockDeadlockCount.Enabled = false
+
+	scraper := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
+
+	// Setup mock client
+	fc := &fakeClient{}
+	adminStatus, err := loadAdminStatusAsMap()
+	require.NoError(t, err)
+	topStats, err := loadTopAsMap()
+	require.NoError(t, err)
+
+	// Mock expectations - only admin-level commands should be called
+	fc.On("ServerStatus", mock.Anything, "admin").Return(adminStatus, nil)
+	fc.On("TopStats", mock.Anything).Return(topStats, nil)
+
+	// These should NOT be called when database iteration is skipped
+	fc.On("ListDatabaseNames", mock.Anything, mock.Anything, mock.Anything).Maybe().Return([]string{}, errors.New("should not be called"))
+	fc.On("DBStats", mock.Anything, mock.Anything).Maybe().Return(bson.M{}, errors.New("should not be called"))
+	fc.On("ListCollectionNames", mock.Anything, mock.Anything).Maybe().Return([]string{}, errors.New("should not be called"))
+	fc.On("IndexStats", mock.Anything, mock.Anything, mock.Anything).Maybe().Return([]bson.M{}, errors.New("should not be called"))
+
+	scraper.client = fc
+
+	errs := &scrapererror.ScrapeErrors{}
+	scraper.collectMetrics(t.Context(), errs)
+
+	// Verify no errors occurred
+	require.NoError(t, errs.Combine())
+
+	// Verify that only admin-level commands were called
+	fc.AssertCalled(t, "ServerStatus", mock.Anything, "admin")
+	fc.AssertCalled(t, "TopStats", mock.Anything)
+
+	// Verify that database-level commands were NOT called
+	fc.AssertNotCalled(t, "ListDatabaseNames", mock.Anything, mock.Anything, mock.Anything)
+	fc.AssertNotCalled(t, "DBStats", mock.Anything, mock.Anything)
+	fc.AssertNotCalled(t, "ListCollectionNames", mock.Anything, mock.Anything)
+	fc.AssertNotCalled(t, "IndexStats", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/receiver/mongodbreceiver/testdata/scraper/partial_scrape_no_db_count.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/partial_scrape_no_db_count.yaml
@@ -1,0 +1,238 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: server.address
+          value:
+            stringValue: ecb6adf34046
+    scopeMetrics:
+      - metrics:
+          - description: The number of cache operations of the instance.
+            name: mongodb.cache.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "201"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "14"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: miss
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The number of open cursors maintained for clients.
+            name: mongodb.cursor.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{cursors}'
+          - description: The number of cursors that have timed out.
+            name: mongodb.cursor.timeout.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{cursors}'
+          - description: The time the global lock has been held.
+            name: mongodb.global_lock.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58964"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: The health status of the server.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mongodb.health
+            unit: "1"
+          - description: The number of bytes received.
+            name: mongodb.network.io.receive
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3056"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of by transmitted.
+            name: mongodb.network.io.transmit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5393"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of requests received by the server.
+            name: mongodb.network.request.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{requests}'
+          - description: The number of operations executed.
+            name: mongodb.operation.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The latency of operations.
+            gauge:
+              dataPoints:
+                - asInt: "8631"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mongodb.operation.latency.time
+            unit: us
+          - description: The number of replicated operations executed.
+            name: mongodb.operation.repl.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "27"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "19"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{sessions}'
+          - description: The amount of time that the server has been running.
+            name: mongodb.uptime
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58965"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
+          version: latest


### PR DESCRIPTION
## Description

This PR fixes issue #45924 where the MongoDB receiver unconditionally executes database-level commands (ListDatabaseNames, DBStats, ListCollectionNames, IndexStats) even when all database-level metrics are disabled in the configuration. This causes noisy "Unauthorized" errors on sharded clusters when using `direct_connection: true` to monitor individual shard/configsvr nodes.

The fix adds a check to skip database iteration entirely when all database metrics are disabled, while still collecting admin-level server metrics.

## Link to tracking issue

Fixes #45924

## Testing

### Unit Tests
Added comprehensive test coverage:
- `TestRequiresDatabaseIteration` - Verifies the helper method correctly identifies when database iteration is needed (7 test cases)
- `TestCollectMetricsSkipsDatabaseIteration` - Verifies database commands are skipped when all database metrics are disabled
- `TestAllMetricsCategorized` - Ensures all metrics are properly categorized as either database or server metrics (prevents regression if new metrics are added)

All existing tests continue to pass (60+ test cases).

### Manual Testing
Tested with MongoDB sharded cluster using `direct_connection: true` and all database metrics disabled:
- Verified no "Unauthorized" errors in logs
- Verified admin-level server metrics are still collected
- Verified database commands are skipped

## Documentation

No documentation changes required. This is an internal optimization that doesn't change the receiver's API or configuration.