### PR TITLE
encoding/jsonlogencodingextension: add unwrap support for extracting records from JSON wrappers

### DIFF
--- a/extension/encoding/jsonlogencodingextension/README.md
+++ b/extension/encoding/jsonlogencodingextension/README.md
@@ -13,10 +13,12 @@
 
 ## Configuration
 
-| Name       | Description                                                                           | Default |
-|------------|---------------------------------------------------------------------------------------|---------|
-| mode       | What mode of the JSON encoding extension you want                                     | body    |
-| array_mode | Set whether JSON payloads is extracted from an array(legacy mode). Accepts a boolean. | true    |
+| Name          | Description                                                                           | Default |
+|---------------|---------------------------------------------------------------------------------------|---------|
+| mode          | What mode of the JSON encoding extension you want                                     | body    |
+| array_mode    | Set whether JSON payloads is extracted from an array(legacy mode). Accepts a boolean. | true    |
+| unwrap        | JSONPath expression to extract individual records from a wrapper (unmarshal only).     |         |
+| unwrap_target | Body map key for storing raw JSON string per record. Requires `unwrap`.               |         |
 
 ### Mode
 
@@ -67,4 +69,366 @@ Configuration accepts a boolean.
   New line delimited JSON payload
   > {"key": "value"}\
   > {"key": "value"}
