### PR TITLE
[reciever/splunkenterprise]46126 fix adhoc searches

### DIFF
--- a/.chloggen/46126-fix-adhoc-searches.yaml
+++ b/.chloggen/46126-fix-adhoc-searches.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/splunkenterprise
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixes a bug with how ad-hoc search based metrics were being recorded
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46126]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -199,7 +199,7 @@ func (s *splunkScraper) scrapeLicenseUsageByIndex(_ context.Context, now pcommon
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -282,7 +282,7 @@ func (s *splunkScraper) scrapeAvgExecLatencyByHost(_ context.Context, now pcommo
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -368,7 +368,7 @@ func (s *splunkScraper) scrapeIndexerAvgRate(_ context.Context, now pcommon.Time
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -453,7 +453,7 @@ func (s *splunkScraper) scrapeIndexerPipelineQueues(_ context.Context, now pcomm
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -572,7 +572,7 @@ func (s *splunkScraper) scrapeBucketsSearchableStatus(_ context.Context, now pco
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -666,7 +666,7 @@ func (s *splunkScraper) scrapeIndexesBucketCountAdHoc(_ context.Context, now pco
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -782,7 +782,7 @@ func (s *splunkScraper) scrapeSchedulerCompletionRatioByHost(_ context.Context, 
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -868,7 +868,7 @@ func (s *splunkScraper) scrapeIndexerRawWriteSecondsByHost(_ context.Context, no
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -954,7 +954,7 @@ func (s *splunkScraper) scrapeIndexerCPUSecondsByHost(_ context.Context, now pco
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -1040,7 +1040,7 @@ func (s *splunkScraper) scrapeAvgIopsByHost(_ context.Context, now pcommon.Times
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -1126,7 +1126,7 @@ func (s *splunkScraper) scrapeSchedulerRunTimeByHost(_ context.Context, now pcom
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
 			sr.Fields = nil
-			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
+			if (sr.offset + sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -198,7 +198,8 @@ func (s *splunkScraper) scrapeLicenseUsageByIndex(_ context.Context, now pcommon
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -216,13 +217,13 @@ func (s *splunkScraper) scrapeLicenseUsageByIndex(_ context.Context, now pcommon
 
 	// Record the results
 	var indexName string
+	var v float64
 	for _, f := range fields {
 		switch fieldName := f.FieldName; fieldName {
 		case "indexname":
 			indexName = f.Value
-			continue
 		case "By":
-			v, err := strconv.ParseFloat(f.Value, 64)
+			v, err = strconv.ParseFloat(f.Value, 64)
 			if err != nil {
 				errs <- err
 				continue
@@ -280,7 +281,8 @@ func (s *splunkScraper) scrapeAvgExecLatencyByHost(_ context.Context, now pcommo
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -306,7 +308,6 @@ func (s *splunkScraper) scrapeAvgExecLatencyByHost(_ context.Context, now pcommo
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "latency_avg_exec":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -366,7 +367,8 @@ func (s *splunkScraper) scrapeIndexerAvgRate(_ context.Context, now pcommon.Time
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -391,7 +393,6 @@ func (s *splunkScraper) scrapeIndexerAvgRate(_ context.Context, now pcommon.Time
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "indexer_avg_kbps":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -451,7 +452,8 @@ func (s *splunkScraper) scrapeIndexerPipelineQueues(_ context.Context, now pcomm
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -481,7 +483,6 @@ func (s *splunkScraper) scrapeIndexerPipelineQueues(_ context.Context, now pcomm
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "agg_queue_ratio":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -570,7 +571,8 @@ func (s *splunkScraper) scrapeBucketsSearchableStatus(_ context.Context, now pco
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -601,10 +603,8 @@ func (s *splunkScraper) scrapeBucketsSearchableStatus(_ context.Context, now pco
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "is_searchable":
 			searchable = f.Value
-			continue
 		case "bucket_count":
 			v, err := strconv.ParseInt(f.Value, 10, 64)
 			bc = v
@@ -665,7 +665,8 @@ func (s *splunkScraper) scrapeIndexesBucketCountAdHoc(_ context.Context, now pco
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -691,7 +692,6 @@ func (s *splunkScraper) scrapeIndexesBucketCountAdHoc(_ context.Context, now pco
 		switch fieldName := f.FieldName; fieldName {
 		case "title":
 			indexer = f.Value
-			continue
 		case "total_size_gb":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -781,7 +781,8 @@ func (s *splunkScraper) scrapeSchedulerCompletionRatioByHost(_ context.Context, 
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -807,7 +808,6 @@ func (s *splunkScraper) scrapeSchedulerCompletionRatioByHost(_ context.Context, 
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "completion_ratio":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -867,7 +867,8 @@ func (s *splunkScraper) scrapeIndexerRawWriteSecondsByHost(_ context.Context, no
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -893,7 +894,6 @@ func (s *splunkScraper) scrapeIndexerRawWriteSecondsByHost(_ context.Context, no
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "raw_data_write_seconds":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -953,7 +953,8 @@ func (s *splunkScraper) scrapeIndexerCPUSecondsByHost(_ context.Context, now pco
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -979,7 +980,6 @@ func (s *splunkScraper) scrapeIndexerCPUSecondsByHost(_ context.Context, now pco
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "service_cpu_seconds":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {
@@ -1039,7 +1039,8 @@ func (s *splunkScraper) scrapeAvgIopsByHost(_ context.Context, now pcommon.Times
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -1065,7 +1066,6 @@ func (s *splunkScraper) scrapeAvgIopsByHost(_ context.Context, now pcommon.Times
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "iops":
 			v, err := strconv.ParseInt(f.Value, 10, 64)
 			if err != nil {
@@ -1125,7 +1125,8 @@ func (s *splunkScraper) scrapeSchedulerRunTimeByHost(_ context.Context, now pcom
 		// the 200 is coming after the first request which provides a jobId to retrieve results
 		if sr.Return == 200 && sr.Jobid != nil {
 			fields = append(fields, sr.Fields...)
-			if sr.count >= sr.TotalCount.Count || sr.offset >= sr.TotalCount.Count {
+			sr.Fields = nil
+			if sr.count >= sr.TotalCount.Count || (sr.offset+sr.count) >= sr.TotalCount.Count {
 				break
 			}
 			sr.offset += sr.count
@@ -1151,7 +1152,6 @@ func (s *splunkScraper) scrapeSchedulerRunTimeByHost(_ context.Context, now pcom
 		switch fieldName := f.FieldName; fieldName {
 		case "host":
 			host = f.Value
-			continue
 		case "run_time_avg":
 			v, err := strconv.ParseFloat(f.Value, 64)
 			if err != nil {

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -75,7 +75,7 @@ func mockJobsSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 // second call to jobs api which includes a jobid
-func mockJobsSearchGetResponse(t *testing.T, w http.ResponseWriter, r *http.Request) {
+func mockJobsSearchGetResponse(w http.ResponseWriter, r *http.Request) {
 	status := http.StatusOK
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(status)
@@ -134,7 +134,7 @@ func lookupSearchJobReturn(r *http.Request) []byte {
 }
 
 // mock server create
-func createMockServer(t *testing.T) *httptest.Server {
+func createMockServer() *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		url := r.URL.String()
 		switch {
@@ -151,7 +151,7 @@ func createMockServer(t *testing.T) *httptest.Server {
 		case strings.EqualFold(url, "/services/search/v2/jobs/"):
 			mockJobsSearch(w, r)
 		case strings.Contains(url, "results"):
-			mockJobsSearchGetResponse(t, w, r)
+			mockJobsSearchGetResponse(w, r)
 		default:
 			http.NotFoundHandler().ServeHTTP(w, r)
 		}
@@ -208,7 +208,7 @@ func createConfig(ts *httptest.Server, badConfig bool) *Config {
 }
 
 func TestScraper(t *testing.T) {
-	ts := createMockServer(t)
+	ts := createMockServer()
 	defer ts.Close()
 
 	cfg := createConfig(ts, false)
@@ -237,7 +237,7 @@ func TestScraper(t *testing.T) {
 }
 
 func TestScrapeError(t *testing.T) {
-	ts := createMockServer(t)
+	ts := createMockServer()
 	defer ts.Close()
 
 	cfg := createConfig(ts, true)

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -228,7 +228,7 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedFile := filepath.Join("testdata", "scraper", "expected.yaml")
-	golden.WriteMetrics(t, expectedFile, actualMetrics) // run tests with this line whenever metrics are modified
+	// golden.WriteMetrics(t, expectedFile, actualMetrics) // run tests with this line whenever metrics are modified
 
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -79,7 +79,7 @@ func mockJobsSearchGetResponse(t *testing.T, w http.ResponseWriter, r *http.Requ
 	status := http.StatusOK
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(status)
-	_, _ = w.Write(lookupSearchJobReturn(t, r))
+	_, _ = w.Write(lookupSearchJobReturn(r))
 }
 
 // this returns a jobid associated with the specific body
@@ -106,7 +106,7 @@ func getJobsSearchResponse(r *http.Request) []byte {
 
 // this is for when you send in a jobid and wish to read the actual search
 // response
-func lookupSearchJobReturn(t *testing.T, r *http.Request) []byte {
+func lookupSearchJobReturn(r *http.Request) []byte {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return []byte(`error`)

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -75,11 +75,11 @@ func mockJobsSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 // second call to jobs api which includes a jobid
-func mockJobsSearchGetResponse(w http.ResponseWriter, r *http.Request) {
+func mockJobsSearchGetResponse(t *testing.T, w http.ResponseWriter, r *http.Request) {
 	status := http.StatusOK
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(status)
-	_, _ = w.Write(lookupSearchJobReturn(r))
+	_, _ = w.Write(lookupSearchJobReturn(t, r))
 }
 
 // this returns a jobid associated with the specific body
@@ -106,7 +106,7 @@ func getJobsSearchResponse(r *http.Request) []byte {
 
 // this is for when you send in a jobid and wish to read the actual search
 // response
-func lookupSearchJobReturn(r *http.Request) []byte {
+func lookupSearchJobReturn(t *testing.T, r *http.Request) []byte {
 	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return []byte(`error`)
@@ -124,10 +124,10 @@ func lookupSearchJobReturn(r *http.Request) []byte {
 	case "/services/search/v2/jobs/3/results":
 		return []byte(`<?xml version="1.0" encoding="UTF-8"?><response><sid>some-id</sid><result><field k="host"><value><text>some-host</text></value></field><field k="run_time_avg"><value><text>200.40</text></value></field></result></response>`)
 	case "/services/search/v2/jobs/4/results": // this is the case in which we test pagination
-		if vals.Get("offset") < vals.Get("count") {
-			return []byte(`<?xml version='1.0' encoding='UTF-8'?><results preview='0'><meta><fieldOrder><field summary.count="101" summary.dc="1" summary.numcount="0">By</field><field summary.count="101" summary.dc="1" summary.numcount="0">indexname</field></fieldOrder></meta><result offset='0'><field k='By'><value><text>101</text></value></field><field k='indexname'><value><text>some_val2</text></value></field></result></results>`)
+		if vals.Get("offset") == "0" {
+			return []byte(`<?xml version='1.0' encoding='UTF-8'?><results preview='0'><meta><fieldOrder><field summary.count="101" summary.dc="1" summary.numcount="0">By</field><field summary.count="101" summary.dc="1" summary.numcount="0">indexname</field></fieldOrder></meta><result offset='0'><field k='indexname'><value><text>some_val1</text></value></field><field k='By'><value><text>104</text></value></field></result><result offset='1'><field k='indexname'><value><text>some_val5</text></value></field><field k='By'><value><text>105</text></value></field></result></results>`)
 		}
-		return []byte(`<?xml version='1.0' encoding='UTF-8'?><results preview='0'><meta><fieldOrder><field summary.count="101" summary.dc="1" summary.numcount="0">By</field><field summary.count="101" summary.dc="1" summary.numcount="0">indexname</field></fieldOrder></meta><result offset='101'><field k='By'><value><text>100</text></value></field><field k='indexname'><value><text>some_val2</text></value></field></result></results>`)
+		return []byte(`<?xml version='1.0' encoding='UTF-8'?><results preview='0'><meta><fieldOrder><field summary.count="101" summary.dc="1" summary.numcount="0">By</field><field summary.count="101" summary.dc="1" summary.numcount="0">indexname</field></fieldOrder></meta><result offset='101'><field k='indexname'><value><text>some_val2</text></value></field><field k='By'><value><text>93</text></value></field></result></results>`)
 	default:
 		return []byte(`error`)
 	}
@@ -136,7 +136,6 @@ func lookupSearchJobReturn(r *http.Request) []byte {
 // mock server create
 func createMockServer(t *testing.T) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Log(r.URL.String())
 		url := r.URL.String()
 		switch {
 		case strings.EqualFold(url, "/services/server/introspection/indexer?output_mode=json"):
@@ -152,7 +151,7 @@ func createMockServer(t *testing.T) *httptest.Server {
 		case strings.EqualFold(url, "/services/search/v2/jobs/"):
 			mockJobsSearch(w, r)
 		case strings.Contains(url, "results"):
-			mockJobsSearchGetResponse(w, r)
+			mockJobsSearchGetResponse(t, w, r)
 		default:
 			http.NotFoundHandler().ServeHTTP(w, r)
 		}
@@ -229,7 +228,7 @@ func TestScraper(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedFile := filepath.Join("testdata", "scraper", "expected.yaml")
-	// golden.WriteMetrics(t, expectedFile, actualMetrics) // run tests with this line whenever metrics are modified
+	golden.WriteMetrics(t, expectedFile, actualMetrics) // run tests with this line whenever metrics are modified
 
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)

--- a/receiver/splunkenterprisereceiver/search_result.go
+++ b/receiver/splunkenterprisereceiver/search_result.go
@@ -51,14 +51,28 @@ var apiDict = map[string]string{
 	`SplunkLicenses`:                    `/services/licenser/licenses?output_mode=json`,
 }
 
+// Struct containing information relating to search based metrics
 type searchResponse struct {
-	search     string
-	Jobid      *string `xml:"sid"`
-	Return     int
-	count      int
-	offset     int
+	// search job being run
+	search string
+
+	// id of job running the search
+	Jobid *string `xml:"sid"`
+
+	// response code
+	Return int
+
+	// number of responses per page
+	count int
+
+	// offset of first result value in a page
+	offset int
+
+	// total number of responses for the query results
 	TotalCount metaField `xml:"meta>fieldOrder>field"`
-	Fields     []*field  `xml:"result>field"`
+
+	// returned results
+	Fields []*field `xml:"result>field"`
 }
 
 type metaField struct {

--- a/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
+++ b/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
@@ -215,11 +215,11 @@ resourceMetrics:
           - description: Gauge tracking the indexed license usage per index
             gauge:
               dataPoints:
-                - asInt: "101"
+                - asInt: "104"
                   attributes:
                     - key: splunk.index.name
                       value:
-                        stringValue: ""
+                        stringValue: some_val1
                     - key: splunk.splunkd.build
                       value:
                         stringValue: ""
@@ -228,7 +228,7 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "101"
+                - asInt: "93"
                   attributes:
                     - key: splunk.index.name
                       value:
@@ -241,50 +241,11 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "100"
+                - asInt: "105"
                   attributes:
                     - key: splunk.index.name
                       value:
-                        stringValue: some_val2
-                    - key: splunk.splunkd.build
-                      value:
-                        stringValue: ""
-                    - key: splunk.splunkd.version
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "101"
-                  attributes:
-                    - key: splunk.index.name
-                      value:
-                        stringValue: some_val2
-                    - key: splunk.splunkd.build
-                      value:
-                        stringValue: ""
-                    - key: splunk.splunkd.version
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "100"
-                  attributes:
-                    - key: splunk.index.name
-                      value:
-                        stringValue: some_val2
-                    - key: splunk.splunkd.build
-                      value:
-                        stringValue: ""
-                    - key: splunk.splunkd.version
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "100"
-                  attributes:
-                    - key: splunk.index.name
-                      value:
-                        stringValue: some_val2
+                        stringValue: some_val5
                     - key: splunk.splunkd.build
                       value:
                         stringValue: ""

--- a/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
+++ b/receiver/splunkenterprisereceiver/testdata/scraper/expected.yaml
@@ -228,11 +228,11 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "93"
+                - asInt: "105"
                   attributes:
                     - key: splunk.index.name
                       value:
-                        stringValue: some_val2
+                        stringValue: some_val5
                     - key: splunk.splunkd.build
                       value:
                         stringValue: ""
@@ -241,11 +241,11 @@ resourceMetrics:
                         stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "105"
+                - asInt: "93"
                   attributes:
                     - key: splunk.index.name
                       value:
-                        stringValue: some_val5
+                        stringValue: some_val2
                     - key: splunk.splunkd.build
                       value:
                         stringValue: ""


### PR DESCRIPTION
#### Description
Fixes a bug where ad-hoc searches would emit some metrics without attributes.

#### Link to tracking issue
Fixes [46126](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46126)

#### Testing
Unit tests were expanded to better examine the scrape function for a search based metric