### PR TITLE
[exporter/clickhouse] log an error instead of exiting on failure to validate features

### DIFF
--- a/.chloggen/clickhouse-validate-feature.yaml
+++ b/.chloggen/clickhouse-validate-feature.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not crash the exporter if it cannot inspect the table schemas
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46285]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously setting `create_schema: false` would skip validating the actual connection on start. This was useful
+  if you had unstable targets, as you could run the collector and let the sending queue/failover connector handle
+  connection errors to ClickHouse.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -60,7 +60,7 @@ func (e *logsExporter) start(ctx context.Context, _ component.Host) error {
 
 	err = e.detectSchemaFeatures(ctx)
 	if err != nil {
-		return fmt.Errorf("schema detection: %w", err)
+		e.logger.Error("schema detection failed", zap.Error(err))
 	}
 
 	e.renderInsertLogsSQL()

--- a/exporter/clickhouseexporter/exporter_logs_json.go
+++ b/exporter/clickhouseexporter/exporter_logs_json.go
@@ -67,7 +67,7 @@ func (e *logsJSONExporter) start(ctx context.Context, _ component.Host) error {
 
 	err = e.detectSchemaFeatures(ctx)
 	if err != nil {
-		return fmt.Errorf("schema detection: %w", err)
+		e.logger.Error("schema detection failed", zap.Error(err))
 	}
 
 	e.renderInsertLogsJSONSQL()

--- a/exporter/clickhouseexporter/exporter_traces_json.go
+++ b/exporter/clickhouseexporter/exporter_traces_json.go
@@ -66,7 +66,7 @@ func (e *tracesJSONExporter) start(ctx context.Context, _ component.Host) error 
 
 	err = e.detectSchemaFeatures(ctx)
 	if err != nil {
-		return fmt.Errorf("schema detection: %w", err)
+		e.logger.Error("schema detection failed", zap.Error(err))
 	}
 
 	e.renderInsertTracesJSONSQL()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Previously setting `create_schema: false` would skip validating the actual connection on start. This was useful if you had unstable targets, as you could run the collector and let the sending queue/failover connector handle connection errors to ClickHouse.
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46285

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
