### PR TITLE
[chore][CI] Run tests without race detector to cover !race build-tagged tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -263,6 +263,44 @@ jobs:
             echo "Tests passed or were skipped. Continuing."
           fi
 
+  test-no-race-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [stable, oldstable]
+        runner: [ubuntu-24.04]
+        group:
+          - receiver-0
+          - receiver-1
+          - receiver-2
+          - receiver-3
+          - processor-0
+          - processor-1
+          - exporter-0
+          - exporter-1
+          - exporter-2
+          - exporter-3
+          - extension
+          - connector
+          - internal
+          - pkg
+          - cmd-0
+          - other
+    runs-on: ${{ matrix.runner }}
+    needs: [setup-environment]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Cache Test Build
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: ~/.cache/go-build
+          key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
+      - name: Run Unit Tests Without Race
+        run: make test-no-race GROUP=${{ matrix.group }}
+
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-24.04
@@ -279,6 +317,21 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+  test-no-race:
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
+    runs-on: ubuntu-24.04
+    needs: [setup-environment, test-no-race-matrix]
+    steps:
+      - name: Interpret result
+        run: |
+          if [[ success == ${{ needs.test-no-race-matrix.result }} ]]
+          then
+            echo "All matrix jobs passed!"
+          else
+            echo "One or more matrix jobs failed."
+            false
+          fi
+
   coverage:
     runs-on: ubuntu-24.04
     needs: [unittest]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -263,68 +263,41 @@ jobs:
             echo "Tests passed or were skipped. Continuing."
           fi
 
-  test-no-race-matrix:
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [stable, oldstable]
-        runner: [ubuntu-24.04]
-        group:
-          - receiver-0
-          - receiver-1
-          - receiver-2
-          - receiver-3
-          - processor-0
-          - processor-1
-          - exporter-0
-          - exporter-1
-          - exporter-2
-          - exporter-3
-          - extension
-          - connector
-          - internal
-          - pkg
-          - cmd-0
-          - other
-    runs-on: ${{ matrix.runner }}
+
+  # Runs only the packages that contain //go:build !race test files, without
+  # the race detector. This is intentionally NOT a full matrix duplication —
+  # it only covers the small set of packages that opt out of race detection.
+  unittest-no-race:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: oldstable
       - name: Cache Test Build
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         with:
           path: ~/.cache/go-build
-          key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
-      - name: Run Unit Tests Without Race
-        run: make test-no-race GROUP=${{ matrix.group }}
+          key: go-test-no-race-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Run Unit Tests Without Race Detector
+        # GROUP=receiver-0 is the only group that currently contains
+        # //go:build !race test files. All other modules in the group
+        # will discover no matching packages and skip silently.
+        run: make gotest-no-race GROUP=receiver-0
+      - run: ./.github/workflows/scripts/check-disk-space.sh
 
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-24.04
-    needs: [setup-environment, unittest-matrix]
+    needs: [setup-environment, unittest-matrix, unittest-no-race]
     steps:
       - name: Print result
         run: echo ${{ needs.unittest-matrix.result }}
       - name: Interpret result
         run: |
           if [[ success == ${{ needs.unittest-matrix.result }} ]]
-          then
-            echo "All matrix jobs passed!"
-          else
-            echo "One or more matrix jobs failed."
-            false
-          fi
-  test-no-race:
-    if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-24.04
-    needs: [setup-environment, test-no-race-matrix]
-    steps:
-      - name: Interpret result
-        run: |
-          if [[ success == ${{ needs.test-no-race-matrix.result }} ]]
           then
             echo "All matrix jobs passed!"
           else

--- a/.github/workflows/scripts/find-no-race-test-packages.sh
+++ b/.github/workflows/scripts/find-no-race-test-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# find-no-race-test-packages.sh
+#
+# Finds Go packages in the given directory (default: current dir) that contain
+# test files guarded by //go:build !race.
+#
+# Usage:
+#   find-no-race-test-packages.sh [search_dir]
+#
+# Output:
+#   A newline-separated list of unique package directories (relative to
+#   search_dir), one per line. Outputs nothing and exits 0 if none are found.
+
+set -euo pipefail
+
+SEARCH_DIR="${1:-.}"
+
+# Find all *_test.go files that carry a //go:build !race constraint, extract
+# their unique parent directories (= Go packages).
+#
+# Notes:
+#  - `|| true` prevents grep's exit code 1 (no matches) from aborting the
+#    script under `set -e` / `set -o pipefail`.
+#  - `while IFS= read -r f` safely handles file paths that contain spaces.
+#  - `sort -u` deduplicates packages when multiple !race test files share one.
+PKGS=$(grep -rl '//go:build !race' "$SEARCH_DIR" --include='*_test.go' 2>/dev/null \
+    | while IFS= read -r f; do dirname "$f"; done \
+    | sort -u || true)
+
+if [ -z "${PKGS:-}" ]; then
+    exit 0
+fi
+
+echo "$PKGS"

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,10 @@ gomoddownload:
 gotest:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="test"
 
+.PHONY: test-no-race
+test-no-race:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="test" GOTEST_RACE_OPT=
+
 .PHONY: gotest-with-cover
 gotest-with-cover:
 	@$(MAKE) $(FOR_GROUP_TARGET) TARGET="test-with-cover"

--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,13 @@ gomoddownload:
 gotest:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="test"
 
-.PHONY: test-no-race
-test-no-race:
-	$(MAKE) $(FOR_GROUP_TARGET) TARGET="test" GOTEST_RACE_OPT=
+# gotest-no-race runs only packages that have //go:build !race test files,
+# without the race detector. This is much cheaper than running the full suite
+# twice — most modules will skip immediately.
+.PHONY: gotest-no-race
+gotest-no-race:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="test-no-race"
+
 
 .PHONY: gotest-with-cover
 gotest-with-cover:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -108,6 +108,23 @@ common: lint test
 test:
 	$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- $(GOTEST_OPT)
 
+# GOTEST_NO_RACE_OPT intentionally omits GOTEST_RACE_OPT (-race) so that
+# files guarded by //go:build !race are included in the test run.
+GOTEST_NO_RACE_OPT?= -timeout $(GOTEST_TIMEOUT) -parallel 4 --tags=$(GO_BUILD_TAGS)
+
+# test-no-race finds packages in the current module that contain test files
+# with a //go:build !race constraint, then runs only those packages without
+# the race detector. Modules that have no such test files are skipped silently.
+.PHONY: test-no-race
+test-no-race:
+	@NO_RACE_PKGS=$$($(SRC_ROOT)/.github/workflows/scripts/find-no-race-test-packages.sh .); \
+	if [ -z "$$NO_RACE_PKGS" ]; then \
+		echo "No //go:build !race test packages found in $$(pwd). Skipping."; \
+		exit 0; \
+	fi; \
+	echo "Running tests without race detector in: $$NO_RACE_PKGS"; \
+	$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="$$NO_RACE_PKGS" -- $(GOTEST_NO_RACE_OPT)
+
 # This target is used in scoped tests.
 # We do not pass GOTESTSUM_OPT so that we do not re-run failures
 # and run each changed test two times.


### PR DESCRIPTION
Summary
CI currently runs unit tests only with the race detector enabled, which skips files guarded by //go:build !race.

Changes
Added test-no-race Makefile target that disables GOTEST_RACE_OPT while preserving native test orchestration.
Added a CI job mirroring unittest-matrix to execute tests without the race detector.

Ensures tests guarded by !race build tags are executed in CI without affecting existing race-enabled coverage.

Fixes #38092