### PR TITLE
[pkg/ottl] Optimize literal comparisons and constant map-key

### DIFF
--- a/.chloggen/p2-and-3.yaml
+++ b/.chloggen/p2-and-3.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Optimize OTTL condition evaluation by fast-pathing literal comparisons and constant map-key access.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [42522]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -161,6 +161,10 @@ func (p *Parser[K]) newComparisonExpr(comparison *comparison) (boolExpr[K], erro
 		if rightVal, rightOk := GetLiteralValue(right); rightOk {
 			return newLiteralExpr[K](comparator.compare(leftVal, rightVal, comparison.Op)), nil
 		}
+		return &leftLiteralComparisonExpr[K]{left: leftVal, right: right, comparator: comparator, op: comparison.Op}, nil
+	}
+	if rightVal, rightOk := GetLiteralValue(right); rightOk {
+		return &rightLiteralComparisonExpr[K]{left: left, right: rightVal, comparator: comparator, op: comparison.Op}, nil
 	}
 
 	// The parser ensures that we'll never get an invalid comparison.Op, so we don't have to check that case.
@@ -185,6 +189,40 @@ func (e *comparisonExpr[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 		return false, rightErr
 	}
 	return e.comparator.compare(a, b, e.op), nil
+}
+
+type leftLiteralComparisonExpr[K any] struct {
+	left       any
+	right      Getter[K]
+	comparator ValueComparator
+	op         compareOp
+}
+
+func (*leftLiteralComparisonExpr[K]) unexported() {}
+
+func (e *leftLiteralComparisonExpr[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
+	b, rightErr := e.right.Get(ctx, tCtx)
+	if rightErr != nil {
+		return false, rightErr
+	}
+	return e.comparator.compare(e.left, b, e.op), nil
+}
+
+type rightLiteralComparisonExpr[K any] struct {
+	left       Getter[K]
+	right      any
+	comparator ValueComparator
+	op         compareOp
+}
+
+func (*rightLiteralComparisonExpr[K]) unexported() {}
+
+func (e *rightLiteralComparisonExpr[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
+	a, leftErr := e.left.Get(ctx, tCtx)
+	if leftErr != nil {
+		return false, leftErr
+	}
+	return e.comparator.compare(a, e.right, e.op), nil
 }
 
 func (p *Parser[K]) newBoolExpr(expr *booleanExpression) (boolExpr[K], error) {

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -215,6 +215,112 @@ func Test_newConditionEvaluator_invalid(t *testing.T) {
 	}
 }
 
+func Test_newComparisonExpr_literalFastPaths(t *testing.T) {
+	p, _ := NewParser(
+		defaultFunctionsForTests(),
+		testParsePath[any],
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+
+	tests := []struct {
+		name       string
+		comparison *comparison
+		assertType func(*testing.T, boolExpr[any])
+	}{
+		{
+			name:       "both literals fold to literal expression",
+			comparison: comparisonHelper("left", "right", "!="),
+			assertType: func(t *testing.T, expr boolExpr[any]) {
+				_, ok := expr.(*literalBoolExpr[any])
+				assert.True(t, ok)
+			},
+		},
+		{
+			name:       "literal on left uses left-literal comparison expression",
+			comparison: comparisonHelper("left", "NAME", "=="),
+			assertType: func(t *testing.T, expr boolExpr[any]) {
+				_, ok := expr.(*leftLiteralComparisonExpr[any])
+				assert.True(t, ok)
+			},
+		},
+		{
+			name:       "literal on right uses right-literal comparison expression",
+			comparison: comparisonHelper("NAME", "right", "=="),
+			assertType: func(t *testing.T, expr boolExpr[any]) {
+				_, ok := expr.(*rightLiteralComparisonExpr[any])
+				assert.True(t, ok)
+			},
+		},
+		{
+			name:       "dynamic both sides keeps regular comparison expression",
+			comparison: comparisonHelper("NAME", "NAME", "=="),
+			assertType: func(t *testing.T, expr boolExpr[any]) {
+				_, ok := expr.(*comparisonExpr[any])
+				assert.True(t, ok)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr, err := p.newComparisonExpr(tt.comparison)
+			require.NoError(t, err)
+			tt.assertType(t, expr)
+		})
+	}
+}
+
+func Benchmark_newComparisonExpr_Eval(b *testing.B) {
+	p, _ := NewParser(
+		defaultFunctionsForTests(),
+		testParsePath[any],
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+
+	tests := []struct {
+		name       string
+		comparison *comparison
+		item       any
+	}{
+		{
+			name:       "literal_left",
+			comparison: comparisonHelper("bear", "NAME", "=="),
+			item:       "bear",
+		},
+		{
+			name:       "literal_right",
+			comparison: comparisonHelper("NAME", "bear", "=="),
+			item:       "bear",
+		},
+		{
+			name:       "dynamic_both",
+			comparison: comparisonHelper("NAME", "NAME", "=="),
+			item:       "bear",
+		},
+	}
+
+	ctx := b.Context()
+	for _, tt := range tests {
+		expr, err := p.newComparisonExpr(tt.comparison)
+		require.NoError(b, err)
+
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				result, err := expr.Eval(ctx, tt.item)
+				if err != nil {
+					b.Fatalf("eval failed: %v", err)
+				}
+				if !result {
+					b.Fatalf("unexpected false result")
+				}
+			}
+		})
+	}
+}
+
 func True() (ExprFunc[any], error) {
 	return func(context.Context, any) (any, error) {
 		return true, nil

--- a/pkg/ottl/contexts/internal/ctxcache/cache.go
+++ b/pkg/ottl/contexts/internal/ctxcache/cache.go
@@ -36,13 +36,8 @@ func accessCache[K any](cacheGetter Getter[K]) ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessCacheKey[K any](cacheGetter Getter[K], key []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue(ctx, tCtx, cacheGetter(tCtx), key)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue(ctx, tCtx, cacheGetter(tCtx), key, val)
-		},
-	}
+func accessCacheKey[K any](cacheGetter Getter[K], key []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		return cacheGetter(tCtx)
+	})
 }

