### PR TITLE
[chore] Use Make target for githubgen invocation

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Gen CODEOWNERS
         run: |
           cd pr
-          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} ../.tools/githubgen codeowners
+          GITHUB_TOKEN=${{ steps.otelbot-token.outputs.token }} make codeowners
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gencodeowners" or apply this diff and commit the changes in this PR.' && git diff && exit 1)
 
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -4,8 +4,8 @@ on:
     branches: [main]
     paths:
       - .github/CODEOWNERS
-      - ./.github/workflows/generate-component-labels.yml
-      - ./.github/workflows/scripts/generate-component-labels.sh
+      - .github/workflows/generate-component-labels.yml
+      - .github/workflows/scripts/generate-component-labels.sh
   workflow_dispatch:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,10 @@ update-codeowners: generate gengithub
 gencodeowners:
 	$(GITHUBGEN) -skipgithub
 
+.PHONY: codeowners
+codeowners:
+	$(GITHUBGEN) codeowners
+
 .PHONY: generate-chloggen-components
 generate-chloggen-components:
 	$(GITHUBGEN) chloggen-components


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow up from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/45739 to use Make to invoke githubgen.

I tried to clean things up a bit, but wasn't sure what should be used when and what makes sense to change. I've opened an issue to track this in case anyone would like to go deeper: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46150.