### PR TITLE
[chore][countconnector|fileexporter]: fix testdata for profiles

### DIFF
--- a/connector/countconnector/testdata/profiles/condition_and_attribute.yaml
+++ b/connector/countconnector/testdata/profiles/condition_and_attribute.yaml
@@ -19,12 +19,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -49,12 +51,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/default_attribute_value.yaml
+++ b/connector/countconnector/testdata/profiles/default_attribute_value.yaml
@@ -15,6 +15,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -24,6 +25,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -33,6 +35,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -57,6 +60,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -66,6 +70,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -75,6 +80,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -102,6 +108,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -111,6 +118,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -120,6 +128,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -147,6 +156,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -156,6 +166,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -165,6 +176,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/input.yaml
+++ b/connector/countconnector/testdata/profiles/input.yaml
@@ -1,135 +1,6 @@
-resourceProfiles:
-  - resource:
-      attributes:
-        - key: resource.required
-          value:
-            stringValue: foo
-        - key: resource.optional
-          value:
-            stringValue: bar
-    scopeProfiles:
-      - profiles:
-          - attributeIndices: [0, 1]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [0, 2]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [3]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-          - attributeIndices: []
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 100
-        scope: {}
-
-  - resource:
-      attributes:
-        - key: resource.required
-          value:
-            stringValue: foo
-        - key: resource.optional
-          value:
-            stringValue: notbar
-    scopeProfiles:
-      - profiles:
-          - attributeIndices: [0, 1]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [0, 2]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [3]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-          - attributeIndices: []
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 100
-        scope: {}
-
-  - resource:
-      attributes:
-        - key: resource.required
-          value:
-            stringValue: notfoo
-    scopeProfiles:
-      - profiles:
-          - attributeIndices: [0, 1]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [0, 2]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [3]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-          - attributeIndices: []
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 100
-        scope: {}
-
-  - resource: {}
-    scopeProfiles:
-      - profiles:
-          - attributeIndices: [0, 1]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [0, 2]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [3]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-          - attributeIndices: []
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 100
-        scope: {}
 dictionary:
   attributeTable:
+    - {}
     - keyStrindex: 1
       value:
         stringValue: foo
@@ -142,9 +13,162 @@ dictionary:
     - keyStrindex: 1
       value:
         stringValue: notfoo
-  stringTable:
-    - count
-    - profile.required
-    - profile.optional
   stackTable:
     - {}
+  stringTable:
+    - ""
+    - profile.required
+    - profile.optional
+    - foo
+    - bar
+    - notbar
+    - notfoo
+    - resource.required
+    - resource.optional
+resourceProfiles:
+  - resource:
+      attributes:
+        - keyRef: 7
+          value:
+            stringValueRef: 3
+        - keyRef: 8
+          value:
+            stringValueRef: 4
+    scopeProfiles:
+      - profiles:
+          - attributeIndices:
+              - 1
+              - 2
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 1
+              - 3
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 4
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+        scope: {}
+  - resource:
+      attributes:
+        - keyRef: 7
+          value:
+            stringValueRef: 3
+        - keyRef: 8
+          value:
+            stringValueRef: 5
+    scopeProfiles:
+      - profiles:
+          - attributeIndices:
+              - 1
+              - 2
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 1
+              - 3
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 4
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+        scope: {}
+  - resource:
+      attributes:
+        - keyRef: 7
+          value:
+            stringValueRef: 6
+    scopeProfiles:
+      - profiles:
+          - attributeIndices:
+              - 1
+              - 2
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 1
+              - 3
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 4
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+        scope: {}
+  - resource: {}
+    scopeProfiles:
+      - profiles:
+          - attributeIndices:
+              - 1
+              - 2
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 3
+              - 1
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - attributeIndices:
+              - 4
+            periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+          - periodType: {}
+            sampleType: {}
+            samples:
+              - timestampsUnixNano:
+                  - "0"
+        scope: {}

--- a/connector/countconnector/testdata/profiles/input.yaml
+++ b/connector/countconnector/testdata/profiles/input.yaml
@@ -28,12 +28,12 @@ dictionary:
 resourceProfiles:
   - resource:
       attributes:
-        - keyRef: 7
+        - keyStrindex: 7
           value:
-            stringValueRef: 3
-        - keyRef: 8
+            stringValueStrindex: 3
+        - keyStrindex: 8
           value:
-            stringValueRef: 4
+            stringValueStrindex: 4
     scopeProfiles:
       - profiles:
           - attributeIndices:
@@ -67,12 +67,12 @@ resourceProfiles:
         scope: {}
   - resource:
       attributes:
-        - keyRef: 7
+        - keyStrindex: 7
           value:
-            stringValueRef: 3
-        - keyRef: 8
+            stringValueStrindex: 3
+        - keyStrindex: 8
           value:
