### PR TITLE
docs: Update kubeletstats receiver documentation to use more fine-grained permissions

### DIFF
--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -326,7 +326,7 @@ with detailed sample configurations in [testdata/config.yaml](./testdata/config.
 
 ### Role-based access control
 
-The Kubelet Stats Receiver needs `get` permissions on the `nodes/stats` resources. Additionally, when using `extra_metadata_labels` or any of the `{request|limit}_utilization` metrics the receiver also needs `get` permissions for `nodes/proxy` resources.
+The Kubelet Stats Receiver needs `get` permissions on the `nodes/stats` resources. Additionally, when using `extra_metadata_labels` or any of the `{request|limit}_utilization` metrics the receiver also needs `get` permissions for `nodes/pods` resources.
 
 When using `k8s_api_config` to collect detailed volume metadata from PersistentVolumeClaims (as described in [Collecting Additional Volume Metadata](#collecting-additional-volume-metadata)), the receiver also needs `get` permissions for `persistentvolumeclaims` and `persistentvolumes` resources.
 
@@ -343,7 +343,7 @@ rules:
   # Only needed if you are using extra_metadata_labels or
   # are collecting the request/limit utilization metrics
   - apiGroups: [""]
-    resources: ["nodes/proxy"]
+    resources: ["nodes/pods"]
     verbs: ["get"]
 
   # Only needed if you are using k8s_api_config to collect


### PR DESCRIPTION
Context: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/2056

When using the `/pods` endpoint on the kubelet, you only need the "pods" subresource, not the entire "proxy" subresource:

https://kubernetes.io/docs/reference/access-authn-authz/kubelet-authn-authz/#fine-grained-authorization