### PR TITLE
pkg/ottl: add typed slice getter support for function args

### DIFF
--- a/.chloggen/46140.yaml
+++ b/.chloggen/46140.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "pkg/ottl: add typed slice getter support for function args"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45980, 27821, 38690]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/LANGUAGE.md
+++ b/pkg/ottl/LANGUAGE.md
@@ -65,6 +65,8 @@ The following types are supported for single-value parameters in OTTL functions:
 - `FloatLikeGetter`
 - `StringGetter`
 - `StringLikeGetter`
+- `StringSliceGetter`
+- `StringLikeSliceGetter`
 - `IntGetter`
 - `IntLikeGetter`
 - `BoolGetter`

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -308,6 +308,26 @@ func (g StandardPSliceGetter[K]) Get(ctx context.Context, tCtx K) (pcommon.Slice
 	if err != nil {
 		return pcommon.Slice{}, fmt.Errorf("error getting value in %T: %w", g, err)
 	}
+	return valueToPSlice(val)
+}
+
+func newPSliceFromIntegers[T constraints.Integer](source []T) (pcommon.Slice, error) {
+	return newPSliceFrom(source, func(target *pcommon.Value, value T) {
+		target.SetInt(int64(value))
+	})
+}
+
+func newPSliceFrom[T any](source []T, set func(target *pcommon.Value, value T)) (pcommon.Slice, error) {
+	s := pcommon.NewSlice()
+	s.EnsureCapacity(len(source))
+	for _, v := range source {
+		empty := s.AppendEmpty()
+		set(&empty, v)
+	}
+	return s, nil
+}
+
+func valueToPSlice(val any) (pcommon.Slice, error) {
 	if val == nil {
 		return pcommon.Slice{}, TypeError("expected pcommon.Slice but got nil")
 	}
@@ -320,12 +340,7 @@ func (g StandardPSliceGetter[K]) Get(ctx context.Context, tCtx K) (pcommon.Slice
 		}
 		return pcommon.Slice{}, TypeError(fmt.Sprintf("expected pcommon.Slice but got %v", v.Type()))
 	case []any:
-		s := pcommon.NewSlice()
-		err = s.FromRaw(v)
-		if err != nil {
-			return pcommon.Slice{}, err
-		}
-		return s, nil
+		return newPSliceFromAny(v)
 	// Handle common slice types returned by OTTL functions
 	case []string:
 		return newPSliceFrom(v, func(target *pcommon.Value, value string) { target.SetStr(value) })
@@ -356,20 +371,46 @@ func (g StandardPSliceGetter[K]) Get(ctx context.Context, tCtx K) (pcommon.Slice
 	}
 }
 
