### PR TITLE
[exporter/elasticsearch] Fix retry backoff overflow handling edge case

### DIFF
--- a/.chloggen/elasticsearch-retry-backoff-overflow.yaml
+++ b/.chloggen/elasticsearch-retry-backoff-overflow.yaml
@@ -1,7 +1,7 @@
 change_type: bug_fix
 component: exporter/elasticsearch
 note: Fix retry exponential backoff overflow handling in Elasticsearch exporter
-issues: [39304]
+issues: [46178]
 subtext: |
   The retry delay growth now guards against duration overflow while preserving
   exponential backoff with jitter, so retries cap correctly at the configured

--- a/.chloggen/elasticsearch-retry-backoff-overflow.yaml
+++ b/.chloggen/elasticsearch-retry-backoff-overflow.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: exporter/elasticsearch
+note: Fix retry exponential backoff overflow handling in Elasticsearch exporter
+issues: [39304]
+subtext: |
+  The retry delay growth now guards against duration overflow while preserving
+  exponential backoff with jitter, so retries cap correctly at the configured
+  max interval even for large attempt counts.
+change_logs: [user]

--- a/.chloggen/elasticsearch-retry-backoff-overflow.yaml
+++ b/.chloggen/elasticsearch-retry-backoff-overflow.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 component: exporter/elasticsearch
-note: Fix retry exponential backoff overflow handling in Elasticsearch exporter
+note: Fix retry exponential backoff overflow handling edge case
 issues: [46178]
 subtext: |
   The retry delay growth now guards against duration overflow while preserving

--- a/exporter/elasticsearchexporter/esclient.go
+++ b/exporter/elasticsearchexporter/esclient.go
@@ -260,13 +260,17 @@ func addrsToURLs(addrs []string) ([]*url.URL, error) {
 	return urls, nil
 }
 
+// createElasticsearchBackoffFunc creates an exponential backoff with equal jitter.
 func createElasticsearchBackoffFunc(config *RetrySettings) func(int) time.Duration {
 	if !config.Enabled {
 		return nil
 	}
 
 	return func(attempts int) time.Duration {
-		next := min(config.MaxInterval, config.InitialInterval*(1<<(attempts-1)))
+		next := config.InitialInterval << (attempts - 1) // config.InitialInterval * 2 ^ (attempts - 1)
+		if next <= 0 || next > config.MaxInterval {      // guard against overflow
+			next = config.MaxInterval
+		}
 		nextWithJitter := next/2 + time.Duration(rand.Float64()*float64(next/2))
 		return nextWithJitter
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Guard exponential retry backoff against duration overflow so delay growth remains bounded and correctly caps at max_interval while preserving jitter.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
