### PR TITLE
[processor/transform] Add alpha feature gate for aggregate_on_attributes

### DIFF
--- a/.chloggen/46049-transform-aggregate-on-attributes.yaml
+++ b/.chloggen/46049-transform-aggregate-on-attributes.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: processor/transform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "[processor/transform] Add alpha feature gate for aggregate_on_attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46049]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -541,11 +541,13 @@ The `aggregate_on_attributes` function aggregates all data points in the metric.
 
 The optional `attributes` argument controls which datapoint attributes are kept before aggregation:
 
-- omitted (`aggregate_on_attributes(function)`): all existing data point attributes are kept. Aggregation only combines data points that already share the same full attribute set.
+- omitted (`aggregate_on_attributes(function)`): all existing data point attributes are kept. Aggregation only combines data points that already share the same full attribute set. A warning is logged because this is effectively a no-op for attribute filtering.
 - `[]` (empty list): all datapoint attributes are removed. Aggregation is performed across all data points in the metric.
 - `[...]` (list of attribute keys): only the specified data point attributes are kept. All other attributes are removed, and aggregation is performed by grouping on the remaining attributes.
 
 **NOTE:** This function is supported only in `metric` context.
+
+**NOTE:** The omitted-argument form can be made invalid by enabling the `transform.aggregateonattributes.requireattributes` feature gate.
 
 The following metric types can be aggregated:
 
