### PR TITLE
[pkg/xk8stest] display collector pod events

### DIFF
--- a/.chloggen/xk8stest-pod-diagnostics.yaml
+++ b/.chloggen/xk8stest-pod-diagnostics.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: pkg/xk8stest
+
+note: Display pod events on collector startup timeout for easier diagnosis of e2e failures.
+
+issues: [46305]
+
+subtext:
+
+change_logs: [user]

--- a/.chloggen/xk8stest-pod-diagnostics.yaml
+++ b/.chloggen/xk8stest-pod-diagnostics.yaml
@@ -8,4 +8,4 @@ issues: [46305]
 
 subtext:
 
-change_logs: [user]
+change_logs: [api]

--- a/pkg/xk8stest/k8s_collector.go
+++ b/pkg/xk8stest/k8s_collector.go
@@ -5,6 +5,8 @@ package xk8stest // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -61,51 +63,127 @@ func CreateCollectorObjects(t *testing.T, client *K8sClient, testID, manifestsDi
 func WaitForCollectorToStart(t *testing.T, client *K8sClient, podNamespace string, podLabels map[string]any) {
 	podGVR := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 	listOptions := metav1.ListOptions{LabelSelector: SelectorFromMap(podLabels).String()}
-	podTimeoutMinutes := 3
+	timeout := 3 * time.Minute
+	poll := 2 * time.Second
+	deadline := time.Now().Add(timeout)
+
 	t.Logf("waiting for collector pods to be ready")
-	require.Eventuallyf(t, func() bool {
-		list, err := client.DynamicClient.Resource(podGVR).Namespace(podNamespace).List(t.Context(), listOptions)
-		require.NoError(t, err, "failed to list collector pods")
-		podsNotReady := len(list.Items)
-		if podsNotReady == 0 {
-			t.Log("did not find collector pods")
-			return false
-		}
-
-		var pods v1.PodList
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.UnstructuredContent(), &pods)
-		require.NoError(t, err, "failed to convert unstructured to podList")
-
-		for i := range pods.Items {
-			pod := &pods.Items[i]
-			podReady := false
-			if pod.Status.Phase != v1.PodRunning {
-				t.Logf("pod %v is not running, current phase: %v", pod.Name, pod.Status.Phase)
-				continue
-			}
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
-					podsNotReady--
-					podReady = true
-				}
-			}
-			// Add some debug logs for crashing pods
-			if !podReady {
-				for i := range pod.Status.ContainerStatuses {
-					cs := &pod.Status.ContainerStatuses[i]
-					restartCount := cs.RestartCount
-					if restartCount > 0 && cs.LastTerminationState.Terminated != nil {
-						t.Logf("restart count = %d for container %s in pod %s, last terminated reason: %s", restartCount, cs.Name, pod.Name, cs.LastTerminationState.Terminated.Reason)
-						t.Logf("termination message: %s", cs.LastTerminationState.Terminated.Message)
-					}
-				}
-			}
-		}
-		if podsNotReady == 0 {
+	for time.Now().Before(deadline) {
+		if collectorPodsReady(t, client, podNamespace, podGVR, listOptions) {
 			t.Logf("collector pods are ready")
+			return
+		}
+		time.Sleep(poll)
+	}
+
+	logCollectorPodDiagnostics(t, client, podNamespace, podGVR, listOptions)
+	require.Fail(t, "collector pods were not ready", "timed out after %s", timeout)
+}
+
+func collectorPodsReady(t *testing.T, client *K8sClient, namespace string, podGVR schema.GroupVersionResource, listOptions metav1.ListOptions) bool {
+	t.Helper()
+	list, err := client.DynamicClient.Resource(podGVR).Namespace(namespace).List(t.Context(), listOptions)
+	require.NoError(t, err, "failed to list collector pods")
+	if len(list.Items) == 0 {
+		t.Log("did not find collector pods")
+		return false
+	}
+
+	var pods v1.PodList
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.UnstructuredContent(), &pods)
+	require.NoError(t, err, "failed to convert unstructured to podList")
+
+	podsNotReady := len(pods.Items)
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		podReady := false
+		if pod.Status.Phase != v1.PodRunning {
+			t.Logf("pod %v is not running, current phase: %v", pod.Name, pod.Status.Phase)
+			continue
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+				podsNotReady--
+				podReady = true
+			}
+		}
+		// Add some debug logs for crashing pods
+		if !podReady {
+			for i := range pod.Status.ContainerStatuses {
+				cs := &pod.Status.ContainerStatuses[i]
+				restartCount := cs.RestartCount
+				if restartCount > 0 && cs.LastTerminationState.Terminated != nil {
+					t.Logf("restart count = %d for container %s in pod %s, last terminated reason: %s", restartCount, cs.Name, pod.Name, cs.LastTerminationState.Terminated.Reason)
+					t.Logf("termination message: %s", cs.LastTerminationState.Terminated.Message)
+				}
+			}
+		}
+	}
+	return podsNotReady == 0
+}
+
+func logCollectorPodDiagnostics(t *testing.T, client *K8sClient, namespace string, podGVR schema.GroupVersionResource, listOptions metav1.ListOptions) {
+	t.Helper()
+	list, err := client.DynamicClient.Resource(podGVR).Namespace(namespace).List(t.Context(), listOptions)
+	if err != nil {
+		return
+	}
+	var pods v1.PodList
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(list.UnstructuredContent(), &pods); err != nil {
+		return
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if podReady(pod) {
+			continue
+		}
+		t.Logf("--- events for pod %s (phase: %s) ---", pod.Name, pod.Status.Phase)
+		logPodEvents(t, client, namespace, pod.Name)
+	}
+}
+
+func podReady(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodRunning {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
 			return true
 		}
-		return false
-	}, time.Duration(podTimeoutMinutes)*time.Minute, 2*time.Second,
-		"collector pods were not ready within %d minutes", podTimeoutMinutes)
+	}
+	return false
+}
+
+func logPodEvents(t *testing.T, client *K8sClient, namespace, podName string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	eventsGVR := schema.GroupVersionResource{Version: "v1", Resource: "events"}
+	list, err := client.DynamicClient.Resource(eventsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
+	})
+	if err != nil || len(list.Items) == 0 {
+		t.Logf("  no events found")
+		return
+	}
+	for _, item := range list.Items {
+		fields := item.Object
+		source := ""
+		if s, ok := fields["source"].(map[string]any); ok {
+			source = strField(s, "component")
+		}
+		t.Logf("  %s  %s  %s  %s",
+			strField(fields, "type"),
+			strField(fields, "reason"),
+			source,
+			strField(fields, "message"))
+	}
+}
+
+func strField(obj map[string]any, key string) string {
+	if v, ok := obj[key].(string); ok {
+		return v
+	}
+	return ""
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This change is meant to make debugging errors in k8s e2e tests a little easier. When `WaitForCollectorToStart` times out, we now query and print the pod events for any collector pod that isn't ready. So instead of just a timeout message, you get the below output:

```
❯ go test -v --tags=e2e -run TestE2EConsulDetector -timeout 5m
=== RUN   TestE2EConsulDetector
    k8s_collector.go:70: waiting for collector pods to be ready
    k8s_collector.go:72: did not find collector pods
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:72: pod otelcol-756e59a6-6b5466b969-7lmpl is not running, current phase: Pending
    k8s_collector.go:79: --- events for pod otelcol-756e59a6-6b5466b969-7lmpl (phase: Pending) ---
    k8s_collector.go:79:   Normal  Scheduled  default-scheduler  Successfully assigned default/otelcol-756e59a6-6b5466b969-7lmpl to e2e-test-control-plane
    k8s_collector.go:79:   Normal  Pulling  kubelet  Pulling image "hashicorp/consul:1.22.3-fake"
    k8s_collector.go:79:   Warning  Failed  kubelet  Failed to pull image "hashicorp/consul:1.22.3-fake": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/hashicorp/consul:1.22.3-fake": failed to resolve reference "docker.io/hashicorp/consul:1.22.3-fake": docker.io/hashicorp/consul:1.22.3-fake: not found
    k8s_collector.go:79:   Warning  Failed  kubelet  Error: ErrImagePull
    k8s_collector.go:79:   Normal  Pulled  kubelet  Container image "otelcontribcol:latest" already present on machine
    k8s_collector.go:79:   Normal  Created  kubelet  Created container: otelcol
    k8s_collector.go:79:   Normal  Started  kubelet  Started container otelcol
    k8s_collector.go:79:   Normal  BackOff  kubelet  Back-off pulling image "hashicorp/consul:1.22.3-fake"
    k8s_collector.go:79:   Warning  Failed  kubelet  Error: ImagePullBackOff
    k8s_collector.go:79:   Warning  BackOff  kubelet  Back-off restarting failed container otelcol in pod otelcol-756e59a6-6b5466b969-7lmpl_default(7a9d7066-bf7a-4582-babf-579927682223)
    k8s_collector.go:80: 
                Error Trace:    /Users/jjain/work/opentelemetry-collector-contrib/pkg/xk8stest/k8s_collector.go:80
                                                        /Users/jjain/work/opentelemetry-collector-contrib/pkg/xk8stest/k8s_collector.go:58
                                                        /Users/jjain/work/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/e2e_test.go:420
                Error:          collector pods were not ready
                Test:           TestE2EConsulDetector
                Messages:       timed out after 3m0s
--- FAIL: TestE2EConsulDetector (180.92s)
```

This is meant to make debugging errors in k8s e2e tests a little easier.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46305

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Tried running this on local with a failing e2e test. The output above is from test run.

