### PR TITLE
[chore] Fix failing test TestE2EConsulDetector

### DIFF
--- a/processor/resourcedetectionprocessor/e2e_test.go
+++ b/processor/resourcedetectionprocessor/e2e_test.go
@@ -400,6 +400,7 @@ func TestE2ELambdaDetector(t *testing.T) {
 // and verifying that consul metadata (datacenter, node ID, hostname, and custom meta labels)
 // is correctly detected and attached to metrics.
 func TestE2EConsulDetector(t *testing.T) {
+	t.Skip("Skipping: pod stuck in Pending state in CI. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46302")
 	var expected pmetric.Metrics
 	expectedFile := filepath.Join("testdata", "e2e", "consul", "expected.yaml")
 	expected, err := golden.ReadMetrics(expectedFile)

--- a/processor/resourcedetectionprocessor/e2e_test.go
+++ b/processor/resourcedetectionprocessor/e2e_test.go
@@ -400,7 +400,6 @@ func TestE2ELambdaDetector(t *testing.T) {
 // and verifying that consul metadata (datacenter, node ID, hostname, and custom meta labels)
 // is correctly detected and attached to metrics.
 func TestE2EConsulDetector(t *testing.T) {
-	t.Skip("Skipping: pod stuck in Pending state in CI. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46302")
 	var expected pmetric.Metrics
 	expectedFile := filepath.Join("testdata", "e2e", "consul", "expected.yaml")
 	expected, err := golden.ReadMetrics(expectedFile)

--- a/processor/resourcedetectionprocessor/testdata/e2e/consul/collector/deployment.yaml
+++ b/processor/resourcedetectionprocessor/testdata/e2e/consul/collector/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: {{ .Name }}-sa
       containers:
         - name: consul-agent
-          image: hashicorp/consul:latest
+          image: hashicorp/consul:1.22.3
           args:
             - "agent"
             - "-dev"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This test is failing on unrelated PRs and main. Example failed run [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22334897301/job/64625993084). The image `hashicorp/consul:latest` used in the deployment is no longer available. Pin `hashicorp/consul` to a specific version since the latest tag is no longer available. Ref- https://hub.docker.com/r/hashicorp/consul/tags


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46302
