### PR TITLE
[receiver/azureblob] Support Azure Blob Polling

### DIFF
--- a/.chloggen/dylan_azure-blob-storage.yaml
+++ b/.chloggen/dylan_azure-blob-storage.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: receiver/azureblob
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add options for the Azure Blob receiver to poll for new blobs instead of using Event Hub.
+note: Enable the Azure Blob receiver to poll for new blobs when the Event Hub endpoint is not configured.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [45717]
@@ -15,7 +15,11 @@ issues: [45717]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  The Azure Blob receiver now supports a polling-based ingestion mode that is automatically
+  enabled when no Event Hub endpoint is configured. Instead of relying on
+  event-driven notifications, it periodically checks the storage container
+  for new blobs to ingest.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/dylan_azure-blob-storage.yaml
+++ b/.chloggen/dylan_azure-blob-storage.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/azureblob
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add options for the Azure Blob receiver to poll for new blobs instead of using Event Hub.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45717]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureblobreceiver/blob_eventhandler.go
+++ b/receiver/azureblobreceiver/blob_eventhandler.go
@@ -1,0 +1,114 @@
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type blobEventHandler struct {
+	blobClient          blobClient
+	logsDataConsumer    logsDataConsumer
+	tracesDataConsumer  tracesDataConsumer
+	logsContainerName   string
+	tracesContainerName string
+	logger              *zap.Logger
+	wg                  sync.WaitGroup
+	cancelFunc          context.CancelFunc
+	pollInterval        time.Duration
+}
+
+var _ eventHandler = (*blobEventHandler)(nil)
+
+func (p *blobEventHandler) run(ctx context.Context) error {
+	ctx, p.cancelFunc = context.WithCancel(ctx)
+
+	p.wg.Add(1)
+	go p.pollBlobs(ctx)
+
+	return nil
+}
+
+func (p *blobEventHandler) pollBlobs(ctx context.Context) {
+	defer p.wg.Done()
+
+	ticker := time.NewTicker(p.pollInterval)
+	defer ticker.Stop()
+
+	p.processContainers(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.processContainers(ctx)
+		}
+	}
+}
+
+func (p *blobEventHandler) processContainers(ctx context.Context) {
+	if p.logsContainerName != "" && p.logsDataConsumer != nil {
+		p.processContainer(ctx, p.logsContainerName, func(ctx context.Context, data []byte) error {
+			return p.logsDataConsumer.consumeLogsJSON(ctx, data)
+		})
+	}
+
+	if p.tracesContainerName != "" && p.tracesDataConsumer != nil {
+		p.processContainer(ctx, p.tracesContainerName, func(ctx context.Context, data []byte) error {
+			return p.tracesDataConsumer.consumeTracesJSON(ctx, data)
+		})
+	}
+}
+
+func (p *blobEventHandler) processContainer(ctx context.Context, containerName string, consume func(context.Context, []byte) error) {
+	blobs, err := p.blobClient.listBlobs(ctx, containerName)
+	if err != nil {
+		p.logger.Error("failed to list blobs", zap.String("container", containerName), zap.Error(err))
+		return
+	}
+
+	for _, blobName := range blobs {
+		if ctx.Err() != nil {
+			return
+		}
+
+		blobData, err := p.blobClient.readBlob(ctx, containerName, blobName)
+		if err != nil {
+			p.logger.Error("failed to read blob", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
+			continue
+		}
+
+		if err := consume(ctx, blobData.Bytes()); err != nil {
+			p.logger.Error("failed to consume blob data", zap.String("container", containerName), zap.String("blob", blobName), zap.Error(err))
+		}
+	}
+}
+
+func (p *blobEventHandler) close(_ context.Context) error {
+	if p.cancelFunc != nil {
+		p.cancelFunc()
+	}
+	p.wg.Wait()
+	return nil
+}
+
+func (p *blobEventHandler) setLogsDataConsumer(logsDataConsumer logsDataConsumer) {
+	p.logsDataConsumer = logsDataConsumer
+}
+
+func (p *blobEventHandler) setTracesDataConsumer(tracesDataConsumer tracesDataConsumer) {
+	p.tracesDataConsumer = tracesDataConsumer
+}
+
+func newBlobEventHandler(logsContainerName, tracesContainerName string, blobClient blobClient, logger *zap.Logger) *blobEventHandler {
+	return &blobEventHandler{
+		blobClient:          blobClient,
+		logsContainerName:   logsContainerName,
+		tracesContainerName: tracesContainerName,
+		logger:              logger,
+		pollInterval:        10 * time.Second,
+	}
+}

--- a/receiver/azureblobreceiver/blob_eventhandler.go
+++ b/receiver/azureblobreceiver/blob_eventhandler.go
@@ -1,4 +1,7 @@
-package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
 import (
 	"context"

--- a/receiver/azureblobreceiver/blob_eventhandler_test.go
+++ b/receiver/azureblobreceiver/blob_eventhandler_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewBlobEventHandler(t *testing.T) {
+	blobClient := newMockBlobClient()
+	blobEventHandler := getBlobEventHandler(t, blobClient)
+
+	require.NotNil(t, blobEventHandler)
+	assert.Equal(t, blobClient, blobEventHandler.blobClient)
+}
+
+func TestBlobEventHandler_SetConsumers(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	logsConsumer := newMockLogsDataConsumer()
+	tracesConsumer := newMockTracesDataConsumer()
+
+	handler.setLogsDataConsumer(logsConsumer)
+	handler.setTracesDataConsumer(tracesConsumer)
+
+	assert.Equal(t, logsConsumer, handler.logsDataConsumer)
+	assert.Equal(t, tracesConsumer, handler.tracesDataConsumer)
+}
+
+func TestBlobEventHandler_RunAndClose(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	ctx := context.Background()
+	err := handler.run(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, handler.cancelFunc)
+
+	err = handler.close(ctx)
+	require.NoError(t, err)
+}
+
+func TestBlobEventHandler_ProcessContainers(t *testing.T) {
+	blobClient := &mockBlobClient{}
+	blobClient.On("listBlobs", mock.Anything, logsContainerName).Return([]string{"log1.json", "log2.json"}, nil)
+	blobClient.On("listBlobs", mock.Anything, tracesContainerName).Return([]string{"trace1.json"}, nil)
+	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return(bytes.NewBufferString("{}"), nil)
+
+	handler := getBlobEventHandler(t, blobClient)
+
+	logsConsumer := newMockLogsDataConsumer()
+	tracesConsumer := newMockTracesDataConsumer()
+	handler.setLogsDataConsumer(logsConsumer)
+	handler.setTracesDataConsumer(tracesConsumer)
+
+	handler.processContainers(context.Background())
+
+	logsConsumer.AssertNumberOfCalls(t, "consumeLogsJSON", 2)
+	tracesConsumer.AssertNumberOfCalls(t, "consumeTracesJSON", 1)
+	blobClient.AssertNumberOfCalls(t, "readBlob", 3)
+}
+
+func TestBlobEventHandler_ProcessContainersWithNoConsumers(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	handler.processContainers(context.Background())
+
+	blobClient.AssertNotCalled(t, "listBlobs", mock.Anything, mock.Anything)
+}
+
+func TestBlobEventHandler_DefaultPollInterval(t *testing.T) {
+	blobClient := newMockBlobClient()
+	handler := getBlobEventHandler(t, blobClient)
+
+	assert.Equal(t, 10*time.Second, handler.pollInterval)
+}
+
+func getBlobEventHandler(tb testing.TB, blobClient blobClient) *blobEventHandler {
+	blobEventHandler := newBlobEventHandler(
+		logsContainerName,
+		tracesContainerName,
+		blobClient,
+		zaptest.NewLogger(tb),
+	)
+	return blobEventHandler
+}

--- a/receiver/azureblobreceiver/blob_eventhandler_test.go
+++ b/receiver/azureblobreceiver/blob_eventhandler_test.go
@@ -5,7 +5,6 @@ package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -41,7 +40,7 @@ func TestBlobEventHandler_RunAndClose(t *testing.T) {
 	blobClient := newMockBlobClient()
 	handler := getBlobEventHandler(t, blobClient)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := handler.run(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, handler.cancelFunc)
@@ -63,7 +62,7 @@ func TestBlobEventHandler_ProcessContainers(t *testing.T) {
 	handler.setLogsDataConsumer(logsConsumer)
 	handler.setTracesDataConsumer(tracesConsumer)
 
-	handler.processContainers(context.Background())
+	handler.processContainers(t.Context())
 
 	logsConsumer.AssertNumberOfCalls(t, "consumeLogsJSON", 2)
 	tracesConsumer.AssertNumberOfCalls(t, "consumeTracesJSON", 1)
@@ -74,7 +73,7 @@ func TestBlobEventHandler_ProcessContainersWithNoConsumers(t *testing.T) {
 	blobClient := newMockBlobClient()
 	handler := getBlobEventHandler(t, blobClient)
 
-	handler.processContainers(context.Background())
+	handler.processContainers(t.Context())
 
 	blobClient.AssertNotCalled(t, "listBlobs", mock.Anything, mock.Anything)
 }

--- a/receiver/azureblobreceiver/eventhandler.go
+++ b/receiver/azureblobreceiver/eventhandler.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
+
+import (
+	"context"
+)
+
+type eventHandler interface {
+	run(ctx context.Context) error
+	close(ctx context.Context) error
+	setLogsDataConsumer(logsDataConsumer logsDataConsumer)
+	setTracesDataConsumer(tracesDataConsumer tracesDataConsumer)
+}

--- a/receiver/azureblobreceiver/eventhub_eventhandler.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler.go
@@ -1,4 +1,7 @@
-package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
 import (
 	"context"
@@ -95,7 +98,7 @@ func (p *eventHubEventHandler) receiveEvents(
 
 		timeoutCtx, cancelCtx := context.WithTimeout(
 			ctx,
-			time.Second*time.Duration(p.maxPollEvents),
+			time.Second*time.Duration(p.pollRate),
 		)
 		events, err := pc.ReceiveEvents(timeoutCtx, p.maxPollEvents, &azeventhubs.ReceiveEventsOptions{})
 		cancelCtx()

--- a/receiver/azureblobreceiver/eventhub_eventhandler.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler.go
@@ -1,7 +1,4 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
+package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver
 
 import (
 	"context"
@@ -15,20 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	defaultPollRate      = 5
-	defaultMaxPollEvents = 100
-	defaultConsumerGroup = "$Default"
-)
-
-type blobEventHandler interface {
-	run(ctx context.Context) error
-	close(ctx context.Context) error
-	setLogsDataConsumer(logsDataConsumer logsDataConsumer)
-	setTracesDataConsumer(tracesDataConsumer tracesDataConsumer)
-}
-
-type azureBlobEventHandler struct {
+type eventHubEventHandler struct {
 	blobClient               blobClient
 	logsDataConsumer         logsDataConsumer
 	tracesDataConsumer       tracesDataConsumer
@@ -39,15 +23,19 @@ type azureBlobEventHandler struct {
 	logger                   *zap.Logger
 	wg                       sync.WaitGroup
 	cancelFunc               context.CancelFunc
+
+	pollRate      int
+	maxPollEvents int
+	consumerGroup string
 }
 
-var _ blobEventHandler = (*azureBlobEventHandler)(nil)
+var _ eventHandler = (*eventHubEventHandler)(nil)
 
 const (
 	blobCreatedEventType = "Microsoft.Storage.BlobCreated"
 )
 
-func (p *azureBlobEventHandler) run(ctx context.Context) error {
+func (p *eventHubEventHandler) run(ctx context.Context) error {
 	if p.hub != nil {
 		return nil
 	}
@@ -57,7 +45,7 @@ func (p *azureBlobEventHandler) run(ctx context.Context) error {
 	hub, err := azeventhubs.NewConsumerClientFromConnectionString(
 		p.eventHubConnectionString,
 		"",
-		defaultConsumerGroup,
+		p.consumerGroup,
 		&azeventhubs.ConsumerClientOptions{},
 	)
 	if err != nil {
@@ -91,7 +79,7 @@ func (p *azureBlobEventHandler) run(ctx context.Context) error {
 	return nil
 }
 
-func (p *azureBlobEventHandler) receiveEvents(
+func (p *eventHubEventHandler) receiveEvents(
 	ctx context.Context,
 	pc *azeventhubs.PartitionClient,
 	handler func(ctx context.Context, event *azeventhubs.ReceivedEventData) error,
@@ -107,9 +95,9 @@ func (p *azureBlobEventHandler) receiveEvents(
 
 		timeoutCtx, cancelCtx := context.WithTimeout(
 			ctx,
-			time.Second*time.Duration(defaultPollRate),
+			time.Second*time.Duration(p.maxPollEvents),
 		)
-		events, err := pc.ReceiveEvents(timeoutCtx, defaultMaxPollEvents, &azeventhubs.ReceiveEventsOptions{})
+		events, err := pc.ReceiveEvents(timeoutCtx, p.maxPollEvents, &azeventhubs.ReceiveEventsOptions{})
 		cancelCtx()
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			p.logger.Error(
@@ -126,7 +114,7 @@ func (p *azureBlobEventHandler) receiveEvents(
 	}
 }
 
-func (p *azureBlobEventHandler) newMessageHandler(ctx context.Context, event *azeventhubs.ReceivedEventData) error {
+func (p *eventHubEventHandler) newMessageHandler(ctx context.Context, event *azeventhubs.ReceivedEventData) error {
 	type eventData struct {
 		Topic           string
 		Subject         string
@@ -171,7 +159,7 @@ func (p *azureBlobEventHandler) newMessageHandler(ctx context.Context, event *az
 	return nil
 }
 
-func (p *azureBlobEventHandler) close(ctx context.Context) error {
+func (p *eventHubEventHandler) close(ctx context.Context) error {
 	if p.cancelFunc != nil {
 		p.cancelFunc()
 	}
@@ -187,20 +175,24 @@ func (p *azureBlobEventHandler) close(ctx context.Context) error {
 	return nil
 }
 
-func (p *azureBlobEventHandler) setLogsDataConsumer(logsDataConsumer logsDataConsumer) {
+func (p *eventHubEventHandler) setLogsDataConsumer(logsDataConsumer logsDataConsumer) {
 	p.logsDataConsumer = logsDataConsumer
 }
 
-func (p *azureBlobEventHandler) setTracesDataConsumer(tracesDataConsumer tracesDataConsumer) {
+func (p *eventHubEventHandler) setTracesDataConsumer(tracesDataConsumer tracesDataConsumer) {
 	p.tracesDataConsumer = tracesDataConsumer
 }
 
-func newBlobEventHandler(eventHubConnectionString, logsContainerName, tracesContainerName string, blobClient blobClient, logger *zap.Logger) *azureBlobEventHandler {
-	return &azureBlobEventHandler{
+func newEventHubEventHandler(eventHubConnectionString, logsContainerName, tracesContainerName string, blobClient blobClient, logger *zap.Logger) *eventHubEventHandler {
+	return &eventHubEventHandler{
 		blobClient:               blobClient,
 		logsContainerName:        logsContainerName,
 		tracesContainerName:      tracesContainerName,
 		eventHubConnectionString: eventHubConnectionString,
 		logger:                   logger,
+
+		pollRate:      5,
+		maxPollEvents: 100,
+		consumerGroup: "$Default",
 	}
 }

--- a/receiver/azureblobreceiver/eventhub_eventhandler_test.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler_test.go
@@ -59,8 +59,8 @@ func getEvent(eventData []byte) *azeventhubs.ReceivedEventData {
 	}
 }
 
-func getBlobEventHandler(tb testing.TB, blobClient blobClient) *azureBlobEventHandler {
-	blobEventHandler := newBlobEventHandler(
+func getBlobEventHandler(tb testing.TB, blobClient blobClient) *eventHubEventHandler {
+	blobEventHandler := newEventHubEventHandler(
 		eventHubString,
 		logsContainerName,
 		tracesContainerName,

--- a/receiver/azureblobreceiver/eventhub_eventhandler_test.go
+++ b/receiver/azureblobreceiver/eventhub_eventhandler_test.go
@@ -21,28 +21,28 @@ var (
 	traceEventData = []byte(`[{"topic":"someTopic","subject":"/blobServices/default/containers/traces/blobs/traces-1","eventType":"Microsoft.Storage.BlobCreated","id":"1","data":{"api":"PutBlob","clientRequestId":"1","requestId":"1","eTag":"1","contentType":"text","contentLength":10,"blobType":"BlockBlob","url":"https://oteldata.blob.core.windows.net/traces/traces-1","sequencer":"1","storageDiagnostics":{"batchId":"1"}},"dataVersion":"","metadataVersion":"1","eventTime":"2022-03-25T15:59:50.9251748Z"}]`)
 )
 
-func TestNewBlobEventHandler(t *testing.T) {
+func TestNewEventHubEventHandler(t *testing.T) {
 	blobClient := newMockBlobClient()
-	blobEventHandler := getBlobEventHandler(t, blobClient)
+	blobEventHandler := getEventHubEventHandler(t, blobClient)
 
 	require.NotNil(t, blobEventHandler)
 	assert.Equal(t, blobClient, blobEventHandler.blobClient)
 }
 
-func TestNewMessageHandler(t *testing.T) {
+func TestNewEventHubMessageHandler(t *testing.T) {
 	blobClient := newMockBlobClient()
-	blobEventHandler := getBlobEventHandler(t, blobClient)
+	blobEventHandler := getEventHubEventHandler(t, blobClient)
 
 	logsDataConsumer := newMockLogsDataConsumer()
 	tracesDataConsumer := newMockTracesDataConsumer()
 	blobEventHandler.setLogsDataConsumer(logsDataConsumer)
 	blobEventHandler.setTracesDataConsumer(tracesDataConsumer)
 
-	logEvent := getEvent(logEventData)
+	logEvent := getEventHubEvent(logEventData)
 	err := blobEventHandler.newMessageHandler(t.Context(), logEvent)
 	require.NoError(t, err)
 
-	traceEvent := getEvent(traceEventData)
+	traceEvent := getEventHubEvent(traceEventData)
 	err = blobEventHandler.newMessageHandler(t.Context(), traceEvent)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestNewMessageHandler(t *testing.T) {
 	blobClient.AssertNumberOfCalls(t, "readBlob", 2)
 }
 
-func getEvent(eventData []byte) *azeventhubs.ReceivedEventData {
+func getEventHubEvent(eventData []byte) *azeventhubs.ReceivedEventData {
 	return &azeventhubs.ReceivedEventData{
 		EventData: azeventhubs.EventData{
 			Body: eventData,
@@ -59,7 +59,7 @@ func getEvent(eventData []byte) *azeventhubs.ReceivedEventData {
 	}
 }
 
-func getBlobEventHandler(tb testing.TB, blobClient blobClient) *eventHubEventHandler {
+func getEventHubEventHandler(tb testing.TB, blobClient blobClient) *eventHubEventHandler {
 	blobEventHandler := newEventHubEventHandler(
 		eventHubString,
 		logsContainerName,

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -98,8 +98,8 @@ func (f *blobReceiverFactory) getReceiver(
 			return nil
 		}
 
-		var beh blobEventHandler
-		beh, err = f.getBlobEventHandler(receiverConfig, set.Logger)
+		var beh eventHandler
+		beh, err = f.getEventHandler(receiverConfig, set.Logger)
 		if err != nil {
 			return nil
 		}
@@ -116,7 +116,7 @@ func (f *blobReceiverFactory) getReceiver(
 	return r.Unwrap(), err
 }
 
-func (*blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logger) (blobEventHandler, error) {
+func (*blobReceiverFactory) getEventHandler(cfg *Config, logger *zap.Logger) (eventHandler, error) {
 	var bc blobClient
 	var err error
 
@@ -148,6 +148,10 @@ func (*blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logger)
 		return nil, fmt.Errorf("unknown authentication %v", cfg.Authentication)
 	}
 
-	return newBlobEventHandler(cfg.EventHub.EndPoint, cfg.Logs.ContainerName, cfg.Traces.ContainerName, bc, logger),
+	// If Event Hub is not configured, use the Blob Event Handler
+	if cfg.EventHub.EndPoint == "" {
+		return newBlobEventHandler(cfg.Logs.ContainerName, cfg.Traces.ContainerName, bc, logger), nil
+	}
+	return newEventHubEventHandler(cfg.EventHub.EndPoint, cfg.Logs.ContainerName, cfg.Traces.ContainerName, bc, logger),
 		nil
 }

--- a/receiver/azureblobreceiver/mock_blobclient.go
+++ b/receiver/azureblobreceiver/mock_blobclient.go
@@ -35,8 +35,29 @@ func (_m *mockBlobClient) readBlob(ctx context.Context, containerName, blobName 
 	return r0, r1
 }
 
+func (_m *mockBlobClient) listBlobs(ctx context.Context, containerName string) ([]string, error) {
+	ret := _m.Called(ctx, containerName)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, containerName)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, containerName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 func newMockBlobClient() *mockBlobClient {
 	blobClient := &mockBlobClient{}
 	blobClient.On("readBlob", mock.Anything, mock.Anything, mock.Anything).Return(&bytes.Buffer{}, nil)
+	blobClient.On("listBlobs", mock.Anything, mock.Anything).Return([]string{}, nil)
 	return blobClient
 }

--- a/receiver/azureblobreceiver/receiver.go
+++ b/receiver/azureblobreceiver/receiver.go
@@ -50,10 +50,12 @@ func (b *blobReceiver) Shutdown(ctx context.Context) error {
 
 func (b *blobReceiver) setNextLogsConsumer(nextLogsConsumer consumer.Logs) {
 	b.nextLogsConsumer = nextLogsConsumer
+	b.blobEventHandler.setLogsDataConsumer(b)
 }
 
 func (b *blobReceiver) setNextTracesConsumer(nextTracesConsumer consumer.Traces) {
 	b.nextTracesConsumer = nextTracesConsumer
+	b.blobEventHandler.setTracesDataConsumer(b)
 }
 
 func (b *blobReceiver) consumeLogsJSON(ctx context.Context, json []byte) error {
@@ -112,9 +114,6 @@ func newReceiver(set receiver.Settings, eventHandler eventHandler) (component.Co
 		tracesUnmarshaler: &ptrace.JSONUnmarshaler{},
 		obsrecv:           obsrecv,
 	}
-
-	eventHandler.setLogsDataConsumer(blobReceiver)
-	eventHandler.setTracesDataConsumer(blobReceiver)
 
 	return blobReceiver, nil
 }

--- a/receiver/azureblobreceiver/receiver.go
+++ b/receiver/azureblobreceiver/receiver.go
@@ -29,7 +29,7 @@ type tracesDataConsumer interface {
 }
 
 type blobReceiver struct {
-	blobEventHandler   blobEventHandler
+	blobEventHandler   eventHandler
 	logger             *zap.Logger
 	logsUnmarshaler    plog.Unmarshaler
 	tracesUnmarshaler  ptrace.Unmarshaler
@@ -95,7 +95,7 @@ func (b *blobReceiver) consumeTracesJSON(ctx context.Context, json []byte) error
 }
 
 // Returns a new instance of the log receiver
-func newReceiver(set receiver.Settings, blobEventHandler blobEventHandler) (component.Component, error) {
+func newReceiver(set receiver.Settings, eventHandler eventHandler) (component.Component, error) {
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             set.ID,
 		Transport:              "event",
@@ -106,15 +106,15 @@ func newReceiver(set receiver.Settings, blobEventHandler blobEventHandler) (comp
 	}
 
 	blobReceiver := &blobReceiver{
-		blobEventHandler:  blobEventHandler,
+		blobEventHandler:  eventHandler,
 		logger:            set.Logger,
 		logsUnmarshaler:   &plog.JSONUnmarshaler{},
 		tracesUnmarshaler: &ptrace.JSONUnmarshaler{},
 		obsrecv:           obsrecv,
 	}
 
-	blobEventHandler.setLogsDataConsumer(blobReceiver)
-	blobEventHandler.setTracesDataConsumer(blobReceiver)
+	eventHandler.setLogsDataConsumer(blobReceiver)
+	eventHandler.setTracesDataConsumer(blobReceiver)
 
 	return blobReceiver, nil
 }

--- a/receiver/azureblobreceiver/receiver_test.go
+++ b/receiver/azureblobreceiver/receiver_test.go
@@ -4,6 +4,7 @@
 package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,48 +21,67 @@ var (
 	tracesJSON = []byte(`{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"FilterModule"}},{"key":"service.instance.id","value":{"stringValue":"7020adec-62a0-4cc6-9878-876fec16e961"}},{"key":"telemetry.sdk.name","value":{"stringValue":"opentelemetry"}},{"key":"telemetry.sdk.language","value":{"stringValue":"dotnet"}},{"key":"telemetry.sdk.version","value":{"stringValue":"1.2.0.268"}}]},"scopeSpans":[{"scope":{"name":"IoTSample.FilterModule"},"spans":[{"traceId":"b8c21a8a5aeb50b98f38d548cedc7068","spanId":"4951aca774f96da6","parentSpanId":"c4ad1e000ef8bb19","name":"Upstream","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1645750319674336500","endTimeUnixNano":"1645750319678074800","status":{}},{"traceId":"b8c21a8a5aeb50b98f38d548cedc7068","spanId":"c4ad1e000ef8bb19","parentSpanId":"22ba720ac011163b","name":"FilterTemperature","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1645750319674157400","endTimeUnixNano":"1645750319678086500","attributes":[{"key":"MessageString","value":{"stringValue":"{\"machine\":{\"temperature\":100.2142046553614,\"pressure\":10.024403062003197},\"ambient\":{\"temperature\":20.759989948598662,\"humidity\":24},\"timeCreated\":\"2022-02-25T00:51:59.6685152Z\"}"}},{"key":"MachineTemperature","value":{"doubleValue":100.2142046553614}},{"key":"TemperatureThreshhold","value":{"intValue":"25"}}],"events":[{"timeUnixNano":"1645750319674315300","name":"Machine temperature 100.2142046553614 exceeds threshold 25"},{"timeUnixNano":"1645750319674324100","name":"Message passed threshold"}],"status":{}}]}]}]}`)
 )
 
+var testModes = []string{"eventhub", "polling"}
+
 func TestNewReceiver(t *testing.T) {
-	receiver, err := getBlobReceiver(t)
+	for _, mode := range testModes {
+		t.Run(mode, func(tt *testing.T) {
+			receiver, err := getBlobReceiver(tt, mode)
 
-	require.NoError(t, err)
+			require.NoError(t, err)
 
-	assert.NotNil(t, receiver)
+			assert.NotNil(t, receiver)
+		})
+	}
 }
 
 func TestConsumeLogsJSON(t *testing.T) {
-	receiver, _ := getBlobReceiver(t)
+	for _, mode := range testModes {
+		t.Run(mode, func(tt *testing.T) {
+			receiver, _ := getBlobReceiver(tt, mode)
 
-	logsSink := new(consumertest.LogsSink)
-	logsConsumer, ok := receiver.(logsDataConsumer)
-	require.True(t, ok)
+			logsSink := new(consumertest.LogsSink)
+			logsConsumer, ok := receiver.(logsDataConsumer)
+			require.True(t, ok)
 
-	logsConsumer.setNextLogsConsumer(logsSink)
+			logsConsumer.setNextLogsConsumer(logsSink)
 
-	err := logsConsumer.consumeLogsJSON(t.Context(), logsJSON)
-	require.NoError(t, err)
-	assert.Equal(t, 1, logsSink.LogRecordCount())
+			err := logsConsumer.consumeLogsJSON(t.Context(), logsJSON)
+			require.NoError(t, err)
+			assert.Equal(t, 1, logsSink.LogRecordCount())
+		})
+	}
 }
 
 func TestConsumeTracesJSON(t *testing.T) {
-	receiver, _ := getBlobReceiver(t)
+	for _, mode := range testModes {
+		t.Run(mode, func(tt *testing.T) {
+			receiver, _ := getBlobReceiver(tt, mode)
 
-	tracesSink := new(consumertest.TracesSink)
-	tracesConsumer, ok := receiver.(tracesDataConsumer)
-	require.True(t, ok)
+			tracesSink := new(consumertest.TracesSink)
+			tracesConsumer, ok := receiver.(tracesDataConsumer)
+			require.True(t, ok)
 
-	tracesConsumer.setNextTracesConsumer(tracesSink)
+			tracesConsumer.setNextTracesConsumer(tracesSink)
 
-	err := tracesConsumer.consumeTracesJSON(t.Context(), tracesJSON)
-	require.NoError(t, err)
-	assert.Equal(t, 2, tracesSink.SpanCount())
+			err := tracesConsumer.consumeTracesJSON(t.Context(), tracesJSON)
+			require.NoError(t, err)
+			assert.Equal(t, 2, tracesSink.SpanCount())
+		})
+	}
 }
 
-func getBlobReceiver(t *testing.T) (component.Component, error) {
+func getBlobReceiver(t *testing.T, mode string) (component.Component, error) {
 	set := receivertest.NewNopSettings(metadata.Type)
-
-	blobClient := newMockBlobClient()
-	blobEventHandler := getEventHubEventHandler(t, blobClient)
-
-	getEventHubEventHandler(t, blobClient)
-	return newReceiver(set, blobEventHandler)
+	if mode == "eventhub" {
+		blobClient := newMockBlobClient()
+		blobEventHandler := getEventHubEventHandler(t, blobClient)
+		return newReceiver(set, blobEventHandler)
+	}
+	if mode == "polling" {
+		blobClient := newMockBlobClient()
+		blobEventHandler := getBlobEventHandler(t, blobClient)
+		return newReceiver(set, blobEventHandler)
+	}
+	return nil, errors.New("invalid mode")
 }

--- a/receiver/azureblobreceiver/receiver_test.go
+++ b/receiver/azureblobreceiver/receiver_test.go
@@ -28,9 +28,9 @@ func TestNewReceiver(t *testing.T) {
 		t.Run(mode, func(tt *testing.T) {
 			receiver, err := getBlobReceiver(tt, mode)
 
-			require.NoError(t, err)
+			require.NoError(tt, err)
 
-			assert.NotNil(t, receiver)
+			assert.NotNil(tt, receiver)
 		})
 	}
 }
@@ -42,13 +42,13 @@ func TestConsumeLogsJSON(t *testing.T) {
 
 			logsSink := new(consumertest.LogsSink)
 			logsConsumer, ok := receiver.(logsDataConsumer)
-			require.True(t, ok)
+			require.True(tt, ok)
 
 			logsConsumer.setNextLogsConsumer(logsSink)
 
-			err := logsConsumer.consumeLogsJSON(t.Context(), logsJSON)
-			require.NoError(t, err)
-			assert.Equal(t, 1, logsSink.LogRecordCount())
+			err := logsConsumer.consumeLogsJSON(tt.Context(), logsJSON)
+			require.NoError(tt, err)
+			assert.Equal(tt, 1, logsSink.LogRecordCount())
 		})
 	}
 }
@@ -60,13 +60,13 @@ func TestConsumeTracesJSON(t *testing.T) {
 
 			tracesSink := new(consumertest.TracesSink)
 			tracesConsumer, ok := receiver.(tracesDataConsumer)
-			require.True(t, ok)
+			require.True(tt, ok)
 
 			tracesConsumer.setNextTracesConsumer(tracesSink)
 
-			err := tracesConsumer.consumeTracesJSON(t.Context(), tracesJSON)
-			require.NoError(t, err)
-			assert.Equal(t, 2, tracesSink.SpanCount())
+			err := tracesConsumer.consumeTracesJSON(tt.Context(), tracesJSON)
+			require.NoError(tt, err)
+			assert.Equal(tt, 2, tracesSink.SpanCount())
 		})
 	}
 }

--- a/receiver/azureblobreceiver/receiver_test.go
+++ b/receiver/azureblobreceiver/receiver_test.go
@@ -60,8 +60,8 @@ func getBlobReceiver(t *testing.T) (component.Component, error) {
 	set := receivertest.NewNopSettings(metadata.Type)
 
 	blobClient := newMockBlobClient()
-	blobEventHandler := getBlobEventHandler(t, blobClient)
+	blobEventHandler := getEventHubEventHandler(t, blobClient)
 
-	getBlobEventHandler(t, blobClient)
+	getEventHubEventHandler(t, blobClient)
 	return newReceiver(set, blobEventHandler)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, the Azure Blob receiver requires the use of Azure Event Hub to process logs and traces in Azure Storage. This adds the ability to poll your storage periodically to ingest the data.

Similar to the Azure Event Hub method, the files are deleted after processing.

This requires no new configuration. It simply makes configuring Azure Event Hub optional.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45717

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- Added tests for new mode
- Updated some existing tests to run in both modes

<!--Describe the documentation added.-->
#### Documentation
- Updated `README.md`

<!--Please delete paragraphs that you did not use before submitting.-->
