### PR TITLE
[ci] add missing -z on ORG_TOKEN validation

### DIFF
--- a/.github/workflows/scripts/approve-workflows.sh
+++ b/.github/workflows/scripts/approve-workflows.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-if [[ -z "${PR_NUMBER:-}" || -z "${COMMENT:-}" || -z "${SENDER:-}" || "${ORG_TOKEN:-}" ]]; then
+if [[ -z "${PR_NUMBER:-}" || -z "${COMMENT:-}" || -z "${SENDER:-}" || -z "${ORG_TOKEN:-}" ]]; then
     echo "PR_NUMBER, COMMENT, SENDER or ORG_TOKEN not set"
     exit 0
 fi


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add missing `-z` on `ORG_TOKEN` variable validation

See: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22357319614/job/64700519620