### PR TITLE
[chore] remove k8s v1.32.8 from version matrix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -91,7 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - "v1.32.8"
           - "v1.34.0"
           - "v1.35.0"
         component:


### PR DESCRIPTION
#### Description
Remove k8s v1.32.8 from version matrix as it is approaching EoL (https://endoflife.date/kubernetes) and leads to test flakiness.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46054