-            stringValueRef: 5
+            stringValueStrindex: 5
     scopeProfiles:
       - profiles:
           - attributeIndices:
@@ -106,9 +106,9 @@ resourceProfiles:
         scope: {}
   - resource:
       attributes:
-        - keyRef: 7
+        - keyStrindex: 7
           value:
-            stringValueRef: 6
+            stringValueStrindex: 6
     scopeProfiles:
       - profiles:
           - attributeIndices:

--- a/connector/countconnector/testdata/profiles/multiple_attributes.yaml
+++ b/connector/countconnector/testdata/profiles/multiple_attributes.yaml
@@ -15,6 +15,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -24,6 +25,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -48,6 +50,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -57,6 +60,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -84,6 +88,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -93,6 +98,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -120,6 +126,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -129,6 +136,7 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/multiple_conditions.yaml
+++ b/connector/countconnector/testdata/profiles/multiple_conditions.yaml
@@ -15,6 +15,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -35,6 +36,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/multiple_metrics.yaml
+++ b/connector/countconnector/testdata/profiles/multiple_metrics.yaml
@@ -8,6 +8,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -25,6 +26,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -39,20 +41,22 @@ resourceMetrics:
             stringValue: foo
     scopeMetrics:
       - metrics:
-          - description: All profiles count
-            name: count.all
-            sum:
-              aggregationTemporality: 1
-              dataPoints:
-                - asInt: "4"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
           - description: Count if ...
             name: count.if
             sum:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - description: All profiles count
+            name: count.all
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -67,20 +71,22 @@ resourceMetrics:
             stringValue: foo
     scopeMetrics:
       - metrics:
-          - description: All profiles count
-            name: count.all
-            sum:
-              aggregationTemporality: 1
-              dataPoints:
-                - asInt: "4"
-                  timeUnixNano: "1000000"
-              isMonotonic: true
           - description: Count if ...
             name: count.if
             sum:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - description: All profiles count
+            name: count.all
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/one_attribute.yaml
+++ b/connector/countconnector/testdata/profiles/one_attribute.yaml
@@ -12,12 +12,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -39,12 +41,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -69,12 +73,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -99,12 +105,14 @@ resourceMetrics:
                     - key: profile.required
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
                     - key: profile.required
                       value:
                         stringValue: notfoo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/one_condition.yaml
+++ b/connector/countconnector/testdata/profiles/one_condition.yaml
@@ -15,6 +15,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -35,6 +36,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/countconnector/testdata/profiles/zero_conditions.yaml
+++ b/connector/countconnector/testdata/profiles/zero_conditions.yaml
@@ -8,6 +8,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -25,6 +26,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -45,6 +47,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -65,6 +68,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "4"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/connector/signaltometricsconnector/connector_test.go
+++ b/connector/signaltometricsconnector/connector_test.go
@@ -365,6 +365,7 @@ func assertAggregatedMetrics(t *testing.T, expected, actual pmetric.Metrics) {
 		pmetrictest.IgnoreMetricDataPointsOrder(),
 		pmetrictest.IgnoreMetricsOrder(),
 		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
 	))
 }
 

--- a/connector/signaltometricsconnector/testdata/profiles/exponential_histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/exponential_histograms/output.yaml
@@ -39,6 +39,7 @@ resourceMetrics:
                   negative: {}
                   positive: {}
                   sum: 0
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                   zeroCount: "1"
             name: profiles.foo.exphistogram
@@ -64,6 +65,7 @@ resourceMetrics:
                   negative: {}
                   positive: {}
                   sum: 0
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
                   zeroCount: "3"
             name: total.profiles.resource.foo.exphistogram

--- a/connector/signaltometricsconnector/testdata/profiles/histograms/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/histograms/output.yaml
@@ -56,6 +56,7 @@ resourceMetrics:
                     - 100
                     - 200
                   sum: 0
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
             name: profiles.foo.histogram
         scope:
@@ -89,6 +90,7 @@ resourceMetrics:
                     - 100
                     - 200
                   sum: 0
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
             name: total.profiles.resource.foo.histogram
         scope:

--- a/connector/signaltometricsconnector/testdata/profiles/profiles.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/profiles.yaml
@@ -1,34 +1,3 @@
-resourceProfiles:
-  - resource:
-      attributes:
-        - key: resource.foo
-          value:
-            stringValue: foo
-        - key: resource.bar
-          value:
-            stringValue: bar
-    scopeProfiles:
-      - profiles:
-          - attributeIndices: [0, 1]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            duration: 10000
-          - attributeIndices: [2, 3]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-            stringTable:
-              - count
-            duration: 10000
-          - attributeIndices: [5]
-            sample:
-              - timestampsUnixNano: ["0"]
-            sampleType:
-              unitStrindex: 0
-        scope: {}
 dictionary:
   attributeTable:
     - keyStrindex: 0
