### PR TITLE
[exporter/syslog] Fix timestamp to match syslog spec

### DIFF
--- a/.chloggen/dylan_update-timestamp-format.yaml
+++ b/.chloggen/dylan_update-timestamp-format.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/syslog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the timestamp when using the RFC 3164 formatter to space-pad the day of month for single digit days
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46115]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/syslogexporter/rfc3164_formatter.go
+++ b/exporter/syslogexporter/rfc3164_formatter.go
@@ -35,7 +35,7 @@ func (*rfc3164Formatter) formatPriority(logRecord plog.LogRecord) string {
 }
 
 func (*rfc3164Formatter) formatTimestamp(logRecord plog.LogRecord) string {
-	return logRecord.Timestamp().AsTime().Format("Jan 02 15:04:05")
+	return logRecord.Timestamp().AsTime().Format("Jan _2 15:04:05")
 }
 
 func (*rfc3164Formatter) formatHostname(logRecord plog.LogRecord) string {

--- a/exporter/syslogexporter/rfc3164_formatter_test.go
+++ b/exporter/syslogexporter/rfc3164_formatter_test.go
@@ -38,4 +38,19 @@ func TestRFC3164Formatter(t *testing.T) {
 	actual = newRFC3164Formatter().format(logRecord)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
+
+	// RFC 3164 requires space-padded day of month for single-digit days
+	expected = "<34>Sep  3 23:12:35 myhost app: test message\n"
+	logRecord = plog.NewLogRecord()
+	logRecord.Attributes().PutStr("appname", "app")
+	logRecord.Attributes().PutStr("hostname", "myhost")
+	logRecord.Attributes().PutStr("message", "test message")
+	logRecord.Attributes().PutInt("priority", 34)
+	timestamp, err = time.Parse(time.RFC3339Nano, "2024-09-03T23:12:35.000000Z")
+	require.NoError(t, err)
+	logRecord.SetTimestamp(pcommon.NewTimestampFromTime(timestamp))
+
+	actual = newRFC3164Formatter().format(logRecord)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
According to the RFC 3164:
```
 dd is the day of the month.  If the day of the month is less
 than 10, then it MUST be represented as a space and then the
 number.  For example, the 7th day of August would be
 represented as "Aug  7", with two spaces between the "g" and
 the "7".
```
previously the day was padded with a 0

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46115

<!--Describe what testing was performed and which tests were added.-->
#### Testing
A test was added to confirm that the output is correct
