### PR TITLE
[pkg/ottl] Add delete_matching_values function

### DIFF
--- a/.chloggen/ottl-delete-matching-values.yaml
+++ b/.chloggen/ottl-delete-matching-values.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: pkg/ottl
+note: Add `delete_matching_values` OTTL function to conditionally remove map entries based on value regex.
+issues: [43804]
+subtext:
+change_logs: [user, api]
+

--- a/.chloggen/ottl-delete-matching-values.yaml
+++ b/.chloggen/ottl-delete-matching-values.yaml
@@ -2,6 +2,5 @@ change_type: enhancement
 component: pkg/ottl
 note: Add `delete_matching_values` OTTL function to conditionally remove map entries based on value regex.
 issues: [43804]
-subtext:
 change_logs: [user, api]
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -49,6 +49,7 @@ Available Editors:
 - [delete_index](#delete_index)
 - [delete_key](#delete_key)
 - [delete_matching_keys](#delete_matching_keys)
+- [delete_matching_values](#delete_matching_values)
 - [keep_matching_keys](#keep_matching_keys)
 - [flatten](#flatten)
 - [keep_keys](#keep_keys)
@@ -123,6 +124,22 @@ Examples:
 - `delete_matching_keys(log.attributes, "(?i).*password.*")`
 
 - `delete_matching_keys(resource.attributes, "(?i).*password.*")`
+
+### delete_matching_values
+
+`delete_matching_values(target, pattern)`
+
+The `delete_matching_values` function removes all keys from a `pcommon.Map` whose value matches a regex pattern. Non-string values are evaluated dynamically by converting them to strings before matching.
+
+`target` is a path expression to a `pcommon.Map` type field. `pattern` is a regex string.
+
+All keys whose value match the pattern will be deleted from the map.
+
+Examples:
+
+- `delete_matching_values(log.attributes, "^$")` // deletes entries with an empty string
+
+- `delete_matching_values(resource.attributes, "(?i).*redacted.*")`
 
 ### keep_matching_keys
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -137,8 +137,7 @@ All keys whose values match the pattern will be deleted from the map.
 
 Examples:
 
-- `delete_matching_values(log.attributes, "^$")` // deletes entries with an empty string
-
+- `delete_matching_values(log.attributes, "^$")`
 - `delete_matching_values(resource.attributes, "(?i).*redacted.*")`
 
 ### keep_matching_keys

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -129,11 +129,11 @@ Examples:
 
 `delete_matching_values(target, pattern)`
 
-The `delete_matching_values` function removes all keys from a `pcommon.Map` whose value matches a regex pattern. Non-string values are evaluated dynamically by converting them to strings before matching.
+The `delete_matching_values` function removes all keys from a `pcommon.Map` whose string value matches a regex pattern. Only string-typed values are matched; non-string types (int, bool, map, slice, etc.) are never deleted.
 
 `target` is a path expression to a `pcommon.Map` type field. `pattern` is a regex string.
 
-All keys whose value match the pattern will be deleted from the map.
+All keys whose values match the pattern will be deleted from the map.
 
 Examples:
 

--- a/pkg/ottl/ottlfuncs/func_delete_matching_values.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_values.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type DeleteMatchingValuesArguments[K any] struct {
+	Target  ottl.PMapGetSetter[K]
+	Pattern ottl.StringGetter[K]
+}
+
+func NewDeleteMatchingValuesFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("delete_matching_values", &DeleteMatchingValuesArguments[K]{}, createDeleteMatchingValuesFunction[K])
+}
+
+func createDeleteMatchingValuesFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*DeleteMatchingValuesArguments[K])
+
+	if !ok {
+		return nil, errors.New("DeleteMatchingValuesFactory args must be of type *DeleteMatchingValuesArguments[K]")
+	}
+
+	return deleteMatchingValues(args.Target, args.Pattern)
+}
+
+func deleteMatchingValues[K any](target ottl.PMapGetSetter[K], pattern ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+	compiledPattern, err := newDynamicRegex("delete_matching_values", pattern)
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context, tCtx K) (any, error) {
+		cp, err := compiledPattern.compile(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		val.RemoveIf(func(_ string, value pcommon.Value) bool {
+			return cp.MatchString(value.AsString())
+		})
+		return nil, target.Set(ctx, tCtx, val)
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_values.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_values.go
@@ -46,7 +46,7 @@ func deleteMatchingValues[K any](target ottl.PMapGetSetter[K], pattern ottl.Stri
 			return nil, err
 		}
 		val.RemoveIf(func(_ string, value pcommon.Value) bool {
-			return cp.MatchString(value.AsString())
+			return value.Type() == pcommon.ValueTypeStr && cp.MatchString(value.Str())
 		})
 		return nil, target.Set(ctx, tCtx, val)
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_deleteMatchingValues(t *testing.T) {
+	input := pcommon.NewMap()
+	input.PutStr("test", "hello world")
+	input.PutInt("test2", 3)
+	input.PutBool("test3", true)
+	input.PutStr("test4", "")
+
+	tests := []struct {
+		name    string
+		pattern ottl.StringGetter[pcommon.Map]
+		want    func(pcommon.Map)
+	}{
+		{
+			name:    "delete everything",
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return ".*", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.EnsureCapacity(4)
+			},
+		},
+		{
+			name:    "delete values that are empty strings",
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "^$", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutInt("test2", 3)
+				expectedMap.PutBool("test3", true)
+			},
+		},
+		{
+			name:    "delete numeric value as string",
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "^3$", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutBool("test3", true)
+				expectedMap.PutStr("test4", "")
+			},
+		},
+		{
+			name:    "delete boolean value as string",
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "true", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutInt("test2", 3)
+				expectedMap.PutStr("test4", "")
+			},
+		},
+		{
+			name:    "delete nothing",
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "not a matching pattern", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutInt("test2", 3)
+				expectedMap.PutBool("test3", true)
+				expectedMap.PutStr("test4", "")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scenarioMap := pcommon.NewMap()
+			input.CopyTo(scenarioMap)
+
+			setterWasCalled := false
+			target := &ottl.StandardPMapGetSetter[pcommon.Map]{
+				Getter: func(_ context.Context, tCtx pcommon.Map) (pcommon.Map, error) {
+					return tCtx, nil
+				},
+				Setter: func(_ context.Context, tCtx pcommon.Map, m any) error {
+					setterWasCalled = true
+					if v, ok := m.(pcommon.Map); ok {
+						v.CopyTo(tCtx)
+						return nil
+					}
+					return errors.New("expected pcommon.Map")
+				},
+			}
+
+			exprFunc, err := deleteMatchingValues(target, tt.pattern)
+			require.NoError(t, err)
+
+			_, err = exprFunc(nil, scenarioMap)
+			require.NoError(t, err)
+			assert.True(t, setterWasCalled)
+
+			expected := pcommon.NewMap()
+			tt.want(expected)
+
+			assert.Equal(t, expected, scenarioMap)
+		})
+	}
+}
+
+func Test_deleteMatchingValues_bad_input(t *testing.T) {
+	input := pcommon.NewValueInt(1)
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
+		},
+	}
+
+	pattern := ottl.StandardStringGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "anything", nil
+		},
+	}
+
+	exprFunc, err := deleteMatchingValues(target, pattern)
+	require.NoError(t, err)
+	_, err = exprFunc(nil, input)
+	assert.Error(t, err)
+}
+
+func Test_deleteMatchingValues_get_nil(t *testing.T) {
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(_ context.Context, tCtx any) (pcommon.Map, error) {
+			if v, ok := tCtx.(pcommon.Map); ok {
+				return v, nil
+			}
+			return pcommon.Map{}, errors.New("expected pcommon.Map")
+		},
+	}
+
+	pattern := ottl.StandardStringGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "anything", nil
+		},
+	}
+
+	exprFunc, err := deleteMatchingValues(target, pattern)
+	require.NoError(t, err)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
+}
+
+func Test_deleteMatchingValues_invalid_pattern(t *testing.T) {
+	target := &ottl.StandardPMapGetSetter[any]{
+		Getter: func(context.Context, any) (pcommon.Map, error) {
+			t.Errorf("nothing should be received in this scenario")
+			return pcommon.Map{}, nil
+		},
+	}
+
+	invalidRegexPattern := ottl.StandardStringGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "*", nil
+		},
+	}
+	exprFunc, err := deleteMatchingValues(target, invalidRegexPattern)
+	require.NoError(t, err)
+	_, err = exprFunc(nil, nil)
+	assert.ErrorContains(t, err, "error parsing regexp:")
+}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
@@ -16,66 +16,92 @@ import (
 )
 
 func Test_deleteMatchingValues(t *testing.T) {
-	input := pcommon.NewMap()
-	input.PutStr("test", "hello world")
-	input.PutInt("test2", 3)
-	input.PutBool("test3", true)
-	input.PutStr("test4", "")
-
 	tests := []struct {
 		name    string
+		input   func() pcommon.Map
 		pattern ottl.StringGetter[pcommon.Map]
 		want    func(pcommon.Map)
 	}{
 		{
-			name:    "delete everything",
+			name: "delete everything",
+			input: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "hello world")
+				m.PutStr("key2", "foo bar")
+				return m
+			},
 			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return ".*", nil }},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.EnsureCapacity(4)
