### PR TITLE
[Draft: WIP] Adds fork feature to action config in routing connector

### DIFF
--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -37,9 +37,10 @@ The following settings are available:
 - `table.context (optional, default: resource)`: the [OTTL Context] in which the statement will be evaluated. Currently, only `resource`, `span`, `metric`, `datapoint`, `log`, and `request` are supported.
 - `table.statement`: the routing condition provided as the [OTTL] statement. Required if `table.condition` is not provided. May not be used for `request` context.
 - `table.condition`: the routing condition provided as the [OTTL] condition. Required if `table.statement` is not provided. Required for `request` context.
-- `table.action (optional, default: move)`: determines what happens to the data when the routing condition is met. Valid values are `move` and `copy`.
+- `table.action (optional, default: move)`: determines what happens to the data when the routing condition is met. Valid values are `move`, `copy`, and `fork`.
   - `move`: Matched data is moved to the target pipeline(s) and removed from subsequent route evaluation. This is the default behavior.
   - `copy`: Matched data is copied to the target pipeline(s) but remains available for evaluation by subsequent routes. This allows the same data to be routed to multiple pipelines.
+  - `fork`: Similar to `copy`, matched data is evaluated against all routes and sent to all matching fork pipelines. However, unlike `copy`, if data matches one or more fork routes, it is excluded from the default pipeline.
 - `table.pipelines (required)`: the list of pipelines to use when the routing condition is met.
 - `default_pipelines (optional)`: contains the list of pipelines to use when a record does not meet any of specified conditions.
 - `error_mode (optional)`: determines how errors returned from OTTL statements are handled. Valid values are `propagate`, `ignore` and `silent`. If `ignore` or `silent` is used and a statement's condition has an error then the payload will be routed to the default pipelines. When `silent` is used the error is not logged. If not supplied, `propagate` is used.
@@ -325,6 +326,55 @@ In this example:
 - Production traces are copied to the prod pipeline. Since `action: copy` is used, the traces remain available for subsequent evaluation.
 - High-latency spans (>1000ms) are then moved to the high-latency pipeline. A production trace with high latency will appear in both the prod and high-latency pipelines.
 - Remaining traces go to the default pipeline.
+
+Route logs to specific tenant pipelines, excluding matched logs from the default pipeline using `action: fork`:
+
+```yaml
+receivers:
+    otlp:
+
+exporters:
+  file/acme:
+    path: ./acme.log
+  file/globex:
+    path: ./globex.log
+  file/other:
+    path: ./other.log
+
+connectors:
+  routing:
+    default_pipelines: [logs/other]
+    table:
+      - context: resource
+        condition: attributes["tenant"] == "acme"
+        action: fork
+        pipelines: [logs/acme]
+      - context: resource
+        condition: attributes["tenant"] == "globex"
+        action: fork
+        pipelines: [logs/globex]
+
+service:
+  pipelines:
+    logs/in:
+      receivers: [otlp]
+      exporters: [routing]
+    logs/acme:
+      receivers: [routing]
+      exporters: [file/acme]
+    logs/globex:
+      receivers: [routing]
+      exporters: [file/globex]
+    logs/other:
+      receivers: [routing]
+      exporters: [file/other]
+```
+
+In this example:
+- Logs with tenant=acme are sent to logs/acme only (excluded from logs/other).
+- Logs with tenant=globex are sent to logs/globex only (excluded from logs/other).
+- Logs without a matching tenant go to logs/other.
+- This differs from `action: copy`, where all logs would also be sent to the default pipeline. With `action: fork`, matching any fork route excludes the data from the default pipeline.
 
 ## `match_once`
 

--- a/connector/routingconnector/config.go
+++ b/connector/routingconnector/config.go
@@ -17,6 +17,7 @@ type Action string
 const (
 	Copy Action = "copy"
 	Move Action = "move"
+	Fork Action = "fork"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 	errNoPipelines            = errors.New("invalid route: no pipelines defined")
 	errUnexpectedConsumer     = errors.New("expected consumer to be a connector router")
 	errNoTableItems           = errors.New("invalid routing table: the routing table is empty")
-	errUnexpectedAction       = errors.New("invalid routing action: if provided should be one of move/copy")
+	errUnexpectedAction       = errors.New("invalid routing action: if provided should be one of move/copy/fork")
 )
 
 // Config defines configuration for the Routing processor.
