### PR TITLE
[exporter/clickhouseexporter] Clarify connection_params and multi-endpoint behavior

### DIFF
--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -278,7 +278,9 @@ The following settings are required:
   - http protocol `http://addr1:port,addr2:port` or https `https://addr1:port,addr2:port`
   - clickhouse protocol `clickhouse://addr1:port,addr2:port` or TLS `clickhouse://addr1:port,addr2:port?secure=true`
 
-Many other ClickHouse specific options can be configured through query parameters e.g. `addr?dial_timeout=5s&compress=lz4`. For a full list of options see the [ClickHouse driver documentation](https://github.com/ClickHouse/clickhouse-go/blob/b2f9409ba1c7bb239a4f6553a6da347f3f5f1330/clickhouse_options.go#L174)
+  When multiple endpoints are provided, the driver handles load balancing and automatic failover. By default, it uses `in_order` strategy (tries endpoints in the order specified). Alternatively, use `connection_open_strategy=round_robin` (distributes connections evenly) or `connection_open_strategy=random` (randomly selects endpoints) in `connection_params`. See [connection_open_strategy documentation](https://pkg.go.dev/github.com/ClickHouse/clickhouse-go/v2#readme-connection-strategy).
+
+Many other ClickHouse specific options can be configured through query parameters e.g. `addr?dial_timeout=5s&compress=lz4`. For a full list of options see the [ClickHouse driver documentation](https://pkg.go.dev/github.com/ClickHouse/clickhouse-go/v2#readme-connection-settings-reference)
 
 Connection options:
 
@@ -286,7 +288,7 @@ Connection options:
 - `password` (default = ): The authentication password.
 - `ttl` (default = 0): The data time-to-live example 30m, 48h. Also, 0 means no ttl.
 - `database` (default = default): The database name. Overrides the database defined in `endpoint` when this setting is not equal to `default`.
-- `connection_params` (default = {}). Params is the extra connection parameters with map format. Query parameters provided in `endpoint` will be individually overwritten if present in this map.
+- `connection_params` (default = {}). Extra connection parameters with map format. Query parameters provided in `endpoint` will be individually overwritten if present in this map. Parameters can be either driver parameters (e.g., `connection_open_strategy`, `max_open_conns`) that control client-side behavior, or ClickHouse session settings (e.g., `max_execution_time`) that are passed to the server. See the [driver parameters list](https://pkg.go.dev/github.com/ClickHouse/clickhouse-go/v2#Options) for recognized driver options; all others are treated as session settings.
 - `create_schema` (default = true): When set to true, will run DDL to create the database and tables. (See [schema management](#schema-management))
 - `compress` (default = lz4): Controls the compression algorithm. Valid options: `none` (disabled), `zstd`, `lz4` (default), `gzip`, `deflate`, `br`, `true` (lz4). Ignored if `compress` is set in the `endpoint` or `connection_params`.
 - `async_insert` (default = true): Enables [async inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts). Ignored if async inserts are configured in the `endpoint` or `connection_params`. Async inserts may still be overridden server-side.


### PR DESCRIPTION
## Description

This PR improves the documentation for the ClickHouse exporter by clarifying two key aspects:

1. **`connection_params` dual behavior**: Documents that `connection_params` handles both driver-level parameters (e.g., `connection_open_strategy`, `max_open_conns`) and ClickHouse session settings (e.g., `max_execution_time`), with links to the driver source code for reference.

2. **Multi-endpoint load balancing**: Explains the behavior when multiple endpoints are configured, documenting the three available strategies:
   - `in_order` (default): tries endpoints in the specified order
   - `round_robin`: distributes connections evenly
   - `random`: randomly selects endpoints

## Testing

Documentation-only change. Verified that:
- Links point to correct driver source code locations
- Descriptions accurately reflect driver behavior