### PR TITLE
[receiver/kafkareceiver] Remove deprecated `topic` and `exclude_topic` fields

### DIFF
--- a/.chloggen/remove-deprecated-topic.yaml
+++ b/.chloggen/remove-deprecated-topic.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/docker
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Docker API version auto-negotiation when `api_version` is not specified in config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [44653]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `api_version` is empty or omitted, the Docker client now automatically negotiates
+  the highest mutually supported API version with the daemon using `WithAPIVersionNegotiation()`.
+  Existing configurations with an explicit `api_version` continue to work unchanged.
+  Note: The previous default behavior pinned the API version to 1.44 when not specified.
+  Now it auto-negotiates with the daemon, which may result in a different API version being used.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/remove-deprecated-topic.yaml
+++ b/.chloggen/remove-deprecated-topic.yaml
@@ -1,26 +1,21 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: internal/docker
+component: receiver/kafkareceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add Docker API version auto-negotiation when `api_version` is not specified in config
+note: Remove deprecated topic and exclude_topic fields
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [44653]
+issues: [46232]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: |
-  When `api_version` is empty or omitted, the Docker client now automatically negotiates
-  the highest mutually supported API version with the daemon using `WithAPIVersionNegotiation()`.
-  Existing configurations with an explicit `api_version` continue to work unchanged.
-  Note: The previous default behavior pinned the API version to 1.44 when not specified.
-  Now it auto-negotiates with the daemon, which may result in a different API version being used.
+subtext: 
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/remove-deprecated-topic.yaml
+++ b/.chloggen/remove-deprecated-topic.yaml
@@ -4,7 +4,7 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: receiver/kafkareceiver
+component: receiver/kafka
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove deprecated topic and exclude_topic fields

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -4,7 +4,6 @@
 package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -61,74 +60,6 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 		return err
 	}
 
-	// handle deprecated topic and exclude_topic for log signal
-	if zeroConfig.Logs.Topic != "" {
-		if len(zeroConfig.Logs.Topics) == 0 {
-			c.Logs.Topics = []string{zeroConfig.Logs.Topic}
-			// copy original logs.topic to its alias
-			// required for validation further down in this code
-			c.Logs.topicAlias = c.Logs.Topic
-			c.Logs.Topic = ""
-		}
-	}
-	if zeroConfig.Logs.ExcludeTopic != "" {
-		if len(zeroConfig.Logs.ExcludeTopics) == 0 {
-			c.Logs.ExcludeTopics = []string{zeroConfig.Logs.ExcludeTopic}
-			c.Logs.excludeTopicAlias = c.Logs.ExcludeTopic
-			c.Logs.ExcludeTopic = ""
-		}
-	}
-
-	// handle deprecated topic and exclude_topic for metric signal
-	if zeroConfig.Metrics.Topic != "" {
-		if len(zeroConfig.Metrics.Topics) == 0 {
-			c.Metrics.Topics = []string{zeroConfig.Metrics.Topic}
-			c.Metrics.topicAlias = c.Metrics.Topic
-			c.Metrics.Topic = ""
-		}
-	}
-
-	if zeroConfig.Metrics.ExcludeTopic != "" {
-		if len(zeroConfig.Metrics.ExcludeTopics) == 0 {
-			c.Metrics.ExcludeTopics = []string{zeroConfig.Metrics.ExcludeTopic}
-			c.Metrics.excludeTopicAlias = c.Metrics.ExcludeTopic
-			c.Metrics.ExcludeTopic = ""
-		}
-	}
-
-	// handle deprecated topic and exclude_topic for trace signal
-	if zeroConfig.Traces.Topic != "" {
-		if len(zeroConfig.Traces.Topics) == 0 {
-			c.Traces.Topics = []string{zeroConfig.Traces.Topic}
-			c.Traces.topicAlias = c.Traces.Topic
-			c.Traces.Topic = ""
-		}
-	}
-
-	if zeroConfig.Traces.ExcludeTopic != "" {
-		if len(zeroConfig.Traces.ExcludeTopics) == 0 {
-			c.Traces.ExcludeTopics = []string{zeroConfig.Traces.ExcludeTopic}
-			c.Traces.excludeTopicAlias = c.Traces.ExcludeTopic
-			c.Traces.ExcludeTopic = ""
-		}
-	}
-
-	// handle deprecated topic and exclude_topic for profile signal
-	if zeroConfig.Profiles.Topic != "" {
-		if len(zeroConfig.Profiles.Topics) == 0 {
-			c.Profiles.Topics = []string{zeroConfig.Profiles.Topic}
-			c.Profiles.topicAlias = c.Profiles.Topic
-			c.Profiles.Topic = ""
-		}
-	}
-	if zeroConfig.Profiles.ExcludeTopic != "" {
-		if len(zeroConfig.Profiles.ExcludeTopics) == 0 {
-			c.Profiles.ExcludeTopics = []string{zeroConfig.Profiles.ExcludeTopic}
-			c.Profiles.excludeTopicAlias = c.Profiles.ExcludeTopic
-			c.Profiles.ExcludeTopic = ""
-		}
-	}
-
 	// Set OnPermanentError default value to inherit from OnError for backward compatibility
 	// Only if OnPermanentError was not explicitly set in the config
 	rawConf := conf.Get("message_marking")