+				expectedMap.EnsureCapacity(2)
 			},
 		},
 		{
-			name:    "delete values that are empty strings",
+			name: "delete values that are empty strings",
+			input: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "hello world")
+				m.PutStr("key2", "")
+				return m
+			},
 			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "^$", nil }},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.PutStr("test", "hello world")
-				expectedMap.PutInt("test2", 3)
-				expectedMap.PutBool("test3", true)
+				expectedMap.PutStr("key1", "hello world")
 			},
 		},
 		{
-			name:    "delete numeric value as string",
-			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "^3$", nil }},
-			want: func(expectedMap pcommon.Map) {
-				expectedMap.PutStr("test", "hello world")
-				expectedMap.PutBool("test3", true)
-				expectedMap.PutStr("test4", "")
+			name: "delete nothing",
+			input: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("key1", "hello world")
+				m.PutStr("key2", "foo bar")
+				return m
 			},
-		},
-		{
-			name:    "delete boolean value as string",
-			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "true", nil }},
-			want: func(expectedMap pcommon.Map) {
-				expectedMap.PutStr("test", "hello world")
-				expectedMap.PutInt("test2", 3)
-				expectedMap.PutStr("test4", "")
-			},
-		},
-		{
-			name:    "delete nothing",
 			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "not a matching pattern", nil }},
 			want: func(expectedMap pcommon.Map) {
-				expectedMap.PutStr("test", "hello world")
-				expectedMap.PutInt("test2", 3)
-				expectedMap.PutBool("test3", true)
-				expectedMap.PutStr("test4", "")
+				expectedMap.PutStr("key1", "hello world")
+				expectedMap.PutStr("key2", "foo bar")
+			},
+		},
+		{
+			name: "non-string types are not deleted",
+			input: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("str", "hello")
+				m.PutInt("int", 3)
+				m.PutBool("bool", true)
+				m.PutEmptyMap("map").PutStr("nested", "value")
+				m.PutEmptySlice("slice").AppendEmpty().SetStr("item")
+				return m
+			},
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return ".*", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutInt("int", 3)
+				expectedMap.PutBool("bool", true)
+				expectedMap.PutEmptyMap("map").PutStr("nested", "value")
+				expectedMap.PutEmptySlice("slice").AppendEmpty().SetStr("item")
+			},
+		},
+		{
+			name: "mixed types only delete matching strings",
+			input: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("str1", "sensitive-data")
+				m.PutStr("str2", "safe-value")
+				m.PutInt("int", 42)
+				m.PutBool("bool", false)
+				return m
+			},
+			pattern: ottl.StandardStringGetter[pcommon.Map]{Getter: func(_ context.Context, _ pcommon.Map) (any, error) { return "sensitive.*", nil }},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("str2", "safe-value")
+				expectedMap.PutInt("int", 42)
+				expectedMap.PutBool("bool", false)
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scenarioMap := pcommon.NewMap()
-			input.CopyTo(scenarioMap)
+			scenarioMap := tt.input()
 
 			setterWasCalled := false
 			target := &ottl.StandardPMapGetSetter[pcommon.Map]{
@@ -152,21 +178,4 @@ func Test_deleteMatchingValues_get_nil(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_deleteMatchingValues_invalid_pattern(t *testing.T) {
-	target := &ottl.StandardPMapGetSetter[any]{
-		Getter: func(context.Context, any) (pcommon.Map, error) {
-			t.Errorf("nothing should be received in this scenario")
-			return pcommon.Map{}, nil
-		},
-	}
 
-	invalidRegexPattern := ottl.StandardStringGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
-			return "*", nil
-		},
-	}
-	exprFunc, err := deleteMatchingValues(target, invalidRegexPattern)
-	require.NoError(t, err)
-	_, err = exprFunc(nil, nil)
-	assert.ErrorContains(t, err, "error parsing regexp:")
-}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_values_test.go
@@ -177,5 +177,3 @@ func Test_deleteMatchingValues_get_nil(t *testing.T) {
 	_, err = exprFunc(nil, nil)
 	assert.Error(t, err)
 }
-
-

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -13,6 +13,7 @@ func StandardFuncs[K any]() map[string]ottl.Factory[K] {
 		// Editors
 		NewDeleteKeyFactory[K](),
 		NewDeleteMatchingKeysFactory[K](),
+		NewDeleteMatchingValuesFactory[K](),
 		NewKeepMatchingKeysFactory[K](),
 		NewFlattenFactory[K](),
 		NewKeepKeysFactory[K](),


### PR DESCRIPTION
**Description:**
This PR adds the `delete_matching_values` function to the OpenTelemetry Transformation Language. 
It resolves issue #43804 by allowing users to conditionally delete keys from a `pcommon.Map` where the *value* matches a specific regex pattern (e.g., removing all keys that have an empty string value).

**Link to tracking Issue:**
Resolves #43804 

**Testing:**
100% test coverage implemented in `func_delete_matching_values_test.go`. Verified matching of empty strings, bools, and ints.

**Documentation:**
Added the function specification to the `pkg/ottl/ottlfuncs/README.md` documentation.