### PR TITLE
[receiver/awscloudwatchreceiver] fix logs being skipped

### DIFF
--- a/.chloggen/awscloudwatchreceiver-fix-endtime.yaml
+++ b/.chloggen/awscloudwatchreceiver-fix-endtime.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use the oldest log timestamp as the next poll start time to prevent logs from being ignored"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [41122]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/awscloudwatchreceiver-fix-endtime.yaml
+++ b/.chloggen/awscloudwatchreceiver-fix-endtime.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: awscloudwatchreceiver
+component: receiver/awscloudwatch
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Use the oldest log timestamp as the next poll start time to prevent logs from being ignored"

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -737,7 +737,7 @@ func TestPollForLogsSetsCheckpointLastMessage(t *testing.T) {
 
 	logsRcvr.client = &mc
 	requiredTime, _ := logsRcvr.pollForLogs(
-		context.Background(),
+		t.Context(),
 		&streamNames{},
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -776,7 +776,7 @@ func TestPollForLogsSetsCheckpointNoData(t *testing.T) {
 
 	logsRcvr.client = &mc
 	requiredTime, _ := logsRcvr.pollForLogs(
-		context.Background(),
+		t.Context(),
 		&streamNames{},
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
@@ -850,7 +850,7 @@ func TestPollSetsGroupNextStartTimes(t *testing.T) {
 
 	logsRcvr.client = &mc
 
-	err := logsRcvr.poll(context.Background())
+	err := logsRcvr.poll(t.Context())
 
 	// Verify no errors
 	require.NoError(t, err)

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -694,6 +694,173 @@ func TestDeletedLogGroupDuringAutodiscover(t *testing.T) {
 	mc.AssertExpectations(t)
 }
 
+func TestPollForLogsSetsCheckpointLastMessage(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			testLogGroupName: {
+				Names: []*string{&testLogStreamName},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	logsRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	mc := mockClient{}
+
+	// add 1 millisecond to the returned timestamp
+	expectedTimestamp := time.Date(2020, 1, 1, 0, 0, 0, 1000000, time.UTC)
+
+	mc.On("FilterLogEvents", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events: []types.FilteredLogEvent{
+			{
+				EventId:       aws.String("event1"),
+				LogStreamName: aws.String("stream1"),
+				Message:       aws.String("test message"),
+				Timestamp:     aws.Int64(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()),
+			},
+			{
+				EventId:       aws.String("event2"),
+				LogStreamName: aws.String("stream2"),
+				Message:       aws.String("test message 2"),
+				Timestamp:     aws.Int64(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()),
+			},
+		},
+		NextToken: nil,
+	}, nil)
+
+	logsRcvr.client = &mc
+	requiredTime, _ := logsRcvr.pollForLogs(
+		context.Background(),
+		&streamNames{},
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	)
+
+	require.Equal(t, expectedTimestamp.UnixMilli(), requiredTime.UnixMilli())
+}
+
+func TestPollForLogsSetsCheckpointNoData(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			testLogGroupName: {
+				Names: []*string{&testLogStreamName},
+			},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	logsRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+	mc := mockClient{}
+
+	// if no logs found, should return passed endTime
+	expectedTimestamp := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	mc.On("FilterLogEvents", mock.Anything, mock.Anything, mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events:    []types.FilteredLogEvent{},
+		NextToken: nil,
+	}, nil)
+
+	logsRcvr.client = &mc
+	requiredTime, _ := logsRcvr.pollForLogs(
+		context.Background(),
+		&streamNames{},
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
+	)
+
+	require.Equal(t, expectedTimestamp.UnixMilli(), requiredTime.UnixMilli())
+}
+
+func TestPollSetsGroupNextStartTimes(t *testing.T) {
+	logGroup1 := "log-group-1"
+	logGroup2 := "log-group-2"
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Region = "us-west-1"
+	cfg.Logs.PollInterval = 1 * time.Second
+	cfg.Logs.Groups = GroupConfig{
+		NamedConfigs: map[string]StreamConfig{
+			logGroup1: {},
+			logGroup2: {},
+		},
+	}
+
+	sink := &consumertest.LogsSink{}
+	logsRcvr := newLogsReceiver(cfg, receiver.Settings{
+		TelemetrySettings: component.TelemetrySettings{
+			Logger: zap.NewNop(),
+		},
+	}, sink)
+
+	// Set up initial start times
+	initialTime1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	initialTime2 := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	logsRcvr.groupNextStartTimes = map[string]time.Time{
+		logGroup1: initialTime1,
+		logGroup2: initialTime2,
+	}
+
+	mc := mockClient{}
+
+	// Set up expected return values for each log group
+	expectedTime1 := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	expectedTime2 := time.Date(2020, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	mc.On("FilterLogEvents", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.FilterLogEventsInput) bool {
+		return *input.LogGroupName == logGroup1
+	}), mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events: []types.FilteredLogEvent{
+			{
+				EventId:       aws.String("event1"),
+				LogStreamName: aws.String("stream1"),
+				Message:       aws.String("test message"),
+				Timestamp:     aws.Int64(expectedTime1.Add(-1 * time.Millisecond).UnixMilli()),
+			},
+		},
+		NextToken: nil,
+	}, nil)
+
+	mc.On("FilterLogEvents", mock.Anything, mock.MatchedBy(func(input *cloudwatchlogs.FilterLogEventsInput) bool {
+		return *input.LogGroupName == logGroup2
+	}), mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events: []types.FilteredLogEvent{
+			{
+				EventId:       aws.String("event2"),
+				LogStreamName: aws.String("stream2"),
+				Message:       aws.String("test message"),
+				Timestamp:     aws.Int64(expectedTime2.Add(-1 * time.Millisecond).UnixMilli()),
+			},
+		},
+		NextToken: nil,
+	}, nil)
+
+	logsRcvr.client = &mc
+
+	err := logsRcvr.poll(context.Background())
+
+	// Verify no errors
+	require.NoError(t, err)
+
+	require.Equal(t, expectedTime1.UnixMilli(), logsRcvr.groupNextStartTimes[logGroup1].UnixMilli())
+	require.Equal(t, expectedTime2.UnixMilli(), logsRcvr.groupNextStartTimes[logGroup2].UnixMilli())
+
+	mc.AssertExpectations(t)
+}
+
 func defaultMockClient() client {
 	mc := &mockClient{}
 	mc.On("DescribeLogGroups", mock.Anything, mock.Anything, mock.Anything).Return(


### PR DESCRIPTION
Description

Update the poll and pollForLogs functions to use the oldest log timestamp as the next polling start time.

**Reopened from** #41742 

Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/41122