### PR TITLE
[chore] [receiver/mongodb] Remove startup timing assertion

### DIFF
--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -39,7 +39,6 @@ func TestNewMongodbScraper(t *testing.T) {
 }
 
 func TestScraperLifecycle(t *testing.T) {
-	now := time.Now()
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
 
@@ -54,8 +53,6 @@ func TestScraperLifecycle(t *testing.T) {
 	scraper := newMongodbScraper(receivertest.NewNopSettings(metadata.Type), cfg)
 	require.NoError(t, scraper.start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, scraper.shutdown(t.Context()))
-
-	require.Less(t, time.Since(now), 200*time.Millisecond, "component start and stop should be very fast")
 }
 
 var (


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Removes the startup timing assertion. CI environments are unpredictable, and we shouldn't depend on specific timings.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #44604 
