### PR TITLE
[chore][cmd/opampsupervisor] Respect GOTEST_RACE_OPT to avoid failing e2e tests on Windows 

### DIFF
--- a/cmd/opampsupervisor/Makefile
+++ b/cmd/opampsupervisor/Makefile
@@ -2,4 +2,4 @@ include ../../Makefile.Common
 
 e2e-test:
 	make -C ../../ otelcontribcol
-	go test -v -race --tags=e2e .
+	go test -v $(GOTEST_RACE_OPT) --tags=e2e .


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The change introduced in #45755 broke the CI of e2e-tests on Windows for `cmd/opampsupervisor`.

This will ensure the job will respect the `GOTEST_RACE_OPT` var to avoid failing on Windows.

See: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22322329975/job/64588631259