@@ -54,3 +23,40 @@ dictionary:
     - profile.bar
     - profile.required
     - profile.optional
+    - foo
+    - bar
+    - notbar
+    - notfoo
+    - resource.foo
+    - resource.bar
+resourceProfiles:
+  - resource:
+      attributes:
+        - keyStrindex: 8
+          value:
+            stringValueStrindex: 4
+        - keyStrindex: 9
+          value:
+            stringValueStrindex: 5
+    scopeProfiles:
+      - profiles:
+          - attributeIndices: [0, 1]
+            sample:
+              - timestampsUnixNano: ["0"]
+            sampleType:
+              unitStrindex: 0
+            duration: 10000
+          - attributeIndices: [2, 3]
+            sample:
+              - timestampsUnixNano: ["0"]
+            sampleType:
+              unitStrindex: 0
+            stringTable:
+              - count
+            duration: 10000
+          - attributeIndices: [5]
+            sample:
+              - timestampsUnixNano: ["0"]
+            sampleType:
+              unitStrindex: 0
+        scope: {}

--- a/connector/signaltometricsconnector/testdata/profiles/sum/output.yaml
+++ b/connector/signaltometricsconnector/testdata/profiles/sum/output.yaml
@@ -30,6 +30,7 @@ resourceMetrics:
                     - key: profile.foo
                       value:
                         stringValue: foo
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:
@@ -50,6 +51,7 @@ resourceMetrics:
               aggregationTemporality: 1
               dataPoints:
                 - asInt: "3"
+                  startTimeUnixNano: "1000000"
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope:

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -539,6 +539,13 @@ func TestFileProfilesExporter(t *testing.T) {
 				assert.NoError(t, fe.Shutdown(t.Context()))
 			}()
 
+			// Create expected by marshaling and unmarshaling pd the same way
+			// This ensures the internal dictionary structure matches
+			expectedBuf, err := profilesMarshalers[tt.args.conf.FormatType].MarshalProfiles(testdata.GenerateProfilesTwoProfilesSameResource())
+			assert.NoError(t, err)
+			expected, err := tt.args.unmarshaler.UnmarshalProfiles(expectedBuf)
+			assert.NoError(t, err)
+
 			fi, err := os.Open(fe.writer.path)
 			assert.NoError(t, err)
 			defer fi.Close()
@@ -559,7 +566,7 @@ func TestFileProfilesExporter(t *testing.T) {
 				assert.NoError(t, err)
 				got, err := tt.args.unmarshaler.UnmarshalProfiles(buf)
 				assert.NoError(t, err)
-				assert.Equal(t, pd, got)
+				assert.Equal(t, expected, got)
 			}
 		})
 	}
@@ -738,7 +745,12 @@ func TestConcurrentlyCompress(t *testing.T) {
 	profilesUnmarshaler := &pprofile.JSONUnmarshaler{}
 	gotPd, err := profilesUnmarshaler.UnmarshalProfiles(buf)
 	assert.NoError(t, err)
-	assert.Equal(t, pd, gotPd)
+	// Create expected by marshaling and unmarshaling pd the same way
+	expectedBuf, err := profilesMarshalers[formatTypeJSON].MarshalProfiles(testdata.GenerateProfilesTwoProfilesSameResource())
+	assert.NoError(t, err)
+	expectedPd, err := profilesUnmarshaler.UnmarshalProfiles(expectedBuf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPd, gotPd)
 }
 
 // tsBuffer is a thread safe buffer to prevent race conditions in the CI/CD.

--- a/exporter/kafkaexporter/internal/marshaler/pdata_marshaler_test.go
+++ b/exporter/kafkaexporter/internal/marshaler/pdata_marshaler_test.go
@@ -102,7 +102,14 @@ func testPdataMarshaler[Data any](
 	require.Len(t, messages, 1) // 1 message per batch
 	assert.Nil(t, messages[0].Key)
 
+	// Create expected by marshaling and unmarshaling input the same way
+	// This ensures the internal dictionary structure matches
+	expectedBytes, err := marshal(input)
+	require.NoError(t, err)
+	expected, err := unmarshal(expectedBytes[0].Value)
+	require.NoError(t, err)
+
 	output, err := unmarshal(messages[0].Value)
 	require.NoError(t, err)
-	assert.NoError(t, compare(input, output))
+	assert.NoError(t, compare(expected, output))
 }


### PR DESCRIPTION
This is a complementary change for https://github.com/open-telemetry/opentelemetry-collector/pull/14546. With the change in the Profiling signal, the data in input.yaml no longer meets the expected format.

Without https://github.com/open-telemetry/opentelemetry-collector/pull/14546 being merged, this PR is expected to fail tests in connector/countconnector.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