-func newPSliceFromIntegers[T constraints.Integer](source []T) (pcommon.Slice, error) {
-	return newPSliceFrom(source, func(target *pcommon.Value, value T) {
-		target.SetInt(int64(value))
-	})
-}
-
-func newPSliceFrom[T any](source []T, set func(target *pcommon.Value, value T)) (pcommon.Slice, error) {
+func newPSliceFromAny(source []any) (pcommon.Slice, error) {
 	s := pcommon.NewSlice()
-	s.EnsureCapacity(len(source))
-	for _, v := range source {
-		empty := s.AppendEmpty()
-		set(&empty, v)
+	if err := setPSliceFromAny(s, source); err != nil {
+		return pcommon.Slice{}, err
 	}
 	return s, nil
+}
+
+func setPSliceFromAny(target pcommon.Slice, source []any) error {
+	target.EnsureCapacity(len(source))
+	for i, value := range source {
+		if err := setPValueFromAny(target.AppendEmpty(), value); err != nil {
+			return fmt.Errorf("element %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func setPValueFromAny(target pcommon.Value, value any) error {
+	if value == nil {
+		return nil
+	}
+
+	switch typedVal := value.(type) {
+	case pcommon.Value:
+		typedVal.CopyTo(target)
+	case pcommon.Map:
+		typedVal.CopyTo(target.SetEmptyMap())
+	case pcommon.Slice:
+		typedVal.CopyTo(target.SetEmptySlice())
+	case []any:
+		if err := setPSliceFromAny(target.SetEmptySlice(), typedVal); err != nil {
+			return err
+		}
+	default:
+		if err := target.FromRaw(value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // TypeError represents that a value was not an expected type.
@@ -377,6 +418,57 @@ type TypeError string
 
 func (t TypeError) Error() string {
 	return string(t)
+}
+
+func valueToString(val any) (string, error) {
+	if val == nil {
+		return "", TypeError("expected string but got nil")
+	}
+	switch v := val.(type) {
+	case string:
+		return v, nil
+	case pcommon.Value:
+		if v.Type() == pcommon.ValueTypeStr {
+			return v.Str(), nil
+		}
+		return "", TypeError(fmt.Sprintf("expected string but got %v", v.Type()))
+	default:
+		return "", TypeError(fmt.Sprintf("expected string but got %T", val))
+	}
+}
+
+func valueToStringLike(val any) (*string, error) {
+	if val == nil {
+		return nil, nil
+	}
+	var result string
+	switch v := val.(type) {
+	case string:
+		result = v
+	case []byte:
+		result = hex.EncodeToString(v)
+	case pcommon.Map:
+		resultBytes, err := json.Marshal(v.AsRaw())
+		if err != nil {
+			return nil, err
+		}
+		result = string(resultBytes)
+	case pcommon.Slice:
+		resultBytes, err := json.Marshal(v.AsRaw())
+		if err != nil {
+			return nil, err
+		}
+		result = string(resultBytes)
+	case pcommon.Value:
+		result = v.AsString()
+	default:
+		resultBytes, err := json.Marshal(v)
+		if err != nil {
+			return nil, TypeError(fmt.Sprintf("unsupported type: %T", v))
+		}
+		result = string(resultBytes)
+	}
+	return &result, nil
 }
 
 // StringGetter is a Getter that must return a string.
@@ -414,20 +506,7 @@ func (g StandardStringGetter[K]) Get(ctx context.Context, tCtx K) (string, error
 	if err != nil {
 		return "", fmt.Errorf("error getting value in %T: %w", g, err)
 	}
-	if val == nil {
-		return "", TypeError("expected string but got nil")
-	}
-	switch v := val.(type) {
-	case string:
-		return v, nil
-	case pcommon.Value:
-		if v.Type() == pcommon.ValueTypeStr {
-			return v.Str(), nil
-		}
-		return "", TypeError(fmt.Sprintf("expected string but got %v", v.Type()))
-	default:
-		return "", TypeError(fmt.Sprintf("expected string but got %T", val))
-	}
+	return valueToString(val)
 }
 
 // IntGetter is a Getter that must return an int64.
@@ -735,37 +814,7 @@ func (g StandardStringLikeGetter[K]) Get(ctx context.Context, tCtx K) (*string, 
 	if err != nil {
 		return nil, fmt.Errorf("error getting value in %T: %w", g, err)
 	}
-	if val == nil {
-		return nil, nil
-	}
-	var result string
-	switch v := val.(type) {
-	case string:
-		result = v
-	case []byte:
-		result = hex.EncodeToString(v)
-	case pcommon.Map:
-		resultBytes, err := json.Marshal(v.AsRaw())
-		if err != nil {
-			return nil, err
-		}
-		result = string(resultBytes)
-	case pcommon.Slice:
-		resultBytes, err := json.Marshal(v.AsRaw())
-		if err != nil {
-			return nil, err
-		}
-		result = string(resultBytes)
-	case pcommon.Value:
-		result = v.AsString()
-	default:
-		resultBytes, err := json.Marshal(v)
-		if err != nil {
-			return nil, TypeError(fmt.Sprintf("unsupported type: %T", v))
-		}
-		result = string(resultBytes)
-	}
-	return &result, nil
+	return valueToStringLike(val)
 }
 
 // FloatLikeGetter is a Getter that returns a float64 by converting the underlying value to a float64 if necessary.

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -569,12 +569,38 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return newStandardStringGetter[K](arg)
+	case strings.HasPrefix(name, "StringSliceGetter"):
+		if argVal.List != nil {
+			typedGetters, err := buildSlice[StringGetter[K]](argVal, reflect.TypeFor[[]StringGetter[K]](), p.buildArg, "StringGetter")
+			if err != nil {
+				return nil, err
+			}
+			return newStringSliceGetterFromStringGetters(typedGetters.([]StringGetter[K])), nil
+		}
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return newStandardStringSliceGetter[K](arg)
 	case strings.HasPrefix(name, "StringLikeGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {
 			return nil, err
 		}
 		return newStandardStringLikeGetter[K](arg)
+	case strings.HasPrefix(name, "StringLikeSliceGetter"):
+		if argVal.List != nil {
+			typedGetters, err := buildSlice[StringLikeGetter[K]](argVal, reflect.TypeFor[[]StringLikeGetter[K]](), p.buildArg, "StringLikeGetter")
+			if err != nil {
+				return nil, err
+			}
+			return newStringLikeSliceGetterFromStringLikeGetters(typedGetters.([]StringLikeGetter[K])), nil
+		}
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return newStandardStringLikeSliceGetter[K](arg)
 	case strings.HasPrefix(name, "FloatGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2010,6 +2010,189 @@ func Test_ArgumentsNotMutated(t *testing.T) {
 	assert.Zero(t, args.OptionalFloatArg)
 }
 
+func Test_NewFunctionCall_TypedSliceGetters(t *testing.T) {
+	p, err := NewParser(
+		CreateFactoryMap(
+			createFactory[any](
+				"testing_stringslicegetter",
+				&stringSliceGetterArguments{},
+				functionWithStringSliceGetter,
+			),
+			createFactory[any](
+				"testing_stringlikeslicegetter",
+				&stringLikeSliceGetterArguments{},
+				functionWithStringLikeSliceGetter,
+			),
+		),
+		testParsePath[any],
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+	require.NoError(t, err)
+
+	makePathArg := func() argument {
+		return argument{
+			Value: value{
+				Literal: &mathExprLiteral{
+					Path: &path{
+						Fields: []field{
+							{Name: "name"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		function string
+		tCtx     any
+		want     any
+	}{
+		{
+			name:     "string slice getter",
+			function: "testing_stringslicegetter",
+			tCtx:     []string{"a", "b"},
+			want:     2,
+		},
+		{
+			name:     "string like slice getter",
+			function: "testing_stringlikeslicegetter",
+			tCtx:     []any{"a", int64(1), nil},
+			want:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := p.newFunctionCall(editor{
+				Function: tt.function,
+				Arguments: []argument{
+					makePathArg(),
+				},
+			})
+			require.NoError(t, err)
+
+			got, err := fn.Eval(t.Context(), tt.tCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_NewFunctionCall_StringSliceGetterListValidation(t *testing.T) {
+	p, err := NewParser(
+		CreateFactoryMap(
+			createFactory[any](
+				"testing_stringslicegetter",
+				&stringSliceGetterArguments{},
+				functionWithStringSliceGetter,
+			),
+			createFactory[any](
+				"testing_stringlikeslicegetter",
+				&stringLikeSliceGetterArguments{},
+				functionWithStringLikeSliceGetter,
+			),
+		),
+		testParsePath[any],
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+	require.NoError(t, err)
+
+	t.Run("string slice getter rejects invalid literal element at parse-time", func(t *testing.T) {
+		_, err = p.newFunctionCall(editor{
+			Function: "testing_stringslicegetter",
+			Arguments: []argument{
+				{
+					Value: value{
+						List: &list{
+							Values: []value{
+								{String: ottltest.Strp("a")},
+								{Literal: &mathExprLiteral{Int: ottltest.Intp(1)}},
+								{
+									Literal: &mathExprLiteral{
+										Path: &path{
+											Fields: []field{
+												{Name: "name"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "error while parsing list argument at index 1")
+		assert.ErrorContains(t, err, "expected string but got int64")
+	})
+
+	t.Run("string slice getter accepts valid mixed list", func(t *testing.T) {
+		fn, err := p.newFunctionCall(editor{
+			Function: "testing_stringslicegetter",
+			Arguments: []argument{
+				{
+					Value: value{
+						List: &list{
+							Values: []value{
+								{String: ottltest.Strp("a")},
+								{
+									Literal: &mathExprLiteral{
+										Path: &path{
+											Fields: []field{
+												{Name: "name"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		got, err := fn.Eval(t.Context(), "b")
+		require.NoError(t, err)
+		assert.Equal(t, 2, got)
+	})
+
+	t.Run("string like slice getter preserves scalar conversion semantics", func(t *testing.T) {
+		fn, err := p.newFunctionCall(editor{
+			Function: "testing_stringlikeslicegetter",
+			Arguments: []argument{
+				{
+					Value: value{
+						List: &list{
+							Values: []value{
+								{String: ottltest.Strp("a")},
+								{Literal: &mathExprLiteral{Int: ottltest.Intp(1)}},
+								{
+									Literal: &mathExprLiteral{
+										Path: &path{
+											Fields: []field{
+												{Name: "name"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		got, err := fn.Eval(t.Context(), true)
+		require.NoError(t, err)
+		assert.Equal(t, 3, got)
+	})
+}
+
 func functionWithNoArguments() (ExprFunc[any], error) {
 	return func(context.Context, any) (any, error) {
 		return nil, nil
@@ -2169,6 +2352,34 @@ type intLikeGetterSliceArguments struct {
 func functionWithIntLikeGetterSlice(getters []IntLikeGetter[any]) (ExprFunc[any], error) {
 	return func(context.Context, any) (any, error) {
 		return len(getters), nil
+	}, nil
+}
+
+type stringSliceGetterArguments struct {
+	StringSliceGetter StringSliceGetter[any]
+}
+
+func functionWithStringSliceGetter(getter StringSliceGetter[any]) (ExprFunc[any], error) {
+	return func(ctx context.Context, tCtx any) (any, error) {
+		vals, err := getter.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return len(vals), nil
+	}, nil
+}
+
+type stringLikeSliceGetterArguments struct {
+	StringLikeSliceGetter StringLikeSliceGetter[any]
+}
+
+func functionWithStringLikeSliceGetter(getter StringLikeSliceGetter[any]) (ExprFunc[any], error) {
+	return func(ctx context.Context, tCtx any) (any, error) {
+		vals, err := getter.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return len(vals), nil
 	}, nil
 }
 

--- a/pkg/ottl/slice_getters.go
+++ b/pkg/ottl/slice_getters.go
@@ -1,0 +1,173 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
+)
+
+// StringSliceGetter is a Getter that must return []string.
+type StringSliceGetter[K any] interface {
+	// Get retrieves a []string value.
+	Get(ctx context.Context, tCtx K) ([]string, error)
+}
+
+// newStandardStringSliceGetter creates a new StandardStringSliceGetter from a Getter[K],
+// also checking if the Getter is a literalGetter.
+func newStandardStringSliceGetter[K any](getter Getter[K]) (StringSliceGetter[K], error) {
+	g := StandardStringSliceGetter[K]{
+		Getter: getter.Get,
+	}
+	if isLiteralGetter(getter) {
+		val, err := g.Get(context.Background(), *new(K))
+		if err != nil {
+			return nil, err
+		}
+		return newLiteral[K, []string](val), nil
+	}
+	return g, nil
+}
+
+type stringGetterListAsSliceGetter[K any] struct {
+	elems []StringGetter[K]
+}
+
+func newStringSliceGetterFromStringGetters[K any](elems []StringGetter[K]) StringSliceGetter[K] {
+	values := make([]string, 0, len(elems))
+	for _, elem := range elems {
+		val, isLiteral := GetLiteralValue[K, string](elem)
+		if !isLiteral {
+			return &stringGetterListAsSliceGetter[K]{elems: elems}
+		}
+		values = append(values, val)
+	}
+	return newLiteral[K, []string](values)
+}
+
+func (g *stringGetterListAsSliceGetter[K]) Get(ctx context.Context, tCtx K) ([]string, error) {
+	values := make([]string, len(g.elems))
+	for i, elem := range g.elems {
+		val, err := elem.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = val
+	}
+	return values, nil
+}
+
+// StandardStringSliceGetter is a basic implementation of StringSliceGetter.
+type StandardStringSliceGetter[K any] struct {
+	Getter func(ctx context.Context, tCtx K) (any, error)
+}
+
+func (g StandardStringSliceGetter[K]) Get(ctx context.Context, tCtx K) ([]string, error) {
+	val, err := g.Getter(ctx, tCtx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting value in %T: %w", g, err)
+	}
+	sliceVal, err := valueToPSlice(val)
+	if err != nil {
+		return nil, err
+	}
+	return pSliceToStringSlice(sliceVal)
+}
+
+// StringLikeSliceGetter is a Getter that must return []*string.
+type StringLikeSliceGetter[K any] interface {
+	// Get retrieves a []*string value.
+	Get(ctx context.Context, tCtx K) ([]*string, error)
+}
+
+// newStandardStringLikeSliceGetter creates a new StandardStringLikeSliceGetter from a Getter[K],
+// also checking if the Getter is a literalGetter.
+func newStandardStringLikeSliceGetter[K any](getter Getter[K]) (StringLikeSliceGetter[K], error) {
+	g := StandardStringLikeSliceGetter[K]{
+		Getter: getter.Get,
+	}
+	if isLiteralGetter(getter) {
+		val, err := g.Get(context.Background(), *new(K))
+		if err != nil {
+			return nil, err
+		}
+		return newLiteral[K, []*string](val), nil
+	}
+	return g, nil
+}
+
+type stringLikeGetterListAsSliceGetter[K any] struct {
+	elems []StringLikeGetter[K]
+}
+
+func newStringLikeSliceGetterFromStringLikeGetters[K any](elems []StringLikeGetter[K]) StringLikeSliceGetter[K] {
+	values := make([]*string, 0, len(elems))
+	for _, elem := range elems {
+		val, isLiteral := GetLiteralValue[K, *string](elem)
+		if !isLiteral {
+			return &stringLikeGetterListAsSliceGetter[K]{elems: elems}
+		}
+		values = append(values, val)
+	}
+	return newLiteral[K, []*string](values)
+}
+
+func (g *stringLikeGetterListAsSliceGetter[K]) Get(ctx context.Context, tCtx K) ([]*string, error) {
+	values := make([]*string, len(g.elems))
+	for i, elem := range g.elems {
+		val, err := elem.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = val
+	}
+	return values, nil
+}
+
+// StandardStringLikeSliceGetter is a basic implementation of StringLikeSliceGetter.
+type StandardStringLikeSliceGetter[K any] struct {
+	Getter func(ctx context.Context, tCtx K) (any, error)
+}
+
+func (g StandardStringLikeSliceGetter[K]) Get(ctx context.Context, tCtx K) ([]*string, error) {
+	val, err := g.Getter(ctx, tCtx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting value in %T: %w", g, err)
+	}
+	sliceVal, err := valueToPSlice(val)
+	if err != nil {
+		return nil, err
+	}
+	return pSliceToStringLikeSlice(sliceVal)
+}
+
+func pSliceToStringSlice(sliceVal pcommon.Slice) ([]string, error) {
+	values := make([]string, sliceVal.Len())
+	for i := 0; i < sliceVal.Len(); i++ {
+		strVal, err := valueToString(sliceVal.At(i))
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+		values[i] = strVal
+	}
+	return values, nil
+}
+
+func pSliceToStringLikeSlice(sliceVal pcommon.Slice) ([]*string, error) {
+	values := make([]*string, sliceVal.Len())
+	for i := 0; i < sliceVal.Len(); i++ {
+		// Unwrap pcommon.Value so slice-path elements stringify like literal-list
+		// elements, including bytes (hex here, not pcommon.Value.AsString base64).
+		stringLike, err := valueToStringLike(ottlcommon.GetValue(sliceVal.At(i)))
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+		values[i] = stringLike
+	}
+	return values, nil
+}

--- a/pkg/ottl/slice_getters_test.go
+++ b/pkg/ottl/slice_getters_test.go
@@ -1,0 +1,212 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
+)
+
+func Test_StandardStringSliceGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StandardStringSliceGetter[any]
+		want             []string
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "[]string type",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []string{"a", "b"}, nil
+				},
+			},
+			want:  []string{"a", "b"},
+			valid: true,
+		},
+		{
+			name: "[]any type",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{"a", "b"}, nil
+				},
+			},
+			want:  []string{"a", "b"},
+			valid: true,
+		},
+		{
+			name: "pcommon.Slice type",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					s := pcommon.NewSlice()
+					s.AppendEmpty().SetStr("a")
+					s.AppendEmpty().SetStr("b")
+					return s, nil
+				},
+			},
+			want:  []string{"a", "b"},
+			valid: true,
+		},
+		{
+			name: "invalid element type",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{"a", int64(1)}, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "element 1: expected string but got Int",
+		},
+		{
+			name: "invalid target type",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return true, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected pcommon.Slice but got bool",
+		},
+		{
+			name: "nil",
+			getter: StandardStringSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return nil, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected pcommon.Slice but got nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(t.Context(), nil)
+			if tt.valid {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, val)
+			} else {
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func Test_StandardStringLikeSliceGetter(t *testing.T) {
+	tests := []struct {
+		name                 string
+		getter               StandardStringLikeSliceGetter[any]
+		want                 []*string
+		valid                bool
+		expectedErrorMsg     string
+		expectedErrorContain string
+		wantTypeError        bool
+	}{
+		{
+			name: "[]string type",
+			getter: StandardStringLikeSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []string{"a", "b"}, nil
+				},
+			},
+			want: []*string{
+				ottltest.Strp("a"),
+				ottltest.Strp("b"),
+			},
+			valid: true,
+		},
+		{
+			name: "mixed []any type",
+			getter: StandardStringLikeSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{"a", int64(2), true, nil, []byte{0x0a}}, nil
+				},
+			},
+			want: []*string{
+				ottltest.Strp("a"),
+				ottltest.Strp("2"),
+				ottltest.Strp("true"),
+				nil,
+				ottltest.Strp("0a"),
+			},
+			valid: true,
+		},
+		{
+			name: "pcommon.Value slice with bytes element",
+			getter: StandardStringLikeSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					v := pcommon.NewValueSlice()
+					v.Slice().AppendEmpty().SetEmptyBytes().FromRaw([]byte{0x0a})
+					return v, nil
+				},
+			},
+			want: []*string{
+				ottltest.Strp("0a"),
+			},
+			valid: true,
+		},
+		{
+			name: "invalid element type in []any input",
+			getter: StandardStringLikeSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return []any{"a", make(chan int)}, nil
+				},
+			},
+			valid:                false,
+			expectedErrorContain: "element 1",
+			wantTypeError:        false,
+		},
+		{
+			name: "invalid target type",
+			getter: StandardStringLikeSliceGetter[any]{
+				Getter: func(context.Context, any) (any, error) {
+					return true, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected pcommon.Slice but got bool",
+			wantTypeError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(t.Context(), nil)
+			if tt.valid {
+				require.NoError(t, err)
+				require.Len(t, val, len(tt.want))
+				for i := range val {
+					if tt.want[i] == nil {
+						assert.Nil(t, val[i])
+					} else {
+						require.NotNil(t, val[i])
+						assert.Equal(t, *tt.want[i], *val[i])
+					}
+				}
+				return
+			}
+
+			require.Error(t, err)
+			if tt.expectedErrorMsg != "" {
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+			if tt.expectedErrorContain != "" {
+				assert.ErrorContains(t, err, tt.expectedErrorContain)
+			}
+			if tt.wantTypeError {
+				var typeErr TypeError
+				assert.ErrorAs(t, err, &typeErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add support for using slice/path expressions for function args in OTTL.
This will enable cases like:
```
- set(cache["list_of_keys"], ["test"])
- keep_keys(datapoint.attributes, cache["list_of_keys"])
```
and
```
- Concat(attributes["primitiveValuesSlice"], ";")
- Concat(Split(attributes["flags"], "|"), ";")
```
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45980
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27821
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/38690

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tested and added unit tests.
<!--Describe the documentation added.-->
#### Documentation
TODO
<!--Please delete paragraphs that you did not use before submitting.-->
