### PR TITLE
[chore] pkg/xk8stest - display pod logs

### DIFF
--- a/.chloggen/xk8stest-pod-diagnostics.yaml
+++ b/.chloggen/xk8stest-pod-diagnostics.yaml
@@ -2,7 +2,7 @@ change_type: enhancement
 
 component: pkg/xk8stest
 
-note: Display pod events on collector startup timeout for easier diagnosis of e2e failures.
+note: Display pod events and logs on collector startup timeout for easier diagnosis of e2e failures.
 
 issues: [46305]
 

--- a/pkg/xk8stest/client.go
+++ b/pkg/xk8stest/client.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -18,6 +19,7 @@ type K8sClient struct {
 	DynamicClient   *dynamic.DynamicClient
 	DiscoveryClient *discovery.DiscoveryClient
 	Mapper          *restmapper.DeferredDiscoveryRESTMapper
+	restConfig      *rest.Config
 }
 
 func NewK8sClient(kubeconfigPath string) (*K8sClient, error) {
@@ -42,5 +44,6 @@ func NewK8sClient(kubeconfigPath string) (*K8sClient, error) {
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 	return &K8sClient{
 		DynamicClient: dynamicClient, DiscoveryClient: discoveryClient, Mapper: mapper,
+		restConfig: restConfig,
 	}, nil
 }

--- a/pkg/xk8stest/go.mod
+++ b/pkg/xk8stest/go.mod
@@ -65,6 +65,7 @@ require (
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/grpc v1.76.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.4.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Get container logs, in addition to pod events, for any collector pod that isn't ready and print them in the test output. 
Ran the changes with a broken test, the output with failing collector pods looks like - 

```
❯ go test -v --tags=e2e -run TestE2EConsulDetector -timeout 5m
=== RUN   TestE2EConsulDetector
    k8s_collector.go:73: waiting for collector pods to be ready
    k8s_collector.go:75: did not find collector pods
    k8s_collector.go:75: pod otelcol-f6842d73-6898b5b9df-t29r5 is not running, current phase: Pending
    k8s_collector.go:75: pod otelcol-f6842d73-6898b5b9df-t29r5 is not running, current phase: Pending
    k8s_collector.go:75: pod otelcol-f6842d73-6898b5b9df-t29r5 is not running, current phase: Pending
    k8s_collector.go:82: --- events for pod otelcol-f6842d73-6898b5b9df-t29r5 (phase: Pending) ---
    k8s_collector.go:82:   Normal  Scheduled  default-scheduler  Successfully assigned default/otelcol-f6842d73-6898b5b9df-t29r5 to e2e-test-control-plane
    k8s_collector.go:82:   Normal  Pulling  kubelet  Pulling image "hashicorp/consul:1.22.3-fake"
    k8s_collector.go:82:   Warning  Failed  kubelet  Failed to pull image "hashicorp/consul:1.22.3-fake": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/hashicorp/consul:1.22.3-fake": failed to resolve reference "docker.io/hashicorp/consul:1.22.3-fake": docker.io/hashicorp/consul:1.22.3-fake: not found
    k8s_collector.go:82:   Warning  Failed  kubelet  Error: ErrImagePull
    k8s_collector.go:82:   Normal  Pulled  kubelet  Container image "otelcontribcol:latest" already present on machine
    k8s_collector.go:82:   Normal  Created  kubelet  Created container: otelcol
    k8s_collector.go:82:   Normal  Started  kubelet  Started container otelcol
    k8s_collector.go:82:   Normal  BackOff  kubelet  Back-off pulling image "hashicorp/consul:1.22.3-fake"
    k8s_collector.go:82:   Warning  Failed  kubelet  Error: ImagePullBackOff
    k8s_collector.go:82:   Warning  BackOff  kubelet  Back-off restarting failed container otelcol in pod otelcol-f6842d73-6898b5b9df-t29r5_default(2cee6cca-7647-4f04-b78f-fded64df64d6)
    k8s_collector.go:82: --- logs for container otelcol in pod otelcol-f6842d73-6898b5b9df-t29r5 (restarts: 5, last exit reason: Error) ---
    k8s_collector.go:210:   Error: invalid configuration: service::pipelines::metrics: references processor "batch" which is not configured
    k8s_collector.go:83: 
                Error Trace:    /Users/jjain/work/opentelemetry-collector-contrib/pkg/xk8stest/k8s_collector.go:83
                                                        /Users/jjain/work/opentelemetry-collector-contrib/pkg/xk8stest/k8s_collector.go:61
                                                        /Users/jjain/work/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/e2e_test.go:420
                Error:          collector pods were not ready
                Test:           TestE2EConsulDetector
                Messages:       timed out after 3m0s
--- FAIL: TestE2EConsulDetector (180.89s)
FAIL
exit status 1
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor  181.821s
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46305 
