### PR TITLE
[receiver/aws_cloudwatch]: add cloud.account.id to resource attributes

### DIFF
--- a/.chloggen/add_cloud_account_id.yaml
+++ b/.chloggen/add_cloud_account_id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add cloud.account.id to resource attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [45038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/add_cloud_account_id.yaml
+++ b/.chloggen/add_cloud_account_id.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/awscloudwatch
+component: receiver/aws_cloudwatch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: add cloud.account.id to resource attributes

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -21,7 +21,7 @@ the [AWS SDK for Cloudwatch Logs](https://docs.aws.amazon.com/sdk-for-go/api/ser
 
 This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) as mode of authentication, which includes [Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances.
 
-The receiver makes requests to the `sts.GetCallerIdentity` API endpoint, which is used to populate the `cloud.account.id` attribute. If this request is blocked or restricted then this attribute is omited.
+The receiver makes requests to the `sts.GetCallerIdentity` API endpoint, which is used to populate the `cloud.account.id` attribute. If this request is blocked or restricted then this attribute is omitted.
 
 ## Configuration
 

--- a/receiver/awscloudwatchreceiver/README.md
+++ b/receiver/awscloudwatchreceiver/README.md
@@ -21,6 +21,8 @@ the [AWS SDK for Cloudwatch Logs](https://docs.aws.amazon.com/sdk-for-go/api/ser
 
 This receiver uses the [AWS SDK](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) as mode of authentication, which includes [Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) and [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) authentication for EC2 instances.
 
+The receiver makes requests to the `sts.GetCallerIdentity` API endpoint, which is used to populate the `cloud.account.id` attribute. If this request is blocked or restricted then this attribute is omited.
+
 ## Configuration
 
 ### Top Level Parameters

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.38
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.67.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.82.3
+	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.159.0
@@ -42,7 +43,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7 // indirect
 	github.com/aws/smithy-go v1.27.8 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.28
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.44.0
 	github.com/goccy/go-json v0.10.6
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.156.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.156.0
@@ -43,7 +44,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.32.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.37.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.44.0 // indirect
 	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -46,6 +47,7 @@ type logsReceiver struct {
 	doneChan                      chan bool
 	storageID                     *component.ID
 	cloudwatchCheckpointPersister *cloudwatchCheckpointPersister
+	accountID                     string
 }
 
 type client interface {
@@ -385,6 +387,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
+			resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}
@@ -498,6 +501,14 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
+	if err != nil {
+		return err
+	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
+
+	stsClient := sts.NewFromConfig(cfg)
+	stsResult, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	l.accountID = *stsResult.Account
+
 	return err
 }

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -387,7 +387,9 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			if l.accountID != "" {
+				resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			}
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -507,7 +507,7 @@ func (l *logsReceiver) ensureSession() error {
 
 	stsClient := sts.NewFromConfig(cfg)
 	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	if len(*stsResult.Account) > 0 {
+	if stsClient != nil && len(*stsResult.Account) > 0 {
 		l.accountID = *stsResult.Account
 	}
 

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -387,7 +387,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			if l.accountID != "" {
+			if len(l.accountID) > 0 {
 				resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			}
 			if logStreamName != "" {
@@ -503,14 +503,13 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
-	if err != nil {
-		return err
-	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
 
 	stsClient := sts.NewFromConfig(cfg)
-	stsResult, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	l.accountID = *stsResult.Account
+	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	if len(*stsResult.Account) > 0 {
+		l.accountID = *stsResult.Account
+	}
 
 	return err
 }

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -507,7 +507,7 @@ func (l *logsReceiver) ensureSession() error {
 
 	stsClient := sts.NewFromConfig(cfg)
 	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	if stsClient != nil && len(*stsResult.Account) > 0 {
+	if stsClient != nil && *stsResult.Account != "" {
 		l.accountID = *stsResult.Account
 	}
 

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -387,7 +387,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			if len(l.accountID) > 0 {
+			if l.accountID != "" {
 				resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			}
 			if logStreamName != "" {

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -506,7 +506,7 @@ func (l *logsReceiver) ensureSession() error {
 
 	stsClient := sts.NewFromConfig(cfg)
 	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	if stsClient != nil && len(*stsResult.Account) > 0 {
+	if stsClient != nil && *stsResult.Account != "" {
 		l.accountID = *stsResult.Account
 	}
 

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -386,7 +386,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			if len(l.accountID) > 0 {
+			if l.accountID != "" {
 				resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			}
 			if logStreamName != "" {

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -506,7 +506,7 @@ func (l *logsReceiver) ensureSession() error {
 
 	stsClient := sts.NewFromConfig(cfg)
 	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	if len(*stsResult.Account) > 0 {
+	if stsClient != nil && len(*stsResult.Account) > 0 {
 		l.accountID = *stsResult.Account
 	}
 

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -386,7 +386,9 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			if l.accountID != "" {
+				resourceAttributes.PutStr("cloud.account.id", l.accountID)
+			}
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -46,6 +47,7 @@ type logsReceiver struct {
 	doneChan                      chan bool
 	storageID                     *component.ID
 	cloudwatchCheckpointPersister *cloudwatchCheckpointPersister
+	accountID                     string
 }
 
 type client interface {
@@ -384,6 +386,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
+			resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			if logStreamName != "" {
 				resourceAttributes.PutStr("cloudwatch.log.stream", logStreamName)
 			}
@@ -497,6 +500,14 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
+	if err != nil {
+		return err
+	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
+
+	stsClient := sts.NewFromConfig(cfg)
+	stsResult, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	l.accountID = *stsResult.Account
+
 	return err
 }

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -386,7 +386,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			resourceAttributes := resourceLogs.Resource().Attributes()
 			resourceAttributes.PutStr("aws.region", l.region)
 			resourceAttributes.PutStr("cloudwatch.log.group.name", logGroupName)
-			if l.accountID != "" {
+			if len(l.accountID) > 0 {
 				resourceAttributes.PutStr("cloud.account.id", l.accountID)
 			}
 			if logStreamName != "" {
@@ -502,14 +502,13 @@ func (l *logsReceiver) ensureSession() error {
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), cfgOptions...)
-	if err != nil {
-		return err
-	}
 	l.client = cloudwatchlogs.NewFromConfig(cfg)
 
 	stsClient := sts.NewFromConfig(cfg)
-	stsResult, err := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
-	l.accountID = *stsResult.Account
+	stsResult, _ := stsClient.GetCallerIdentity(context.Background(), &sts.GetCallerIdentityInput{})
+	if len(*stsResult.Account) > 0 {
+		l.accountID = *stsResult.Account
+	}
 
 	return err
 }

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -196,6 +196,43 @@ func TestPrefixedConfig(t *testing.T) {
 	require.NoError(t, plogtest.CompareLogs(expected, logs, plogtest.IgnoreObservedTimestamp()))
 }
 
+func TestWithAccountId(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			testLogGroupName: {
+				Names: []*string{&testLogStreamName},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	alertRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	alertRcvr.client = defaultMockClient()
+	alertRcvr.accountID = "111111111111"
+
+	err := alertRcvr.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	err = alertRcvr.Shutdown(t.Context())
+	require.NoError(t, err)
+
+	logs := sink.AllLogs()[0]
+	expected, err := golden.ReadLogs(filepath.Join("testdata", "processed", "prefixed-with-accountid.yaml"))
+	require.NoError(t, err)
+	require.NoError(t, plogtest.CompareLogs(expected, logs, plogtest.IgnoreObservedTimestamp()))
+}
+
 func TestPrefixedNamedStreamsConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Region = "us-west-1"

--- a/receiver/awscloudwatchreceiver/testdata/processed/prefixed-with-accountid.yaml
+++ b/receiver/awscloudwatchreceiver/testdata/processed/prefixed-with-accountid.yaml
@@ -1,0 +1,75 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: aws.region
+          value:
+            stringValue: us-west-1
+        - key: cloudwatch.log.group.name
+          value:
+            stringValue: test-log-group-name
+        - key: cloudwatch.log.stream
+          value:
+            stringValue: test-log-stream-name
+        - key: cloud.account.id
+          value:
+            stringValue: "111111111111"
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333379"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333380"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+        scope: {}
+  - resource:
+      attributes:
+        - key: aws.region
+          value:
+            stringValue: us-west-1
+        - key: cloudwatch.log.group.name
+          value:
+            stringValue: test-log-group-name
+        - key: cloudwatch.log.stream
+          value:
+            stringValue: test-log-stream-name-2
+        - key: cloud.account.id
+          value:
+            stringValue: "111111111111"
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333381"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333382"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+        scope: {}


### PR DESCRIPTION
#### Description
Logs coming from this receiver are missing `cloud.account.id`, if the collector is running in the same account as the source log groups then the attribute can be added using resource detection. 

However if the collector is running in different account then we need to use the established pattern identifying the account id, using the `sts` call to `GetCallerIdentity`. This will work as expected in both use cases.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45038 
Re-Open: #45039

