### PR TITLE
[chore] add geekdave as codeowner of oraclecloud rdp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,7 +224,7 @@ processor/resourcedetectionprocessor/internal/digitalocean/      @open-telemetry
 processor/resourcedetectionprocessor/internal/dynatrace/         @open-telemetry/collector-contrib-approvers @bacherfl @evan-bradley
 processor/resourcedetectionprocessor/internal/hetzner/           @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole @paulojmdias
 processor/resourcedetectionprocessor/internal/openstack/nova/    @open-telemetry/collector-contrib-approvers @dashpole @paulojmdias
-processor/resourcedetectionprocessor/internal/oraclecloud/       @open-telemetry/collector-contrib-approvers @dashpole
+processor/resourcedetectionprocessor/internal/oraclecloud/       @open-telemetry/collector-contrib-approvers @dashpole @geekdave
 processor/resourcedetectionprocessor/internal/scaleway/          @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole @paulojmdias
 processor/resourcedetectionprocessor/internal/upcloud/           @open-telemetry/collector-contrib-approvers @dashpole @paulojmdias
 processor/resourcedetectionprocessor/internal/vultr/             @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole @paulojmdias

--- a/processor/resourcedetectionprocessor/internal/oraclecloud/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/oraclecloud/metadata.yaml
@@ -5,7 +5,7 @@ status:
   stability:
     alpha: [traces, metrics, logs, profiles]
   codeowners:
-    active: [dashpole]
+    active: [dashpole, geekdave]
 
 resource_attributes:
   cloud.availability_zone:


### PR DESCRIPTION
Discussed with [@dashpole](https://github.com/dashpole) and now that I am a codeowner for [the oraclecloud area in the semconv repo](https://github.com/orgs/open-telemetry/teams/semconv-oracle-cloud-approvers), I am requesting codeowner status for the Oracle Cloud Resource Detection Processor in collector-contrib as well.