### PR TITLE
[processor/transform] Add normalize_genai_attributes OTTL function

### DIFF
--- a/.chloggen/normalize-genai-attributes.yaml
+++ b/.chloggen/normalize-genai-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/transform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add normalize_genai_attributes OTTL function to map GenAI telemetry attributes from OpenInference and OpenLLMetry to OTel GenAI Semantic Conventions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46069]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -275,6 +275,7 @@ In addition to the common OTTL functions, the processor defines its own function
 **Traces only functions**
 
 - [set_semconv_span_name](#set_semconv_span_name)
+- [normalize_genai_attributes](#normalize_genai_attributes)
 
 ### convert_sum_to_gauge
 
@@ -729,6 +730,30 @@ Examples:
 - `set_semconv_span_name("1.37.0")`
 
 - `set_semconv_span_name("1.37.0", "original_span_name")`
+
+### normalize_genai_attributes
+
+`normalize_genai_attributes(semconvVersion, Optional[profiles], Optional[remove_originals])`
+
+The `normalize_genai_attributes()` function maps GenAI telemetry attributes from third-party instrumentation libraries to the official [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This is useful when ingesting traces from libraries like [OpenInference](https://github.com/Arize-ai/openinference), [OpenLLMetry](https://github.com/traceloop/openllmetry), or framework-specific instrumentations (LangChain, CrewAI, PydanticAI) that use non-standard attribute names.
+
+Parameters:
+
+* `semconvVersion` is the target semantic conventions version. `1.39.0` is currently the only supported version.
+* `profiles` is an optional list of mapping profiles to apply. When omitted, all profiles are applied. Supported profiles: `openinference`, `openllmetry`, `langchain`, `crewai`, `pydanticai`. See [profile definitions](internal/traces/func_normalize_genai_attributes.go) for the full attribute mappings.
+* `remove_originals` is an optional boolean (default `false`). When `true`, source attributes are removed after mapping.
+
+The function also performs value mapping for `gen_ai.operation.name` — for example, OpenInference's `openinference.span.kind: "LLM"` becomes `gen_ai.operation.name: "chat"`, and `"AGENT"` becomes `"invoke_agent"`.
+
+Attributes that don't match any mapping profile pass through unchanged.
+
+Examples:
+
+- `normalize_genai_attributes("1.39.0")`
+
+- `normalize_genai_attributes("1.39.0", remove_originals=true)`
+
+- `normalize_genai_attributes("1.39.0", profiles=["openinference", "openllmetry"], remove_originals=true)`
 
 ## Examples
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -735,15 +735,15 @@ Examples:
 
 `normalize_genai_attributes(semconvVersion, Optional[profiles], Optional[remove_originals])`
 
-The `normalize_genai_attributes()` function maps GenAI telemetry attributes from third-party instrumentation libraries to the official [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This is useful when ingesting traces from libraries like [OpenInference](https://github.com/Arize-ai/openinference), [OpenLLMetry](https://github.com/traceloop/openllmetry), or framework-specific instrumentations (LangChain, CrewAI, PydanticAI) that use non-standard attribute names.
+The `normalize_genai_attributes()` function maps GenAI telemetry attributes from [OpenInference](https://github.com/Arize-ai/openinference) and [OpenLLMetry](https://github.com/traceloop/openllmetry) to the official [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). These instrumentation libraries cover 60+ GenAI frameworks (LangChain, CrewAI, Strands, etc.) but use non-standard attribute names.
 
 Parameters:
 
 * `semconvVersion` is the target semantic conventions version. `1.39.0` is currently the only supported version.
-* `profiles` is an optional list of mapping profiles to apply. When omitted, all profiles are applied. Supported profiles: `openinference`, `openllmetry`, `langchain`, `crewai`, `pydanticai`. See [profile definitions](internal/traces/func_normalize_genai_attributes.go) for the full attribute mappings.
+* `profiles` is an optional list of mapping profiles to apply. When omitted, all profiles are applied. Supported profiles: `openinference`, `openllmetry`. See [profile definitions](internal/traces/func_normalize_genai_attributes.go) for the full attribute mappings.
 * `remove_originals` is an optional boolean (default `false`). When `true`, source attributes are removed after mapping.
 
-The function also performs value mapping for `gen_ai.operation.name` — for example, OpenInference's `openinference.span.kind: "LLM"` becomes `gen_ai.operation.name: "chat"`, and `"AGENT"` becomes `"invoke_agent"`.
+The function also performs value mapping for `gen_ai.operation.name` (e.g. OpenInference's `"LLM"` becomes `"chat"`, `"AGENT"` becomes `"invoke_agent"`) and type conversion where needed (e.g. `llm.response.finish_reason` string is wrapped into a `gen_ai.response.finish_reasons` string array).
 
 Attributes that don't match any mapping profile pass through unchanged.
 
@@ -753,7 +753,7 @@ Examples:
 
 - `normalize_genai_attributes("1.39.0", remove_originals=true)`
 
-- `normalize_genai_attributes("1.39.0", profiles=["openinference", "openllmetry"], remove_originals=true)`
+- `normalize_genai_attributes("1.39.0", profiles=["openinference"], remove_originals=true)`
 
 ## Examples
 

--- a/processor/transformprocessor/internal/traces/func_normalize_genai_attributes.go
+++ b/processor/transformprocessor/internal/traces/func_normalize_genai_attributes.go
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package traces // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
+)
+
+const supportedGenAISemconvVersion = "1.39.0"
+
+type normalizeGenaiAttributesArguments struct {
+	SemconvVersion  string
+	Profiles        ottl.Optional[[]string]
+	RemoveOriginals ottl.Optional[bool]
+}
+
+func NewNormalizeGenaiAttributesFactory() ottl.Factory[*ottlspan.TransformContext] {
+	return ottl.NewFactory("normalize_genai_attributes", &normalizeGenaiAttributesArguments{}, createNormalizeGenaiAttributesFunction)
+}
+
+func createNormalizeGenaiAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlspan.TransformContext], error) {
+	args, ok := oArgs.(*normalizeGenaiAttributesArguments)
+	if !ok {
+		return nil, errors.New("args must be of type *normalizeGenaiAttributesArguments")
+	}
+
+	if args.SemconvVersion != supportedGenAISemconvVersion {
+		return nil, fmt.Errorf("unsupported semconv version: %s, supported version: %s", args.SemconvVersion, supportedGenAISemconvVersion)
+	}
+
+	// Determine which profiles to use
+	var profileNames []string
+	if args.Profiles.IsEmpty() {
+		profileNames = allProfileNames
+	} else {
+		profileNames = args.Profiles.Get()
+		for _, p := range profileNames {
+			if _, ok := profileRegistry[p]; !ok {
+				return nil, fmt.Errorf("unknown profile: %q, supported profiles: %v", p, allProfileNames)
+			}
+		}
+	}
+
+	removeOriginals := args.RemoveOriginals.GetOr(false)
+	lookupTable := buildGenaiLookupTable(profileNames)
+
+	return func(_ context.Context, tCtx *ottlspan.TransformContext) (any, error) {
+		normalizeGenaiAttributes(tCtx.GetSpan(), lookupTable, removeOriginals)
+		return nil, nil
+	}, nil
+}
+
+func normalizeGenaiAttributes(span ptrace.Span, lookupTable map[string]string, removeOriginals bool) {
+	attrs := span.Attributes()
+
+	var renames []struct{ from, to string }
+	attrs.Range(func(k string, _ pcommon.Value) bool {
+		if target, ok := lookupTable[k]; ok {
+			renames = append(renames, struct{ from, to string }{k, target})
+		}
+		return true
+	})
+
+	for _, r := range renames {
+		if val, ok := attrs.Get(r.from); ok {
+			if val.Type() == pcommon.ValueTypeStr {
+				if transformed := transformGenaiValue(r.to, val.Str()); transformed != val.Str() {
+					attrs.PutStr(r.to, transformed)
+				} else {
+					val.CopyTo(attrs.PutEmpty(r.to))
+				}
+			} else {
+				val.CopyTo(attrs.PutEmpty(r.to))
+			}
+			if removeOriginals {
+				attrs.Remove(r.from)
+			}
+		}
+	}
+}
+
+// --- Mapping data ---
+
+type genaiMapping struct {
+	from string
+	to   string
+}
+
+var allProfileNames = []string{"openinference", "openllmetry", "langchain", "crewai", "pydanticai"}
+
+var profileRegistry = map[string][]genaiMapping{
+	"openinference": {
+		{"llm.token_count.prompt", "gen_ai.usage.input_tokens"},
+		{"llm.token_count.completion", "gen_ai.usage.output_tokens"},
+		{"llm.model_name", "gen_ai.request.model"},
+		{"llm.provider", "gen_ai.provider.name"},
+		{"llm.system", "gen_ai.system"},
+		{"llm.input_messages", "gen_ai.input.messages"},
+		{"llm.output_messages", "gen_ai.output.messages"},
+		{"embedding.model_name", "gen_ai.request.model"},
+		{"tool.name", "gen_ai.tool.name"},
+		{"tool.description", "gen_ai.tool.description"},
+		{"tool_call.function.arguments", "gen_ai.tool.call.arguments"},
+		{"tool_call.id", "gen_ai.tool.call.id"},
+		{"reranker.model_name", "gen_ai.request.model"},
+		{"agent.name", "gen_ai.agent.name"},
+		{"session.id", "gen_ai.conversation.id"},
+		{"openinference.span.kind", "gen_ai.operation.name"},
+	},
+	"openllmetry": {
+		{"llm.usage.prompt_tokens", "gen_ai.usage.input_tokens"},
+		{"llm.usage.completion_tokens", "gen_ai.usage.output_tokens"},
+		{"llm.request.model", "gen_ai.request.model"},
+		{"llm.response.model", "gen_ai.response.model"},
+		{"llm.request.max_tokens", "gen_ai.request.max_tokens"},
+		{"llm.request.temperature", "gen_ai.request.temperature"},
+		{"llm.request.top_p", "gen_ai.request.top_p"},
+		{"llm.top_k", "gen_ai.request.top_k"},
+		{"llm.frequency_penalty", "gen_ai.request.frequency_penalty"},
+		{"llm.presence_penalty", "gen_ai.request.presence_penalty"},
+		{"llm.chat.stop_sequences", "gen_ai.request.stop_sequences"},
+		{"llm.request.functions", "gen_ai.tool.definitions"},
+		{"llm.response.finish_reason", "gen_ai.response.finish_reasons"},
+		{"llm.response.stop_reason", "gen_ai.response.finish_reasons"},
+		{"llm.request.type", "gen_ai.operation.name"},
+		{"traceloop.span.kind", "gen_ai.operation.name"},
+		{"traceloop.entity.name", "gen_ai.agent.name"},
+		{"traceloop.entity.input", "gen_ai.input.messages"},
+		{"traceloop.entity.output", "gen_ai.output.messages"},
+		{"traceloop.association.properties", "gen_ai.conversation.id"},
+	},
+	"langchain": {
+		{"lc.metadata.thread_id", "gen_ai.conversation.id"},
+		{"langgraph.node.name", "gen_ai.agent.name"},
+	},
+	"crewai": {
+		{"agent_role", "gen_ai.agent.name"},
+		{"crew_id", "gen_ai.conversation.id"},
+	},
+	"pydanticai": {
+		{"agent_name", "gen_ai.agent.name"},
+	},
+}
+
+func buildGenaiLookupTable(profiles []string) map[string]string {
+	table := make(map[string]string)
+	for _, name := range profiles {
+		for _, m := range profileRegistry[name] {
+			table[m.from] = m.to
+		}
+	}
+	return table
+}
+
+// --- Value mappings ---
+
+var operationNameValues = map[string]string{
+	// OpenInference span kinds
+	"LLM": "chat", "EMBEDDING": "embeddings", "CHAIN": "invoke_agent",
+	"RETRIEVER": "retrieval", "RERANKER": "retrieval", "TOOL": "execute_tool",
+	"AGENT": "invoke_agent", "GUARDRAIL": "guardrail", "EVALUATOR": "evaluate",
+	"PROMPT": "text_completion",
+	// OpenLLMetry traceloop.span.kind
+	"workflow": "invoke_agent", "task": "invoke_agent", "agent": "invoke_agent", "tool": "execute_tool",
+	// OpenLLMetry llm.request.type
+	"completion": "text_completion", "chat": "chat", "rerank": "retrieval", "embedding": "embeddings",
+}
+
+func transformGenaiValue(targetKey string, value string) string {
+	if targetKey != "gen_ai.operation.name" {
+		return value
+	}
+	if mapped, ok := operationNameValues[value]; ok {
+		return mapped
+	}
+	if mapped, ok := operationNameValues[strings.ToUpper(value)]; ok {
+		return mapped
+	}
+	if mapped, ok := operationNameValues[strings.ToLower(value)]; ok {
+		return mapped
+	}
+	return value
+}

--- a/processor/transformprocessor/internal/traces/func_normalize_genai_attributes.go
+++ b/processor/transformprocessor/internal/traces/func_normalize_genai_attributes.go
@@ -60,27 +60,43 @@ func createNormalizeGenaiAttributesFunction(_ ottl.FunctionContext, oArgs ottl.A
 	}, nil
 }
 
-func normalizeGenaiAttributes(span ptrace.Span, lookupTable map[string]string, removeOriginals bool) {
+func normalizeGenaiAttributes(span ptrace.Span, lookupTable map[string]genaiTarget, removeOriginals bool) {
 	attrs := span.Attributes()
 
-	var renames []struct{ from, to string }
+	type rename struct {
+		from   string
+		target genaiTarget
+	}
+	renames := make([]rename, 0, len(lookupTable))
 	attrs.Range(func(k string, _ pcommon.Value) bool {
 		if target, ok := lookupTable[k]; ok {
-			renames = append(renames, struct{ from, to string }{k, target})
+			renames = append(renames, rename{k, target})
 		}
 		return true
 	})
 
+	if len(renames) == 0 {
+		return
+	}
+
 	for _, r := range renames {
 		if val, ok := attrs.Get(r.from); ok {
-			if val.Type() == pcommon.ValueTypeStr {
-				if transformed := transformGenaiValue(r.to, val.Str()); transformed != val.Str() {
-					attrs.PutStr(r.to, transformed)
+			// Skip if target attribute already exists (e.g. multiple source attrs map to same target)
+			if _, exists := attrs.Get(r.target.key); exists {
+				continue
+			}
+			if r.target.wrapSlice && val.Type() == pcommon.ValueTypeStr {
+				arr := attrs.PutEmptySlice(r.target.key)
+				arr.AppendEmpty().SetStr(val.Str())
+			} else if val.Type() == pcommon.ValueTypeStr {
+				strVal := val.Str()
+				if transformed := transformGenaiValue(r.target.key, strVal); transformed != strVal {
+					attrs.PutStr(r.target.key, transformed)
 				} else {
-					val.CopyTo(attrs.PutEmpty(r.to))
+					val.CopyTo(attrs.PutEmpty(r.target.key))
 				}
 			} else {
-				val.CopyTo(attrs.PutEmpty(r.to))
+				val.CopyTo(attrs.PutEmpty(r.target.key))
 			}
 			if removeOriginals {
 				attrs.Remove(r.from)
@@ -92,71 +108,68 @@ func normalizeGenaiAttributes(span ptrace.Span, lookupTable map[string]string, r
 // --- Mapping data ---
 
 type genaiMapping struct {
-	from string
-	to   string
+	from      string
+	to        string
+	wrapSlice bool // when true, wrap scalar string value into a single-element string slice
 }
 
-var allProfileNames = []string{"openinference", "openllmetry", "langchain", "crewai", "pydanticai"}
+var allProfileNames = []string{"openinference", "openllmetry"}
 
 var profileRegistry = map[string][]genaiMapping{
+	// OpenInference: https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md
 	"openinference": {
-		{"llm.token_count.prompt", "gen_ai.usage.input_tokens"},
-		{"llm.token_count.completion", "gen_ai.usage.output_tokens"},
-		{"llm.model_name", "gen_ai.request.model"},
-		{"llm.provider", "gen_ai.provider.name"},
-		{"llm.system", "gen_ai.system"},
-		{"llm.input_messages", "gen_ai.input.messages"},
-		{"llm.output_messages", "gen_ai.output.messages"},
-		{"embedding.model_name", "gen_ai.request.model"},
-		{"tool.name", "gen_ai.tool.name"},
-		{"tool.description", "gen_ai.tool.description"},
-		{"tool_call.function.arguments", "gen_ai.tool.call.arguments"},
-		{"tool_call.id", "gen_ai.tool.call.id"},
-		{"reranker.model_name", "gen_ai.request.model"},
-		{"agent.name", "gen_ai.agent.name"},
-		{"session.id", "gen_ai.conversation.id"},
-		{"openinference.span.kind", "gen_ai.operation.name"},
+		{from: "llm.token_count.prompt", to: "gen_ai.usage.input_tokens"},
+		{from: "llm.token_count.completion", to: "gen_ai.usage.output_tokens"},
+		{from: "llm.model_name", to: "gen_ai.request.model"},
+		{from: "llm.provider", to: "gen_ai.provider.name"},
+		{from: "llm.input_messages", to: "gen_ai.input.messages"},
+		{from: "llm.output_messages", to: "gen_ai.output.messages"},
+		{from: "embedding.model_name", to: "gen_ai.request.model"},
+		{from: "tool.name", to: "gen_ai.tool.name"},
+		{from: "tool.description", to: "gen_ai.tool.description"},
+		{from: "tool_call.function.arguments", to: "gen_ai.tool.call.arguments"},
+		{from: "tool_call.id", to: "gen_ai.tool.call.id"},
+		{from: "reranker.model_name", to: "gen_ai.request.model"},
+		{from: "agent.name", to: "gen_ai.agent.name"},
+		{from: "session.id", to: "gen_ai.conversation.id"},
+		{from: "openinference.span.kind", to: "gen_ai.operation.name"},
 	},
+	// OpenLLMetry: https://www.traceloop.com/docs/openllmetry/contributing/semantic-conventions
 	"openllmetry": {
-		{"llm.usage.prompt_tokens", "gen_ai.usage.input_tokens"},
-		{"llm.usage.completion_tokens", "gen_ai.usage.output_tokens"},
-		{"llm.request.model", "gen_ai.request.model"},
-		{"llm.response.model", "gen_ai.response.model"},
-		{"llm.request.max_tokens", "gen_ai.request.max_tokens"},
-		{"llm.request.temperature", "gen_ai.request.temperature"},
-		{"llm.request.top_p", "gen_ai.request.top_p"},
-		{"llm.top_k", "gen_ai.request.top_k"},
-		{"llm.frequency_penalty", "gen_ai.request.frequency_penalty"},
-		{"llm.presence_penalty", "gen_ai.request.presence_penalty"},
-		{"llm.chat.stop_sequences", "gen_ai.request.stop_sequences"},
-		{"llm.request.functions", "gen_ai.tool.definitions"},
-		{"llm.response.finish_reason", "gen_ai.response.finish_reasons"},
-		{"llm.response.stop_reason", "gen_ai.response.finish_reasons"},
-		{"llm.request.type", "gen_ai.operation.name"},
-		{"traceloop.span.kind", "gen_ai.operation.name"},
-		{"traceloop.entity.name", "gen_ai.agent.name"},
-		{"traceloop.entity.input", "gen_ai.input.messages"},
-		{"traceloop.entity.output", "gen_ai.output.messages"},
-		{"traceloop.association.properties", "gen_ai.conversation.id"},
-	},
-	"langchain": {
-		{"lc.metadata.thread_id", "gen_ai.conversation.id"},
-		{"langgraph.node.name", "gen_ai.agent.name"},
-	},
-	"crewai": {
-		{"agent_role", "gen_ai.agent.name"},
-		{"crew_id", "gen_ai.conversation.id"},
-	},
-	"pydanticai": {
-		{"agent_name", "gen_ai.agent.name"},
+		{from: "llm.usage.prompt_tokens", to: "gen_ai.usage.input_tokens"},
+		{from: "llm.usage.completion_tokens", to: "gen_ai.usage.output_tokens"},
+		{from: "llm.request.model", to: "gen_ai.request.model"},
+		{from: "llm.response.model", to: "gen_ai.response.model"},
+		{from: "llm.request.max_tokens", to: "gen_ai.request.max_tokens"},
+		{from: "llm.request.temperature", to: "gen_ai.request.temperature"},
+		{from: "llm.request.top_p", to: "gen_ai.request.top_p"},
+		{from: "llm.top_k", to: "gen_ai.request.top_k"},
+		{from: "llm.frequency_penalty", to: "gen_ai.request.frequency_penalty"},
+		{from: "llm.presence_penalty", to: "gen_ai.request.presence_penalty"},
+		{from: "llm.chat.stop_sequences", to: "gen_ai.request.stop_sequences"},
+		{from: "llm.request.functions", to: "gen_ai.tool.definitions"},
+		{from: "llm.response.finish_reason", to: "gen_ai.response.finish_reasons", wrapSlice: true},
+		{from: "llm.response.stop_reason", to: "gen_ai.response.finish_reasons", wrapSlice: true},
+		{from: "llm.request.type", to: "gen_ai.operation.name"},
+		{from: "traceloop.span.kind", to: "gen_ai.operation.name"},
+		{from: "traceloop.entity.name", to: "gen_ai.agent.name"},
+		{from: "traceloop.entity.input", to: "gen_ai.input.messages"},
+		{from: "traceloop.entity.output", to: "gen_ai.output.messages"},
 	},
 }
 
-func buildGenaiLookupTable(profiles []string) map[string]string {
-	table := make(map[string]string)
+type genaiTarget struct {
+	key       string
+	wrapSlice bool
+}
+
+// buildGenaiLookupTable merges mappings from the selected profiles into a single lookup table.
+// If multiple profiles map the same source attribute to different targets, the last profile wins.
+func buildGenaiLookupTable(profiles []string) map[string]genaiTarget {
+	table := make(map[string]genaiTarget)
 	for _, name := range profiles {
 		for _, m := range profileRegistry[name] {
-			table[m.from] = m.to
+			table[m.from] = genaiTarget{key: m.to, wrapSlice: m.wrapSlice}
 		}
 	}
 	return table
@@ -168,7 +181,7 @@ var operationNameValues = map[string]string{
 	// OpenInference span kinds
 	"LLM": "chat", "EMBEDDING": "embeddings", "CHAIN": "invoke_agent",
 	"RETRIEVER": "retrieval", "RERANKER": "retrieval", "TOOL": "execute_tool",
-	"AGENT": "invoke_agent", "GUARDRAIL": "guardrail", "EVALUATOR": "evaluate",
+	"AGENT": "invoke_agent",
 	"PROMPT": "text_completion",
 	// OpenLLMetry traceloop.span.kind
 	"workflow": "invoke_agent", "task": "invoke_agent", "agent": "invoke_agent", "tool": "execute_tool",
@@ -176,17 +189,20 @@ var operationNameValues = map[string]string{
 	"completion": "text_completion", "chat": "chat", "rerank": "retrieval", "embedding": "embeddings",
 }
 
+// operationNameValuesNormalized is built at init with lowercased keys for case-insensitive lookup.
+var operationNameValuesNormalized = func() map[string]string {
+	m := make(map[string]string, len(operationNameValues))
+	for k, v := range operationNameValues {
+		m[strings.ToLower(k)] = v
+	}
+	return m
+}()
+
 func transformGenaiValue(targetKey string, value string) string {
 	if targetKey != "gen_ai.operation.name" {
 		return value
 	}
-	if mapped, ok := operationNameValues[value]; ok {
-		return mapped
-	}
-	if mapped, ok := operationNameValues[strings.ToUpper(value)]; ok {
-		return mapped
-	}
-	if mapped, ok := operationNameValues[strings.ToLower(value)]; ok {
+	if mapped, ok := operationNameValuesNormalized[strings.ToLower(value)]; ok {
 		return mapped
 	}
 	return value

--- a/processor/transformprocessor/internal/traces/func_normalize_genai_attributes_test.go
+++ b/processor/transformprocessor/internal/traces/func_normalize_genai_attributes_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -17,17 +18,17 @@ import (
 
 func TestNormalizeGenaiAttributes_AllProfiles(t *testing.T) {
 	span := ptrace.NewSpan()
-	span.Attributes().PutStr("llm.token_count.prompt", "100")
+	span.Attributes().PutInt("llm.token_count.prompt", 100)
 	span.Attributes().PutStr("llm.model_name", "gpt-4")
 	span.Attributes().PutStr("openinference.span.kind", "LLM")
-	span.Attributes().PutStr("agent_role", "researcher")
+	span.Attributes().PutStr("agent.name", "researcher")
 
 	lookupTable := buildGenaiLookupTable(allProfileNames)
 	normalizeGenaiAttributes(span, lookupTable, false)
 
 	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
 	require.True(t, ok)
-	assert.Equal(t, "100", val.Str())
+	assert.Equal(t, int64(100), val.Int())
 
 	val, ok = span.Attributes().Get("gen_ai.request.model")
 	require.True(t, ok)
@@ -48,7 +49,7 @@ func TestNormalizeGenaiAttributes_AllProfiles(t *testing.T) {
 
 func TestNormalizeGenaiAttributes_RemoveOriginals(t *testing.T) {
 	span := ptrace.NewSpan()
-	span.Attributes().PutStr("llm.usage.prompt_tokens", "200")
+	span.Attributes().PutInt("llm.usage.prompt_tokens", 200)
 	span.Attributes().PutStr("llm.request.model", "claude-3")
 
 	lookupTable := buildGenaiLookupTable([]string{"openllmetry"})
@@ -97,8 +98,8 @@ func TestNormalizeGenaiAttributes_ValueMapping(t *testing.T) {
 
 func TestNormalizeGenaiAttributes_SpecificProfiles(t *testing.T) {
 	span := ptrace.NewSpan()
-	span.Attributes().PutStr("llm.token_count.prompt", "100")  // openinference
-	span.Attributes().PutStr("llm.usage.prompt_tokens", "200") // openllmetry
+	span.Attributes().PutInt("llm.token_count.prompt", 100)  // openinference
+	span.Attributes().PutInt("llm.usage.prompt_tokens", 200) // openllmetry
 
 	// Only enable openinference
 	lookupTable := buildGenaiLookupTable([]string{"openinference"})
@@ -107,11 +108,25 @@ func TestNormalizeGenaiAttributes_SpecificProfiles(t *testing.T) {
 	// openinference mapping should apply
 	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
 	require.True(t, ok)
-	assert.Equal(t, "100", val.Str())
+	assert.Equal(t, int64(100), val.Int())
 
 	// openllmetry source should be untouched
 	_, ok = span.Attributes().Get("llm.usage.prompt_tokens")
 	assert.True(t, ok)
+}
+
+func TestNormalizeGenaiAttributes_WrapSlice(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("llm.response.finish_reason", "stop")
+
+	lookupTable := buildGenaiLookupTable([]string{"openllmetry"})
+	normalizeGenaiAttributes(span, lookupTable, true)
+
+	val, ok := span.Attributes().Get("gen_ai.response.finish_reasons")
+	require.True(t, ok)
+	assert.Equal(t, pcommon.ValueTypeSlice, val.Type())
+	assert.Equal(t, 1, val.Slice().Len())
+	assert.Equal(t, "stop", val.Slice().At(0).Str())
 }
 
 func TestNormalizeGenaiAttributes_NoGenaiSpan(t *testing.T) {
@@ -150,7 +165,7 @@ func TestCreateNormalizeGenaiAttributesFunction_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	span := ptrace.NewSpan()
-	span.Attributes().PutStr("llm.token_count.prompt", "50")
+	span.Attributes().PutInt("llm.token_count.prompt", 50)
 	span.Attributes().PutStr("openinference.span.kind", "AGENT")
 
 	tCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
@@ -159,7 +174,7 @@ func TestCreateNormalizeGenaiAttributesFunction_Integration(t *testing.T) {
 
 	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
 	require.True(t, ok)
-	assert.Equal(t, "50", val.Str())
+	assert.Equal(t, int64(50), val.Int())
 
 	val, ok = span.Attributes().Get("gen_ai.operation.name")
 	require.True(t, ok)

--- a/processor/transformprocessor/internal/traces/func_normalize_genai_attributes_test.go
+++ b/processor/transformprocessor/internal/traces/func_normalize_genai_attributes_test.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package traces
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
+)
+
+func TestNormalizeGenaiAttributes_AllProfiles(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("llm.token_count.prompt", "100")
+	span.Attributes().PutStr("llm.model_name", "gpt-4")
+	span.Attributes().PutStr("openinference.span.kind", "LLM")
+	span.Attributes().PutStr("agent_role", "researcher")
+
+	lookupTable := buildGenaiLookupTable(allProfileNames)
+	normalizeGenaiAttributes(span, lookupTable, false)
+
+	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
+	require.True(t, ok)
+	assert.Equal(t, "100", val.Str())
+
+	val, ok = span.Attributes().Get("gen_ai.request.model")
+	require.True(t, ok)
+	assert.Equal(t, "gpt-4", val.Str())
+
+	val, ok = span.Attributes().Get("gen_ai.operation.name")
+	require.True(t, ok)
+	assert.Equal(t, "chat", val.Str())
+
+	val, ok = span.Attributes().Get("gen_ai.agent.name")
+	require.True(t, ok)
+	assert.Equal(t, "researcher", val.Str())
+
+	// Originals should still exist (remove_originals=false)
+	_, ok = span.Attributes().Get("llm.token_count.prompt")
+	assert.True(t, ok)
+}
+
+func TestNormalizeGenaiAttributes_RemoveOriginals(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("llm.usage.prompt_tokens", "200")
+	span.Attributes().PutStr("llm.request.model", "claude-3")
+
+	lookupTable := buildGenaiLookupTable([]string{"openllmetry"})
+	normalizeGenaiAttributes(span, lookupTable, true)
+
+	_, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
+	assert.True(t, ok)
+
+	// Originals should be removed
+	_, ok = span.Attributes().Get("llm.usage.prompt_tokens")
+	assert.False(t, ok)
+	_, ok = span.Attributes().Get("llm.request.model")
+	assert.False(t, ok)
+}
+
+func TestNormalizeGenaiAttributes_ValueMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		srcKey   string
+		srcVal   string
+		wantKey  string
+		wantVal  string
+		profiles []string
+	}{
+		{"OpenInference LLM", "openinference.span.kind", "LLM", "gen_ai.operation.name", "chat", []string{"openinference"}},
+		{"OpenInference AGENT", "openinference.span.kind", "AGENT", "gen_ai.operation.name", "invoke_agent", []string{"openinference"}},
+		{"OpenInference TOOL", "openinference.span.kind", "TOOL", "gen_ai.operation.name", "execute_tool", []string{"openinference"}},
+		{"OpenLLMetry chat", "llm.request.type", "chat", "gen_ai.operation.name", "chat", []string{"openllmetry"}},
+		{"OpenLLMetry workflow", "traceloop.span.kind", "workflow", "gen_ai.operation.name", "invoke_agent", []string{"openllmetry"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := ptrace.NewSpan()
+			span.Attributes().PutStr(tt.srcKey, tt.srcVal)
+
+			lookupTable := buildGenaiLookupTable(tt.profiles)
+			normalizeGenaiAttributes(span, lookupTable, true)
+
+			val, ok := span.Attributes().Get(tt.wantKey)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantVal, val.Str())
+		})
+	}
+}
+
+func TestNormalizeGenaiAttributes_SpecificProfiles(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("llm.token_count.prompt", "100")  // openinference
+	span.Attributes().PutStr("llm.usage.prompt_tokens", "200") // openllmetry
+
+	// Only enable openinference
+	lookupTable := buildGenaiLookupTable([]string{"openinference"})
+	normalizeGenaiAttributes(span, lookupTable, true)
+
+	// openinference mapping should apply
+	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
+	require.True(t, ok)
+	assert.Equal(t, "100", val.Str())
+
+	// openllmetry source should be untouched
+	_, ok = span.Attributes().Get("llm.usage.prompt_tokens")
+	assert.True(t, ok)
+}
+
+func TestNormalizeGenaiAttributes_NoGenaiSpan(t *testing.T) {
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("http.method", "GET")
+	span.Attributes().PutStr("http.url", "https://example.com")
+
+	lookupTable := buildGenaiLookupTable(allProfileNames)
+	normalizeGenaiAttributes(span, lookupTable, true)
+
+	// Nothing should change
+	assert.Equal(t, 2, span.Attributes().Len())
+}
+
+func TestCreateNormalizeGenaiAttributesFunction_UnsupportedVersion(t *testing.T) {
+	_, err := createNormalizeGenaiAttributesFunction(ottl.FunctionContext{}, &normalizeGenaiAttributesArguments{
+		SemconvVersion: "1.0.0",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported semconv version")
+}
+
+func TestCreateNormalizeGenaiAttributesFunction_UnknownProfile(t *testing.T) {
+	_, err := createNormalizeGenaiAttributesFunction(ottl.FunctionContext{}, &normalizeGenaiAttributesArguments{
+		SemconvVersion: supportedGenAISemconvVersion,
+		Profiles:       ottl.NewTestingOptional([]string{"nonexistent"}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown profile")
+}
+
+func TestCreateNormalizeGenaiAttributesFunction_Integration(t *testing.T) {
+	fn, err := createNormalizeGenaiAttributesFunction(ottl.FunctionContext{}, &normalizeGenaiAttributesArguments{
+		SemconvVersion: supportedGenAISemconvVersion,
+	})
+	require.NoError(t, err)
+
+	span := ptrace.NewSpan()
+	span.Attributes().PutStr("llm.token_count.prompt", "50")
+	span.Attributes().PutStr("openinference.span.kind", "AGENT")
+
+	tCtx := ottlspan.NewTransformContextPtr(ptrace.NewResourceSpans(), ptrace.NewScopeSpans(), span)
+	_, err = fn(context.Background(), tCtx)
+	require.NoError(t, err)
+
+	val, ok := span.Attributes().Get("gen_ai.usage.input_tokens")
+	require.True(t, ok)
+	assert.Equal(t, "50", val.Str())
+
+	val, ok = span.Attributes().Get("gen_ai.operation.name")
+	require.True(t, ok)
+	assert.Equal(t, "invoke_agent", val.Str())
+}

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -18,6 +18,7 @@ func SpanFunctions() map[string]ottl.Factory[*ottlspan.TransformContext] {
 	spanFunctions := ottl.CreateFactoryMap(
 		ottlfuncs.NewIsRootSpanFactoryNew(),
 		NewSetSemconvSpanNameFactory(),
+		NewNormalizeGenaiAttributesFactory(),
 	)
 
 	maps.Copy(functions, spanFunctions)

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -18,6 +18,7 @@ func Test_SpanFunctions(t *testing.T) {
 	expected := ottlfuncs.StandardFuncs[*ottlspan.TransformContext]()
 	expected["IsRootSpan"] = ottlfuncs.NewIsRootSpanFactoryNew()
 	expected["set_semconv_span_name"] = NewSetSemconvSpanNameFactory()
+	expected["normalize_genai_attributes"] = NewNormalizeGenaiAttributesFactory()
 
 	actual := SpanFunctions()
 	require.Len(t, actual, len(expected))


### PR DESCRIPTION
#### Description

Proposal: #46069

Adds `normalize_genai_attributes()` as an OTTL function in the transform processor. Maps GenAI telemetry attributes from [OpenInference](https://github.com/Arize-ai/openinference) and [OpenLLMetry](https://github.com/traceloop/openllmetry) to the official [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) (v1.39.0). These two instrumentation libraries cover 60+ GenAI frameworks (LangChain, CrewAI, Strands, etc.).

Follows the `set_semconv_span_name()` pattern from #43145, as suggested in the proposal discussion.

#### Why?

The GenAI instrumentation space is fragmented. OpenInference and OpenLLMetry each use different attribute names for the same concepts (e.g. `llm.usage.prompt_tokens` vs `llm.token_count.prompt` vs `gen_ai.usage.input_tokens`). This normalizes them to `gen_ai.*` in a single OTTL call.

```yaml
processors:
  transform:
    trace_statements:
      - normalize_genai_attributes("1.39.0")
      - normalize_genai_attributes("1.39.0", remove_originals=true)
      - normalize_genai_attributes("1.39.0", profiles=["openinference"], remove_originals=true)
```

Also handles value mapping for `gen_ai.operation.name` (e.g. OpenInference's `LLM` → `chat`, `AGENT` → `invoke_agent`) and type conversion where needed (e.g. `llm.response.finish_reason` string wrapped into `gen_ai.response.finish_reasons` string array).

#### Link to tracking issue

Fixes #46069

#### Testing

Unit tests for both profiles, value transforms, type conversion (wrapSlice), profile selection, `remove_originals` flag, and error cases (bad version, unknown profile). Also tested against real traces from LangChain, LangGraph, CrewAI, and Strands with both OpenInference and OpenLLMetry instrumentation.

#### Documentation

Added `normalize_genai_attributes` to the transform processor README with parameter descriptions, usage examples, and a link to the profile definitions source.