### PR TITLE
[chore][processor/resourcedetection] ensure metadata servers are reachable when collector starts

### DIFF
--- a/processor/resourcedetectionprocessor/testdata/e2e/akamai/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/akamai/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/aks/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/aks/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/alibaba_ecs/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 100.100.100.200 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 100.100.100.200:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/azure/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/azure/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/digitalocean/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/hetzner/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/hetzner/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/nova/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/nova/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/oraclecloud/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/scaleway/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/scaleway/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables ip6tables iproute2 curl
               # IPv4 redirect for 169.254.42.42
               iptables -t nat -A OUTPUT -d 169.254.42.42 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80

--- a/processor/resourcedetectionprocessor/testdata/e2e/upcloud/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/upcloud/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"

--- a/processor/resourcedetectionprocessor/testdata/e2e/vultr/collector/05-deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/vultr/collector/05-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - sh
             - -c
             - |
+              set -e
               apk add --no-cache iptables
               iptables -t nat -A OUTPUT -d 169.254.169.254 -p tcp --dport 80 -j DNAT --to-destination 127.0.0.1:80
               echo "iptables rule added to redirect 169.254.169.254:80 -> 127.0.0.1:80"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Without `set -e` into the `initContainers` needed for the route traffic to the metadata servers, if the command fails, the container silently continues, and the collector can start and emit empty resource attributes since it cannot reach the endpoint.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #45872
