### PR TITLE
[receiver/datadog] Add new `/intake` behaviour

### DIFF
--- a/.chloggen/datadogreceiver_intake-swallow.yaml
+++ b/.chloggen/datadogreceiver_intake-swallow.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add 'swallow' intake endpoint setting
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The 'swallow' setting causes the `/intake` endpoint of the datadogreceiver
+  to return "202 Accepted" (the expected response from `/intake`)
+  but to discard the received data without any further processing.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/datadogreceiver_intake-swallow.yaml
+++ b/.chloggen/datadogreceiver_intake-swallow.yaml
@@ -10,7 +10,7 @@ component: receiver/datadog
 note: Add 'swallow' intake endpoint setting
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [46185]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/datadogreceiver/README.md
+++ b/receiver/datadogreceiver/README.md
@@ -87,6 +87,9 @@ receivers:
           fail_on_invalid_key: true
 ```
 
+There is also a `behavior: swallow` setting, which causes the receiver to discard the `/intake` data but to still return a `202 Accepted`.
+This is useful for preventing clients from complaining about bad responses from the `/intake` endpoint when its functionality is not wanted.
+
 ### Metric Tag→Attribute Conversion
 
 Datadog [metric tags](https://docs.datadoghq.com/getting_started/tagging/) are expected to be in a `key:value` format.

--- a/receiver/datadogreceiver/config.go
+++ b/receiver/datadogreceiver/config.go
@@ -28,6 +28,7 @@ const (
 
 	configIntakeBehaviorDisable = "disable"
 	configIntakeBehaviorProxy   = "proxy"
+	configIntakeBehaviorSwallow = "swallow"
 )
 
 type Config struct {
@@ -49,6 +50,7 @@ type IntakeConfig struct {
 	// The value should be one of:
 	// `disable` (default) - disable the endpoint entirely
 	// `proxy` - proxy the requests to Datadog itself
+	// `swallow` - return "202 Accepted" but discard the data (fake-proxy)
 	Behavior string `mapstructure:"behavior"`
 	// Proxy controls how the `/intake` proxy operates
 	Proxy ProxyConfig `mapstructure:"proxy"`
@@ -65,7 +67,7 @@ type ProxyConfig struct {
 
 func (c *Config) Validate() error {
 	behavior := c.Intake.Behavior
-	isValidBehavior := behavior == "" || behavior == configIntakeBehaviorDisable || behavior == configIntakeBehaviorProxy
+	isValidBehavior := behavior == "" || behavior == configIntakeBehaviorDisable || behavior == configIntakeBehaviorProxy || behavior == configIntakeBehaviorSwallow
 	if !isValidBehavior {
 		return fmt.Errorf(`"intake.behavior" has an invalid value "%s"`, behavior)
 	}

--- a/receiver/datadogreceiver/config.schema.yaml
+++ b/receiver/datadogreceiver/config.schema.yaml
@@ -4,7 +4,7 @@ $defs:
     type: object
     properties:
       behavior:
-        description: 'Behavior sets how the `/intake` endpoint should behave. The value should be one of: `disable` (default) - disable the endpoint entirely `proxy` - proxy the requests to Datadog itself'
+        description: 'Behavior sets how the `/intake` endpoint should behave. The value should be one of: `disable` (default) - disable the endpoint entirely `proxy` - proxy the requests to Datadog itself `swallow` - return "202 Accepted" but discard the data (fake-proxy)'
         type: string
       proxy:
         description: Proxy controls how the `/intake` proxy operates

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -624,7 +624,15 @@ func (ddr *datadogReceiver) handleSketches(w http.ResponseWriter, req *http.Requ
 
 // handleIntake handles operational calls made by the agent to submit host tags and other metadata to the backend.
 func (ddr *datadogReceiver) handleIntake(w http.ResponseWriter, req *http.Request) {
-	if ddr.intakeReverseProxy == nil {
+	if ddr.config.Intake.Behavior == configIntakeBehaviorSwallow {
+		w.Header().Set("content-type", "text/plain")
+		w.Header().Set("content-length", "8")
+		w.Header().Set("x-content-type-options", "nosniff")
+		// at the time of writing `date` and `strict-transport-security` are also sent as response headers by Datadog
+		// but those are more complicated to set here and do not seem critical to clients so we don't set them
+		w.WriteHeader(202)
+		w.Write([]byte("Accepted"))
+	} else if ddr.intakeReverseProxy == nil {
 		http.Error(w, "intake endpoint not enabled", http.StatusMethodNotAllowed)
 	} else {
 		ddr.intakeReverseProxy.ServeHTTP(w, req)

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -624,17 +624,18 @@ func (ddr *datadogReceiver) handleSketches(w http.ResponseWriter, req *http.Requ
 
 // handleIntake handles operational calls made by the agent to submit host tags and other metadata to the backend.
 func (ddr *datadogReceiver) handleIntake(w http.ResponseWriter, req *http.Request) {
-	if ddr.config.Intake.Behavior == configIntakeBehaviorSwallow {
+	switch ddr.config.Intake.Behavior {
+	case configIntakeBehaviorSwallow:
 		w.Header().Set("content-type", "text/plain")
 		w.Header().Set("content-length", "8")
 		w.Header().Set("x-content-type-options", "nosniff")
 		// at the time of writing `date` and `strict-transport-security` are also sent as response headers by Datadog
 		// but those are more complicated to set here and do not seem critical to clients so we don't set them
-		w.WriteHeader(202)
-		w.Write([]byte("Accepted"))
-	} else if ddr.intakeReverseProxy == nil {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("Accepted"))
+	case configIntakeBehaviorDisable:
 		http.Error(w, "intake endpoint not enabled", http.StatusMethodNotAllowed)
-	} else {
+	case configIntakeBehaviorProxy:
 		ddr.intakeReverseProxy.ServeHTTP(w, req)
 	}
 }


### PR DESCRIPTION
#### Description

Datadog's /intake endpoint is used by clients (such as a datadog agent) to record information about the system they're running on. It's not a metrics/logs/traces endpoint, but instead accepts metadata about a specific host on which telemetry is collected. This metadata is used by Datadog to enrich metrics for a specific host (e.g. host-specific tags that should be associated with all metrics from that host).

Clients expect to receive a "202 Accepted" from the `/intake` endpoint. Currently, if not reverse proxying, the OpenTelemetry Collector returns a 4xx status code. This causes clients to flag that the `/intake` endpoint is failing (e.g. the agent will spam error logs). The new "swallow" setting added in this PR allows the OpenTelemetry Collector to respond in a way that clients expect without actually processing the `/intake` data (the default "disable" behavior).

#### Testing

Ran both simulated calls and ran a client against this receiver. The collector properly received and responded to the /intake calls, and the client saw "202 Accepted".

#### Documentation

Updated the README for the receiver and the schema documentation.