+
+### unwrap
+
+A JSONPath expression used to extract individual log records from a wrapper structure during unmarshaling. When set, `array_mode` is ignored for the unmarshal path. The marshal path is not affected by this option.
+
+This is useful when the input JSON contains records nested inside a wrapper object. For example, Azure Event Hub diagnostic logs arrive wrapped in a `{"records": [...]}` envelope.
+
+Common JSONPath expressions:
+
+- `$.records[*]` : Extract from `{"records": [{...}, {...}]}` (e.g., Azure Event Hub diagnostic logs)
+- `$[*]` : Extract from a bare JSON array `[{...}, {...}]` (e.g., Azure Blob Storage)
+- `$.data.items[*]` : Extract from a nested structure `{"data": {"items": [{...}]}}`
+
+When the input is not valid JSON (e.g., NDJSON with multiple objects separated by newlines), the extension falls back to splitting by newlines and treating each line as an individual record.
+
+### unwrap_target
+
+When `unwrap_target` is set, each extracted record is stored as a **raw JSON string** under the specified key in the body map, instead of being parsed into an OpenTelemetry map. This is useful when you want to forward log events without modifying or parsing their content.
+
+- `unwrap_target: "message"` : Body becomes `{"message": "{\"level\":\"info\",\"msg\":\"hello\"}"}`
+- `unwrap_target: "event"` : Body becomes `{"event": "{\"level\":\"info\",\"msg\":\"hello\"}"}`
+- `unwrap_target:` (empty, default) : JSON is fully parsed into an OpenTelemetry map (existing behavior)
+
+This option requires `unwrap` to be set.
+
+## Examples
+
+This section demonstrates how different configuration options affect the encoding and decoding of log events.
+
+### Example 1: Body Mode with Array Mode (Default)
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    array_mode: true
+```
+
+#### Unmarshal (JSON → OpenTelemetry Logs)
+
+**Input JSON:**
+```json
+[
+  {"level": "info", "message": "User logged in", "userId": 12345},
+  {"level": "error", "message": "Connection timeout", "duration": 5000}
+]
+```
+
+**Result:** Creates 2 OpenTelemetry log records
+- Log Record 1 body: `{"level": "info", "message": "User logged in", "userId": 12345}`
+- Log Record 2 body: `{"level": "error", "message": "Connection timeout", "duration": 5000}`
+
+#### Marshal (OpenTelemetry Logs → JSON)
+
+**Input:** 2 OpenTelemetry log records with bodies as shown above
+
+**Output JSON:**
+```json
+[
+  {"level": "info", "message": "User logged in", "userId": 12345},
+  {"level": "error", "message": "Connection timeout", "duration": 5000}
+]
+```
+
+**Result:** The logs are marshaled back into a JSON array with the same structure.
+
+### Example 2: Body Mode without Array Mode (Single Document)
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    array_mode: false
+```
+
+#### Unmarshal (JSON → OpenTelemetry Logs)
+
+**Input JSON:**
+```json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "severity": "WARN",
+  "message": "High memory usage detected",
+  "metrics": {
+    "memory_used": 8192,
+    "memory_total": 16384
+  }
+}
+```
+
+**Result:** Creates 1 OpenTelemetry log record
+- Log Record 1 body: `{"timestamp": "2024-01-15T10:30:00Z", "severity": "WARN", "message": "High memory usage detected", "metrics": {"memory_used": 8192, "memory_total": 16384}}`
+
+#### Marshal (OpenTelemetry Logs → JSON)
+
+**Input:** 1 OpenTelemetry log record with body as shown above
+
+**Output JSON:**
+```json
+{"timestamp": "2024-01-15T10:30:00Z", "severity": "WARN", "message": "High memory usage detected", "metrics": {"memory_used": 8192, "memory_total": 16384}}
+```
+
+**Result:** The log is marshaled as a single JSON document (not wrapped in an array).
+
+### Example 3: Body Mode without Array Mode (NDJSON)
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    array_mode: false
+```
+
+#### Unmarshal (NDJSON → OpenTelemetry Logs)
+
+**Input NDJSON (newline-delimited JSON):**
+```json
+{"timestamp": "2024-01-15T10:30:00Z", "level": "INFO", "message": "Request received"}
+{"timestamp": "2024-01-15T10:30:01Z", "level": "INFO", "message": "Request processed"}
+{"timestamp": "2024-01-15T10:30:02Z", "level": "INFO", "message": "Response sent"}
+```
+
+**Result:** Creates 3 OpenTelemetry log records
+- Log Record 1 body: `{"timestamp": "2024-01-15T10:30:00Z", "level": "INFO", "message": "Request received"}`
+- Log Record 2 body: `{"timestamp": "2024-01-15T10:30:01Z", "level": "INFO", "message": "Request processed"}`
+- Log Record 3 body: `{"timestamp": "2024-01-15T10:30:02Z", "level": "INFO", "message": "Response sent"}`
+
+#### Marshal (OpenTelemetry Logs → NDJSON)
+
+**Input:** 3 OpenTelemetry log records with bodies as shown above
+
+**Output NDJSON:**
+```json
+{"timestamp": "2024-01-15T10:30:00Z", "level": "INFO", "message": "Request received"}
+{"timestamp": "2024-01-15T10:30:01Z", "level": "INFO", "message": "Request processed"}
+{"timestamp": "2024-01-15T10:30:02Z", "level": "INFO", "message": "Response sent"}
+```
+
+**Result:** Each log record is marshaled as a separate JSON document on its own line (NDJSON format).
+
+### Example 4: Body with Inline Attributes Mode
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body_with_inline_attributes
+    array_mode: true
+```
+
+#### Marshal (OpenTelemetry Logs → JSON with Attributes)
+
+**Input OpenTelemetry Logs:**
+Logs with:
+- Resource attributes: `{"service.name": "web-api", "deployment.environment": "production"}`
+- Log Record 1:
+  - Body: `{"message": "API request", "path": "/users"}`
+  - Attributes: `{"http.method": "GET", "http.status_code": 200}`
+- Log Record 2:
+  - Body: `"Simple string log"`
+  - Attributes: `{}`
+
+**Output JSON:**
+```json
+[
+  {
+    "body": {
+      "message": "API request",
+      "path": "/users"
+    },
+    "logAttributes": {
+      "http.method": "GET",
+      "http.status_code": 200
+    },
+    "resourceAttributes": {
+      "service.name": "web-api",
+      "deployment.environment": "production"
+    }
+  },
+  {
+    "body": "Simple string log",
+    "resourceAttributes": {
+      "service.name": "web-api",
+      "deployment.environment": "production"
+    }
+  }
+]
+```
+
+**Result:** This mode embeds resource attributes and log attributes directly into the JSON output alongside the body, making it easier to export logs with full context in a single JSON structure. Note that log attributes are only included if they exist on the log record.
+
+#### Unmarshal (JSON with Attributes → OpenTelemetry Logs)
+
+**Input JSON:**
+```json
+[
+  {
+    "body": {
+      "message": "API request",
+      "path": "/users"
+    },
+    "logAttributes": {
+      "http.method": "GET",
+      "http.status_code": 200
+    },
+    "resourceAttributes": {
+      "service.name": "web-api",
+      "deployment.environment": "production"
+    }
+  }
+]
+```
+
+**Result:** Creates OpenTelemetry logs with:
+- Resource attributes populated from `resourceAttributes`
+- Log record body populated from `body`
+- Log record attributes populated from `logAttributes`
+
+### Comparison: Array Mode vs Non-Array Mode
+
+| Feature | `array_mode: true` | `array_mode: false` |
+|---------|-------------------|---------------------|
+| **Input Format** | Must be JSON array: `[{...}, {...}]` | Accepts single document `{...}` or NDJSON |
+| **Use Case** | Legacy compatibility, batch processing | Modern streaming logs, flexible input |
+| **Output Format** | Always JSON array | NDJSON (newline-delimited) |
+| **Performance** | Requires full array in memory | Can process line-by-line |
+
+### Example 5: Unwrap Azure Event Hub Messages
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    unwrap: "$.records[*]"
+```
+
+#### Unmarshal (Wrapped JSON → OpenTelemetry Logs)
+
+**Input JSON:**
+```json
+{
+  "records": [
+    {"time": "2024-01-15T10:30:00Z", "category": "Administrative", "operationName": "Create"},
+    {"time": "2024-01-15T10:30:01Z", "category": "Security", "operationName": "Login"}
+  ]
+}
+```
+
+**Result:** Creates 2 OpenTelemetry log records
+- Log Record 1 body: `{"time": "2024-01-15T10:30:00Z", "category": "Administrative", "operationName": "Create"}`
+- Log Record 2 body: `{"time": "2024-01-15T10:30:01Z", "category": "Security", "operationName": "Login"}`
+
+### Example 6: Unwrap with Nested JSONPath
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    unwrap: "$.data.items[*]"
+```
+
+#### Unmarshal (Nested JSON → OpenTelemetry Logs)
+
+**Input JSON:**
+```json
+{
+  "data": {
+    "items": [
+      {"id": 1, "type": "click"},
+      {"id": 2, "type": "view"}
+    ]
+  },
+  "metadata": {"source": "analytics"}
+}
+```
+
+**Result:** Creates 2 OpenTelemetry log records (metadata is discarded)
+- Log Record 1 body: `{"id": 1, "type": "click"}`
+- Log Record 2 body: `{"id": 2, "type": "view"}`
+
+### Example 7: Unwrap with NDJSON Fallback
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    unwrap: "$.records[*]"
+```
+
+When the input is not valid JSON (e.g., NDJSON), the extension falls back to splitting by newlines:
+
+**Input NDJSON:**
+```json
+{"level": "info", "message": "Request received"}
+{"level": "error", "message": "Connection timeout"}
+```
+
+**Result:** Creates 2 OpenTelemetry log records
+- Log Record 1 body: `{"level": "info", "message": "Request received"}`
+- Log Record 2 body: `{"level": "error", "message": "Connection timeout"}`
+
+### Example 8: Unwrap with unwrap_target (Raw JSON Passthrough)
+
+**Configuration:**
+```yaml
+extensions:
+  jsonlogencoding:
+    mode: body
+    unwrap: "$.records[*]"
+    unwrap_target: "message"
+```
+
+#### Unmarshal (Wrapped JSON → OpenTelemetry Logs with Raw Body)
+
+**Input JSON:**
+```json
+{
+  "records": [
+    {"time": "2024-01-15T10:30:00Z", "category": "Administrative", "operationName": "Create"},
+    {"time": "2024-01-15T10:30:01Z", "category": "Security", "operationName": "Login"}
+  ]
+}
+```
+
+**Result:** Creates 2 OpenTelemetry log records with raw JSON strings in the body:
+- Log Record 1 body: `{"message": "{\"time\": \"2024-01-15T10:30:00Z\", \"category\": \"Administrative\", \"operationName\": \"Create\"}"}`
+- Log Record 2 body: `{"message": "{\"time\": \"2024-01-15T10:30:01Z\", \"category\": \"Security\", \"operationName\": \"Login\"}"}`
+
+Note: Without `unwrap_target`, the JSON would be fully parsed into an OpenTelemetry map. With `unwrap_target: "message"`, the raw JSON is preserved as a string under the `message` key.
+
+### Common Use Cases
+
+**Use Case 1: Processing Application Logs from Files**
+- Configuration: `mode: body`, `array_mode: false`
+- Input: NDJSON log files (one JSON object per line)
+- Benefit: Efficiently process large log files without loading everything into memory
+
+**Use Case 2: Exporting Logs with Full Context**
+- Configuration: `mode: body_with_inline_attributes`, `array_mode: true`
+- Output: Complete log records with resource and log attributes embedded
+- Benefit: Easy to import into systems that expect flat JSON with all metadata
+
+**Use Case 3: API Ingestion with Batched Logs**
+- Configuration: `mode: body`, `array_mode: true`
+- Input: API responses containing arrays of log events
+- Benefit: Direct compatibility with JSON API responses
+
+**Use Case 4: Azure Event Hub Diagnostic Logs**
+- Configuration: `mode: body`, `unwrap: "$.records[*]"`
+- Input: Azure diagnostic logs wrapped in `{"records": [...]}`
+- Benefit: Automatically extracts individual records from Azure's wrapper format
+
+**Use Case 5: Raw Log Forwarding**
+- Configuration: `mode: body`, `unwrap: "$.records[*]"`, `unwrap_target: "message"`
+- Input: Azure diagnostic logs wrapped in `{"records": [...]}`
+- Benefit: Forwards raw JSON to a backend without parsing, preserving the original format
   

--- a/extension/encoding/jsonlogencodingextension/config.go
+++ b/extension/encoding/jsonlogencodingextension/config.go
@@ -3,7 +3,12 @@
 
 package jsonlogencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension"
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
 
 type JSONEncodingMode string
 
@@ -17,6 +22,20 @@ type Config struct {
 	Mode      JSONEncodingMode `mapstructure:"mode,omitempty"`
 	ArrayMode bool             `mapstructure:"array_mode,omitempty"`
 
+	// Unwrap is a JSONPath expression used to extract individual log records
+	// from a wrapper structure during unmarshaling. For example, "$.records[*]"
+	// extracts each element from a {"records": [...]} wrapper. When set,
+	// array_mode is ignored for unmarshaling. Leave empty to use existing
+	// array_mode behavior.
+	Unwrap string `mapstructure:"unwrap,omitempty"`
+
+	// UnwrapTarget is the body map key where the raw JSON string of each
+	// extracted record is stored. When set (e.g., "message"), the body becomes
+	// a map like {"message": "<raw JSON>"}. When empty, the JSON is fully
+	// parsed into an OpenTelemetry map (the default behavior). Only used when
+	// unwrap is set.
+	UnwrapTarget string `mapstructure:"unwrap_target,omitempty"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }
@@ -25,8 +44,24 @@ func (c *Config) Validate() error {
 	// validate marshaling mode
 	switch c.Mode {
 	case JSONEncodingModeBodyWithInlineAttributes, JSONEncodingModeBody:
-		return nil
+	default:
+		return fmt.Errorf("invalid mode %q", c.Mode)
 	}
 
-	return fmt.Errorf("invalid mode %q", c.Mode)
+	// validate unwrap JSONPath expression if set
+	if c.Unwrap != "" {
+		if !strings.HasPrefix(c.Unwrap, "$") {
+			return fmt.Errorf("invalid unwrap expression %q: must be a JSONPath starting with $", c.Unwrap)
+		}
+		if _, err := json.CreatePath(c.Unwrap); err != nil {
+			return fmt.Errorf("invalid unwrap JSONPath expression %q: %w", c.Unwrap, err)
+		}
+	}
+
+	// unwrap_target requires unwrap
+	if c.UnwrapTarget != "" && c.Unwrap == "" {
+		return fmt.Errorf("unwrap_target requires unwrap to be set")
+	}
+
+	return nil
 }

