### PR TITLE
[chore] fix githubgen allowlist adding Mrod1598

### DIFF
--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -2,3 +2,4 @@ KiranmayiB
 steven-freed
 garrett-splunk
 robertgustafsonsplunk
+Mrod1598


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

It seems @Mrod1598 was removed from the @open-telemetry organization.

This PR adds him to the allowlist to fix the CI.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22244001752/job/64353928057?pr=46038