### PR TITLE
[chore][receiver/hostmetrics] document system.processes.created platform restriction to Linux and OpenBSD

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -55,7 +55,7 @@ The available scrapers are:
 | [network]    | All                          | Network interface I/O metrics & TCP connection metrics |
 | [nfs]        | Linux                        | NFS server and client metrics                          |
 | [paging]     | All                          | Paging/Swap space utilization and I/O metrics          |
-| [processes]  | Linux, Mac, FreeBSD, OpenBSD | Process count metrics                                  |
+| [processes]  | Linux, Mac, FreeBSD, OpenBSD | Process count metrics. `system.processes.created` is only available on Linux and OpenBSD.  |
 | [process]    | Linux, Windows, Mac, FreeBSD | Per process CPU, Memory, and Disk I/O metrics          |
 | [system]     | Linux, Windows, Mac          | Miscellaneous system metrics                           |
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/documentation.md
@@ -28,7 +28,7 @@ Total number of processes in each state.
 
 ### system.processes.created
 
-Total number of created processes.
+Total number of created processes. This metric is only available on Linux and OpenBSD.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic | Stability |
 | ---- | ----------- | ---------- | ----------------------- | --------- | --------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/generated_package_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/generated_package_test.go
@@ -3,9 +3,8 @@
 package processesscraper
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -163,7 +163,7 @@ type metricSystemProcessesCreated struct {
 // init fills system.processes.created metric with initial data.
 func (m *metricSystemProcessesCreated) init() {
 	m.data.SetName("system.processes.created")
-	m.data.SetDescription("Total number of created processes.")
+	m.data.SetDescription("Total number of created processes. This metric is only available on Linux and OpenBSD.")
 	m.data.SetUnit("{processes}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_test.go
@@ -110,7 +110,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["system.processes.created"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Total number of created processes.", ms.At(i).Description())
+					assert.Equal(t, "Total number of created processes. This metric is only available on Linux and OpenBSD.", ms.At(i).Description())
 					assert.Equal(t, "{processes}", ms.At(i).Unit())
 					assert.True(t, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -29,7 +29,7 @@ metrics:
     attributes: [status]
   system.processes.created:
     enabled: true
-    description: Total number of created processes.
+    description: Total number of created processes. This metric is only available on Linux and OpenBSD.
     unit: "{processes}"
     stability: development
     sum:


### PR DESCRIPTION
## Description

Update the documentation for `system.processes.created` to clarify that the metric is only supported on **Linux** and **OpenBSD**.

The runtime implementation already restricts this metric to those operating systems (via `enableProcessesCreated` in [`processes_scraper_unix.go`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go#L19)), but the documentation did not reflect this restriction — causing confusion for users on other platforms (e.g., macOS) who enable it and see no output.

Since per-metric OS annotations are not supported in the `mdatagen` schema, the metric description in `metadata.yaml` was updated to include the platform restriction, and all generated files were regenerated.

### Changes

- **`metadata.yaml`**: Updated `system.processes.created` description to note Linux/OpenBSD-only availability
- **`documentation.md`**: Regenerated via `go generate` to reflect the updated description
- **`generated_metrics.go`** / **`generated_metrics_test.go`**: Regenerated — description string and test assertion updated
- **`generated_package_test.go`** / **`generated_config_test.go`**: Regenerated — import order normalized by `mdatagen`
- **`README.md`**: Updated the processes scraper row in the scrapers table to note the platform restriction

### Link to tracking issue

Fixes #45721

### Documentation

Updated metric description in `metadata.yaml`, regenerated `documentation.md` and generated Go files, and updated the main `README.md`.