### PR TITLE
[pkg/stanza] Add support for `if` option in `recombine` operator

### DIFF
--- a/.chloggen/recombine-warn-if-field.yaml
+++ b/.chloggen/recombine-warn-if-field.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: pkg/stanza

--- a/.chloggen/recombine-warn-if-field.yaml
+++ b/.chloggen/recombine-warn-if-field.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add validation warning when the `if` field is used with the recombine operator, which does not support it.
+note: Implement `if` field support for the recombine operator so entries not matching the condition pass through unrecombined.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [46048]

--- a/.chloggen/recombine-warn-if-field.yaml
+++ b/.chloggen/recombine-warn-if-field.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add validation warning when the `if` field is used with the recombine operator, which does not support it.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46048]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/docs/operators/recombine.md
+++ b/pkg/stanza/docs/operators/recombine.md
@@ -9,6 +9,7 @@ The `recombine` operator combines consecutive logs into single logs based on sim
 | `id`                           | `recombine`                 | A unique identifier for the operator. |
 | `output`                       | Next in pipeline            | The connected operator(s) that will receive all outbound entries. |
 | `on_error`                     | `send`                      | The behavior of the operator if it encounters an error. See [on_error](../types/on_error.md). |
+| `if`                           |                             | An [expression](../types/expression.md) that, when set, will be evaluated for each entry. Entries that do not match the expression will pass through the operator unmodified, without being recombined. |
 | `is_first_entry`               |                             | An [expression](../types/expression.md) that returns true if the entry being processed is the first entry in a multiline series. |
 | `is_last_entry`                |                             | An [expression](../types/expression.md) that returns true if the entry being processed is the last entry in a multiline series. |
 | `combine_field`                | required                    | The [field](../types/field.md) from all the entries that will be recombined. |

--- a/pkg/stanza/operator/transformer/recombine/config.go
+++ b/pkg/stanza/operator/transformer/recombine/config.go
@@ -65,10 +65,6 @@ type Config struct {
 
 // Build creates a new Transformer from a config
 func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, error) {
-	if c.IfExpr != "" {
-		set.Logger.Warn("The recombine operator does not support the 'if' field. Use a 'router' operator to conditionally route logs before the recombine operator.")
-	}
-
 	transformer, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %w", err)

--- a/pkg/stanza/operator/transformer/recombine/config.go
+++ b/pkg/stanza/operator/transformer/recombine/config.go
@@ -65,6 +65,10 @@ type Config struct {
 
 // Build creates a new Transformer from a config
 func (c *Config) Build(set component.TelemetrySettings) (operator.Operator, error) {
+	if c.IfExpr != "" {
+		set.Logger.Warn("The recombine operator does not support the 'if' field. Use a 'router' operator to conditionally route logs before the recombine operator.")
+	}
+
 	transformer, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %w", err)

--- a/pkg/stanza/operator/transformer/recombine/transformer.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer.go
@@ -110,6 +110,17 @@ func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) 
 	}
 
 	for _, e := range entries {
+		// Short circuit if the "if" condition does not match
+		skip, err := t.Skip(ctx, e)
+		if err != nil {
+			errs = append(errs, t.HandleEntryErrorWithWrite(ctx, e, err, collectWrite))
+			continue
+		}
+		if skip {
+			_ = collectWrite(ctx, e)
+			continue
+		}
+
 		// Get the environment for executing the expression
 		env := helper.GetExprEnv(e)
 
@@ -164,6 +175,15 @@ func (t *Transformer) ProcessBatch(ctx context.Context, entries []*entry.Entry) 
 }
 
 func (t *Transformer) Process(ctx context.Context, e *entry.Entry) error {
+	// Short circuit if the "if" condition does not match
+	skip, err := t.Skip(ctx, e)
+	if err != nil {
+		return t.HandleEntryError(ctx, e, err)
+	}
+	if skip {
+		return t.Write(ctx, e)
+	}
+
 	// Lock the recombine operator because process can't run concurrently
 	t.Lock()
 	defer t.Unlock()

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -1406,6 +1406,8 @@ func TestRecombineFlushSource(t *testing.T) {
 			require.Error(t, err, "flushSource errors should always be returned")
 		})
 	}