--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/goccy/go-json"
 	"go.opentelemetry.io/collector/component"
@@ -99,6 +100,10 @@ func (e *jsonLogExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 	p := plog.NewLogs()
 	sl := p.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
 
+	if e.config.Unwrap != "" {
+		return e.unmarshalLogsWithUnwrap(buf)
+	}
+
 	if e.config.ArrayMode {
 		// Default mode to handle arrays having backward compatibility
 		var jsonLogs []map[string]any
@@ -122,6 +127,43 @@ func (e *jsonLogExtension) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 			}
 
 			if err := sl.LogRecords().AppendEmpty().Body().SetEmptyMap().FromRaw(record); err != nil {
+				return p, err
+			}
+		}
+	}
+
+	return p, nil
+}
+
+func (e *jsonLogExtension) unmarshalLogsWithUnwrap(buf []byte) (plog.Logs, error) {
+	p := plog.NewLogs()
+
+	records, err := extractRecords(buf, e.config.Unwrap)
+	if err != nil {
+		return p, err
+	}
+
+	if len(records) == 0 {
+		return p, nil
+	}
+
+	sl := p.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
+	now := pcommon.NewTimestampFromTime(time.Now())
+
+	for _, record := range records {
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetObservedTimestamp(now)
+
+		if e.config.UnwrapTarget != "" {
+			// Store the raw JSON string under the configured field name
+			lr.Body().SetEmptyMap().PutStr(e.config.UnwrapTarget, string(record))
+		} else {
+			// Parse JSON into an OpenTelemetry map (default behavior)
+			var m map[string]any
+			if err := json.Unmarshal(record, &m); err != nil {
+				return p, fmt.Errorf("failed to unmarshal extracted record: %w", err)
+			}
+			if err := lr.Body().SetEmptyMap().FromRaw(m); err != nil {
 				return p, err
 			}
 		}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_custom.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_custom.yml
@@ -1,0 +1,11 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: event
+                    value:
+                      stringValue: '{"level": "info", "msg": "hello"}'
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_message.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_message.yml
@@ -1,0 +1,17 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: '{"level": "info", "msg": "hello"}'
+          - body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: '{"level": "error", "msg": "oops"}'
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_ndjson.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_content_field_ndjson.yml
@@ -1,0 +1,17 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: '{"a":1}'
+          - body:
+              kvlistValue:
+                values:
+                  - key: message
+                    value:
+                      stringValue: '{"b":2}'
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_custom_field.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_custom_field.yml
@@ -1,0 +1,14 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: type
+                    value:
+                      stringValue: click
+                  - key: page
+                    value:
+                      stringValue: /home
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_json_array.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_json_array.yml
@@ -1,0 +1,23 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: info
+                  - key: message
+                    value:
+                      stringValue: hello
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: error
+                  - key: message
+                    value:
+                      stringValue: oops
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_ndjson.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_ndjson.yml
@@ -1,0 +1,23 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: info
+                  - key: message
+                    value:
+                      stringValue: hello
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: error
+                  - key: message
+                    value:
+                      stringValue: oops
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_nested_path.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_nested_path.yml
@@ -1,0 +1,23 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: info
+                  - key: message
+                    value:
+                      stringValue: hello
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: error
+                  - key: message
+                    value:
+                      stringValue: oops
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_object_records.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_object_records.yml
@@ -1,0 +1,23 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: info
+                  - key: message
+                    value:
+                      stringValue: hello
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: error
+                  - key: message
+                    value:
+                      stringValue: oops
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/testdata/unwrap_single_element.yml
+++ b/extension/encoding/jsonlogencodingextension/testdata/unwrap_single_element.yml
@@ -1,0 +1,14 @@
+resourceLogs:
+  - resource: {}
+    scopeLogs:
+      - logRecords:
+          - body:
+              kvlistValue:
+                values:
+                  - key: level
+                    value:
+                      stringValue: info
+                  - key: message
+                    value:
+                      stringValue: only one
+        scope: {}

--- a/extension/encoding/jsonlogencodingextension/unwrap.go
+++ b/extension/encoding/jsonlogencodingextension/unwrap.go
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonlogencodingextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension"
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+
+	"github.com/goccy/go-json"
+)
+
+// extractRecords extracts individual JSON records from the input bytes using
+// the provided JSONPath expression. It first tries to apply the JSONPath to
+// the input as a single JSON document. If the input is not valid JSON (e.g.,
+// NDJSON), it falls back to splitting by newlines.
+func extractRecords(input []byte, jsonPathExpr string) ([][]byte, error) {
+	input = bytes.TrimSpace(input)
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	// Try applying JSONPath to the input as a single JSON document
+	if input[0] == '{' || input[0] == '[' {
+		path, err := json.CreatePath(jsonPathExpr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSONPath expression %q: %w", jsonPathExpr, err)
+		}
+
+		records, err := path.Extract(input)
+		if err == nil {
+			// JSONPath extraction succeeded
+			result := make([][]byte, 0, len(records))
+			for _, r := range records {
+				trimmed := bytes.TrimSpace(r)
+				if len(trimmed) > 0 {
+					result = append(result, trimmed)
+				}
+			}
+			return result, nil
+		}
+
+		// If the input starts with '{' and JSONPath extraction failed,
+		// it may be NDJSON (multiple JSON objects separated by newlines)
+		if input[0] == '{' {
+			return splitNDJSON(input)
+		}
+
+		// For array-like input that failed JSONPath, return the error
+		return nil, fmt.Errorf("failed to extract records using JSONPath %q: %w", jsonPathExpr, err)
+	}
+
+	return nil, fmt.Errorf("unsupported input format: expected JSON object or array, got %q", string(input[:min(len(input), 20)]))
+}
+
+// splitNDJSON splits newline-delimited JSON input into individual records.
+func splitNDJSON(input []byte) ([][]byte, error) {
+	var records [][]byte
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		// Make a copy since scanner reuses the buffer
+		record := make([]byte, len(line))
+		copy(record, line)
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading NDJSON input: %w", err)
+	}
+	return records, nil
+}