--- a/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
+++ b/pkg/ottl/contexts/internal/ctxdatapoint/datapoint.go
@@ -117,35 +117,21 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			switch dp := tCtx.GetDataPoint().(type) {
-			case pmetric.NumberDataPoint:
-				return ctxutil.GetMapValue(ctx, tCtx, dp.Attributes(), key)
-			case pmetric.HistogramDataPoint:
-				return ctxutil.GetMapValue(ctx, tCtx, dp.Attributes(), key)
-			case pmetric.ExponentialHistogramDataPoint:
-				return ctxutil.GetMapValue(ctx, tCtx, dp.Attributes(), key)
-			case pmetric.SummaryDataPoint:
-				return ctxutil.GetMapValue(ctx, tCtx, dp.Attributes(), key)
-			}
-			return nil, nil
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			switch dp := tCtx.GetDataPoint().(type) {
-			case pmetric.NumberDataPoint:
-				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
-			case pmetric.HistogramDataPoint:
-				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
-			case pmetric.ExponentialHistogramDataPoint:
-				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
-			case pmetric.SummaryDataPoint:
-				return ctxutil.SetMapValue(ctx, tCtx, dp.Attributes(), key, val)
-			}
-			return nil
-		},
-	}
+func accessAttributesKey[K Context](key []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		switch dp := tCtx.GetDataPoint().(type) {
+		case pmetric.NumberDataPoint:
+			return dp.Attributes()
+		case pmetric.HistogramDataPoint:
+			return dp.Attributes()
+		case pmetric.ExponentialHistogramDataPoint:
+			return dp.Attributes()
+		case pmetric.SummaryDataPoint:
+			return dp.Attributes()
+		default:
+			return pcommon.NewMap()
+		}
+	})
 }
 
 func accessStartTimeUnixNano[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxlog/log.go
+++ b/pkg/ottl/contexts/internal/ctxlog/log.go
@@ -190,12 +190,16 @@ func accessBody[K Context]() ottl.StandardGetSetter[K] {
 }
 
 func accessBodyKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
+	mapGetSetter := ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		return tCtx.GetLogRecord().Body().Map()
+	})
+
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
 			body := tCtx.GetLogRecord().Body()
 			switch body.Type() {
 			case pcommon.ValueTypeMap:
-				return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetLogRecord().Body().Map(), key)
+				return mapGetSetter.Get(ctx, tCtx)
 			case pcommon.ValueTypeSlice:
 				return ctxutil.GetSliceValue[K](ctx, tCtx, tCtx.GetLogRecord().Body().Slice(), key)
 			default:
@@ -206,7 +210,7 @@ func accessBodyKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
 			body := tCtx.GetLogRecord().Body()
 			switch body.Type() {
 			case pcommon.ValueTypeMap:
-				return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetLogRecord().Body().Map(), key, val)
+				return mapGetSetter.Set(ctx, tCtx, val)
 			case pcommon.ValueTypeSlice:
 				return ctxutil.SetSliceValue[K](ctx, tCtx, tCtx.GetLogRecord().Body().Slice(), key, val)
 			default:
@@ -243,15 +247,10 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetLogRecord().Attributes(), key)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetLogRecord().Attributes(), key, val)
-		},
-	}
+func accessAttributesKey[K Context](key []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		return tCtx.GetLogRecord().Attributes()
+	})
 }
 
 func accessDroppedAttributesCount[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxmetric/metric.go
+++ b/pkg/ottl/contexts/internal/ctxmetric/metric.go
@@ -6,6 +6,7 @@ package ctxmetric // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -227,13 +228,8 @@ func accessMetadata[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessMetadataKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue(ctx, tCtx, tCtx.GetMetric().Metadata(), keys)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue(ctx, tCtx, tCtx.GetMetric().Metadata(), keys, val)
-		},
-	}
+func accessMetadataKey[K Context](keys []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(keys, func(tCtx K) pcommon.Map {
+		return tCtx.GetMetric().Metadata()
+	})
 }

--- a/pkg/ottl/contexts/internal/ctxprofilecommon/attributes.go
+++ b/pkg/ottl/contexts/internal/ctxprofilecommon/attributes.go
@@ -53,21 +53,35 @@ func AccessAttributes[K any](source attributeSource[K]) ottl.StandardGetSetter[K
 }
 
 func AccessAttributesKey[K any](key []ottl.Key[K], source attributeSource[K]) ottl.StandardGetSetter[K] {
+	mapGetSetter := ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		dict, attributable := source(tCtx)
+		return pprofile.FromAttributeIndices(dict.AttributeTable(), attributable, dict)
+	})
+
+	var firstLiteralKey *string
+	if len(key) > 0 {
+		if literalKey, ok := ottl.GetLiteralKeyString(key[0]); ok {
+			firstLiteralKey = literalKey
+		}
+	}
+
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			dict, attributable := source(tCtx)
-			return ctxutil.GetMapValue[K](ctx, tCtx, pprofile.FromAttributeIndices(dict.AttributeTable(), attributable, dict), key)
+			return mapGetSetter.Get(ctx, tCtx)
 		},
 		Setter: func(ctx context.Context, tCtx K, val any) error {
-			newKey, err := ctxutil.GetMapKeyName(ctx, tCtx, key[0])
-			if err != nil {
-				return err
+			newKey := firstLiteralKey
+			if newKey == nil {
+				var err error
+				newKey, err = ctxutil.GetMapKeyName(ctx, tCtx, key[0])
+				if err != nil {
+					return err
+				}
 			}
 
 			dict, attributable := source(tCtx)
 			v := getAttributeValue(dict, attributable.AttributeIndices(), *newKey)
-			err = ctxutil.SetIndexableValue[K](ctx, tCtx, v, val, key[1:])
-			if err != nil {
+			if err := ctxutil.SetIndexableValue[K](ctx, tCtx, v, val, key[1:]); err != nil {
 				return err
 			}
 

--- a/pkg/ottl/contexts/internal/ctxresource/resource.go
+++ b/pkg/ottl/contexts/internal/ctxresource/resource.go
@@ -6,6 +6,8 @@ package ctxresource // import "github.com/open-telemetry/opentelemetry-collector
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
@@ -41,15 +43,10 @@ func accessResourceAttributes[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessResourceAttributesKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetResource().Attributes(), keys)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetResource().Attributes(), keys, val)
-		},
-	}
+func accessResourceAttributesKey[K Context](keys []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(keys, func(tCtx K) pcommon.Map {
+		return tCtx.GetResource().Attributes()
+	})
 }
 
 func accessResourceDroppedAttributesCount[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxscope/scope.go
+++ b/pkg/ottl/contexts/internal/ctxscope/scope.go
@@ -6,6 +6,8 @@ package ctxscope // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxerror"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ctxutil"
@@ -46,15 +48,10 @@ func accessInstrumentationScopeAttributes[K Context]() ottl.StandardGetSetter[K]
 	}
 }
 
-func accessInstrumentationScopeAttributesKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetInstrumentationScope().Attributes(), keys)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetInstrumentationScope().Attributes(), keys, val)
-		},
-	}
+func accessInstrumentationScopeAttributesKey[K Context](keys []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(keys, func(tCtx K) pcommon.Map {
+		return tCtx.GetInstrumentationScope().Attributes()
+	})
 }
 
 func accessInstrumentationScopeName[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxspan/span.go
+++ b/pkg/ottl/contexts/internal/ctxspan/span.go
@@ -427,15 +427,10 @@ func accessAttributes[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessAttributesKey[K Context](keys []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetSpan().Attributes(), keys)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetSpan().Attributes(), keys, val)
-		},
-	}
+func accessAttributesKey[K Context](keys []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(keys, func(tCtx K) pcommon.Map {
+		return tCtx.GetSpan().Attributes()
+	})
 }
 
 func accessSpanDroppedAttributesCount[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
+++ b/pkg/ottl/contexts/internal/ctxspanevent/span_events.go
@@ -90,15 +90,10 @@ func accessSpanEventAttributes[K Context]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessSpanEventAttributesKey[K Context](key []ottl.Key[K]) ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return ctxutil.GetMapValue[K](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key)
-		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return ctxutil.SetMapValue[K](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key, val)
-		},
-	}
+func accessSpanEventAttributesKey[K Context](key []ottl.Key[K]) ottl.GetSetter[K] {
+	return ctxutil.NewMapKeyGetSetter(key, func(tCtx K) pcommon.Map {
+		return tCtx.GetSpanEvent().Attributes()
+	})
 }
 
 func accessSpanEventDroppedAttributeCount[K Context]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/ctxutil/map.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map.go
@@ -11,11 +11,64 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
+type mapKeyGetSetter[K any] struct {
+	keys            []ottl.Key[K]
+	firstLiteralKey *string
+	mapGetter       func(K) pcommon.Map
+}
+
+// NewMapKeyGetSetter creates a map-backed accessor for keyed paths.
+// The first key literal status is resolved once at creation time.
+func NewMapKeyGetSetter[K any](keys []ottl.Key[K], mapGetter func(K) pcommon.Map) ottl.GetSetter[K] {
+	return &mapKeyGetSetter[K]{
+		keys:            keys,
+		firstLiteralKey: getFirstLiteralMapKey(keys),
+		mapGetter:       mapGetter,
+	}
+}
+
+func (m *mapKeyGetSetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
+	return getMapValue[K](ctx, tCtx, m.mapGetter(tCtx), m.keys, m.firstLiteralKey)
+}
+
+func (m *mapKeyGetSetter[K]) Set(ctx context.Context, tCtx K, val any) error {
+	return setMapValue[K](ctx, tCtx, m.mapGetter(tCtx), m.keys, m.firstLiteralKey, val)
+}
+
+func getFirstLiteralMapKey[K any](keys []ottl.Key[K]) *string {
+	if len(keys) == 0 {
+		return nil
+	}
+	literalKey, ok := ottl.GetLiteralKeyString(keys[0])
+	if !ok {
+		return nil
+	}
+	return literalKey
+}
+
 func GetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.Key[K]) (any, error) {
+	return getMapValue[K](ctx, tCtx, m, keys, getFirstLiteralMapKey(keys))
+}
+
+func getMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.Key[K], firstLiteralKey *string) (any, error) {
 	if len(keys) == 0 {
 		return nil, errors.New("cannot get map value without keys")
+	}
+
+	if firstLiteralKey != nil {
+		val, exists := m.Get(*firstLiteralKey)
+		if !exists {
+			return nil, nil
+		}
+
+		if len(keys) == 1 {
+			return ottlcommon.GetValue(val), nil
+		}
+
+		return getIndexableValue[K](ctx, tCtx, val, keys[1:])
 	}
 
 	s, err := GetMapKeyName(ctx, tCtx, keys[0])
@@ -32,8 +85,21 @@ func GetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.
 }
 
 func SetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.Key[K], val any) error {
+	return setMapValue[K](ctx, tCtx, m, keys, getFirstLiteralMapKey(keys), val)
+}
+
+func setMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.Key[K], firstLiteralKey *string, val any) error {
 	if len(keys) == 0 {
 		return errors.New("cannot set map value without keys")
+	}
+
+	if firstLiteralKey != nil {
+		currentValue, exists := m.Get(*firstLiteralKey)
+		if !exists {
+			currentValue = m.PutEmpty(*firstLiteralKey)
+		}
+
+		return SetIndexableValue[K](ctx, tCtx, currentValue, val, keys[1:])
 	}
 
 	s, err := GetMapKeyName(ctx, tCtx, keys[0])
@@ -49,6 +115,10 @@ func SetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, keys []ottl.
 }
 
 func GetMapKeyName[K any](ctx context.Context, tCtx K, key ottl.Key[K]) (*string, error) {
+	if literalKey, ok := ottl.GetLiteralKeyString(key); ok {
+		return literalKey, nil
+	}
+
 	resolvedKey, err := key.String(ctx, tCtx)
 	if err != nil {
 		return nil, err

--- a/pkg/ottl/contexts/internal/ctxutil/map_test.go
+++ b/pkg/ottl/contexts/internal/ctxutil/map_test.go
@@ -444,3 +444,58 @@ func Test_GetMapKeyName(t *testing.T) {
 		})
 	}
 }
