### PR TITLE
[receiver/k8s_cluster] Define entities and relationships in metadata.yaml

### DIFF
--- a/.chloggen/k8scluster-entities-relationships.yaml
+++ b/.chloggen/k8scluster-entities-relationships.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/k8s_cluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Define entities and relationships for Kubernetes resources in metadata.yaml.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41080]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/documentation.md
+++ b/receiver/k8sclusterreceiver/documentation.md
@@ -519,3 +519,202 @@ The number of load balancer ingress points (external IPs/hostnames) assigned to 
 | openshift.clusterquota.uid | The k8s ClusterResourceQuota uid. | Any Str | true |
 | os.description | The os description used by Kubernetes Node. | Any Str | false |
 | os.type | The os type used by Kubernetes Node. | Any Str | false |
+
+## Entities
+
+The following entities are defined for this component:
+
+### k8s.namespace
+
+A Kubernetes namespace
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.namespace.uid`
+
+**Descriptive Attributes:**
+- `k8s.namespace.name`
+
+### k8s.node
+
+A Kubernetes node
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.node.uid`
+
+**Descriptive Attributes:**
+- `k8s.node.name`
+- `k8s.kubelet.version`
+- `container.runtime`
+- `container.runtime.version`
+- `os.description`
+- `os.type`
+
+### k8s.deployment
+
+A Kubernetes deployment
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.deployment.uid`
+
+**Descriptive Attributes:**
+- `k8s.deployment.name`
+
+### k8s.replicaset
+
+A Kubernetes replicaset
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.replicaset.uid`
+
+**Descriptive Attributes:**
+- `k8s.replicaset.name`
+
+### k8s.statefulset
+
+A Kubernetes statefulset
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.statefulset.uid`
+
+**Descriptive Attributes:**
+- `k8s.statefulset.name`
+
+### k8s.daemonset
+
+A Kubernetes daemonset
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.daemonset.uid`
+
+**Descriptive Attributes:**
+- `k8s.daemonset.name`
+
+### k8s.cronjob
+
+A Kubernetes cronjob
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.cronjob.uid`
+
+**Descriptive Attributes:**
+- `k8s.cronjob.name`
+
+### k8s.job
+
+A Kubernetes job
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.job.uid`
+
+**Descriptive Attributes:**
+- `k8s.job.name`
+
+### k8s.pod
+
+A Kubernetes pod
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.pod.uid`
+
+**Descriptive Attributes:**
+- `k8s.pod.name`
+- `k8s.pod.qos_class`
+
+### k8s.container
+
+A Kubernetes container
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `container.id`
+
+**Descriptive Attributes:**
+- `k8s.container.name`
+- `container.image.name`
+- `container.image.tag`
+- `k8s.container.status.last_terminated_reason`
+
+### k8s.replicationcontroller
+
+A Kubernetes replication controller
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.replicationcontroller.uid`
+
+**Descriptive Attributes:**
+- `k8s.replicationcontroller.name`
+
+### k8s.resourcequota
+
+A Kubernetes resource quota
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.resourcequota.uid`
+
+**Descriptive Attributes:**
+- `k8s.resourcequota.name`
+
+### k8s.service
+
+A Kubernetes service
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.service.uid`
+
+**Descriptive Attributes:**
+- `k8s.service.name`
+- `k8s.service.type`
+- `k8s.service.publish_not_ready_addresses`
+- `k8s.service.traffic_distribution`
+
+### k8s.hpa
+
+A Kubernetes horizontal pod autoscaler
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `k8s.hpa.uid`
+
+**Descriptive Attributes:**
+- `k8s.hpa.name`
+- `k8s.hpa.scaletargetref.apiversion`
+- `k8s.hpa.scaletargetref.kind`
+- `k8s.hpa.scaletargetref.name`
+
+### openshift.clusterquota
+
+An OpenShift cluster resource quota
+
+**Stability:** Development
+
+**Identifying Attributes:**
+- `openshift.clusterquota.uid`
+
+**Descriptive Attributes:**
+- `openshift.clusterquota.name`

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/k8sleaderelector v0.146.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.146.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.146.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sleaderelectortest v0.146.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.146.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.146.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.146.0
@@ -27,6 +28,7 @@ require (
 	go.opentelemetry.io/collector/consumer/consumertest v0.146.1
 	go.opentelemetry.io/collector/filter v0.146.1
 	go.opentelemetry.io/collector/pdata v1.52.0
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.1
 	go.opentelemetry.io/collector/pipeline v1.52.0
 	go.opentelemetry.io/collector/receiver v1.52.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.146.1
@@ -39,8 +41,6 @@ require (
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
 )
-
-require github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sleaderelectortest v0.146.0
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/receiver/k8sclusterreceiver/go.sum
+++ b/receiver/k8sclusterreceiver/go.sum
@@ -242,6 +242,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.1 h1:W0bNpO+H7zLtH0+FfIBjTdU
 go.opentelemetry.io/collector/pdata/pprofile v0.146.1/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1 h1:MbDzTt/R+aXWrLa+c3WfQx9Wjd/XK6pTgM4dcWLUdlE=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.1 h1:kbjTAH6IsyzSXB9kh7cCeHloGAauGToWB9SFGeBjyJo=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.1/go.mod h1:UR/HuN42zhocRh0JTrTQKeywNOEzKU5HCOQpIMgyPS0=
 go.opentelemetry.io/collector/pipeline v1.52.0 h1:3I7Dq1eFUjM+OTqyESXBIa59fUjGBLoEkw3k8vRaOKQ=
 go.opentelemetry.io/collector/pipeline v1.52.0/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.1 h1:BG+d2LjF87d6wnJg0d9iQxLzMcawY0Nldg7LpVkfkno=

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_resource.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_resource.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/xpdata/entity"
 )
 
 // ResourceBuilder is a helper struct to build resources predefined in metadata.yaml.