--- a/extension/encoding/jsonlogencodingextension/unwrap_test.go
+++ b/extension/encoding/jsonlogencodingextension/unwrap_test.go
@@ -1,0 +1,388 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jsonlogencodingextension
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
+)
+
+func TestExtractRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		jsonPath    string
+		wantCount   int
+		wantErr     string
+		wantRecords []string
+	}{
+		{
+			name:      "object records with $.records[*]",
+			input:     `{"records": [{"id": 1}, {"id": 2}]}`,
+			jsonPath:  "$.records[*]",
+			wantCount: 2,
+		},
+		{
+			name:      "JSON array with $[*]",
+			input:     `[{"id": 1}, {"id": 2}, {"id": 3}]`,
+			jsonPath:  "$[*]",
+			wantCount: 3,
+		},
+		{
+			name:      "NDJSON fallback",
+			input:     "{\"a\":1}\n{\"b\":2}\n{\"c\":3}",
+			jsonPath:  "$.records[*]",
+			wantCount: 3,
+		},
+		{
+			name:      "NDJSON with empty lines",
+			input:     "{\"a\":1}\n\n{\"b\":2}\n",
+			jsonPath:  "$.records[*]",
+			wantCount: 2,
+		},
+		{
+			name:      "single object matching $[*] on array",
+			input:     `[{"id": 1}]`,
+			jsonPath:  "$[*]",
+			wantCount: 1,
+		},
+		{
+			name:      "nested path",
+			input:     `{"data": {"items": [{"id": 1}, {"id": 2}]}}`,
+			jsonPath:  "$.data.items[*]",
+			wantCount: 2,
+		},
+		{
+			name:      "custom field name",
+			input:     `{"events": [{"type": "click"}, {"type": "view"}]}`,
+			jsonPath:  "$.events[*]",
+			wantCount: 2,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			jsonPath:  "$.records[*]",
+			wantCount: 0,
+		},
+		{
+			name:      "whitespace only input",
+			input:     "   \n  ",
+			jsonPath:  "$.records[*]",
+			wantCount: 0,
+		},
+		{
+			name:    "invalid input",
+			input:   "not json at all",
+			jsonPath: "$.records[*]",
+			wantErr: "unsupported input format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			records, err := extractRecords([]byte(tt.input), tt.jsonPath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, records, tt.wantCount)
+		})
+	}
+}
+
+// set to true to regenerate golden files, then set back to false
+var updateGoldenFiles = false
+
+func TestUnmarshalLogsWithUnwrap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		unwrap   string
+		input    string
+		wantLogs int
+		logsPath string
+	}{
+		{
+			name:     "unwrap object records",
+			unwrap:   "$.records[*]",
+			input:    `{"records": [{"level": "info", "message": "hello"}, {"level": "error", "message": "oops"}]}`,
+			wantLogs: 2,
+			logsPath: filepath.Join(testDataDir, "unwrap_object_records.yml"),
+		},
+		{
+			name:     "unwrap JSON array",
+			unwrap:   "$[*]",
+			input:    `[{"level": "info", "message": "hello"}, {"level": "error", "message": "oops"}]`,
+			wantLogs: 2,
+			logsPath: filepath.Join(testDataDir, "unwrap_json_array.yml"),
+		},
+		{
+			name:     "unwrap NDJSON fallback",
+			unwrap:   "$.records[*]",
+			input:    "{\"level\":\"info\",\"message\":\"hello\"}\n{\"level\":\"error\",\"message\":\"oops\"}",
+			wantLogs: 2,
+			logsPath: filepath.Join(testDataDir, "unwrap_ndjson.yml"),
+		},
+		{
+			name:     "unwrap nested path",
+			unwrap:   "$.data.items[*]",
+			input:    `{"data": {"items": [{"level": "info", "message": "hello"}, {"level": "error", "message": "oops"}]}}`,
+			wantLogs: 2,
+			logsPath: filepath.Join(testDataDir, "unwrap_nested_path.yml"),
+		},
+		{
+			name:     "unwrap custom field",
+			unwrap:   "$.events[*]",
+			input:    `{"events": [{"type": "click", "page": "/home"}]}`,
+			wantLogs: 1,
+			logsPath: filepath.Join(testDataDir, "unwrap_custom_field.yml"),
+		},
+		{
+			name:     "unwrap single element array",
+			unwrap:   "$.records[*]",
+			input:    `{"records": [{"level": "info", "message": "only one"}]}`,
+			wantLogs: 1,
+			logsPath: filepath.Join(testDataDir, "unwrap_single_element.yml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &jsonLogExtension{
+				config: &Config{
+					Mode:   JSONEncodingModeBody,
+					Unwrap: tt.unwrap,
+				},
+			}
+
+			logs, err := e.UnmarshalLogs([]byte(tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantLogs, logs.LogRecordCount())
+
+			if updateGoldenFiles {
+				golden.WriteLogs(t, tt.logsPath, logs)
+			}
+
+			expected, err := golden.ReadLogs(tt.logsPath)
+			require.NoError(t, err)
+			require.NoError(t, plogtest.CompareLogs(expected, logs, plogtest.IgnoreObservedTimestamp()))
+		})
+	}
+}
+
+func TestUnmarshalLogsWithUnwrapTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		unwrap       string
+		unwrapTarget string
+		input        string
+		wantLogs     int
+		logsPath     string
+	}{
+		{
+			name:         "unwrap_target message with object records",
+			unwrap:       "$.records[*]",
+			unwrapTarget: "message",
+			input:        `{"records": [{"level": "info", "msg": "hello"}, {"level": "error", "msg": "oops"}]}`,
+			wantLogs:     2,
+			logsPath:     filepath.Join(testDataDir, "unwrap_content_field_message.yml"),
+		},
+		{
+			name:         "unwrap_target custom name",
+			unwrap:       "$.records[*]",
+			unwrapTarget: "event",
+			input:        `{"records": [{"level": "info", "msg": "hello"}]}`,
+			wantLogs:     1,
+			logsPath:     filepath.Join(testDataDir, "unwrap_content_field_custom.yml"),
+		},
+		{
+			name:         "unwrap_target with NDJSON fallback",
+			unwrap:       "$.records[*]",
+			unwrapTarget: "message",
+			input:        "{\"a\":1}\n{\"b\":2}",
+			wantLogs:     2,
+			logsPath:     filepath.Join(testDataDir, "unwrap_content_field_ndjson.yml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &jsonLogExtension{
+				config: &Config{
+					Mode:         JSONEncodingModeBody,
+					Unwrap:       tt.unwrap,
+					UnwrapTarget: tt.unwrapTarget,
+				},
+			}
+
+			logs, err := e.UnmarshalLogs([]byte(tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantLogs, logs.LogRecordCount())
+
+			if updateGoldenFiles {
+				golden.WriteLogs(t, tt.logsPath, logs)
+			}
+
+			expected, err := golden.ReadLogs(tt.logsPath)
+			require.NoError(t, err)
+			require.NoError(t, plogtest.CompareLogs(expected, logs, plogtest.IgnoreObservedTimestamp()))
+		})
+	}
+}
+
+func TestUnmarshalLogsWithUnwrap_ObservedTimestamp(t *testing.T) {
+	t.Parallel()
+	e := &jsonLogExtension{
+		config: &Config{
+			Mode:   JSONEncodingModeBody,
+			Unwrap: "$.records[*]",
+		},
+	}
+
+	logs, err := e.UnmarshalLogs([]byte(`{"records": [{"id": 1}]}`))
+	require.NoError(t, err)
+	require.Equal(t, 1, logs.LogRecordCount())
+
+	lr := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.NotZero(t, lr.ObservedTimestamp(), "ObservedTimestamp should be set")
+}
+
+func TestUnmarshalLogsWithUnwrap_EmptyInput(t *testing.T) {
+	t.Parallel()
+	e := &jsonLogExtension{
+		config: &Config{
+			Mode:   JSONEncodingModeBody,
+			Unwrap: "$.records[*]",
+		},
+	}
+
+	logs, err := e.UnmarshalLogs([]byte(""))
+	require.NoError(t, err)
+	assert.Equal(t, 0, logs.LogRecordCount())
+}
+
+func TestUnmarshalLogsWithUnwrap_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	e := &jsonLogExtension{
+		config: &Config{
+			Mode:   JSONEncodingModeBody,
+			Unwrap: "$.records[*]",
+		},
+	}
+
+	_, err := e.UnmarshalLogs([]byte("not json"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported input format")
+}
+
+func TestConfigValidation_Unwrap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		unwrap  string
+		wantErr string
+	}{
+		{
+			name:   "valid JSONPath records",
+			unwrap: "$.records[*]",
+		},
+		{
+			name:   "valid JSONPath array",
+			unwrap: "$[*]",
+		},
+		{
+			name:   "valid JSONPath nested",
+			unwrap: "$.data.items[*]",
+		},
+		{
+			name:   "empty unwrap is valid",
+			unwrap: "",
+		},
+		{
+			name:    "missing $ prefix",
+			unwrap:  "records[*]",
+			wantErr: "must be a JSONPath starting with $",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &Config{
+				Mode:   JSONEncodingModeBody,
+				Unwrap: tt.unwrap,
+			}
+			err := c.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigValidation_UnwrapTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		unwrap       string
+		unwrapTarget string
+		wantErr      string
+	}{
+		{
+			name:         "unwrap_target with unwrap is valid",
+			unwrap:       "$.records[*]",
+			unwrapTarget: "message",
+		},
+		{
+			name:         "unwrap_target without unwrap is invalid",
+			unwrap:       "",
+			unwrapTarget: "message",
+			wantErr:      "unwrap_target requires unwrap to be set",
+		},
+		{
+			name:         "empty unwrap_target is always valid",
+			unwrap:       "",
+			unwrapTarget: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &Config{
+				Mode:         JSONEncodingModeBody,
+				Unwrap:       tt.unwrap,
+				UnwrapTarget: tt.unwrapTarget,
+			}
+			err := c.Validate()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add `unwrap` and `unwrap_target` options to the `encoding/jsonlogencodingextension` extension.

##### Example: Unwrap Azure Event Hub Messages

**Configuration:**
```yaml
extensions:
  jsonlogencoding:
    mode: body
    unwrap: "$.records[*]"
```

###### Unmarshal (Wrapped JSON → OpenTelemetry Logs)

**Input JSON:**
```json
{
  "records": [
    {"time": "2024-01-15T10:30:00Z", "category": "Administrative", "operationName": "Create"},
    {"time": "2024-01-15T10:30:01Z", "category": "Security", "operationName": "Login"}
  ]
}
```

**Result:** Creates 2 OpenTelemetry log records
- Log Record 1 body: `{"time": "2024-01-15T10:30:00Z", "category": "Administrative", "operationName": "Create"}`
- Log Record 2 body: `{"time": "2024-01-15T10:30:01Z", "category": "Security", "operationName": "Login"}`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