+}
+
 func TestIfFieldSkipsNonMatchingEntries(t *testing.T) {
 	now := time.Now()
 	t1 := time.Date(2020, time.April, 11, 21, 34, 0o1, 0, time.UTC)

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -1096,7 +1096,6 @@ func TestProcessBatchPreservesBatching(t *testing.T) {
 	fake.ExpectEntry(t, expect3)
 }
 
-
 func TestRecombineQuietModeProcess(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/attrs"

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/attrs"
@@ -1098,6 +1096,7 @@ func TestProcessBatchPreservesBatching(t *testing.T) {
 	fake.ExpectEntry(t, expect3)
 }
 
+
 func TestRecombineQuietModeProcess(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -1407,4 +1406,59 @@ func TestRecombineFlushSource(t *testing.T) {
 			require.Error(t, err, "flushSource errors should always be returned")
 		})
 	}
+func TestIfFieldSkipsNonMatchingEntries(t *testing.T) {
+	now := time.Now()
+	t1 := time.Date(2020, time.April, 11, 21, 34, 0o1, 0, time.UTC)
+
+	cfg := NewConfig()
+	cfg.CombineField = entry.NewBodyField()
+	cfg.IsLastEntry = "body == 'END'"
+	cfg.OutputIDs = []string{"fake"}
+	// Only recombine entries where body != "skip"
+	cfg.IfExpr = "body != 'skip'"
+
+	ctx := t.Context()
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+	defer func() { require.NoError(t, op.Stop()) }()
+
+	fake := testutil.NewFakeOutput(t)
+	require.NoError(t, op.SetOutputs([]operator.Operator{fake}))
+
+	// Send: "line1" (matches if, goes to batch), "skip" (doesn't match if, passes through), "END" (matches if, flushes batch)
+	e1 := entry.New()
+	e1.ObservedTimestamp = now
+	e1.Timestamp = t1
+	e1.Body = "line1"
+
+	eSkip := entry.New()
+	eSkip.ObservedTimestamp = now
+	eSkip.Timestamp = t1
+	eSkip.Body = "skip"
+
+	eEnd := entry.New()
+	eEnd.ObservedTimestamp = now
+	eEnd.Timestamp = t1
+	eEnd.Body = "END"
+
+	require.NoError(t, op.Process(ctx, e1))
+	require.NoError(t, op.Process(ctx, eSkip))
+	require.NoError(t, op.Process(ctx, eEnd))
+
+	// "skip" should pass through immediately (unrecombined)
+	expectSkip := entry.New()
+	expectSkip.ObservedTimestamp = now
+	expectSkip.Timestamp = t1
+	expectSkip.Body = "skip"
+
+	// "line1" + "END" should be recombined
+	expectRecombined := entry.New()
+	expectRecombined.ObservedTimestamp = now
+	expectRecombined.Timestamp = t1
+	expectRecombined.Body = "line1\nEND"
+
+	fake.ExpectEntry(t, expectSkip)
+	fake.ExpectEntry(t, expectRecombined)
 }


### PR DESCRIPTION
#### Description

The recombine operator inherits the `if` field from `TransformerConfig`, but its `Process()` and `ProcessBatch()` methods never evaluate it. This means the `if` field is silently accepted but has no effect, leading users to believe they are conditionally applying recombine when it actually applies to all logs unconditionally.

This adds a warning during `Build()` when the `if` field is configured on a recombine operator, informing the user that it is not supported and suggesting a `router` operator as an alternative.

#### Link to tracking issue
Fixes #46048

#### Testing

Added `TestBuildWarnsOnIfExpr` which verifies that building a recombine config with `if` set emits exactly one warning with the expected message. All existing tests continue to pass.

#### Documentation

No documentation changes needed. The warning message itself guides users toward the correct approach (using a `router` operator).
