### PR TITLE
[internal/metadataproviders/azure] fix Metadata header case

### DIFF
--- a/.chloggen/fix-azure-imds-metadata-header.yaml
+++ b/.chloggen/fix-azure-imds-metadata-header.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: internal/metadataproviders/azure
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Azure IMDS header value
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46281]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Azure's IMDS endpoint is expecting the `Metadata` header to be `true`, not `True`, the latter causing 400s.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/.chloggen/fix-azure-imds-metadata-header.yaml
+++ b/.chloggen/fix-azure-imds-metadata-header.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: internal/metadataproviders/azure
+component: internal/metadataproviders
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix Azure IMDS header value

--- a/.chloggen/fix-azure-imds-metadata-header.yaml
+++ b/.chloggen/fix-azure-imds-metadata-header.yaml
@@ -24,4 +24,4 @@ subtext: Azure's IMDS endpoint is expecting the `Metadata` header to be `true`, 
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: [user, api]
+change_logs: [user]

--- a/internal/metadataproviders/azure/metadata.go
+++ b/internal/metadataproviders/azure/metadata.go
@@ -77,7 +77,8 @@ func (p *azureProviderImpl) Metadata(ctx context.Context) (*ComputeMetadata, err
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Add("Metadata", "True")
+	// As per the Azure IMDS documentation, the Metadata header must be set to "true" (note lowercase).
+	req.Header.Add("Metadata", "true")
 	q := req.URL.Query()
 	q.Add(formatKey, jsonFormat)
 	q.Add(apiVersionKey, apiVersion)

--- a/processor/resourcedetectionprocessor/testdata/e2e/aks/collector/01-metadata-configmap.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/aks/collector/01-metadata-configmap.yaml
@@ -51,7 +51,7 @@ data:
             if path == "/metadata/instance/compute":
                 # Check for required Metadata header
                 metadata_header = self.headers.get("Metadata")
-                if metadata_header != "True":
+                if metadata_header != "true":
                     self.send_response(400)
                     self.send_header("Content-Type", "text/plain")
                     self.end_headers()

--- a/processor/resourcedetectionprocessor/testdata/e2e/azure/collector/01-metadata-configmap.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/azure/collector/01-metadata-configmap.yaml
@@ -50,7 +50,7 @@ data:
             if path == "/metadata/instance/compute":
                 # Check for required Metadata header
                 metadata_header = self.headers.get("Metadata")
-                if metadata_header != "True":
+                if metadata_header != "true":
                     self.send_response(400)
                     self.send_header("Content-Type", "text/plain")
                     self.end_headers()


### PR DESCRIPTION
#### Description

Azure's IMDS endpoint is expecting the `Metadata` header to be [`true`, not `True`][1], which is resulting in 400s and therefore the azure metadataprovider and anything depending on it (e.g. azure/aks resourceprovider) to not work. I have verified this in an AKS cluster in the uksouth and useast2 locations.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- `make test`

[1]: https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux#security-and-authentication