### PR TITLE
[receiver/nginx] Enable reaggregation feature

### DIFF
--- a/.chloggen/46368-enable-nginx-reaggregation.yaml
+++ b/.chloggen/46368-enable-nginx-reaggregation.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/nginx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable reaggregation feature for nginx receiver by setting reaggregation_enabled and 
+       defining requirement levels for attributes."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46368]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -9,10 +9,13 @@ status:
     active: [colelaven, ishleenk17]
     emeritus: [djaglowski]
 
+reaggregation_enabled: true
+
 attributes:
   state:
     description: The state of a connection
     type: string
+    requirement_level: recommended
     enum:
       - active
       - reading


### PR DESCRIPTION
  Enable re-aggregation for the nginx receiver by setting
   reaggregation_enabled
  and defining appropriate requirement_level for
  attributes.

  Resolves #46368

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

  Enable re-aggregation for the nginx receiver by setting
   reaggregation_enabled
  and defining appropriate requirement_level for
  attributes.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46368 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
 didnt add any test cases or files. ran make test in the reciever/nginxreceiver folder.

<!--Describe the documentation added.-->
#### Documentation
didin't add anything.

<!--Please delete paragraphs that you did not use before submitting.-->