@@ -958,3 +960,15 @@ The feature is currently only available for log processing.
   ```
   
   Run collector: `./otelcol --config config.yaml --feature-gates=transform.flatten.logs`
+
+### `transform.aggregateonattributes.requireattributes`
+
+The `transform.aggregateonattributes.requireattributes` [feature gate](https://github.com/open-telemetry/opentelemetry-collector/blob/main/featuregate/README.md#collector-feature-gates) makes the `attributes` argument of `aggregate_on_attributes` required.
+
+When this feature gate is enabled:
+
+- `aggregate_on_attributes("sum")` returns a parse error.
+- Use `aggregate_on_attributes("sum", [])` to remove all datapoint attributes before aggregation.
+- Use `aggregate_on_attributes("sum", ["attr1", "attr2"])` to keep only specific attributes before aggregation.
+
+Run collector: `./otelcol --config config.yaml --feature-gates=transform.aggregateonattributes.requireattributes`

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics.go
@@ -15,6 +15,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
+var (
+	aggregateOnAttributesMissingAttributesWarning = "aggregate_on_attributes called without the attributes argument; attribute filtering is skipped, and datapoints are only merged when their full attribute sets already match. Pass [] to remove all attributes or pass a list to keep specific attributes. This will become an error when the " + aggregateOnAttributesRequireAttributesFeatureGate.ID() + " feature gate is enabled."
+
+	errAggregateOnAttributesAttributesRequired = errors.New("'aggregate_on_attributes' requires the 'attributes' argument when the '" + aggregateOnAttributesRequireAttributesFeatureGate.ID() + "' feature gate is enabled")
+)
+
 type aggregateOnAttributesArguments struct {
 	AggregationFunction string
 	Attributes          ottl.Optional[[]string]
@@ -24,7 +30,7 @@ func newAggregateOnAttributesFactory() ottl.Factory[*ottlmetric.TransformContext
 	return ottl.NewFactory("aggregate_on_attributes", &aggregateOnAttributesArguments{}, createAggregateOnAttributesFunction)
 }
 
-func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
+func createAggregateOnAttributesFunction(fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[*ottlmetric.TransformContext], error) {
 	args, ok := oArgs.(*aggregateOnAttributesArguments)
 
 	if !ok {
@@ -34,6 +40,16 @@ func createAggregateOnAttributesFunction(_ ottl.FunctionContext, oArgs ottl.Argu
 	t, err := aggregateutil.ConvertToAggregationFunction(args.AggregationFunction)
 	if err != nil {
 		return nil, fmt.Errorf("invalid aggregation function: '%s', valid options: %s", err.Error(), aggregateutil.GetSupportedAggregationFunctionsList())
+	}
+
+	if args.Attributes.IsEmpty() {
+		if aggregateOnAttributesRequireAttributesFeatureGate.IsEnabled() {
+			return nil, errAggregateOnAttributesAttributesRequired
+		}
+
+		if fCtx.Set.Logger != nil {
+			fCtx.Set.Logger.Warn(aggregateOnAttributesMissingAttributesWarning)
+		}
 	}
 
 	return AggregateOnAttributes(t, args.Attributes)

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -9,13 +9,79 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/aggregateutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
+
+func Test_createAggregateOnAttributesFunction_MissingAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		enabled    bool
+		attributes ottl.Optional[[]string]
+		wantErr    error
+		wantWarn   bool
+	}{
+		{
+			name:       "gate disabled with omitted attributes logs warning",
+			enabled:    false,
+			attributes: ottl.Optional[[]string]{},
+			wantWarn:   true,
+		},
+		{
+			name:       "gate enabled with omitted attributes returns error",
+			enabled:    true,
+			attributes: ottl.Optional[[]string]{},
+			wantErr:    errAggregateOnAttributesAttributesRequired,
+		},
+		{
+			name:       "gate enabled with explicit empty attributes is allowed",
+			enabled:    true,
+			attributes: ottl.NewTestingOptional[[]string]([]string{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousValue := aggregateOnAttributesRequireAttributesFeatureGate.IsEnabled()
+			require.NoError(t, featuregate.GlobalRegistry().Set(aggregateOnAttributesRequireAttributesFeatureGate.ID(), tt.enabled))
+			t.Cleanup(func() {
+				require.NoError(t, featuregate.GlobalRegistry().Set(aggregateOnAttributesRequireAttributesFeatureGate.ID(), previousValue))
+			})
+
+			core, observedLogs := observer.New(zap.WarnLevel)
+			settings := componenttest.NewNopTelemetrySettings()
+			settings.Logger = zap.New(core)
+
+			_, err := createAggregateOnAttributesFunction(
+				ottl.FunctionContext{Set: settings},
+				&aggregateOnAttributesArguments{
+					AggregationFunction: "sum",
+					Attributes:          tt.attributes,
+				},
+			)
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.wantWarn {
+				assert.Equal(t, 1, observedLogs.FilterMessage(aggregateOnAttributesMissingAttributesWarning).Len())
+			} else {
+				assert.Equal(t, 0, observedLogs.FilterMessage(aggregateOnAttributesMissingAttributesWarning).Len())
+			}
+		})
+	}
+}
 
 func Test_aggregateOnAttributes(t *testing.T) {
 	attr := ottl.Optional[[]string]{}

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -14,11 +14,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
 
-var UseConvertBetweenSumAndGaugeMetricContext = featuregate.GlobalRegistry().MustRegister(
-	"processor.transform.ConvertBetweenSumAndGaugeMetricContext",
-	featuregate.StageStable,
-	featuregate.WithRegisterDescription("When enabled will use metric context for conversion between sum and gauge"),
-	featuregate.WithRegisterToVersion("v0.114.0"),
+var (
+	UseConvertBetweenSumAndGaugeMetricContext = featuregate.GlobalRegistry().MustRegister(
+		"processor.transform.ConvertBetweenSumAndGaugeMetricContext",
+		featuregate.StageStable,
+		featuregate.WithRegisterDescription("When enabled will use metric context for conversion between sum and gauge"),
+		featuregate.WithRegisterToVersion("v0.114.0"),
+	)
+
+	aggregateOnAttributesRequireAttributesFeatureGate = featuregate.GlobalRegistry().MustRegister(
+		"transform.aggregateonattributes.requireattributes",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("When enabled, aggregate_on_attributes requires the attributes argument."),
+		featuregate.WithRegisterFromVersion("v0.147.0"),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46049"),
+	)
 )
 
 func DataPointFunctions() map[string]ottl.Factory[*ottldatapoint.TransformContext] {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add an alpha feature gate to control whether `aggregate_on_attributes` requires the attributes argument.

When the gate is disabled (default), omitted attributes now logs a warning. When enabled, omitted attributes returns an error.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Part of #46049

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation
Documented the gate and behavior in `processor/transformprocessor/README.md`.
<!--Please delete paragraphs that you did not use before submitting.-->
