### PR TITLE
[extension/awslogs_encoding] introduce streaming contract for AWS logs encoding extension

### DIFF
--- a/.chloggen/feat_aws-logs-extension-adopt-streaming.yaml
+++ b/.chloggen/feat_aws-logs-extension-adopt-streaming.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awslogs_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adopt encoding extension streaming contract for AWS Logs Extension encoding
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46214]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/encoding/awslogsencodingextension/README.md
+++ b/extension/encoding/awslogsencodingextension/README.md
@@ -171,6 +171,19 @@ otelcol --config=config.yaml --feature-gates --feature-gates=<FEATURE_GATE_ID>
 | `userIdentity.arn`              | `aws.principal.arn`            | `aws.user_identity.principal.arn`             |
 | `userIdentity.type`             | `aws.principal.type`           | `aws.user_identity.principal.type`            |
 
+## Streaming Support
+
+The extension implements streaming support which allows processing of input data to be processed without loading entire logs into memory.
+The implementation follows `encoding.LogsDecoderExtension` contract and streamed unmarhaling is exposed through `NewLogsDecoder`.
+
+Note that, unlike non-streaming unmarshaling, caller is expected to detect and perform decompression operations (e.g. un-gzip).
+This allows streaming implementation to work independently of compression algorithms and buffer sizes.
+
+The table below summarizes streaming support details for each log type, along with the offset tracking mechanism,
+
+| Log Type      | Sub Log Type/Source            | Offset Tracking                   | Notes |
+|---------------|--------------------------------|-----------------------------------|-------|
+
 ## Produced Records per Format
 
 ### VPC flow log record fields

--- a/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
+++ b/extension/encoding/awslogsencodingextension/internal/unmarshaler/unmarshaler.go
@@ -7,8 +7,17 @@ import (
 	"io"
 
 	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 )
 
+// AWSUnmarshaler is the base interface for all AWS log format unmarshalers.
 type AWSUnmarshaler interface {
 	UnmarshalAWSLogs(reader io.Reader) (plog.Logs, error)
+}
+
+// StreamingLogsUnmarshaler is optionally implemented by unmarshalers that support streaming decoding.
+type StreamingLogsUnmarshaler interface {
+	AWSUnmarshaler
+	NewLogsDecoder(reader io.Reader, options ...encoding.DecoderOption) (encoding.LogsDecoder, error)
 }


### PR DESCRIPTION
#### Description

Adopt encoding extension streaming contract for AWS logs encoding extension.

No signals adopt the contract within this PR. Individual signal adoption will be followed up based on this change.

#### Testing

N/A

#### Documentation

To be done with signals 
