### PR TITLE
receiver/azureeventhub: fail closed when strict auth mode is enabled

### DIFF
--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -45,6 +45,15 @@ The ID of an authentication extension to use. This can be used to authenticate u
 managed identity, or service principal.
 When this field is set, `connection` is ignored and `event_hub` section is required.
 
+### require_auth (Optional)
+Enables strict auth-only mode.
+
+When set to `true`:
+- `auth` must be configured.
+- `connection` must not be set.
+
+This is useful for deployments that want to fail closed if auth extension wiring is missing.
+
 ### group (Optional)
 The Consumer Group to read from. If empty will default to the default Consumer Group $Default
 
@@ -127,6 +136,14 @@ receivers:
     auth: azureauth
     partition: foo
     group: bar
+
+  # Example with strict auth mode
+  azure_event_hub/auth_strict:
+    require_auth: true
+    event_hub:
+      name: hubName
+      namespace: namespace.servicebus.windows.net
+    auth: azureauth
 ```
 
 This component can persist its state using the [storage extension].

--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -63,6 +63,9 @@ func (config *Config) Validate() error {
 	if config.RequireAuth && config.Auth == nil {
 		return errors.New("auth is required when require_auth is enabled")
 	}
+	if config.RequireAuth && config.Connection != "" {
+		return errors.New("connection must not be set when require_auth is enabled")
+	}
 
 	if config.Auth != nil {
 		if config.EventHub.Name == "" {

--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Offset                   string         `mapstructure:"offset"`
 	StorageID                *component.ID  `mapstructure:"storage"`
 	Auth                     *component.ID  `mapstructure:"auth"`
+	RequireAuth              bool           `mapstructure:"require_auth"`
 	Format                   string         `mapstructure:"format"`
 	ConsumerGroup            string         `mapstructure:"group"`
 	ApplySemanticConventions bool           `mapstructure:"apply_semantic_conventions"`
@@ -59,6 +60,10 @@ type TimeFormat struct {
 
 // Validate config
 func (config *Config) Validate() error {
+	if config.RequireAuth && config.Auth == nil {
+		return errors.New("auth is required when require_auth is enabled")
+	}
+
 	if config.Auth != nil {
 		if config.EventHub.Name == "" {
 			return errors.New("event_hub.name is required when using auth")

--- a/receiver/azureeventhubreceiver/config.schema.yaml
+++ b/receiver/azureeventhubreceiver/config.schema.yaml
@@ -51,6 +51,8 @@ properties:
   poll_rate:
     description: azeventhub lib specific
     type: integer
+  require_auth:
+    type: boolean
   storage:
     x-pointer: true
     type: string

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -46,6 +46,21 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id:                  component.NewIDWithName(metadata.Type, "auth_required_missing_auth"),
+			expectedErrContains: "auth is required when require_auth is enabled",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "auth_required_with_auth"),
+			expected: &Config{
+				EventHub: EventHubConfig{
+					Name:      "hubName",
+					Namespace: "namespace.servicebus.windows.net",
+				},
+				Auth:        &authID,
+				RequireAuth: true,
+			},
+		},
+		{
 			id:                  component.NewIDWithName(metadata.Type, "missing_connection"),
 			expectedErrContains: "missing connection",
 		},

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -50,6 +50,10 @@ func TestLoadConfig(t *testing.T) {
 			expectedErrContains: "auth is required when require_auth is enabled",
 		},
 		{
+			id:                  component.NewIDWithName(metadata.Type, "auth_required_missing_auth_with_connection"),
+			expectedErrContains: "auth is required when require_auth is enabled",
+		},
+		{
 			id: component.NewIDWithName(metadata.Type, "auth_required_with_auth"),
 			expected: &Config{
 				EventHub: EventHubConfig{
@@ -58,6 +62,17 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Auth:        &authID,
 				RequireAuth: true,
+			},
+		},
+		{
+			id:                  component.NewIDWithName(metadata.Type, "auth_required_with_auth_and_connection"),
+			expectedErrContains: "connection must not be set when require_auth is enabled",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "require_auth_disabled_with_connection"),
+			expected: &Config{
+				Connection: "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName",
+				RequireAuth: false,
 			},
 		},
 		{

--- a/receiver/azureeventhubreceiver/testdata/config.yaml
+++ b/receiver/azureeventhubreceiver/testdata/config.yaml
@@ -25,6 +25,17 @@ azure_event_hub/auth:
     namespace: namespace.servicebus.windows.net
   auth: azureauth
 
+azure_event_hub/auth_required_missing_auth:
+  require_auth: true
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+
+azure_event_hub/auth_required_with_auth:
+  require_auth: true
+  event_hub:
+    name: hubName
+    namespace: namespace.servicebus.windows.net
+  auth: azureauth
+
 azure_event_hub/auth_missing_event_hub_name:
   auth: azureauth
   event_hub:

--- a/receiver/azureeventhubreceiver/testdata/config.yaml
+++ b/receiver/azureeventhubreceiver/testdata/config.yaml
@@ -36,6 +36,22 @@ azure_event_hub/auth_required_with_auth:
     namespace: namespace.servicebus.windows.net
   auth: azureauth
 
+azure_event_hub/auth_required_missing_auth_with_connection:
+  require_auth: true
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+
+azure_event_hub/auth_required_with_auth_and_connection:
+  require_auth: true
+  event_hub:
+    name: hubName
+    namespace: namespace.servicebus.windows.net
+  auth: azureauth
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+
+azure_event_hub/require_auth_disabled_with_connection:
+  require_auth: false
+  connection: Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName
+
 azure_event_hub/auth_missing_event_hub_name:
   auth: azureauth
   event_hub:


### PR DESCRIPTION
## Problem
When `require_auth: true` is enabled, allowing ambiguous `auth`/`connection` combinations weakens strict fail-closed intent.

## What changed
- Tightened validation for strict mode in `azureeventhubreceiver`:
  - `auth` is required when `require_auth` is true.
  - `connection` must not be set when `require_auth` is true.
- Added strict-mode config matrix tests.
- Updated receiver README to document strict-mode contract.

## Validation
- `cd receiver/azureeventhubreceiver && go test ./... -run 'TestValidate|TestLoadConfig' -count=1`

Refs #46110