@@ -334,6 +335,201 @@ func (rb *ResourceBuilder) SetOsType(val string) {
 	if rb.config.OsType.Enabled {
 		rb.res.Attributes().PutStr("os.type", val)
 	}
+}
+
+// AssociateWithK8sNamespace associates the resource with entity type "k8s.namespace".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sNamespace() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.namespace")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.namespace.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.namespace.name")
+}
+
+// AssociateWithK8sNode associates the resource with entity type "k8s.node".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sNode() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.node")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.node.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.node.name")
+	descKeys.Append("k8s.kubelet.version")
+	descKeys.Append("container.runtime")
+	descKeys.Append("container.runtime.version")
+	descKeys.Append("os.description")
+	descKeys.Append("os.type")
+}
+
+// AssociateWithK8sDeployment associates the resource with entity type "k8s.deployment".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sDeployment() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.deployment")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.deployment.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.deployment.name")
+}
+
+// AssociateWithK8sReplicaset associates the resource with entity type "k8s.replicaset".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sReplicaset() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.replicaset")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.replicaset.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.replicaset.name")
+}
+
+// AssociateWithK8sStatefulset associates the resource with entity type "k8s.statefulset".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sStatefulset() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.statefulset")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.statefulset.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.statefulset.name")
+}
+
+// AssociateWithK8sDaemonset associates the resource with entity type "k8s.daemonset".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sDaemonset() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.daemonset")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.daemonset.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.daemonset.name")
+}
+
+// AssociateWithK8sCronjob associates the resource with entity type "k8s.cronjob".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sCronjob() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.cronjob")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.cronjob.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.cronjob.name")
+}
+
+// AssociateWithK8sJob associates the resource with entity type "k8s.job".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sJob() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.job")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.job.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.job.name")
+}
+
+// AssociateWithK8sPod associates the resource with entity type "k8s.pod".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sPod() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.pod")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.pod.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.pod.name")
+	descKeys.Append("k8s.pod.qos_class")
+}
+
+// AssociateWithK8sContainer associates the resource with entity type "k8s.container".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sContainer() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.container")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("container.id")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.container.name")
+	descKeys.Append("container.image.name")
+	descKeys.Append("container.image.tag")
+	descKeys.Append("k8s.container.status.last_terminated_reason")
+}
+
+// AssociateWithK8sReplicationcontroller associates the resource with entity type "k8s.replicationcontroller".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sReplicationcontroller() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.replicationcontroller")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.replicationcontroller.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.replicationcontroller.name")
+}
+
+// AssociateWithK8sResourcequota associates the resource with entity type "k8s.resourcequota".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sResourcequota() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.resourcequota")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.resourcequota.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.resourcequota.name")
+}
+
+// AssociateWithK8sService associates the resource with entity type "k8s.service".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sService() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.service")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.service.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.service.name")
+	descKeys.Append("k8s.service.type")
+	descKeys.Append("k8s.service.publish_not_ready_addresses")
+	descKeys.Append("k8s.service.traffic_distribution")
+}
+
+// AssociateWithK8sHpa associates the resource with entity type "k8s.hpa".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithK8sHpa() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("k8s.hpa")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("k8s.hpa.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("k8s.hpa.name")
+	descKeys.Append("k8s.hpa.scaletargetref.apiversion")
+	descKeys.Append("k8s.hpa.scaletargetref.kind")
+	descKeys.Append("k8s.hpa.scaletargetref.name")
+}
+
+// AssociateWithOpenshiftClusterquota associates the resource with entity type "openshift.clusterquota".
+// This method is experimental and will be replaced with an entity builder pattern in the future.
+// However, for now, it allows associating resources with entities and producing correct entity references.
+func (rb *ResourceBuilder) AssociateWithOpenshiftClusterquota() {
+	entityRef := entity.ResourceEntityRefs(rb.res).AppendEmpty()
+	entityRef.SetType("openshift.clusterquota")
+	idKeys := entityRef.IdKeys()
+	idKeys.Append("openshift.clusterquota.uid")
+	descKeys := entityRef.DescriptionKeys()
+	descKeys.Append("openshift.clusterquota.name")
 }
 
 // Emit returns the built resource and resets the internal builder state.

