### PR TITLE
[PoC][extension/datadog] populate gateway info

### DIFF
--- a/extension/datadogextension/README.md
+++ b/extension/datadogextension/README.md
@@ -105,6 +105,102 @@ extensions:
     deployment_type: daemonset
 ```
 
+## Gateway Service Discovery
+
+When `deployment_type` is `gateway`, you can set `gateway_service` to the name of the Kubernetes Service that fronts the collector. The extension will query the Kubernetes EndpointSlice API at startup to discover which pods and endpoints back the service, and include that information in the metadata payload sent to Datadog.
+
+**Configuration:**
+
+```yaml
+extensions:
+  datadog:
+    api:
+      key: <YOUR_DATADOG_API_KEY>
+      site: "datadoghq.com"
+    deployment_type: gateway
+    gateway_service: "monitoring/otelcol-gateway"   # namespace/service, or just "service"
+```
+
+- `gateway_service`: The name of the Kubernetes Service. Accepts `"service-name"` or `"namespace/service-name"` format. When no namespace is provided, the extension tries to determine the current namespace from the in-cluster service account (i.e. `/var/run/secrets/kubernetes.io/serviceaccount/namespace`); if that is not available, the API call is made with an empty namespace (which lists across all namespaces).
+
+**What is collected:**
+
+The extension lists EndpointSlices with the label `kubernetes.io/service-name=<service>` using the Kubernetes `discovery.k8s.io/v1` API and populates the following fields in the payload:
+
+| Field | Description |
+|---|---|
+| `service` | The configured service name |
+| `namespace` | Kubernetes namespace |
+| `ports` | Port/protocol strings exposed by the service (e.g. `"4317/TCP"`) |
+| `pods` | Names of the pods currently backing the service |
+| `addresses` | Endpoint IP addresses of the backing pods |
+| `address_type` | Address family: `IPv4`, `IPv6`, or `FQDN` |
+
+If the Kubernetes client cannot be initialized or the API call returns an error, a warning is logged and the payload is sent without gateway info — the rest of the extension continues to function normally.
+
+**Authentication:**
+
+The extension uses the standard Kubernetes client-go authentication chain:
+
+1. **In-cluster** (recommended for production): When the collector runs as a Pod, it automatically uses the Pod's service account token and CA certificate mounted at `/var/run/secrets/kubernetes.io/serviceaccount/`.
+2. **Kubeconfig** (for out-of-cluster use): When not running in a Pod, the extension falls back to the default kubeconfig (typically `~/.kube/config` or the path in `$KUBECONFIG`).
+
+**Kubernetes RBAC:**
+
+The service account running the collector Pod needs permission to list EndpointSlices. Grant it with a `ClusterRole` and `ClusterRoleBinding`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otelcol-gateway-discovery
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otelcol-gateway-discovery
+subjects:
+  - kind: ServiceAccount
+    name: <collector-service-account>
+    namespace: <collector-namespace>
+roleRef:
+  kind: ClusterRole
+  name: otelcol-gateway-discovery
+  apiGroup: rbac.authorization.k8s.io
+```
+
+If `gateway_service` includes an explicit namespace (e.g. `"monitoring/otelcol-gateway"`), a namespace-scoped `Role` / `RoleBinding` is sufficient:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: otelcol-gateway-discovery
+  namespace: monitoring
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: otelcol-gateway-discovery
+  namespace: monitoring
+subjects:
+  - kind: ServiceAccount
+    name: <collector-service-account>
+    namespace: <collector-namespace>
+roleRef:
+  kind: Role
+  name: otelcol-gateway-discovery
+  apiGroup: rbac.authorization.k8s.io
+```
+
 ## Notes
 - The extension is in active development. Functionality and configuration options may change as Datadog OpenTelemetry monitoring features evolve.
 - Please see [official documentation on Datadog's website](https://docs.datadoghq.com/opentelemetry/integrations/datadog_extension/) for more details.

--- a/extension/datadogextension/config.go
+++ b/extension/datadogextension/config.go
@@ -27,6 +27,12 @@ type Config struct {
 	// DeploymentType indicates the type of deployment (gateway, daemonset, or unknown).
 	// Defaults to "unknown" if not set.
 	DeploymentType string `mapstructure:"deployment_type"`
+	// GatewayService is the name of the k8s Service that fronts this gateway collector.
+	// When set, the extension queries kubectl to retrieve endpoint slice information for
+	// the service and includes it in the reported payload. Supports "service" or
+	// "namespace/service" format; if no namespace is given, the current kubeconfig
+	// context namespace is used. Requires kubectl to be available on the PATH.
+	GatewayService string `mapstructure:"gateway_service"`
 }
 
 // Validate ensures that the configuration is valid.

--- a/extension/datadogextension/config_test.go
+++ b/extension/datadogextension/config_test.go
@@ -197,6 +197,26 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "Valid configuration with gateway_service",
+			config: Config{
+				API: datadogconfig.APIConfig{
+					Site: datadogconfig.DefaultSite,
+					Key:  "1234567890abcdef1234567890abcdef",
+				},
+				HTTPConfig: &httpserver.Config{
+					ServerConfig: confighttp.ServerConfig{
+						NetAddr: confignet.AddrConfig{
+							Transport: confignet.TransportTypeTCP,
+							Endpoint:  "localhost:8080",
+						},
+					},
+					Path: "/metadata",
+				},
+				GatewayService: "monitoring/otelcol-gateway",
+			},
+			wantErr: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/extension/datadogextension/extension.go
+++ b/extension/datadogextension/extension.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/componentchecker"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/gateway"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/httpserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
@@ -89,6 +90,10 @@ type datadogExtension struct {
 
 	// Fields for periodic payload sending
 	payloadSender *payloadSender
+
+	// gatewayLister is used to fetch gateway EndpointSlice information via the Kubernetes API.
+	// Initialized from NewK8sLister when gateway_service is configured; can be swapped in tests.
+	gatewayLister gateway.EndpointSliceLister
 }
 
 var (
@@ -100,7 +105,7 @@ var (
 // NotifyConfig implements the extensioncapabilities.ConfigWatcher interface, which allows
 // this extension to be notified of the Collector's effective configuration.
 // This method is called during startup by the Collector's service after calling Start.
-func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) error {
+func (e *datadogExtension) NotifyConfig(ctx context.Context, conf *confmap.Conf) error {
 	e.configs.mutex.Lock()
 	defer e.configs.mutex.Unlock()
 
@@ -146,6 +151,16 @@ func (e *datadogExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) e
 		e.logger.Warn("Failed to populate active components list", zap.Error(err))
 	} else if activeComponents != nil {
 		otelCollectorPayload.ActiveComponents = *activeComponents
+	}
+
+	// Populate GatewayInfo if a gateway_service is configured.
+	if e.configs.extension.GatewayService != "" && e.gatewayLister != nil {
+		gatewayInfo, err := gateway.FetchGatewayInfo(ctx, e.configs.extension.GatewayService, e.gatewayLister)
+		if err != nil {
+			e.logger.Warn("Failed to fetch gateway endpoint slice info", zap.String("service", e.configs.extension.GatewayService), zap.Error(err))
+		} else {
+			otelCollectorPayload.GatewayInfo = &gatewayInfo
+		}
 	}
 
 	// TODO: Populate HealthStatus from the pkg/status.
@@ -414,6 +429,14 @@ func newExtension(
 			ticker:  ticker,
 			channel: channel,
 		},
+	}
+	if cfg.GatewayService != "" {
+		lister, listerErr := gateway.NewK8sLister()
+		if listerErr != nil {
+			set.Logger.Warn("Failed to create Kubernetes client for gateway service discovery; gateway info will not be collected", zap.Error(listerErr))
+		} else {
+			e.gatewayLister = lister
+		}
 	}
 	return e, nil
 }

--- a/extension/datadogextension/go.mod
+++ b/extension/datadogextension/go.mod
@@ -28,6 +28,9 @@ require (
 	go.opentelemetry.io/collector/service v0.146.1
 	go.opentelemetry.io/collector/service/hostcapabilities v0.146.1
 	go.uber.org/zap v1.27.1
+	k8s.io/api v0.35.1
+	k8s.io/apimachinery v0.35.1
+	k8s.io/client-go v0.35.1
 )
 
 require (
@@ -295,9 +298,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.1 // indirect
-	k8s.io/apimachinery v0.35.1 // indirect
-	k8s.io/client-go v0.35.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/extension/datadogextension/internal/gateway/gateway.go
+++ b/extension/datadogextension/internal/gateway/gateway.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gateway provides utilities for querying Kubernetes EndpointSlice information
+// for a gateway collector deployment using the Kubernetes API.
+package gateway // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/gateway"
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/datadogextension/internal/payload"
+)
+
+// EndpointSliceLister lists EndpointSlices for a given namespace and label selector.
+// This interface allows tests to inject a fake implementation.
+type EndpointSliceLister interface {
+	ListEndpointSlices(ctx context.Context, namespace, labelSelector string) ([]discoveryv1.EndpointSlice, error)
+}
+
+// k8sLister is the real implementation backed by a Kubernetes client.
+type k8sLister struct {
+	client kubernetes.Interface
+}
+
+// ListEndpointSlices queries the Kubernetes API for EndpointSlices matching the given label selector.
+func (l *k8sLister) ListEndpointSlices(ctx context.Context, namespace, labelSelector string) ([]discoveryv1.EndpointSlice, error) {
+	list, err := l.client.DiscoveryV1().EndpointSlices(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// NewK8sLister creates an EndpointSliceLister backed by a Kubernetes client.
+// It tries in-cluster config first, then falls back to the default kubeconfig.
+func NewK8sLister() (EndpointSliceLister, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		// Fall back to kubeconfig (e.g. for local development or out-of-cluster deployments)
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
+		cfg, err = kubeconfig.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
+		}
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	return &k8sLister{client: client}, nil
+}
+
+// FetchGatewayInfo queries the Kubernetes EndpointSlice(s) that back the given
+// service and returns a populated GatewayInfo.
+//
+// service may be in "name" or "namespace/name" format. When no namespace is
+// provided, FetchGatewayInfo attempts to determine the current namespace from
+// the in-cluster service account file.
+func FetchGatewayInfo(ctx context.Context, service string, lister EndpointSliceLister) (payload.GatewayInfo, error) {
+	svcName, namespace := parseServiceName(service)
+
+	if namespace == "" {
+		if ns, err := getInClusterNamespace(); err == nil {
+			namespace = ns
+		}
+	}
+
+	labelSelector := "kubernetes.io/service-name=" + svcName
+	slices, err := lister.ListEndpointSlices(ctx, namespace, labelSelector)
+	if err != nil {
+		return payload.GatewayInfo{}, fmt.Errorf("failed to list endpoint slices for service %q: %w", service, err)
+	}
+
+	return buildGatewayInfo(svcName, namespace, slices), nil
+}
+
+// parseServiceName splits "namespace/service" into its components.
+// If no slash is present the namespace is returned as an empty string.
+func parseServiceName(service string) (name, namespace string) {
+	if idx := strings.IndexByte(service, '/'); idx != -1 {
+		return service[idx+1:], service[:idx]
+	}
+	return service, ""
+}
+
+const inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func getInClusterNamespace() (string, error) {
+	if _, err := os.Stat(inClusterNamespacePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("not running in-cluster, namespace not determinable")
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %w", err)
+	}
+	ns, err := os.ReadFile(inClusterNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %w", err)
+	}
+	return string(ns), nil
+}
+
+func buildGatewayInfo(svcName, namespace string, slices []discoveryv1.EndpointSlice) payload.GatewayInfo {
+	info := payload.GatewayInfo{
+		Service:   svcName,
+		Namespace: namespace,
+	}
+
+	portsSet := make(map[string]struct{})
+	podsSet := make(map[string]struct{})
+	addressesSet := make(map[string]struct{})
+
+	for _, slice := range slices {
+		if info.AddressType == "" {
+			info.AddressType = string(slice.AddressType)
+		}
+
+		for _, p := range slice.Ports {
+			if p.Port == nil {
+				continue
+			}
+			portStr := fmt.Sprintf("%d", *p.Port)
+			if p.Protocol != nil && string(*p.Protocol) != "" {
+				portStr += "/" + string(*p.Protocol)
+			}
+			portsSet[portStr] = struct{}{}
+		}
+
+		for _, ep := range slice.Endpoints {
+			if ep.TargetRef != nil && ep.TargetRef.Kind == "Pod" {
+				podsSet[ep.TargetRef.Name] = struct{}{}
+			}
+			for _, addr := range ep.Addresses {
+				addressesSet[addr] = struct{}{}
+			}
+		}
+	}
+
+	for p := range portsSet {
+		info.Ports = append(info.Ports, p)
+	}
+	for pod := range podsSet {
+		info.Pods = append(info.Pods, pod)
+	}
+	for addr := range addressesSet {
+		info.Addresses = append(info.Addresses, addr)
+	}
+
+	// Sort for deterministic output.
+	sort.Strings(info.Ports)
+	sort.Strings(info.Pods)
+	sort.Strings(info.Addresses)
+
+	return info
+}

--- a/extension/datadogextension/internal/gateway/gateway_test.go
+++ b/extension/datadogextension/internal/gateway/gateway_test.go
@@ -1,0 +1,179 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+// fakeLister is a test double for EndpointSliceLister.
+type fakeLister struct {
+	slices            []discoveryv1.EndpointSlice
+	err               error
+	capturedNamespace string
+	capturedSelector  string
+}
+
+func (f *fakeLister) ListEndpointSlices(_ context.Context, namespace, labelSelector string) ([]discoveryv1.EndpointSlice, error) {
+	f.capturedNamespace = namespace
+	f.capturedSelector = labelSelector
+	return f.slices, f.err
+}
+
+// makeSampleSlices returns a minimal but realistic EndpointSlice list.
+func makeSampleSlices() []discoveryv1.EndpointSlice {
+	tcp := corev1.ProtocolTCP
+	port4317 := int32(4317)
+	port4318 := int32(4318)
+	return []discoveryv1.EndpointSlice{
+		{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{
+					Addresses: []string{"10.0.0.1"},
+					TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: "otelcol-pod-abc"},
+				},
+				{
+					Addresses: []string{"10.0.0.2"},
+					TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: "otelcol-pod-def"},
+				},
+			},
+			Ports: []discoveryv1.EndpointPort{
+				{Port: &port4317, Protocol: &tcp},
+				{Port: &port4318, Protocol: &tcp},
+			},
+		},
+	}
+}
+
+func TestFetchGatewayInfo_Success(t *testing.T) {
+	lister := &fakeLister{slices: makeSampleSlices()}
+	info, err := FetchGatewayInfo(context.Background(), "my-service", lister)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-service", info.Service)
+	assert.Equal(t, "IPv4", info.AddressType)
+	assert.Equal(t, []string{"4317/TCP", "4318/TCP"}, info.Ports)
+	assert.Equal(t, []string{"otelcol-pod-abc", "otelcol-pod-def"}, info.Pods)
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, info.Addresses)
+}
+
+func TestFetchGatewayInfo_WithNamespace(t *testing.T) {
+	lister := &fakeLister{slices: makeSampleSlices()}
+	info, err := FetchGatewayInfo(context.Background(), "monitoring/my-service", lister)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-service", info.Service)
+	assert.Equal(t, "monitoring", info.Namespace)
+
+	// Verify the namespace and label selector were passed correctly.
+	assert.Equal(t, "monitoring", lister.capturedNamespace)
+	assert.Equal(t, "kubernetes.io/service-name=my-service", lister.capturedSelector)
+}
+
+func TestFetchGatewayInfo_WithoutNamespace(t *testing.T) {
+	lister := &fakeLister{slices: makeSampleSlices()}
+	// Without a namespace, FetchGatewayInfo tries in-cluster namespace detection,
+	// which will fail outside a cluster, so namespace stays "".
+	_, err := FetchGatewayInfo(context.Background(), "my-service", lister)
+	require.NoError(t, err)
+
+	// Label selector should still reference the service.
+	assert.Equal(t, "kubernetes.io/service-name=my-service", lister.capturedSelector)
+}
+
+func TestFetchGatewayInfo_ListerError(t *testing.T) {
+	lister := &fakeLister{err: fmt.Errorf("connection refused")}
+	_, err := FetchGatewayInfo(context.Background(), "my-service", lister)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list endpoint slices")
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestFetchGatewayInfo_EmptyItemList(t *testing.T) {
+	lister := &fakeLister{slices: []discoveryv1.EndpointSlice{}}
+	info, err := FetchGatewayInfo(context.Background(), "my-service", lister)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-service", info.Service)
+	assert.Empty(t, info.Ports)
+	assert.Empty(t, info.Pods)
+	assert.Empty(t, info.Addresses)
+}
+
+func TestFetchGatewayInfo_MultipleSlices(t *testing.T) {
+	// Two slices → deduplication of ports, union of pods/addresses.
+	tcp := corev1.ProtocolTCP
+	port4317 := int32(4317)
+	port4318 := int32(4318)
+	lister := &fakeLister{
+		slices: []discoveryv1.EndpointSlice{
+			{
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{Addresses: []string{"10.0.0.1"}, TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: "pod-a"}},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{Port: &port4317, Protocol: &tcp},
+				},
+			},
+			{
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{Addresses: []string{"10.0.0.2"}, TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: "pod-b"}},
+				},
+				Ports: []discoveryv1.EndpointPort{
+					{Port: &port4317, Protocol: &tcp},
+					{Port: &port4318, Protocol: &tcp},
+				},
+			},
+		},
+	}
+	info, err := FetchGatewayInfo(context.Background(), "my-svc", lister)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"4317/TCP", "4318/TCP"}, info.Ports)
+	assert.Equal(t, []string{"pod-a", "pod-b"}, info.Pods)
+	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, info.Addresses)
+}
+
+func TestFetchGatewayInfo_NilPortIgnored(t *testing.T) {
+	// A port entry with nil port should be silently skipped.
+	lister := &fakeLister{
+		slices: []discoveryv1.EndpointSlice{
+			{
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints:   []discoveryv1.Endpoint{},
+				Ports:       []discoveryv1.EndpointPort{{Port: nil}},
+			},
+		},
+	}
+	info, err := FetchGatewayInfo(context.Background(), "svc", lister)
+	require.NoError(t, err)
+	assert.Empty(t, info.Ports)
+}
+
+func TestParseServiceName(t *testing.T) {
+	tests := []struct {
+		input         string
+		wantName      string
+		wantNamespace string
+	}{
+		{"my-service", "my-service", ""},
+		{"default/my-service", "my-service", "default"},
+		{"monitoring/otelcol-gateway", "otelcol-gateway", "monitoring"},
+	}
+	for _, tt := range tests {
+		name, ns := parseServiceName(tt.input)
+		assert.Equal(t, tt.wantName, name, "input: %s", tt.input)
+		assert.Equal(t, tt.wantNamespace, ns, "input: %s", tt.input)
+	}
+}

--- a/extension/datadogextension/internal/payload/payload.go
+++ b/extension/datadogextension/internal/payload/payload.go
@@ -38,6 +38,23 @@ type OtelCollector struct {
 	CollectorResourceAttributes map[string]string  `json:"collector_resource_attributes"`
 	CollectorDeploymentType     string             `json:"collector_deployment_type"` // deployment type: gateway, daemonset, or unknown
 	TTL                         int64              `json:"ttl"`
+	GatewayInfo                 *GatewayInfo       `json:"gateway_info,omitempty"` // k8s service and pod info for gateway deployments
+}
+
+// GatewayInfo contains information about the k8s service and backing pods for a gateway collector.
+type GatewayInfo struct {
+	// Service is the name of the k8s Service.
+	Service string `json:"service"`
+	// Namespace is the k8s namespace of the service.
+	Namespace string `json:"namespace"`
+	// Ports is the list of ports exposed by the k8s Service (e.g. "4317/TCP").
+	Ports []string `json:"ports"`
+	// Pods is the list of pod names backing the k8s Service.
+	Pods []string `json:"pods"`
+	// Addresses is the list of endpoint IP addresses backing the k8s Service.
+	Addresses []string `json:"addresses"`
+	// AddressType indicates the address family used by the endpoint slice (IPv4, IPv6, or FQDN).
+	AddressType string `json:"address_type"`
 }
 
 type CollectorModule struct {

--- a/extension/datadogextension/internal/payload/payload_test.go
+++ b/extension/datadogextension/internal/payload/payload_test.go
@@ -400,6 +400,39 @@ func TestCompleteOtelCollectorPayload(t *testing.T) {
 	assert.Equal(t, "gateway", metadataMap["collector_deployment_type"])
 }
 
+func TestOtelCollectorPayload_GatewayInfo(t *testing.T) {
+	gatewayInfo := &GatewayInfo{
+		Service:     "otelcol-gateway",
+		Namespace:   "monitoring",
+		Ports:       []string{"4317/TCP", "4318/TCP"},
+		Pods:        []string{"otelcol-pod-abc", "otelcol-pod-def"},
+		Addresses:   []string{"10.0.0.1", "10.0.0.2"},
+		AddressType: "IPv4",
+	}
+	oc := &OtelCollectorPayload{
+		Hostname:  "test_host",
+		Timestamp: time.Now().UnixNano(),
+		UUID:      "test-uuid",
+		Metadata: OtelCollector{
+			GatewayInfo: gatewayInfo,
+		},
+	}
+
+	jsonData, err := json.Marshal(oc)
+	require.NoError(t, err)
+
+	var back OtelCollectorPayload
+	require.NoError(t, json.Unmarshal(jsonData, &back))
+	require.NotNil(t, back.Metadata.GatewayInfo)
+	assert.Equal(t, gatewayInfo, back.Metadata.GatewayInfo)
+
+	// When GatewayInfo is nil it should be omitted from JSON.
+	ocNil := &OtelCollectorPayload{Hostname: "h", Metadata: OtelCollector{}}
+	nilJSON, err := json.Marshal(ocNil)
+	require.NoError(t, err)
+	assert.NotContains(t, string(nilJSON), "gateway_info")
+}
+
 func TestPrepareOtelCollectorMetadata_DeploymentType(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/extension/datadogextension/internal/payload/testdata/sample-otelcollectorpayload.json
+++ b/extension/datadogextension/internal/payload/testdata/sample-otelcollectorpayload.json
@@ -55,7 +55,15 @@
     "full_configuration": "{\"receivers\":{\"otlp\":{}},\"exporters\":{\"debug\":{}},\"service\":{\"pipelines\":{\"metrics\":{\"receivers\":[\"otlp\"],\"exporters\":[\"debug\"]}}}}",
     "health_status": "{\"status\":\"healthy\"}",
     "collector_resource_attributes": {},
-    "collector_deployment_type": "gateway"
+    "collector_deployment_type": "gateway",
+    "gateway_info": {
+      "service": "otelcol-gateway",
+      "namespace": "monitoring",
+      "ports": ["4317/TCP", "4318/TCP"],
+      "pods": ["otelcol-pod-abc", "otelcol-pod-def"],
+      "addresses": ["10.0.0.1", "10.0.0.2"],
+      "address_type": "IPv4"
+    }
   },
   "uuid": "123e4567-e89b-12d3-a456-426614174000"
 }


### PR DESCRIPTION
#### Description
Adds a new optional `gateway_service` config field. When set to a Kubernetes Service name (or namespace/service), the extension lists k8s endpointslices at startup to discover the pods, endpoint addresses, and ports backing that service, and reports the result as a new `gateway_info` block in the OtelCollector metadata payload.
