### PR TITLE
[chore][exporter/datadog,connector/datadog] Disable Datadog/datadog-agent modules updates on the Datadog exporter and Datadog connector

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,14 @@
       "enabled": false
     },
     {
+      "matchPaths": [
+        "exporter/datadogexporter/**",
+        "connector/datadogconnector/**"
+      ],
+      "matchPackagePatterns": ["^github.com/DataDog/datadog-agent"],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "gomod"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -106,7 +106,9 @@
     {
       "matchPaths": [
         "exporter/datadogexporter/**",
-        "connector/datadogconnector/**"
+        "connector/datadogconnector/**",
+        "internal/datadog/**",
+        "pkg/datadog/**"
       ],
       "matchPackagePatterns": ["^github.com/DataDog/datadog-agent"],
       "enabled": false


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds rule for disabling automatic DataDog/datadog-agent module dependency updates on the Datadog exporter, Datadog connector and all nested modules.

Going further, we want to handle these updates manually on an ad hoc basis 

See https://docs.mend.io/wsk/renovate-package-rules-guide#How-Package-Rules-Work for reference.