### PR TITLE
[chore][hostmetricsreceiver] Fix example config: uptime scraper renamed to system

### DIFF
--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -15,7 +15,7 @@ receivers:
       nfs:
       paging:
       processes:
-      uptime:
+      system:
 
 exporters:
   debug:


### PR DESCRIPTION
#### Description

The hostmetricsreceiver `uptime` scraper was renamed to system awhile ago, see #36123 . However, the sample config was never updated to match this, if the users uses `uptime` in their config the collector will not run as the `uptime` scraper is no longer present, this scraper has been renamed to system.

#### Using uptime

##### Config

```yaml
extensions:
  zpages:
    endpoint: 0.0.0.0:55679

receivers:
  hostmetrics:
    collection_interval: 1m
    scrapers:
      ...
      uptime:

exporters:
  debug:
  prometheus:
    endpoint: 0.0.0.0:8889

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      exporters: [prometheus, debug]

  extensions: [zpages]
```

##### Output

```bash
opentelemetry-collector-contrib main  ✗ make run otelcontribcol
cd ./cmd/otelcontribcol && GO111MODULE=on go run --race . --config ../../local/config.yaml
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

'receivers' error reading configuration for "hostmetrics": '' invalid scraper key: uptime
exit status 1
make: *** [Makefile:359: run] Error 1
```

#### Fix

Use `system` instead of uptime, this is only an issue with the [example-config.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/example_config.yaml?plain=1#L18) for hostmetrics, this work just renames `uptime` to `system`.