--- a/receiver/k8sclusterreceiver/internal/node/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/node/nodes.go
@@ -59,7 +59,6 @@ func RecordMetrics(mb *metadata.MetricsBuilder, node *corev1.Node, ts pcommon.Ti
 	rb.SetK8sNodeUID(string(node.UID))
 	rb.SetK8sNodeName(node.Name)
 	rb.SetK8sKubeletVersion(node.Status.NodeInfo.KubeletVersion)
-
 	mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }
 

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -11,6 +11,192 @@ status:
 
 sem_conv_version: 1.18.0
 
+entities:
+  - type: k8s.namespace
+    brief: A Kubernetes namespace
+    stability: development
+    identity:
+      - ref: k8s.namespace.uid
+    description:
+      - ref: k8s.namespace.name
+
+  - type: k8s.node
+    brief: A Kubernetes node
+    stability: development
+    identity:
+      - ref: k8s.node.uid
+    description:
+      - ref: k8s.node.name
+      - ref: k8s.kubelet.version
+      - ref: container.runtime
+      - ref: container.runtime.version
+      - ref: os.description
+      - ref: os.type
+
+  - type: k8s.deployment
+    brief: A Kubernetes deployment
+    stability: development
+    identity:
+      - ref: k8s.deployment.uid
+    description:
+      - ref: k8s.deployment.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.replicaset
+    brief: A Kubernetes replicaset
+    stability: development
+    identity:
+      - ref: k8s.replicaset.uid
+    description:
+      - ref: k8s.replicaset.name
+    relationships:
+      - type: managed_by
+        target: k8s.deployment
+
+  - type: k8s.statefulset
+    brief: A Kubernetes statefulset
+    stability: development
+    identity:
+      - ref: k8s.statefulset.uid
+    description:
+      - ref: k8s.statefulset.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.daemonset
+    brief: A Kubernetes daemonset
+    stability: development
+    identity:
+      - ref: k8s.daemonset.uid
+    description:
+      - ref: k8s.daemonset.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.cronjob
+    brief: A Kubernetes cronjob
+    stability: development
+    identity:
+      - ref: k8s.cronjob.uid
+    description:
+      - ref: k8s.cronjob.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.job
+    brief: A Kubernetes job
+    stability: development
+    identity:
+      - ref: k8s.job.uid
+    description:
+      - ref: k8s.job.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+      - type: managed_by
+        target: k8s.cronjob
+
+  - type: k8s.pod
+    brief: A Kubernetes pod
+    stability: development
+    identity:
+      - ref: k8s.pod.uid
+    description:
+      - ref: k8s.pod.name
+      - ref: k8s.pod.qos_class
+    relationships:
+      - type: scheduled_on
+        target: k8s.node
+      - type: part_of
+        target: k8s.namespace
+      - type: managed_by
+        target: k8s.replicaset
+      - type: managed_by
+        target: k8s.statefulset
+      - type: managed_by
+        target: k8s.daemonset
+      - type: managed_by
+        target: k8s.job
+      - type: managed_by
+        target: k8s.replicationcontroller
+
+  - type: k8s.container
+    brief: A Kubernetes container
+    stability: development
+    identity:
+      - ref: container.id
+    description:
+      - ref: k8s.container.name
+      - ref: container.image.name
+      - ref: container.image.tag
+      - ref: k8s.container.status.last_terminated_reason
+    relationships:
+      - type: child_of
+        target: k8s.pod
+
+  - type: k8s.replicationcontroller
+    brief: A Kubernetes replication controller
+    stability: development
+    identity:
+      - ref: k8s.replicationcontroller.uid
+    description:
+      - ref: k8s.replicationcontroller.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.resourcequota
+    brief: A Kubernetes resource quota
+    stability: development
+    identity:
+      - ref: k8s.resourcequota.uid
+    description:
+      - ref: k8s.resourcequota.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.service
+    brief: A Kubernetes service
+    stability: development
+    identity:
+      - ref: k8s.service.uid
+    description:
+      - ref: k8s.service.name
+      - ref: k8s.service.type
+      - ref: k8s.service.publish_not_ready_addresses
+      - ref: k8s.service.traffic_distribution
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: k8s.hpa
+    brief: A Kubernetes horizontal pod autoscaler
+    stability: development
+    identity:
+      - ref: k8s.hpa.uid
+    description:
+      - ref: k8s.hpa.name
+      - ref: k8s.hpa.scaletargetref.apiversion
+      - ref: k8s.hpa.scaletargetref.kind
+      - ref: k8s.hpa.scaletargetref.name
+    relationships:
+      - type: part_of
+        target: k8s.namespace
+
+  - type: openshift.clusterquota
+    brief: An OpenShift cluster resource quota
+    stability: development
+    identity:
+      - ref: openshift.clusterquota.uid
+    description:
+      - ref: openshift.clusterquota.name
+
 resource_attributes:
   container.id:
     description: The container id.