@@ -148,32 +79,6 @@ func (c *Config) Unmarshal(conf *confmap.Conf) error {
 
 // Validate checks the receiver configuration is valid.
 func (c *Config) Validate() error {
-	if c.Logs.Topic != "" && len(c.Logs.Topics) != 0 {
-		return errors.New("both logs.topic and logs.topics cannot be set")
-	}
-	if c.Metrics.Topic != "" && len(c.Metrics.Topics) != 0 {
-		return errors.New("both metrics.topic and metrics.topics cannot be set")
-	}
-	if c.Traces.Topic != "" && len(c.Traces.Topics) != 0 {
-		return errors.New("both traces.topic and traces.topics cannot be set")
-	}
-	if c.Profiles.Topic != "" && len(c.Profiles.Topics) != 0 {
-		return errors.New("both profiles.topic and profiles.topics cannot be set")
-	}
-
-	if c.Logs.ExcludeTopic != "" && len(c.Logs.ExcludeTopics) != 0 {
-		return errors.New("both logs.exclude_topic and logs.exclude_topics cannot be set")
-	}
-	if c.Metrics.ExcludeTopic != "" && len(c.Metrics.ExcludeTopics) != 0 {
-		return errors.New("both metrics.exclude_topic and metrics.exclude_topics cannot be set")
-	}
-	if c.Traces.ExcludeTopic != "" && len(c.Traces.ExcludeTopics) != 0 {
-		return errors.New("both traces.exclude_topic and traces.exclude_topics cannot be set")
-	}
-	if c.Profiles.ExcludeTopic != "" && len(c.Profiles.ExcludeTopics) != 0 {
-		return errors.New("both profiles.exclude_topic and profiles.exclude_topics cannot be set")
-	}
-
 	// Validate that exclude_topic is only used with regex topic patterns
 	if err := validateExcludeTopic("logs", c.Logs.Topics, c.Logs.ExcludeTopics); err != nil {
 		return err
@@ -234,12 +139,6 @@ func validateExcludeTopic(signalType string, topics, excludeTopics []string) err
 
 // TopicEncodingConfig holds signal-specific topic and encoding configuration.
 type TopicEncodingConfig struct {
-	// Deprecated [v0.142.0]: Use Topics
-	Topic string `mapstructure:"topic"`
-
-	// alias for Topic
-	topicAlias string
-
 	// Topics holds the name of the Kafka topics from which messages of the
 	// signal type should be consumed.
 	//
@@ -254,12 +153,6 @@ type TopicEncodingConfig struct {
 	//
 	// Defaults to "otlp_proto".
 	Encoding string `mapstructure:"encoding"`
-
-	// Deprecated [v0.142.0]: Use ExcludeTopics
-	ExcludeTopic string `mapstructure:"exclude_topic"`
-
-	// alias for exclude_topic
-	excludeTopicAlias string
 
 	// Optional exclude topics option, used only in regex mode.
 	ExcludeTopics []string `mapstructure:"exclude_topics"`

--- a/receiver/kafkareceiver/config.schema.yaml
+++ b/receiver/kafkareceiver/config.schema.yaml
@@ -45,17 +45,11 @@ $defs:
       encoding:
         description: Encoding holds the expected encoding of messages for the signal type Defaults to "otlp_proto".
         type: string
-      exclude_topic:
-        description: 'Deprecated [v0.142.0]: Use ExcludeTopics'
-        type: string
       exclude_topics:
         description: Optional exclude topics option, used only in regex mode.
         type: array
         items:
           type: string
-      topic:
-        description: 'Deprecated [v0.142.0]: Use Topics'
-        type: string
       topics:
         description: 'Topics holds the name of the Kafka topics from which messages of the signal type should be consumed. The default depends on the signal type: - "otlp_spans" for traces - "otlp_metrics" for metrics - "otlp_logs" for logs - "otlp_profiles" for profiles'
         type: array

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -32,44 +32,6 @@ func TestLoadConfig(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			id: component.NewIDWithName(metadata.Type, "legacy_topic"),
-			expected: &Config{
-				ClientConfig: func() configkafka.ClientConfig {
-					config := configkafka.NewDefaultClientConfig()
-					return config
-				}(),
-				ConsumerConfig: func() configkafka.ConsumerConfig {
-					config := configkafka.NewDefaultConsumerConfig()
-					return config
-				}(),
-				Logs: TopicEncodingConfig{
-					// if deprecated topic is set and topics is not set
-					// give precedence to topic
-					topicAlias: "legacy_logs",
-					Topics:     []string{"legacy_logs"},
-					Encoding:   "otlp_proto",
-				},
-				Metrics: TopicEncodingConfig{
-					topicAlias: "legacy_metric",
-					Topics:     []string{"legacy_metric"},
-					Encoding:   "otlp_proto",
-				},
-				Traces: TopicEncodingConfig{
-					topicAlias: "legacy_spans",
-					Topics:     []string{"legacy_spans"},
-					Encoding:   "otlp_proto",
-				},
-				Profiles: TopicEncodingConfig{
-					topicAlias: "legacy_profile",
-					Topics:     []string{"legacy_profile"},
-					Encoding:   "otlp_proto",
-				},
-				ErrorBackOff: configretry.BackOffConfig{
-					Enabled: false,
-				},
-			},
-		},
-		{
 			id: component.NewIDWithName(metadata.Type, "logs"),
 			expected: &Config{
 				ClientConfig: func() configkafka.ClientConfig {
@@ -99,7 +61,7 @@ func TestLoadConfig(t *testing.T) {
 					return config
 				}(),
 				Logs: TopicEncodingConfig{
-					Topics:   []string{"logs"}, // topics is given precedence if it is set
+					Topics:   []string{"logs"},
 					Encoding: "direct",
 				},
 				Metrics: TopicEncodingConfig{
@@ -372,28 +334,6 @@ func TestConfigValidate(t *testing.T) {
 				},
 			},
 			expectedErr: "traces.exclude_topics is configured but none of the configured traces.topics use regex pattern (must start with '^')",
-		},
-		{
-			name: "invalid config when both topic and topics are set",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					Topic:    "legacy_log",
-					Topics:   []string{"logs"},
-					Encoding: "otlp_proto",
-				},
-			},
-			expectedErr: "both logs.topic and logs.topics cannot be set",
-		},
-		{
-			name: "invalid config when both exclude_topic and exclude_topics are set",
-			config: &Config{
-				Logs: TopicEncodingConfig{
-					ExcludeTopic:  "^logs-[invalid(regex",
-					ExcludeTopics: []string{"^logs-[invalid(regex"},
-					Encoding:      "otlp_proto",
-				},
-			},
-			expectedErr: "both logs.exclude_topic and logs.exclude_topics cannot be set",
 		},
 		{
 			name: "invalid config with non-regex topic and exclude_topic for profiles",

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -75,12 +75,7 @@ func newLogsReceiver(config *Config, set receiver.Settings, nextConsumer consume
 		if err != nil {
 			return nil, err
 		}
-		if config.Logs.topicAlias != "" {
-			set.Logger.Warn("logs.topic is deprecated, please use logs.topics instead")
-		}
-		if config.Logs.excludeTopicAlias != "" {
-			set.Logger.Warn("logs.exclude_topic is deprecated, please use logs.exclude_topics instead")
-		}
+
 		return func(ctx context.Context, message kafkaMessage, attrs attribute.Set) error {
 			return processMessage(ctx, message, config, set.Logger, telBldr,
 				&logsHandler{
@@ -104,12 +99,6 @@ func newMetricsReceiver(config *Config, set receiver.Settings, nextConsumer cons
 		unmarshaler, err := newMetricsUnmarshaler(config.Metrics.Encoding, set, host)
 		if err != nil {
 			return nil, err
-		}
-		if config.Metrics.topicAlias != "" {
-			set.Logger.Warn("metrics.topic is deprecated, please use metrics.topics instead")
-		}
-		if config.Metrics.excludeTopicAlias != "" {
-			set.Logger.Warn("metrics.exclude_topic is deprecated, please use metrics.exclude_topics instead")
 		}
 
 		return func(ctx context.Context, message kafkaMessage, attrs attribute.Set) error {
@@ -137,13 +126,6 @@ func newTracesReceiver(config *Config, set receiver.Settings, nextConsumer consu
 			return nil, err
 		}
 
-		if config.Traces.topicAlias != "" {
-			set.Logger.Warn("traces.topic is deprecated, please use traces.topics instead")
-		}
-		if config.Traces.excludeTopicAlias != "" {
-			set.Logger.Warn("traces.exclude_topic is deprecated, please use traces.exclude_topics instead")
-		}
-
 		return func(ctx context.Context, message kafkaMessage, attrs attribute.Set) error {
 			return processMessage(ctx, message, config, set.Logger, telBldr,
 				&tracesHandler{
@@ -167,12 +149,6 @@ func newProfilesReceiver(config *Config, set receiver.Settings, nextConsumer xco
 		unmarshaler, err := newProfilesUnmarshaler(config.Profiles.Encoding, set, host)
 		if err != nil {
 			return nil, err
-		}
-		if config.Profiles.topicAlias != "" {
-			set.Logger.Warn("profiles.topic is deprecated, please use profiles.topics instead")
-		}
-		if config.Profiles.excludeTopicAlias != "" {
-			set.Logger.Warn("profiles.exclude_topic is deprecated, please use profiles.exclude_topics instead")
 		}
 
 		return func(ctx context.Context, message kafkaMessage, attrs attribute.Set) error {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR removes the deprecated topic and exclude_topic fields from kafka configuration