@@ -63,6 +64,8 @@ func (e *Action) UnmarshalText(text []byte) error {
 		*e = Copy
 	case string(Move):
 		*e = Move
+	case string(Fork):
+		*e = Fork
 	default:
 		return fmt.Errorf("invalid Action string: %s", str)
 	}
@@ -93,7 +96,7 @@ func (c *Config) Validate() error {
 		switch item.Action {
 		case "":
 			item.Action = Move // use move if empty.
-		case Copy, Move: // ok
+		case Copy, Move, Fork: // ok
 		default:
 			return errUnexpectedAction
 		}

--- a/connector/routingconnector/config_test.go
+++ b/connector/routingconnector/config_test.go
@@ -388,7 +388,7 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
-			error: "invalid routing action: if provided should be one of move/copy",
+			error: "invalid routing action: if provided should be one of move/copy/fork",
 		},
 		{
 			name: "valid action: copy",

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -62,14 +62,17 @@ func (*logsConnector) Capabilities() consumer.Capabilities {
 func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	groups := make(map[consumer.Logs]plog.Logs)
 	matched := plog.NewLogs()
+	anyForkMatched := false
 	for i := 0; i < len(c.router.routeSlice) && ld.ResourceLogs().Len() > 0; i++ {
 		var errs error
 		route := c.router.routeSlice[i]
+		routeMatched := false
 		switch route.statementContext {
 		case "request":
 			if route.requestCondition.matchRequest(ctx) {
+				routeMatched = true
 				switch route.action {
-				case Copy:
+				case Copy, Fork:
 					ld.CopyTo(matched)
 				default:
 					// all logs are routed
@@ -78,7 +81,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			}
 		case "", "resource":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				plogutil.CopyResourcesIf(ld, matched,
 					func(rl plog.ResourceLogs) bool {
 						rtx := ottlresource.NewTransformContextPtr(rl.Resource(), rl)
@@ -88,6 +91,9 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -109,7 +115,7 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 			}
 		case "log":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				plogutil.CopyRecordsWithContextIf(ld, matched,
 					func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
 						ltx := ottllog.NewTransformContextPtr(rl, sl, lr)
@@ -119,6 +125,9 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -142,10 +151,16 @@ func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		if errs != nil && c.config.ErrorMode == ottl.PropagateError {
 			return errs
 		}
+		if routeMatched && route.action == Fork {
+			anyForkMatched = true
+		}
 		groupAllLogs(groups, route.consumer, matched)
 	}
 	// anything left wasn't matched by any route. Send to default consumer
-	groupAllLogs(groups, c.router.defaultConsumer, ld)
+	// unless a fork route matched (fork excludes from default)
+	if !anyForkMatched {
+		groupAllLogs(groups, c.router.defaultConsumer, ld)
+	}
 	var errs error
 	for consumer, group := range groups {
 		err := consumer.ConsumeLogs(ctx, group)

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -1093,6 +1093,319 @@ func TestLogsCopyAndMoveConfig(t *testing.T) {
 	})
 }
 
+func TestLogsForkAction(t *testing.T) {
+	logsDefault := pipeline.NewIDWithName(pipeline.SignalLogs, "default")
+	logs0 := pipeline.NewIDWithName(pipeline.SignalLogs, "0")
+	logs1 := pipeline.NewIDWithName(pipeline.SignalLogs, "1")
+
+	cfg := &Config{
+		DefaultPipelines: []pipeline.ID{logsDefault},
+		Table: []RoutingTableItem{
+			{
+				Condition: `attributes["X-Tenant"] == "acme"`,
+				Pipelines: []pipeline.ID{logs0},
+				Action:    Fork,
+			},
+			{
+				Condition: `attributes["X-Tenant"] == "globex"`,
+				Pipelines: []pipeline.ID{logs1},
+				Action:    Fork,
+			},
+		},
+	}
+
+	var defaultSink, sink0, sink1 consumertest.LogsSink
+
+	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+		logsDefault: &defaultSink,
+		logs0:       &sink0,
+		logs1:       &sink1,
+	})
+
+	resetSinks := func() {
+		defaultSink.Reset()
+		sink0.Reset()
+		sink1.Reset()
+	}
+
+	factory := NewFactory()
+	conn, err := factory.CreateLogsToLogs(
+		t.Context(),
+		connectortest.NewNopSettings(metadata.Type),
+		cfg,
+		router.(consumer.Logs),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Start(t.Context(), componenttest.NewNopHost()))
+
+	t.Run("fork matched excludes from default", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Empty(t, sink1.AllLogs())
+		assert.Empty(t, defaultSink.AllLogs())
+	})
+
+	t.Run("fork no match goes to default", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "other")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Empty(t, sink0.AllLogs())
+		assert.Empty(t, sink1.AllLogs())
+		assert.Len(t, defaultSink.AllLogs(), 1)
+	})
+
+	t.Run("multiple fork routes both match", func(t *testing.T) {
+		resetSinks()
+
+		// Send two logs, each matching a different fork route
+		l := plog.NewLogs()
+
+		rl1 := l.ResourceLogs().AppendEmpty()
+		rl1.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rl1.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		rl2 := l.ResourceLogs().AppendEmpty()
+		rl2.Resource().Attributes().PutStr("X-Tenant", "globex")
+		rl2.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Len(t, sink1.AllLogs(), 1)
+		assert.Empty(t, defaultSink.AllLogs())
+	})
+
+	t.Run("fork with log context", func(t *testing.T) {
+		resetSinks()
+
+		cfgLog := &Config{
+			DefaultPipelines: []pipeline.ID{logsDefault},
+			Table: []RoutingTableItem{
+				{
+					Context:   "log",
+					Condition: `severity_number >= SEVERITY_NUMBER_ERROR`,
+					Pipelines: []pipeline.ID{logs0},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerLog := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+			logsDefault: &defaultSink,
+			logs0:       &sink0,
+		})
+
+		factory := NewFactory()
+		connLog, err := factory.CreateLogsToLogs(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgLog,
+			routerLog.(consumer.Logs),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connLog)
+		require.NoError(t, connLog.Start(t.Context(), componenttest.NewNopHost()))
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		sl := rl.ScopeLogs().AppendEmpty()
+
+		// Add error log
+		lr1 := sl.LogRecords().AppendEmpty()
+		lr1.SetSeverityNumber(plog.SeverityNumberError)
+
+		// Add info log
+		lr2 := sl.LogRecords().AppendEmpty()
+		lr2.SetSeverityNumber(plog.SeverityNumberInfo)
+
+		require.NoError(t, connLog.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, sink0.AllLogs(), 1)
+		// Error log should be in sink0, info log should NOT be in default (fork matched)
+		assert.Empty(t, defaultSink.AllLogs())
+	})
+
+	t.Run("fork with copy mixed", func(t *testing.T) {
+		resetSinks()
+
+		cfgMixed := &Config{
+			DefaultPipelines: []pipeline.ID{logsDefault},
+			Table: []RoutingTableItem{
+				{
+					Condition: `attributes["copy-me"] == "yes"`,
+					Pipelines: []pipeline.ID{logs0},
+					Action:    Copy,
+				},
+				{
+					Condition: `attributes["fork-me"] == "yes"`,
+					Pipelines: []pipeline.ID{logs1},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerMixed := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+			logsDefault: &defaultSink,
+			logs0:       &sink0,
+			logs1:       &sink1,
+		})
+
+		factory := NewFactory()
+		connMixed, err := factory.CreateLogsToLogs(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgMixed,
+			routerMixed.(consumer.Logs),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connMixed)
+		require.NoError(t, connMixed.Start(t.Context(), componenttest.NewNopHost()))
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("copy-me", "yes")
+		rl.Resource().Attributes().PutStr("fork-me", "yes")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, connMixed.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, sink0.AllLogs(), 1) // Copy route
+		assert.Len(t, sink1.AllLogs(), 1) // Fork route
+		assert.Empty(t, defaultSink.AllLogs()) // Fork excludes from default
+	})
+}
+
+func TestMixedCopyAndForkActions(t *testing.T) {
+	logsDefault := pipeline.NewIDWithName(pipeline.SignalLogs, "default")
+	logsArchive := pipeline.NewIDWithName(pipeline.SignalLogs, "archive")
+	logsAcme := pipeline.NewIDWithName(pipeline.SignalLogs, "acme")
+
+	cfg := &Config{
+		DefaultPipelines: []pipeline.ID{logsDefault},
+		Table: []RoutingTableItem{
+			{
+				Condition: `attributes["archive"] == "yes"`,
+				Pipelines: []pipeline.ID{logsArchive},
+				Action:    Copy,
+			},
+			{
+				Condition: `attributes["tenant"] == "acme"`,
+				Pipelines: []pipeline.ID{logsAcme},
+				Action:    Fork,
+			},
+		},
+	}
+
+	var defaultSink, archiveSink, acmeSink consumertest.LogsSink
+
+	router := connector.NewLogsRouter(map[pipeline.ID]consumer.Logs{
+		logsDefault: &defaultSink,
+		logsArchive: &archiveSink,
+		logsAcme:    &acmeSink,
+	})
+
+	factory := NewFactory()
+	conn, err := factory.CreateLogsToLogs(
+		t.Context(),
+		connectortest.NewNopSettings(metadata.Type),
+		cfg,
+		router.(consumer.Logs),
+	)
+
+	require.NoError(t, err)
+	require.NoError(t, conn.Start(t.Context(), componenttest.NewNopHost()))
+
+	t.Run("copy + fork both match", func(t *testing.T) {
+		defaultSink.Reset()
+		archiveSink.Reset()
+		acmeSink.Reset()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("archive", "yes")
+		rl.Resource().Attributes().PutStr("tenant", "acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, archiveSink.AllLogs(), 1, "should be in archive (copy)")
+		assert.Len(t, acmeSink.AllLogs(), 1, "should be in acme (fork)")
+		assert.Empty(t, defaultSink.AllLogs(), "should NOT be in default (fork matched)")
+	})
+
+	t.Run("copy only matches", func(t *testing.T) {
+		defaultSink.Reset()
+		archiveSink.Reset()
+		acmeSink.Reset()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("archive", "yes")
+		rl.Resource().Attributes().PutStr("tenant", "other")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, archiveSink.AllLogs(), 1, "should be in archive (copy)")
+		assert.Empty(t, acmeSink.AllLogs(), "should NOT be in acme")
+		assert.Len(t, defaultSink.AllLogs(), 1, "SHOULD be in default (no fork matched)")
+	})
+
+	t.Run("fork only matches", func(t *testing.T) {
+		defaultSink.Reset()
+		archiveSink.Reset()
+		acmeSink.Reset()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("archive", "no")
+		rl.Resource().Attributes().PutStr("tenant", "acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Empty(t, archiveSink.AllLogs(), "should NOT be in archive")
+		assert.Len(t, acmeSink.AllLogs(), 1, "should be in acme (fork)")
+		assert.Empty(t, defaultSink.AllLogs(), "should NOT be in default (fork matched)")
+	})
+
+	t.Run("nothing matches", func(t *testing.T) {
+		defaultSink.Reset()
+		archiveSink.Reset()
+		acmeSink.Reset()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("archive", "no")
+		rl.Resource().Attributes().PutStr("tenant", "other")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Empty(t, archiveSink.AllLogs(), "should NOT be in archive")
+		assert.Empty(t, acmeSink.AllLogs(), "should NOT be in acme")
+		assert.Len(t, defaultSink.AllLogs(), 1, "SHOULD be in default")
+	})
+}
+
 func setLogRecordMap(lr plog.LogRecord, key, value string) plog.LogRecord {
 	lr.Body().SetEmptyMap().PutStr(key, value)
 	return lr

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -63,14 +63,17 @@ func (*metricsConnector) Capabilities() consumer.Capabilities {
 func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 	groups := make(map[consumer.Metrics]pmetric.Metrics)
 	matched := pmetric.NewMetrics()
+	anyForkMatched := false
 	for i := 0; i < len(c.router.routeSlice) && md.ResourceMetrics().Len() > 0; i++ {
 		var errs error
 		route := c.router.routeSlice[i]
+		routeMatched := false
 		switch route.statementContext {
 		case "request":
 			if route.requestCondition.matchRequest(ctx) {
+				routeMatched = true
 				switch route.action {
-				case Copy:
+				case Copy, Fork:
 					md.CopyTo(matched)
 				default:
 					// all metrics are routed
@@ -79,7 +82,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			}
 		case "", "resource":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				pmetricutil.CopyResourcesIf(md, matched,
 					func(rs pmetric.ResourceMetrics) bool {
 						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
@@ -89,6 +92,9 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -110,7 +116,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			}
 		case "metric":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				pmetricutil.CopyMetricsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) bool {
 						mtx := ottlmetric.NewTransformContextPtr(rm, sm, m)
@@ -120,6 +126,9 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -141,7 +150,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 			}
 		case "datapoint":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				pmetricutil.CopyDataPointsWithContextIf(md, matched,
 					func(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric, dp any) bool {
 						dptx := ottldatapoint.NewTransformContextPtr(rm, sm, m, dp)
@@ -151,6 +160,9 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -174,10 +186,16 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 		if errs != nil && c.config.ErrorMode == ottl.PropagateError {
 			return errs
 		}
+		if routeMatched && route.action == Fork {
+			anyForkMatched = true
+		}
 		groupAllMetrics(groups, route.consumer, matched)
 	}
 	// anything left wasn't matched by any route. Send to default consumer
-	groupAllMetrics(groups, c.router.defaultConsumer, md)
+	// unless a fork route matched (fork excludes from default)
+	if !anyForkMatched {
+		groupAllMetrics(groups, c.router.defaultConsumer, md)
+	}
 	var errs error
 	for consumer, group := range groups {
 		err := consumer.ConsumeMetrics(ctx, group)

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -1325,3 +1325,256 @@ func TestMetricsCopyAndMoveConfig(t *testing.T) {
 		assert.Len(t, sink1.AllMetrics(), 1)
 	})
 }
+
+func TestMetricsForkAction(t *testing.T) {
+	metricsDefault := pipeline.NewIDWithName(pipeline.SignalMetrics, "default")
+	metrics0 := pipeline.NewIDWithName(pipeline.SignalMetrics, "0")
+	metrics1 := pipeline.NewIDWithName(pipeline.SignalMetrics, "1")
+
+	cfg := &Config{
+		DefaultPipelines: []pipeline.ID{metricsDefault},
+		Table: []RoutingTableItem{
+			{
+				Condition: `attributes["X-Tenant"] == "acme"`,
+				Pipelines: []pipeline.ID{metrics0},
+				Action:    Fork,
+			},
+			{
+				Condition: `attributes["X-Tenant"] == "globex"`,
+				Pipelines: []pipeline.ID{metrics1},
+				Action:    Fork,
+			},
+		},
+	}
+
+	var defaultSink, sink0, sink1 consumertest.MetricsSink
+
+	router := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
+		metricsDefault: &defaultSink,
+		metrics0:       &sink0,
+		metrics1:       &sink1,
+	})
+
+	resetSinks := func() {
+		defaultSink.Reset()
+		sink0.Reset()
+		sink1.Reset()
+	}
+
+	factory := NewFactory()
+	conn, err := factory.CreateMetricsToMetrics(
+		t.Context(),
+		connectortest.NewNopSettings(metadata.Type),
+		cfg,
+		router.(consumer.Metrics),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Start(t.Context(), componenttest.NewNopHost()))
+
+	t.Run("fork matched excludes from default", func(t *testing.T) {
+		resetSinks()
+
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), md))
+
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Empty(t, sink1.AllMetrics())
+		assert.Empty(t, defaultSink.AllMetrics())
+	})
+
+	t.Run("fork no match goes to default", func(t *testing.T) {
+		resetSinks()
+
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("X-Tenant", "other")
+		rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), md))
+
+		assert.Empty(t, sink0.AllMetrics())
+		assert.Empty(t, sink1.AllMetrics())
+		assert.Len(t, defaultSink.AllMetrics(), 1)
+	})
+
+	t.Run("multiple fork routes both match", func(t *testing.T) {
+		resetSinks()
+
+		md := pmetric.NewMetrics()
+
+		rm1 := md.ResourceMetrics().AppendEmpty()
+		rm1.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rm1.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+
+		rm2 := md.ResourceMetrics().AppendEmpty()
+		rm2.Resource().Attributes().PutStr("X-Tenant", "globex")
+		rm2.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), md))
+
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 1)
+		assert.Empty(t, defaultSink.AllMetrics())
+	})
+
+	t.Run("fork with metric context", func(t *testing.T) {
+		resetSinks()
+
+		cfgMetric := &Config{
+			DefaultPipelines: []pipeline.ID{metricsDefault},
+			Table: []RoutingTableItem{
+				{
+					Context:   "metric",
+					Condition: `name == "cpu.utilization"`,
+					Pipelines: []pipeline.ID{metrics0},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerMetric := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
+			metricsDefault: &defaultSink,
+			metrics0:       &sink0,
+		})
+
+		factory := NewFactory()
+		connMetric, err := factory.CreateMetricsToMetrics(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgMetric,
+			routerMetric.(consumer.Metrics),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connMetric)
+		require.NoError(t, connMetric.Start(t.Context(), componenttest.NewNopHost()))
+
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		sm := rm.ScopeMetrics().AppendEmpty()
+
+		// Add CPU metric
+		m1 := sm.Metrics().AppendEmpty()
+		m1.SetName("cpu.utilization")
+
+		// Add memory metric
+		m2 := sm.Metrics().AppendEmpty()
+		m2.SetName("memory.usage")
+
+		require.NoError(t, connMetric.ConsumeMetrics(context.Background(), md))
+
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Empty(t, defaultSink.AllMetrics())
+	})
+
+	t.Run("fork with datapoint context", func(t *testing.T) {
+		resetSinks()
+
+		cfgDP := &Config{
+			DefaultPipelines: []pipeline.ID{metricsDefault},
+			Table: []RoutingTableItem{
+				{
+					Context:   "datapoint",
+					Condition: `attributes["critical"] == "true"`,
+					Pipelines: []pipeline.ID{metrics0},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerDP := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
+			metricsDefault: &defaultSink,
+			metrics0:       &sink0,
+		})
+
+		factory := NewFactory()
+		connDP, err := factory.CreateMetricsToMetrics(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgDP,
+			routerDP.(consumer.Metrics),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connDP)
+		require.NoError(t, connDP.Start(t.Context(), componenttest.NewNopHost()))
+
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		sm := rm.ScopeMetrics().AppendEmpty()
+		m := sm.Metrics().AppendEmpty()
+		m.SetName("test.metric")
+		m.SetEmptyGauge()
+
+		// Add critical datapoint
+		dp1 := m.Gauge().DataPoints().AppendEmpty()
+		dp1.Attributes().PutStr("critical", "true")
+		dp1.SetIntValue(100)
+
+		// Add normal datapoint
+		dp2 := m.Gauge().DataPoints().AppendEmpty()
+		dp2.Attributes().PutStr("critical", "false")
+		dp2.SetIntValue(50)
+
+		require.NoError(t, connDP.ConsumeMetrics(context.Background(), md))
+
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Empty(t, defaultSink.AllMetrics())
+	})
+
+	t.Run("fork with copy mixed", func(t *testing.T) {
+		resetSinks()
+
+		cfgMixed := &Config{
+			DefaultPipelines: []pipeline.ID{metricsDefault},
+			Table: []RoutingTableItem{
+				{
+					Condition: `attributes["copy-me"] == "yes"`,
+					Pipelines: []pipeline.ID{metrics0},
+					Action:    Copy,
+				},
+				{
+					Condition: `attributes["fork-me"] == "yes"`,
+					Pipelines: []pipeline.ID{metrics1},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerMixed := connector.NewMetricsRouter(map[pipeline.ID]consumer.Metrics{
+			metricsDefault: &defaultSink,
+			metrics0:       &sink0,
+			metrics1:       &sink1,
+		})
+
+		factory := NewFactory()
+		connMixed, err := factory.CreateMetricsToMetrics(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgMixed,
+			routerMixed.(consumer.Metrics),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connMixed)
+		require.NoError(t, connMixed.Start(t.Context(), componenttest.NewNopHost()))
+
+		md := pmetric.NewMetrics()
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("copy-me", "yes")
+		rm.Resource().Attributes().PutStr("fork-me", "yes")
+		rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+
+		require.NoError(t, connMixed.ConsumeMetrics(context.Background(), md))
+
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 1)
+		assert.Empty(t, defaultSink.AllMetrics())
+	})
+}

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -62,14 +62,17 @@ func (*tracesConnector) Capabilities() consumer.Capabilities {
 func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 	groups := make(map[consumer.Traces]ptrace.Traces)
 	matched := ptrace.NewTraces()
+	anyForkMatched := false
 	for i := 0; i < len(c.router.routeSlice) && td.ResourceSpans().Len() > 0; i++ {
 		var errs error
 		route := c.router.routeSlice[i]
+		routeMatched := false
 		switch route.statementContext {
 		case "request":
 			if route.requestCondition.matchRequest(ctx) {
+				routeMatched = true
 				switch route.action {
-				case Copy:
+				case Copy, Fork:
 					td.CopyTo(matched)
 				default:
 					// all traces are routed
@@ -78,7 +81,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			}
 		case "", "resource":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				ptraceutil.CopyResourcesIf(td, matched,
 					func(rs ptrace.ResourceSpans) bool {
 						rtx := ottlresource.NewTransformContextPtr(rs.Resource(), rs)
@@ -88,6 +91,9 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -109,7 +115,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 			}
 		case "span":
 			switch route.action {
-			case Copy:
+			case Copy, Fork:
 				ptraceutil.CopySpansWithContextIf(td, matched,
 					func(rs ptrace.ResourceSpans, ss ptrace.ScopeSpans, s ptrace.Span) bool {
 						mtx := ottlspan.NewTransformContextPtr(rs, ss, s)
@@ -119,6 +125,9 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 						if err != nil {
 							errs = errors.Join(errs, err)
 							return false
+						}
+						if isMatch {
+							routeMatched = true
 						}
 						return isMatch
 					},
@@ -142,10 +151,16 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) e
 		if errs != nil && c.config.ErrorMode == ottl.PropagateError {
 			return errs
 		}
+		if routeMatched && route.action == Fork {
+			anyForkMatched = true
+		}
 		groupAllTraces(groups, route.consumer, matched)
 	}
 	// anything left wasn't matched by any route. Send to default consumer
-	groupAllTraces(groups, c.router.defaultConsumer, td)
+	// unless a fork route matched (fork excludes from default)
+	if !anyForkMatched {
+		groupAllTraces(groups, c.router.defaultConsumer, td)
+	}
 	var errs error
 	for consumer, group := range groups {
 		err := consumer.ConsumeTraces(ctx, group)

--- a/connector/routingconnector/traces_test.go
+++ b/connector/routingconnector/traces_test.go
@@ -1069,3 +1069,201 @@ func TestTracesCopyAndMoveConfig(t *testing.T) {
 		assert.Len(t, sink1.AllTraces(), 1)
 	})
 }
+
+func TestTracesForkAction(t *testing.T) {
+	tracesDefault := pipeline.NewIDWithName(pipeline.SignalTraces, "default")
+	traces0 := pipeline.NewIDWithName(pipeline.SignalTraces, "0")
+	traces1 := pipeline.NewIDWithName(pipeline.SignalTraces, "1")
+
+	cfg := &Config{
+		DefaultPipelines: []pipeline.ID{tracesDefault},
+		Table: []RoutingTableItem{
+			{
+				Condition: `attributes["X-Tenant"] == "acme"`,
+				Pipelines: []pipeline.ID{traces0},
+				Action:    Fork,
+			},
+			{
+				Condition: `attributes["X-Tenant"] == "globex"`,
+				Pipelines: []pipeline.ID{traces1},
+				Action:    Fork,
+			},
+		},
+	}
+
+	var defaultSink, sink0, sink1 consumertest.TracesSink
+
+	router := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
+		tracesDefault: &defaultSink,
+		traces0:       &sink0,
+		traces1:       &sink1,
+	})
+
+	resetSinks := func() {
+		defaultSink.Reset()
+		sink0.Reset()
+		sink1.Reset()
+	}
+
+	factory := NewFactory()
+	conn, err := factory.CreateTracesToTraces(
+		t.Context(),
+		connectortest.NewNopSettings(metadata.Type),
+		cfg,
+		router.(consumer.Traces),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Start(t.Context(), componenttest.NewNopHost()))
+
+	t.Run("fork matched excludes from default", func(t *testing.T) {
+		resetSinks()
+
+		tr := ptrace.NewTraces()
+		rs := tr.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
+
+		assert.Len(t, sink0.AllTraces(), 1)
+		assert.Empty(t, sink1.AllTraces())
+		assert.Empty(t, defaultSink.AllTraces())
+	})
+
+	t.Run("fork no match goes to default", func(t *testing.T) {
+		resetSinks()
+
+		tr := ptrace.NewTraces()
+		rs := tr.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("X-Tenant", "other")
+		rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
+
+		assert.Empty(t, sink0.AllTraces())
+		assert.Empty(t, sink1.AllTraces())
+		assert.Len(t, defaultSink.AllTraces(), 1)
+	})
+
+	t.Run("multiple fork routes both match", func(t *testing.T) {
+		resetSinks()
+
+		tr := ptrace.NewTraces()
+
+		rs1 := tr.ResourceSpans().AppendEmpty()
+		rs1.Resource().Attributes().PutStr("X-Tenant", "acme")
+		rs1.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+		rs2 := tr.ResourceSpans().AppendEmpty()
+		rs2.Resource().Attributes().PutStr("X-Tenant", "globex")
+		rs2.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
+
+		assert.Len(t, sink0.AllTraces(), 1)
+		assert.Len(t, sink1.AllTraces(), 1)
+		assert.Empty(t, defaultSink.AllTraces())
+	})
+
+	t.Run("fork with span context", func(t *testing.T) {
+		resetSinks()
+
+		cfgSpan := &Config{
+			DefaultPipelines: []pipeline.ID{tracesDefault},
+			Table: []RoutingTableItem{
+				{
+					Context:   "span",
+					Condition: `attributes["error"] == true`,
+					Pipelines: []pipeline.ID{traces0},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerSpan := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
+			tracesDefault: &defaultSink,
+			traces0:       &sink0,
+		})
+
+		factory := NewFactory()
+		connSpan, err := factory.CreateTracesToTraces(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgSpan,
+			routerSpan.(consumer.Traces),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connSpan)
+		require.NoError(t, connSpan.Start(t.Context(), componenttest.NewNopHost()))
+
+		tr := ptrace.NewTraces()
+		rs := tr.ResourceSpans().AppendEmpty()
+		ss := rs.ScopeSpans().AppendEmpty()
+
+		// Add error span
+		s1 := ss.Spans().AppendEmpty()
+		s1.Attributes().PutBool("error", true)
+
+		// Add normal span
+		s2 := ss.Spans().AppendEmpty()
+		s2.Attributes().PutBool("error", false)
+
+		require.NoError(t, connSpan.ConsumeTraces(context.Background(), tr))
+
+		assert.Len(t, sink0.AllTraces(), 1)
+		assert.Empty(t, defaultSink.AllTraces())
+	})
+
+	t.Run("fork with copy mixed", func(t *testing.T) {
+		resetSinks()
+
+		cfgMixed := &Config{
+			DefaultPipelines: []pipeline.ID{tracesDefault},
+			Table: []RoutingTableItem{
+				{
+					Condition: `attributes["copy-me"] == "yes"`,
+					Pipelines: []pipeline.ID{traces0},
+					Action:    Copy,
+				},
+				{
+					Condition: `attributes["fork-me"] == "yes"`,
+					Pipelines: []pipeline.ID{traces1},
+					Action:    Fork,
+				},
+			},
+		}
+
+		routerMixed := connector.NewTracesRouter(map[pipeline.ID]consumer.Traces{
+			tracesDefault: &defaultSink,
+			traces0:       &sink0,
+			traces1:       &sink1,
+		})
+
+		factory := NewFactory()
+		connMixed, err := factory.CreateTracesToTraces(
+			t.Context(),
+			connectortest.NewNopSettings(metadata.Type),
+			cfgMixed,
+			routerMixed.(consumer.Traces),
+		)
+
+		require.NoError(t, err)
+		require.NotNil(t, connMixed)
+		require.NoError(t, connMixed.Start(t.Context(), componenttest.NewNopHost()))
+
+		tr := ptrace.NewTraces()
+		rs := tr.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("copy-me", "yes")
+		rs.Resource().Attributes().PutStr("fork-me", "yes")
+		rs.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+
+		require.NoError(t, connMixed.ConsumeTraces(context.Background(), tr))
+
+		assert.Len(t, sink0.AllTraces(), 1)
+		assert.Len(t, sink1.AllTraces(), 1)
+		assert.Empty(t, defaultSink.AllTraces())
+	})
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
 This PR adds a new `action: fork` to the routing connector, which provides routing behavior that combines aspects of both `copy` and `move` actions.

   **Use Case:**
   Users want to route data to multiple specific pipelines based on conditions while ensuring that matched data does NOT go to the default pipeline. The existing actions don't satisfy this:
   - `action: copy` - Data goes to matched pipelines AND default (not desired)
   - `action: move` - Data stops at first match, can't evaluate multiple routes (not desired)

   **New Behavior with `action: fork`:**
   - Evaluates ALL routing conditions (like `copy`)
   - Sends data to ALL matching fork pipelines (like `copy`)
   - **Excludes data from default pipeline if ANY fork route matches** (unlike `copy`)

   #### Example Configuration

   ```yaml
   connectors:
     routing:
       default_pipelines: [logs/other]
       table:
         - context: resource
           condition: attributes["tenant"] == "acme"
           action: fork
           pipelines: [logs/acme]
         - context: resource
           condition: attributes["tenant"] == "globex"
           action: fork
           pipelines: [logs/globex]
   ```

   **Behavior:**
   - Logs with tenant=acme → logs/acme only (excluded from logs/other)
   - Logs with tenant=globex → logs/globex only (excluded from logs/other)
   - Logs without matching tenant → logs/other


https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45690

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45690

<!--Describe what testing was performed and which tests were added.-->
#### Testing
UTs added. Manual testing in progress.

<!--Describe the documentation added.-->
#### Documentation
Updated along with the existing docs.
<!--Please delete paragraphs that you did not use before submitting.-->