@@ -293,6 +479,7 @@ metrics:
     stability: development
     gauge:
       value_type: double
+    entity: k8s.container
   k8s.container.cpu_request:
     enabled: true
     description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -300,6 +487,7 @@ metrics:
     stability: development
     gauge:
       value_type: double
+    entity: k8s.container
   k8s.container.ephemeralstorage_limit:
     enabled: true
     description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -307,6 +495,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.ephemeralstorage_request:
     enabled: true
     description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -314,6 +503,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.memory_limit:
     enabled: true
     description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -321,6 +511,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.memory_request:
     enabled: true
     description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -328,6 +519,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.ready:
     enabled: true
     description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
@@ -335,6 +527,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.restarts:
     enabled: true
     description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
@@ -342,6 +535,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.status.reason:
     enabled: false
     description: Experimental metric, may experience breaking changes. Describes the number of K8s containers that are currently in a state for a given reason. All possible container state reasons will be reported at each time interval to avoid missing metrics. Only the value corresponding to the current state reason will be non-zero.
@@ -353,6 +547,7 @@ metrics:
       value_type: int
     attributes:
       - k8s.container.status.reason
+    entity: k8s.container
   k8s.container.status.state:
     enabled: false
     description: Experimental metric, may experience breaking changes. Describes the number of K8s containers that are currently in a given state. All possible container states will be reported at each time interval to avoid missing metrics. Only the value corresponding to the current state will be non-zero.
@@ -364,6 +559,7 @@ metrics:
       value_type: int
     attributes:
       - k8s.container.status.state
+    entity: k8s.container
   k8s.container.storage_limit:
     enabled: true
     description: Maximum resource limit set for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -371,6 +567,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.container.storage_request:
     enabled: true
     description: Resource requested for the container. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core for details
@@ -378,6 +575,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.container
   k8s.cronjob.active_jobs:
     enabled: true
     description: The number of actively running jobs for a cronjob
@@ -385,6 +583,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.cronjob
 
   k8s.daemonset.current_scheduled_nodes:
     enabled: true
@@ -393,6 +592,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.daemonset
   k8s.daemonset.desired_scheduled_nodes:
     enabled: true
     description: Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)
@@ -400,6 +600,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.daemonset
   k8s.daemonset.misscheduled_nodes:
     enabled: true
     description: Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod
@@ -407,6 +608,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.daemonset
   k8s.daemonset.ready_nodes:
     enabled: true
     description: Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready
@@ -414,6 +616,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.daemonset
 
   k8s.deployment.available:
     enabled: true
@@ -422,6 +625,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.deployment
 
   k8s.deployment.desired:
     enabled: true
@@ -430,6 +634,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.deployment
   k8s.hpa.current_replicas:
     enabled: true
     description: Current number of pod replicas managed by this autoscaler.
@@ -437,6 +642,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.hpa
 
   k8s.hpa.desired_replicas:
     enabled: true
@@ -445,6 +651,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.hpa
 
   k8s.hpa.max_replicas:
     enabled: true
@@ -453,6 +660,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.hpa
 
   k8s.hpa.min_replicas:
     enabled: true
@@ -461,6 +669,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.hpa
 
   k8s.job.active_pods:
     enabled: true
