### PR TITLE
[connector/otlpjsonconnector] Add unit tests for logs.go

### DIFF
--- a/connector/otlpjsonconnector/logs_test.go
+++ b/connector/otlpjsonconnector/logs_test.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otlpjsonconnector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/connector/connectortest"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector/internal/metadata"
+)
+
+func TestNewLogsConnector(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+
+	c := newLogsConnector(set, cfg, sink)
+
+	require.NotNil(t, c)
+	assert.NotNil(t, c.logger)
+	assert.NotNil(t, c.logsConsumer)
+}
+
+func TestLogsConnectorCapabilities(t *testing.T) {
+	c := &connectorLogs{}
+	caps := c.Capabilities()
+	assert.Equal(t, consumer.Capabilities{MutatesData: false}, caps)
+}
+
+func TestLogsConnectorConsumeLogsWithValidLogPayload(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Create a valid OTLP JSON log payload embedded in a log record
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(`{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"body":{"stringValue":"test log"}}]}]}]}`)
+
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// The valid log payload should be forwarded to the sink
+	assert.Equal(t, 1, sink.LogRecordCount())
+}
+
+func TestLogsConnectorConsumeLogsWithTracePayload(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Create a trace payload in a log body - should be skipped
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(`{"resourceSpans":[{"resource":{},"scopeSpans":[]}]}`)
+
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Trace payloads should be ignored by the logs connector
+	assert.Equal(t, 0, sink.LogRecordCount())
+}
+
+func TestLogsConnectorConsumeLogsWithMetricPayload(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Create a metric payload in a log body - should be skipped
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(`{"resourceMetrics":[{"resource":{},"scopeMetrics":[]}]}`)
+
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Metric payloads should be ignored by the logs connector
+	assert.Equal(t, 0, sink.LogRecordCount())
+}
+
+func TestLogsConnectorConsumeLogsWithInvalidPayload(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Invalid JSON payload
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(`this is not valid otlp json`)
+
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Invalid payloads should be dropped
+	assert.Equal(t, 0, sink.LogRecordCount())
+}
+
+func TestLogsConnectorConsumeLogsWithMalformedLogJSON(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Regex matches but JSON is malformed
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr(`{"resourceLogs": [invalid json`)
+
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+
+	// Malformed JSON should not cause panic but be dropped
+	assert.Equal(t, 0, sink.LogRecordCount())
+}
+
+func TestLogsConnectorConsumeLogsWithEmptyLogs(t *testing.T) {
+	set := connectortest.NewNopSettings(metadata.Type)
+	cfg := createDefaultConfig()
+	sink := &consumertest.LogsSink{}
+	c := newLogsConnector(set, cfg, sink)
+
+	// Empty logs input
+	logs := plog.NewLogs()
+	err := c.ConsumeLogs(context.Background(), logs)
+	require.NoError(t, err)
+	assert.Equal(t, 0, sink.LogRecordCount())
+}

--- a/connector/otlpjsonconnector/logs_test.go
+++ b/connector/otlpjsonconnector/logs_test.go
@@ -4,7 +4,6 @@
 package otlpjsonconnector
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +47,7 @@ func TestLogsConnectorConsumeLogsWithValidLogPayload(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.Body().SetStr(`{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"body":{"stringValue":"test log"}}]}]}]}`)
 
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 
 	// The valid log payload should be forwarded to the sink
@@ -68,7 +67,7 @@ func TestLogsConnectorConsumeLogsWithTracePayload(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.Body().SetStr(`{"resourceSpans":[{"resource":{},"scopeSpans":[]}]}`)
 
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 
 	// Trace payloads should be ignored by the logs connector
@@ -88,7 +87,7 @@ func TestLogsConnectorConsumeLogsWithMetricPayload(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.Body().SetStr(`{"resourceMetrics":[{"resource":{},"scopeMetrics":[]}]}`)
 
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 
 	// Metric payloads should be ignored by the logs connector
@@ -108,7 +107,7 @@ func TestLogsConnectorConsumeLogsWithInvalidPayload(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.Body().SetStr(`this is not valid otlp json`)
 
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 
 	// Invalid payloads should be dropped
@@ -128,7 +127,7 @@ func TestLogsConnectorConsumeLogsWithMalformedLogJSON(t *testing.T) {
 	lr := sl.LogRecords().AppendEmpty()
 	lr.Body().SetStr(`{"resourceLogs": [invalid json`)
 
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 
 	// Malformed JSON should not cause panic but be dropped
@@ -143,7 +142,7 @@ func TestLogsConnectorConsumeLogsWithEmptyLogs(t *testing.T) {
 
 	// Empty logs input
 	logs := plog.NewLogs()
-	err := c.ConsumeLogs(context.Background(), logs)
+	err := c.ConsumeLogs(t.Context(), logs)
 	require.NoError(t, err)
 	assert.Equal(t, 0, sink.LogRecordCount())
 }


### PR DESCRIPTION
## Description

This PR adds unit tests for the previously untested `logs.go` file in the `otlpjsonconnector` package, which contains the logs connector that extracts OTLP log payloads from log record bodies.

### Changes

- New file: `connector/otlpjsonconnector/logs_test.go`

### Tests Added

| Test | What it validates |
|------|-------------------|
| `TestNewLogsConnector` | Constructor creates a properly initialized connector with logger and consumer |
| `TestLogsConnectorCapabilities` | `Capabilities()` returns `MutatesData: false` |
| `TestLogsConnectorConsumeLogsWithValidLogPayload` | Valid OTLP JSON log body is unmarshaled and forwarded to the sink (1 log record) |
| `TestLogsConnectorConsumeLogsWithTracePayload` | Trace payloads in log bodies are correctly skipped |
| `TestLogsConnectorConsumeLogsWithMetricPayload` | Metric payloads in log bodies are correctly skipped |
| `TestLogsConnectorConsumeLogsWithInvalidPayload` | Random text payloads are dropped without error |
| `TestLogsConnectorConsumeLogsWithMalformedLogJSON` | Regex-matching but malformed JSON is handled gracefully |
| `TestLogsConnectorConsumeLogsWithEmptyLogs` | Empty `plog.Logs` input is handled without error |

### Motivation

The logs connector performs critical payload dispatch — it examines each log record body, regex-matches it against OTLP JSON patterns, and routes log payloads to downstream consumers while skipping traces and metrics. This logic had no dedicated unit tests. The existing `connector_test.go` covers higher-level golden-file based scenarios but does not isolate the `ConsumeLogs` method or test edge cases like malformed JSON.

### Testing

```bash
cd connector/otlpjsonconnector && go test -run "TestNewLogsConnector|TestLogsConnector" -v .
```

All 8 tests pass.