### PR TITLE
feat: introduce streaming contract for AWS CloudWatch metrics extension

### DIFF
--- a/.chloggen/feat_aws-metrics-extension-adopt-streaming.yaml
+++ b/.chloggen/feat_aws-metrics-extension-adopt-streaming.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/awscloudwatchmetricstreams_encoding
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adopt encoding extension streaming contract for AWS CloudWatch metrics extension
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46214]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
@@ -34,7 +34,7 @@ extensions:
 
 ## Streaming Support
 
-The table below summarizes offset tracking details for each format,
+The table below summarizes offset tracking details for each format.
 
 | CloudWatch Metrics format | Offset Tracking |
 |---------------------------|-----------------|

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/README.md
@@ -32,6 +32,13 @@ extensions:
     format: json
 ```
 
+## Streaming Support
+
+The table below summarizes offset tracking details for each format,
+
+| CloudWatch Metrics format | Offset Tracking |
+|---------------------------|-----------------|
+
 ## Supported Statistics (JSON format)
 
 When using the JSON format, the extension extracts the following statistics from CloudWatch Metric Streams and converts them to OpenTelemetry Summary metrics:

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/extension.go
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/extension.go
@@ -6,6 +6,7 @@ package awscloudwatchmetricstreamsencodingextension // import "github.com/open-t
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -14,7 +15,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 )
 
-var _ encoding.MetricsUnmarshalerExtension = (*encodingExtension)(nil)
+var (
+	_ encoding.MetricsUnmarshalerExtension = (*encodingExtension)(nil)
+	_ encoding.MetricsDecoderExtension     = (*encodingExtension)(nil)
+)
 
 type encodingExtension struct {
 	unmarshaler pmetric.Unmarshaler
@@ -57,4 +61,21 @@ func (e *encodingExtension) UnmarshalMetrics(record []byte) (pmetric.Metrics, er
 		return pmetric.Metrics{}, fmt.Errorf("failed to unmarshal metrics as '%s' format: %w", e.format, err)
 	}
 	return metrics, nil
+}
+
+// NewMetricsDecoder returns a MetricsDecoder if the underlying unmarshaler supports streaming.
+// Caller must perform any decompression before passing the reader to the decoder.
+// Implementations must utilize derived buffered readers as is.
+func (e *encodingExtension) NewMetricsDecoder(reader io.Reader, options ...encoding.DecoderOption) (encoding.MetricsDecoder, error) {
+	if u, ok := e.unmarshaler.(streamUnmarshal); ok {
+		return u.NewMetricsDecoder(reader, options...)
+	}
+
+	return nil, fmt.Errorf("streaming not supported for format %q", e.format)
+}
+
+// metricsUnmarshal is an interface that's expected to be implemented by metrics format implementations.
+type streamUnmarshal interface {
+	pmetric.Unmarshaler
+	NewMetricsDecoder(reader io.Reader, options ...encoding.DecoderOption) (encoding.MetricsDecoder, error)
 }


### PR DESCRIPTION
#### Description

Adopt encoding extension streaming contract for AWS CloudWatch metrics extension

No signals adopt the contract within this PR. Individual signal adoption will be followed up based on this change.

Related - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46214

#### Testing

N/A

#### Documentation

To be done with signals 