@@ -469,6 +678,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.job
   k8s.job.desired_successful_pods:
     enabled: true
     description: The desired number of successfully finished pods the job should be run with
@@ -476,6 +686,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.job
   k8s.job.failed_pods:
     enabled: true
     description: The number of pods which reached phase Failed for a job
@@ -483,6 +694,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.job
   k8s.job.max_parallel_pods:
     enabled: true
     description: The max desired number of pods the job should run at any given time
@@ -490,6 +702,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.job
   k8s.job.successful_pods:
     enabled: true
     description: The number of pods which reached phase Succeeded for a job
@@ -497,6 +710,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.job
 
   k8s.namespace.phase:
     enabled: true
@@ -505,6 +719,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.namespace
 
   k8s.node.condition:
     enabled: false
@@ -515,6 +730,7 @@ metrics:
       value_type: int
     attributes:
       - condition
+    entity: k8s.node
   # k8s.node.condition_* metrics (k8s.node.condition_ready, k8s.node.condition_memory_pressure, etc) are controlled
   # by node_conditions_to_report config option. By default, only k8s.node.condition_ready is enabled.
 
@@ -528,6 +744,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.pod
   k8s.pod.status_reason:
     enabled: false
     description: Current status reason of the pod (1 - Evicted, 2 - NodeAffinity, 3 - NodeLost, 4 - Shutdown, 5 - UnexpectedAdmissionError, 6 - Unknown)
@@ -535,6 +752,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.pod
 
   k8s.replicaset.available:
     enabled: true
@@ -543,6 +761,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.replicaset
 
   k8s.replicaset.desired:
     enabled: true
@@ -551,6 +770,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.replicaset
   k8s.replication_controller.available:
     enabled: true
     description: Total number of available pods (ready for at least minReadySeconds) targeted by this replication_controller
@@ -558,6 +778,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.replicationcontroller
 
   k8s.replication_controller.desired:
     enabled: true
@@ -566,6 +787,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.replicationcontroller
 
   k8s.resource_quota.hard_limit:
     enabled: true
@@ -576,6 +798,7 @@ metrics:
       value_type: int
     attributes:
       - resource
+    entity: k8s.resourcequota
   k8s.resource_quota.used:
     enabled: true
     description: The usage for a particular resource in a specific namespace. Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores
@@ -585,6 +808,7 @@ metrics:
       value_type: int
     attributes:
       - resource
+    entity: k8s.resourcequota
 
   k8s.service.endpoint.count:
     enabled: false
@@ -597,6 +821,7 @@ metrics:
       - k8s.service.endpoint.address_type
       - k8s.service.endpoint.condition
       - k8s.service.endpoint.zone
+    entity: k8s.service
 
   k8s.service.load_balancer.ingress.count:
     enabled: false
@@ -605,6 +830,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.service
 
   k8s.statefulset.current_pods:
     enabled: true
@@ -613,6 +839,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.statefulset
 
   k8s.statefulset.desired_pods:
     enabled: true
@@ -621,6 +848,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.statefulset
 
   k8s.statefulset.ready_pods:
     enabled: true
@@ -629,6 +857,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.statefulset
 
   k8s.statefulset.updated_pods:
     enabled: true
@@ -637,6 +866,7 @@ metrics:
     stability: development
     gauge:
       value_type: int
+    entity: k8s.statefulset
 
   openshift.appliedclusterquota.limit:
     enabled: true
@@ -648,6 +878,7 @@ metrics:
     attributes:
       - k8s.namespace.name
       - resource
+    entity: openshift.clusterquota
   openshift.appliedclusterquota.used:
     enabled: true
     description: The usage for a particular resource in a specific namespace.
@@ -658,6 +889,7 @@ metrics:
     attributes:
       - k8s.namespace.name
       - resource
+    entity: openshift.clusterquota
   openshift.clusterquota.limit:
     enabled: true
     description: The configured upper limit for a particular resource.
@@ -667,6 +899,7 @@ metrics:
       value_type: int
     attributes:
       - resource
+    entity: openshift.clusterquota
   openshift.clusterquota.used:
     enabled: true
     description: The usage for a particular resource with a configured limit.
@@ -676,6 +909,7 @@ metrics:
       value_type: int
     attributes:
       - resource
+    entity: openshift.clusterquota
 
 tests:
   config:


### PR DESCRIPTION
Define entities and relationships for Kubernetes resources in metadata.yaml.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41080

This PR adds entity type definitions with their identity and descriptive attributes, as well as relationships between entities (e.g., pod managed_by replicaset, deployment part_of namespace). These definitions will be used by the metadata generator to create the necessary code for entity support in a future update.