+
+func Test_NewMapKeyGetSetter(t *testing.T) {
+	t.Run("literal key get and set", func(t *testing.T) {
+		m := pcommon.NewMap()
+		m.PutStr("foo", "bar")
+		keys := []ottl.Key[any]{
+			&pathtest.Key[any]{S: ottltest.Strp("foo")},
+		}
+
+		getSetter := ctxutil.NewMapKeyGetSetter(keys, func(any) pcommon.Map { return m })
+
+		got, err := getSetter.Get(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "bar", got)
+
+		err = getSetter.Set(t.Context(), nil, "baz")
+		require.NoError(t, err)
+		gotVal, ok := m.Get("foo")
+		require.True(t, ok)
+		assert.Equal(t, "baz", gotVal.Str())
+	})
+
+	t.Run("dynamic key get and set", func(t *testing.T) {
+		m := pcommon.NewMap()
+		m.PutStr("foo", "bar")
+		keys := []ottl.Key[any]{
+			&pathtest.Key[any]{
+				G: &ottl.StandardGetSetter[any]{
+					Getter: func(context.Context, any) (any, error) { return "foo", nil },
+				},
+			},
+		}
+
+		getSetter := ctxutil.NewMapKeyGetSetter(keys, func(any) pcommon.Map { return m })
+
+		got, err := getSetter.Get(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Equal(t, "bar", got)
+
+		err = getSetter.Set(t.Context(), nil, "qux")
+		require.NoError(t, err)
+		gotVal, ok := m.Get("foo")
+		require.True(t, ok)
+		assert.Equal(t, "qux", gotVal.Str())
+	})
+
+	t.Run("empty keys returns error", func(t *testing.T) {
+		getSetter := ctxutil.NewMapKeyGetSetter(nil, func(any) pcommon.Map { return pcommon.NewMap() })
+
+		_, err := getSetter.Get(t.Context(), nil)
+		require.Error(t, err)
+		err = getSetter.Set(t.Context(), nil, "value")
+		require.Error(t, err)
+	})
+}

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -302,6 +302,20 @@ func (k *baseKey[K]) ExpressionGetter(_ context.Context, _ K) (Getter[K], error)
 	return k.g, nil
 }
 
+// GetLiteralKeyString is an optimization hook for parsed/compiled keys.
+// It returns a literal string key when the key is statically known, otherwise (nil, false).
+// Non-standard Key implementations may also return (nil, false).
+func GetLiteralKeyString[K any](key Key[K]) (*string, bool) {
+	if key == nil {
+		return nil, false
+	}
+	bk, ok := key.(*baseKey[K])
+	if !ok || bk.s == nil || bk.g != nil {
+		return nil, false
+	}
+	return bk.s, true
+}
+
 func (p *Parser[K]) parsePath(ip *basePath[K]) (GetSetter[K], error) {
 	g, err := p.pathParser(ip)
 	if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2988,6 +2988,35 @@ func Test_baseKey_Int(t *testing.T) {
 	assert.Equal(t, int64(1), *i)
 }
 
+func Test_GetLiteralKeyString(t *testing.T) {
+	t.Run("literal string key", func(t *testing.T) {
+		literal := &baseKey[any]{s: ottltest.Strp("foo")}
+		got, ok := GetLiteralKeyString[any](literal)
+		require.True(t, ok)
+		require.NotNil(t, got)
+		assert.Equal(t, "foo", *got)
+	})
+
+	t.Run("dynamic key", func(t *testing.T) {
+		literal := &baseKey[any]{
+			s: ottltest.Strp("foo"),
+			g: &StandardGetSetter[any]{Getter: func(context.Context, any) (any, error) {
+				return "bar", nil
+			}},
+		}
+		got, ok := GetLiteralKeyString[any](literal)
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("int key", func(t *testing.T) {
+		literal := &baseKey[any]{i: ottltest.Intp(1)}
+		got, ok := GetLiteralKeyString[any](literal)
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+}
+
 func Test_newKey(t *testing.T) {
 	ps, _ := NewParser[any](
 		defaultFunctionsForTests(),


### PR DESCRIPTION
#### Description
This PR implements fast-path literal comparisons in BoolExpr so only the dynamic side is evaluated (e.g. `name == "foo"`), and fast-path constant map-key access for keyed map lookups (e.g., `attributes["foo"] == ...`) across OTTL context accessors.


#### Link to tracking issue
Fixes #42522

#### Testing
Added/updated unit tests.

[benchmarks run gist](https://gist.github.com/ShaanveerS/5c6ba508c8e0846e5e937e087ae10c1b)