### PR TITLE
[chore] ensure validate doesnt run with skip changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -80,6 +80,7 @@ jobs:
           fi
 
       - name: Validate ./.chloggen/*.yaml changes
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
           make chlog-validate \
             || { echo "New ./.chloggen/*.yaml file failed validation."; exit 1; }


### PR DESCRIPTION
This check fails even when skip changelog is enabled, which can be a problem in the case where a component is removed, see https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22147301327/job/64028103853?pr=46040
