### PR TITLE
[ci] use token generated by actions for workflow approval

### DIFF
--- a/.github/workflows/approve-workflows.yml
+++ b/.github/workflows/approve-workflows.yml
@@ -15,15 +15,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        id: otelbot-token
-        with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
       - name: Run approve-workflows.sh
         run: ./.github/workflows/scripts/approve-workflows.sh
         env:
-          GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT: ${{ github.event.comment.body }}
           SENDER: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The action implemented in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46289 is not working properly due to a lack of needed permissions.

This PR matches the same setup as `/rerun` to make it work.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22352715743/job/64683790271

\cc @mx-psi @songy23 as you approved the original implementation 🙏 