### PR TITLE
feat(receiver/redfish): enable re-aggregation feature

### DIFF
--- a/.chloggen/46367-mysql-enable-reaggregation.yaml
+++ b/.chloggen/46367-mysql-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the MySQL receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46367]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/.chloggen/46370-ntp-enable-reaggregation.yaml
+++ b/.chloggen/46370-ntp-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/ntp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the NTP receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46370]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/.chloggen/46375-redfish-enable-reaggregation.yaml
+++ b/.chloggen/46375-redfish-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/redfish
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables dynamic metric reaggregation in the redfish receiver. This does not break existing configuration files.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46375]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/receiver/ntpreceiver/generated_package_test.go
+++ b/receiver/ntpreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package ntpreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/ntpreceiver/internal/metadata/generated_config.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_config.go
@@ -3,6 +3,9 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
@@ -11,6 +14,11 @@ import (
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []string `mapstructure:"attributes"`
+	definedAttributes   []string
+	requiredAttributes  []string
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -22,9 +30,32 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
+	for _, val := range ms.EnabledAttributes {
+		if !slices.Contains(ms.definedAttributes, val) {
+			return fmt.Errorf("%v is not defined in metadata.yaml", val)
+		}
+	}
+
+	for _, val := range ms.requiredAttributes {
+		if !slices.Contains(ms.EnabledAttributes, val) {
+			return fmt.Errorf("`attributes` field must contain required attribute: %v", val)
+		}
+	}
+
+	if ms.AggregationStrategy != AggregationStrategySum &&
+		ms.AggregationStrategy != AggregationStrategyAvg &&
+		ms.AggregationStrategy != AggregationStrategyMin &&
+		ms.AggregationStrategy != AggregationStrategyMax {
+		return fmt.Errorf("invalid aggregation strategy set: '%v'", ms.AggregationStrategy)
+	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
+}
+
+// AttributeConfig holds configuration information for a particular metric.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // MetricsConfig provides config for ntp metrics.
@@ -36,6 +67,11 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		NtpOffset: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{},
+			EnabledAttributes:   []string{},
 		},
 	}
 }

--- a/receiver/ntpreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,7 +27,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NtpOffset: MetricConfig{Enabled: true},
+					NtpOffset: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					NtpHost: ResourceAttributeConfig{Enabled: true},
@@ -37,7 +42,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					NtpOffset: MetricConfig{Enabled: false},
+					NtpOffset: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					NtpHost: ResourceAttributeConfig{Enabled: false},

--- a/receiver/ntpreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -27,9 +35,10 @@ type metricInfo struct {
 }
 
 type metricNtpOffset struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills ntp.offset metric with initial data.
@@ -38,16 +47,45 @@ func (m *metricNtpOffset) init() {
 	m.data.SetDescription("Time difference between local and NTP server clocks")
 	m.data.SetUnit("ns")
 	m.data.SetEmptyGauge()
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricNtpOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -60,6 +98,11 @@ func (m *metricNtpOffset) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricNtpOffset) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/ntpreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/ntpreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["NtpOffset"] = mb.metricNtpOffset.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,11 +80,17 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordNtpOffsetDataPoint(ts, 1)
+			if tt.name == "reaggregate_set" {
+				mb.RecordNtpOffsetDataPoint(ts, 3)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetNtpHost("ntp.host-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricNtpOffset.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -96,17 +112,40 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				case "ntp.offset":
-					assert.False(t, validatedMetrics["ntp.offset"], "Found a duplicate in the metrics slice: ntp.offset")
-					validatedMetrics["ntp.offset"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time difference between local and NTP server clocks", ms.At(i).Description())
-					assert.Equal(t, "ns", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["ntp.offset"], "Found a duplicate in the metrics slice: ntp.offset")
+						validatedMetrics["ntp.offset"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time difference between local and NTP server clocks", ms.At(i).Description())
+						assert.Equal(t, "ns", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+					} else {
+						assert.False(t, validatedMetrics["ntp.offset"], "Found a duplicate in the metrics slice: ntp.offset")
+						validatedMetrics["ntp.offset"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time difference between local and NTP server clocks", ms.At(i).Description())
+						assert.Equal(t, "ns", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["ntp.offset"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+					}
 				}
 			}
 		})

--- a/receiver/ntpreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/ntpreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,15 @@ all_set:
   metrics:
     ntp.offset:
       enabled: true
+      attributes: []
+  resource_attributes:
+    ntp.host:
+      enabled: true
+reaggregate_set:
+  metrics:
+    ntp.offset:
+      enabled: true
+      attributes: []
   resource_attributes:
     ntp.host:
       enabled: true
@@ -10,6 +19,7 @@ none_set:
   metrics:
     ntp.offset:
       enabled: false
+      attributes: []
   resource_attributes:
     ntp.host:
       enabled: false

--- a/receiver/ntpreceiver/metadata.yaml
+++ b/receiver/ntpreceiver/metadata.yaml
@@ -9,6 +9,8 @@ status:
     active: [atoulme, paulojmdias]
     seeking_new: true
 
+reaggregation_enabled: true
+
 resource_attributes:
   ntp.host:
     description: NTP server used. Corresponds to configured `host`.

--- a/receiver/redfishreceiver/documentation.md
+++ b/receiver/redfishreceiver/documentation.md
@@ -24,14 +24,14 @@ Measures the power state of a chassis (-1 unknown, 0 off, 1 on).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| chassis.asset_tag | Chassis asset tag. | Any Str | Recommended |
-| chassis.model | Chassis model. | Any Str | Recommended |
-| chassis.name | Chassis name. | Any Str | Recommended |
-| chassis.manufacturer | Chassis manufacturer. | Any Str | Recommended |
-| chassis.serial_number | Chassis serial number. | Any Str | Recommended |
-| chassis.sku | Chassis sku. | Any Str | Recommended |
-| chassis.chassis_type | Chassis type. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| chassis.asset_tag | Chassis asset tag. | Any Str | Required |
+| chassis.model | Chassis model. | Any Str | Required |
+| chassis.name | Chassis name. | Any Str | Required |
+| chassis.manufacturer | Chassis manufacturer. | Any Str | Required |
+| chassis.serial_number | Chassis serial number. | Any Str | Required |
+| chassis.sku | Chassis sku. | Any Str | Required |
+| chassis.chassis_type | Chassis type. | Any Str | Required |
 
 ### chassis.status.health
 
@@ -45,14 +45,14 @@ Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| chassis.asset_tag | Chassis asset tag. | Any Str | Recommended |
-| chassis.model | Chassis model. | Any Str | Recommended |
-| chassis.name | Chassis name. | Any Str | Recommended |
-| chassis.manufacturer | Chassis manufacturer. | Any Str | Recommended |
-| chassis.serial_number | Chassis serial number. | Any Str | Recommended |
-| chassis.sku | Chassis sku. | Any Str | Recommended |
-| chassis.chassis_type | Chassis type. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| chassis.asset_tag | Chassis asset tag. | Any Str | Required |
+| chassis.model | Chassis model. | Any Str | Required |
+| chassis.name | Chassis name. | Any Str | Required |
+| chassis.manufacturer | Chassis manufacturer. | Any Str | Required |
+| chassis.serial_number | Chassis serial number. | Any Str | Required |
+| chassis.sku | Chassis sku. | Any Str | Required |
+| chassis.chassis_type | Chassis type. | Any Str | Required |
 
 ### chassis.status.state
 
@@ -66,14 +66,14 @@ Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| chassis.asset_tag | Chassis asset tag. | Any Str | Recommended |
-| chassis.model | Chassis model. | Any Str | Recommended |
-| chassis.name | Chassis name. | Any Str | Recommended |
-| chassis.manufacturer | Chassis manufacturer. | Any Str | Recommended |
-| chassis.serial_number | Chassis serial number. | Any Str | Recommended |
-| chassis.sku | Chassis sku. | Any Str | Recommended |
-| chassis.chassis_type | Chassis type. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| chassis.asset_tag | Chassis asset tag. | Any Str | Required |
+| chassis.model | Chassis model. | Any Str | Required |
+| chassis.name | Chassis name. | Any Str | Required |
+| chassis.manufacturer | Chassis manufacturer. | Any Str | Required |
+| chassis.serial_number | Chassis serial number. | Any Str | Required |
+| chassis.sku | Chassis sku. | Any Str | Required |
+| chassis.chassis_type | Chassis type. | Any Str | Required |
 
 ### fan.reading
 
@@ -87,9 +87,9 @@ Measures the reading of a chassis fan.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| fan.name | Fan name. | Any Str | Recommended |
-| fan.reading_units | Fan reading units. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| fan.name | Fan name. | Any Str | Required |
+| fan.reading_units | Fan reading units. | Any Str | Required |
 
 ### fan.status.health
 
@@ -103,8 +103,8 @@ Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| fan.name | Fan name. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| fan.name | Fan name. | Any Str | Required |
 
 ### fan.status.state
 
@@ -118,8 +118,8 @@ Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| fan.name | Fan name. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| fan.name | Fan name. | Any Str | Required |
 
 ### system.powerstate
 
@@ -133,15 +133,15 @@ Measures the power state of a system (-1 unknown, 0 off, 1 on).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| system.id | System id. | Any Str | Recommended |
-| system.asset_tag | System asset tag. | Any Str | Recommended |
-| system.bios_version | System bios version. | Any Str | Recommended |
-| system.model | System model. | Any Str | Recommended |
-| system.name | System name. | Any Str | Recommended |
-| system.manufacturer | System manufacturer. | Any Str | Recommended |
-| system.serial_number | System serial number. | Any Str | Recommended |
-| system.sku | System sku. | Any Str | Recommended |
-| system.system_type | System type. | Any Str | Recommended |
+| system.id | System id. | Any Str | Required |
+| system.asset_tag | System asset tag. | Any Str | Required |
+| system.bios_version | System bios version. | Any Str | Required |
+| system.model | System model. | Any Str | Required |
+| system.name | System name. | Any Str | Required |
+| system.manufacturer | System manufacturer. | Any Str | Required |
+| system.serial_number | System serial number. | Any Str | Required |
+| system.sku | System sku. | Any Str | Required |
+| system.system_type | System type. | Any Str | Required |
 
 ### system.status.health
 
@@ -155,15 +155,15 @@ Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| system.id | System id. | Any Str | Recommended |
-| system.asset_tag | System asset tag. | Any Str | Recommended |
-| system.bios_version | System bios version. | Any Str | Recommended |
-| system.model | System model. | Any Str | Recommended |
-| system.name | System name. | Any Str | Recommended |
-| system.manufacturer | System manufacturer. | Any Str | Recommended |
-| system.serial_number | System serial number. | Any Str | Recommended |
-| system.sku | System sku. | Any Str | Recommended |
-| system.system_type | System type. | Any Str | Recommended |
+| system.id | System id. | Any Str | Required |
+| system.asset_tag | System asset tag. | Any Str | Required |
+| system.bios_version | System bios version. | Any Str | Required |
+| system.model | System model. | Any Str | Required |
+| system.name | System name. | Any Str | Required |
+| system.manufacturer | System manufacturer. | Any Str | Required |
+| system.serial_number | System serial number. | Any Str | Required |
+| system.sku | System sku. | Any Str | Required |
+| system.system_type | System type. | Any Str | Required |
 
 ### system.status.state
 
@@ -177,15 +177,15 @@ Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| system.id | System id. | Any Str | Recommended |
-| system.asset_tag | System asset tag. | Any Str | Recommended |
-| system.bios_version | System bios version. | Any Str | Recommended |
-| system.model | System model. | Any Str | Recommended |
-| system.name | System name. | Any Str | Recommended |
-| system.manufacturer | System manufacturer. | Any Str | Recommended |
-| system.serial_number | System serial number. | Any Str | Recommended |
-| system.sku | System sku. | Any Str | Recommended |
-| system.system_type | System type. | Any Str | Recommended |
+| system.id | System id. | Any Str | Required |
+| system.asset_tag | System asset tag. | Any Str | Required |
+| system.bios_version | System bios version. | Any Str | Required |
+| system.model | System model. | Any Str | Required |
+| system.name | System name. | Any Str | Required |
+| system.manufacturer | System manufacturer. | Any Str | Required |
+| system.serial_number | System serial number. | Any Str | Required |
+| system.sku | System sku. | Any Str | Required |
+| system.system_type | System type. | Any Str | Required |
 
 ### temperature.reading
 
@@ -199,8 +199,8 @@ Measures the reading of a chassis temperature.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| temperature.name | Temperature name. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| temperature.name | Temperature name. | Any Str | Required |
 
 ### temperature.status.health
 
@@ -214,8 +214,8 @@ Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 wa
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| temperature.name | Temperature name. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| temperature.name | Temperature name. | Any Str | Required |
 
 ### temperature.status.state
 
@@ -229,8 +229,8 @@ Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| chassis.id | Chassis id. | Any Str | Recommended |
-| temperature.name | Temperature name. | Any Str | Recommended |
+| chassis.id | Chassis id. | Any Str | Required |
+| temperature.name | Temperature name. | Any Str | Required |
 
 ## Resource Attributes
 

--- a/receiver/redfishreceiver/generated_package_test.go
+++ b/receiver/redfishreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package redfishreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/redfishreceiver/internal/metadata/generated_config.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_config.go
@@ -3,6 +3,9 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
@@ -11,6 +14,11 @@ import (
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []string `mapstructure:"attributes"`
+	definedAttributes   []string
+	requiredAttributes  []string
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -22,9 +30,32 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
+	for _, val := range ms.EnabledAttributes {
+		if !slices.Contains(ms.definedAttributes, val) {
+			return fmt.Errorf("%v is not defined in metadata.yaml", val)
+		}
+	}
+
+	for _, val := range ms.requiredAttributes {
+		if !slices.Contains(ms.EnabledAttributes, val) {
+			return fmt.Errorf("`attributes` field must contain required attribute: %v", val)
+		}
+	}
+
+	if ms.AggregationStrategy != AggregationStrategySum &&
+		ms.AggregationStrategy != AggregationStrategyAvg &&
+		ms.AggregationStrategy != AggregationStrategyMin &&
+		ms.AggregationStrategy != AggregationStrategyMax {
+		return fmt.Errorf("invalid aggregation strategy set: '%v'", ms.AggregationStrategy)
+	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
+}
+
+// AttributeConfig holds configuration information for a particular metric.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // MetricsConfig provides config for redfish metrics.
@@ -47,39 +78,99 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		ChassisPowerstate: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			definedAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
 		},
 		ChassisStatusHealth: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			definedAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
 		},
 		ChassisStatusState: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			definedAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+			EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
 		},
 		FanReading: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "fan.name", "fan.reading_units"},
+			definedAttributes:   []string{"chassis.id", "fan.name", "fan.reading_units"},
+			EnabledAttributes:   []string{"chassis.id", "fan.name", "fan.reading_units"},
 		},
 		FanStatusHealth: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "fan.name"},
+			definedAttributes:   []string{"chassis.id", "fan.name"},
+			EnabledAttributes:   []string{"chassis.id", "fan.name"},
 		},
 		FanStatusState: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "fan.name"},
+			definedAttributes:   []string{"chassis.id", "fan.name"},
+			EnabledAttributes:   []string{"chassis.id", "fan.name"},
 		},
 		SystemPowerstate: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			definedAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
 		},
 		SystemStatusHealth: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			definedAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
 		},
 		SystemStatusState: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			definedAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+			EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
 		},
 		TemperatureReading: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "temperature.name"},
+			definedAttributes:   []string{"chassis.id", "temperature.name"},
+			EnabledAttributes:   []string{"chassis.id", "temperature.name"},
 		},
 		TemperatureStatusHealth: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "temperature.name"},
+			definedAttributes:   []string{"chassis.id", "temperature.name"},
+			EnabledAttributes:   []string{"chassis.id", "temperature.name"},
 		},
 		TemperatureStatusState: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"chassis.id", "temperature.name"},
+			definedAttributes:   []string{"chassis.id", "temperature.name"},
+			EnabledAttributes:   []string{"chassis.id", "temperature.name"},
 		},
 	}
 }

--- a/receiver/redfishreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,18 +27,66 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ChassisPowerstate:       MetricConfig{Enabled: true},
-					ChassisStatusHealth:     MetricConfig{Enabled: true},
-					ChassisStatusState:      MetricConfig{Enabled: true},
-					FanReading:              MetricConfig{Enabled: true},
-					FanStatusHealth:         MetricConfig{Enabled: true},
-					FanStatusState:          MetricConfig{Enabled: true},
-					SystemPowerstate:        MetricConfig{Enabled: true},
-					SystemStatusHealth:      MetricConfig{Enabled: true},
-					SystemStatusState:       MetricConfig{Enabled: true},
-					TemperatureReading:      MetricConfig{Enabled: true},
-					TemperatureStatusHealth: MetricConfig{Enabled: true},
-					TemperatureStatusState:  MetricConfig{Enabled: true},
+					ChassisPowerstate: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					ChassisStatusHealth: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					ChassisStatusState: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					FanReading: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name", "fan.reading_units"},
+					},
+					FanStatusHealth: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name"},
+					},
+					FanStatusState: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name"},
+					},
+					SystemPowerstate: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					SystemStatusHealth: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					SystemStatusState: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					TemperatureReading: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
+					TemperatureStatusHealth: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
+					TemperatureStatusState: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					BaseURL:        ResourceAttributeConfig{Enabled: true},
@@ -49,18 +98,66 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					ChassisPowerstate:       MetricConfig{Enabled: false},
-					ChassisStatusHealth:     MetricConfig{Enabled: false},
-					ChassisStatusState:      MetricConfig{Enabled: false},
-					FanReading:              MetricConfig{Enabled: false},
-					FanStatusHealth:         MetricConfig{Enabled: false},
-					FanStatusState:          MetricConfig{Enabled: false},
-					SystemPowerstate:        MetricConfig{Enabled: false},
-					SystemStatusHealth:      MetricConfig{Enabled: false},
-					SystemStatusState:       MetricConfig{Enabled: false},
-					TemperatureReading:      MetricConfig{Enabled: false},
-					TemperatureStatusHealth: MetricConfig{Enabled: false},
-					TemperatureStatusState:  MetricConfig{Enabled: false},
+					ChassisPowerstate: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					ChassisStatusHealth: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					ChassisStatusState: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "chassis.asset_tag", "chassis.model", "chassis.name", "chassis.manufacturer", "chassis.serial_number", "chassis.sku", "chassis.chassis_type"},
+					},
+					FanReading: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name", "fan.reading_units"},
+					},
+					FanStatusHealth: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name"},
+					},
+					FanStatusState: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "fan.name"},
+					},
+					SystemPowerstate: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					SystemStatusHealth: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					SystemStatusState: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"system.id", "system.asset_tag", "system.bios_version", "system.model", "system.name", "system.manufacturer", "system.serial_number", "system.sku", "system.system_type"},
+					},
+					TemperatureReading: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
+					TemperatureStatusHealth: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
+					TemperatureStatusState: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"chassis.id", "temperature.name"},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					BaseURL:        ResourceAttributeConfig{Enabled: false},

--- a/receiver/redfishreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -71,9 +79,10 @@ type metricInfo struct {
 }
 
 type metricChassisPowerstate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.powerstate metric with initial data.
@@ -83,24 +92,69 @@ func (m *metricChassisPowerstate) init() {
 	m.data.SetUnit("{powerstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisPowerstate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.asset_tag") {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.model") {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.name") {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.manufacturer") {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.serial_number") {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.sku") {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.chassis_type") {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -113,6 +167,11 @@ func (m *metricChassisPowerstate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisPowerstate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -130,9 +189,10 @@ func newMetricChassisPowerstate(cfg MetricConfig) metricChassisPowerstate {
 }
 
 type metricChassisStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.status.health metric with initial data.
@@ -142,24 +202,69 @@ func (m *metricChassisStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.asset_tag") {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.model") {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.name") {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.manufacturer") {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.serial_number") {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.sku") {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.chassis_type") {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -172,6 +277,11 @@ func (m *metricChassisStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -189,9 +299,10 @@ func newMetricChassisStatusHealth(cfg MetricConfig) metricChassisStatusHealth {
 }
 
 type metricChassisStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills chassis.status.state metric with initial data.
@@ -201,24 +312,69 @@ func (m *metricChassisStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricChassisStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, chassisAssetTagAttributeValue string, chassisModelAttributeValue string, chassisNameAttributeValue string, chassisManufacturerAttributeValue string, chassisSerialNumberAttributeValue string, chassisSkuAttributeValue string, chassisChassisTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.asset_tag") {
+		dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.model") {
+		dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.name") {
+		dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.manufacturer") {
+		dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.serial_number") {
+		dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.sku") {
+		dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "chassis.chassis_type") {
+		dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("chassis.asset_tag", chassisAssetTagAttributeValue)
-	dp.Attributes().PutStr("chassis.model", chassisModelAttributeValue)
-	dp.Attributes().PutStr("chassis.name", chassisNameAttributeValue)
-	dp.Attributes().PutStr("chassis.manufacturer", chassisManufacturerAttributeValue)
-	dp.Attributes().PutStr("chassis.serial_number", chassisSerialNumberAttributeValue)
-	dp.Attributes().PutStr("chassis.sku", chassisSkuAttributeValue)
-	dp.Attributes().PutStr("chassis.chassis_type", chassisChassisTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -231,6 +387,11 @@ func (m *metricChassisStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricChassisStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -248,9 +409,10 @@ func newMetricChassisStatusState(cfg MetricConfig) metricChassisStatusState {
 }
 
 type metricFanReading struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.reading metric with initial data.
@@ -260,19 +422,54 @@ func (m *metricFanReading) init() {
 	m.data.SetUnit("{}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanReading) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string, fanReadingUnitsAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "fan.name") {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "fan.reading_units") {
+		dp.Attributes().PutStr("fan.reading_units", fanReadingUnitsAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
-	dp.Attributes().PutStr("fan.reading_units", fanReadingUnitsAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -285,6 +482,11 @@ func (m *metricFanReading) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanReading) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -302,9 +504,10 @@ func newMetricFanReading(cfg MetricConfig) metricFanReading {
 }
 
 type metricFanStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.status.health metric with initial data.
@@ -314,18 +517,51 @@ func (m *metricFanStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "fan.name") {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -338,6 +574,11 @@ func (m *metricFanStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -355,9 +596,10 @@ func newMetricFanStatusHealth(cfg MetricConfig) metricFanStatusHealth {
 }
 
 type metricFanStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills fan.status.state metric with initial data.
@@ -367,18 +609,51 @@ func (m *metricFanStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricFanStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, fanNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "fan.name") {
+		dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("fan.name", fanNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -391,6 +666,11 @@ func (m *metricFanStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFanStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -408,9 +688,10 @@ func newMetricFanStatusState(cfg MetricConfig) metricFanStatusState {
 }
 
 type metricSystemPowerstate struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.powerstate metric with initial data.
@@ -420,25 +701,72 @@ func (m *metricSystemPowerstate) init() {
 	m.data.SetUnit("{powerstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemPowerstate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "system.id") {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.asset_tag") {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.bios_version") {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.model") {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.name") {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.manufacturer") {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.serial_number") {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.sku") {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.system_type") {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -451,6 +779,11 @@ func (m *metricSystemPowerstate) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPowerstate) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -468,9 +801,10 @@ func newMetricSystemPowerstate(cfg MetricConfig) metricSystemPowerstate {
 }
 
 type metricSystemStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.status.health metric with initial data.
@@ -480,25 +814,72 @@ func (m *metricSystemStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "system.id") {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.asset_tag") {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.bios_version") {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.model") {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.name") {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.manufacturer") {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.serial_number") {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.sku") {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.system_type") {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -511,6 +892,11 @@ func (m *metricSystemStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -528,9 +914,10 @@ func newMetricSystemStatusHealth(cfg MetricConfig) metricSystemStatusHealth {
 }
 
 type metricSystemStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills system.status.state metric with initial data.
@@ -540,25 +927,72 @@ func (m *metricSystemStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricSystemStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemIDAttributeValue string, systemAssetTagAttributeValue string, systemBiosVersionAttributeValue string, systemModelAttributeValue string, systemNameAttributeValue string, systemManufacturerAttributeValue string, systemSerialNumberAttributeValue string, systemSkuAttributeValue string, systemSystemTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "system.id") {
+		dp.Attributes().PutStr("system.id", systemIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.asset_tag") {
+		dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.bios_version") {
+		dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.model") {
+		dp.Attributes().PutStr("system.model", systemModelAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.name") {
+		dp.Attributes().PutStr("system.name", systemNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.manufacturer") {
+		dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.serial_number") {
+		dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.sku") {
+		dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "system.system_type") {
+		dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("system.id", systemIDAttributeValue)
-	dp.Attributes().PutStr("system.asset_tag", systemAssetTagAttributeValue)
-	dp.Attributes().PutStr("system.bios_version", systemBiosVersionAttributeValue)
-	dp.Attributes().PutStr("system.model", systemModelAttributeValue)
-	dp.Attributes().PutStr("system.name", systemNameAttributeValue)
-	dp.Attributes().PutStr("system.manufacturer", systemManufacturerAttributeValue)
-	dp.Attributes().PutStr("system.serial_number", systemSerialNumberAttributeValue)
-	dp.Attributes().PutStr("system.sku", systemSkuAttributeValue)
-	dp.Attributes().PutStr("system.system_type", systemSystemTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -571,6 +1005,11 @@ func (m *metricSystemStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -588,9 +1027,10 @@ func newMetricSystemStatusState(cfg MetricConfig) metricSystemStatusState {
 }
 
 type metricTemperatureReading struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.reading metric with initial data.
@@ -600,18 +1040,51 @@ func (m *metricTemperatureReading) init() {
 	m.data.SetUnit("°C")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureReading) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "temperature.name") {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -624,6 +1097,11 @@ func (m *metricTemperatureReading) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureReading) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -641,9 +1119,10 @@ func newMetricTemperatureReading(cfg MetricConfig) metricTemperatureReading {
 }
 
 type metricTemperatureStatusHealth struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.status.health metric with initial data.
@@ -653,18 +1132,51 @@ func (m *metricTemperatureStatusHealth) init() {
 	m.data.SetUnit("{statushealth}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureStatusHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "temperature.name") {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -677,6 +1189,11 @@ func (m *metricTemperatureStatusHealth) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureStatusHealth) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -694,9 +1211,10 @@ func newMetricTemperatureStatusHealth(cfg MetricConfig) metricTemperatureStatusH
 }
 
 type metricTemperatureStatusState struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills temperature.status.state metric with initial data.
@@ -706,18 +1224,51 @@ func (m *metricTemperatureStatusState) init() {
 	m.data.SetUnit("{statusstate}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTemperatureStatusState) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, chassisIDAttributeValue string, temperatureNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "chassis.id") {
+		dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "temperature.name") {
+		dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("chassis.id", chassisIDAttributeValue)
-	dp.Attributes().PutStr("temperature.name", temperatureNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -730,6 +1281,11 @@ func (m *metricTemperatureStatusState) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTemperatureStatusState) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/redfishreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/redfishreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,24 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["ChassisPowerstate"] = mb.metricChassisPowerstate.config.AggregationStrategy
+			aggMap["ChassisStatusHealth"] = mb.metricChassisStatusHealth.config.AggregationStrategy
+			aggMap["ChassisStatusState"] = mb.metricChassisStatusState.config.AggregationStrategy
+			aggMap["FanReading"] = mb.metricFanReading.config.AggregationStrategy
+			aggMap["FanStatusHealth"] = mb.metricFanStatusHealth.config.AggregationStrategy
+			aggMap["FanStatusState"] = mb.metricFanStatusState.config.AggregationStrategy
+			aggMap["SystemPowerstate"] = mb.metricSystemPowerstate.config.AggregationStrategy
+			aggMap["SystemStatusHealth"] = mb.metricSystemStatusHealth.config.AggregationStrategy
+			aggMap["SystemStatusState"] = mb.metricSystemStatusState.config.AggregationStrategy
+			aggMap["TemperatureReading"] = mb.metricTemperatureReading.config.AggregationStrategy
+			aggMap["TemperatureStatusHealth"] = mb.metricTemperatureStatusHealth.config.AggregationStrategy
+			aggMap["TemperatureStatusState"] = mb.metricTemperatureStatusState.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,56 +91,106 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisPowerstateDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisPowerstateDataPoint(ts, 3, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisStatusHealthDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisStatusHealthDataPoint(ts, 3, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordChassisStatusStateDataPoint(ts, 1, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordChassisStatusStateDataPoint(ts, 3, "chassis.id-val", "chassis.asset_tag-val", "chassis.model-val", "chassis.name-val", "chassis.manufacturer-val", "chassis.serial_number-val", "chassis.sku-val", "chassis.chassis_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanReadingDataPoint(ts, 1, "chassis.id-val", "fan.name-val", "fan.reading_units-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanReadingDataPoint(ts, 3, "chassis.id-val", "fan.name-val", "fan.reading_units-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanStatusHealthDataPoint(ts, 1, "chassis.id-val", "fan.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanStatusHealthDataPoint(ts, 3, "chassis.id-val", "fan.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordFanStatusStateDataPoint(ts, 1, "chassis.id-val", "fan.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordFanStatusStateDataPoint(ts, 3, "chassis.id-val", "fan.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemPowerstateDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemPowerstateDataPoint(ts, 3, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemStatusHealthDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemStatusHealthDataPoint(ts, 3, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemStatusStateDataPoint(ts, 1, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordSystemStatusStateDataPoint(ts, 3, "system.id-val", "system.asset_tag-val", "system.bios_version-val", "system.model-val", "system.name-val", "system.manufacturer-val", "system.serial_number-val", "system.sku-val", "system.system_type-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureReadingDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureReadingDataPoint(ts, 3, "chassis.id-val", "temperature.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureStatusHealthDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureStatusHealthDataPoint(ts, 3, "chassis.id-val", "temperature.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTemperatureStatusStateDataPoint(ts, 1, "chassis.id-val", "temperature.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordTemperatureStatusStateDataPoint(ts, 3, "chassis.id-val", "temperature.name-val")
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetBaseURL("base_url-val")
 			rb.SetSystemHostName("system.host_name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricChassisPowerstate.aggDataPoints)
+				assert.Empty(t, mb.metricChassisStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricChassisStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricFanReading.aggDataPoints)
+				assert.Empty(t, mb.metricFanStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricFanStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricSystemPowerstate.aggDataPoints)
+				assert.Empty(t, mb.metricSystemStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricSystemStatusState.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureReading.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureStatusHealth.aggDataPoints)
+				assert.Empty(t, mb.metricTemperatureStatusState.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -141,341 +212,745 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				case "chassis.powerstate":
-					assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
-					validatedMetrics["chassis.powerstate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
-					assert.Equal(t, "{powerstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
+						validatedMetrics["chassis.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
+						assert.Equal(t, "{powerstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.powerstate"], "Found a duplicate in the metrics slice: chassis.powerstate")
+						validatedMetrics["chassis.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a chassis (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
+						assert.Equal(t, "{powerstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.powerstate"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+					}
 				case "chassis.status.health":
-					assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
-					validatedMetrics["chassis.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
-					assert.Equal(t, "{statushealth}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
+						validatedMetrics["chassis.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.status.health"], "Found a duplicate in the metrics slice: chassis.status.health")
+						validatedMetrics["chassis.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+					}
 				case "chassis.status.state":
-					assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
-					validatedMetrics["chassis.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
-					assert.Equal(t, "{statusstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.model")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.name")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
+						validatedMetrics["chassis.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.chassis_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["chassis.status.state"], "Found a duplicate in the metrics slice: chassis.status.state")
+						validatedMetrics["chassis.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["chassis.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("chassis.chassis_type")
+						assert.True(t, ok)
+					}
 				case "fan.reading":
-					assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
-					validatedMetrics["fan.reading"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the reading of a chassis fan.", ms.At(i).Description())
-					assert.Equal(t, "{}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("fan.reading_units")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.reading_units-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
+						validatedMetrics["fan.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis fan.", ms.At(i).Description())
+						assert.Equal(t, "{}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("fan.reading_units")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.reading_units-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.reading"], "Found a duplicate in the metrics slice: fan.reading")
+						validatedMetrics["fan.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis fan.", ms.At(i).Description())
+						assert.Equal(t, "{}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.reading"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("fan.reading_units")
+						assert.True(t, ok)
+					}
 				case "fan.status.health":
-					assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
-					validatedMetrics["fan.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
-					assert.Equal(t, "{statushealth}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
+						validatedMetrics["fan.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.status.health"], "Found a duplicate in the metrics slice: fan.status.health")
+						validatedMetrics["fan.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis fan (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+					}
 				case "fan.status.state":
-					assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
-					validatedMetrics["fan.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
-					assert.Equal(t, "{statusstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("fan.name")
-					assert.True(t, ok)
-					assert.Equal(t, "fan.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
+						validatedMetrics["fan.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+						assert.Equal(t, "fan.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["fan.status.state"], "Found a duplicate in the metrics slice: fan.status.state")
+						validatedMetrics["fan.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis fan (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["fan.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("fan.name")
+						assert.True(t, ok)
+					}
 				case "system.powerstate":
-					assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
-					validatedMetrics["system.powerstate"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
-					assert.Equal(t, "{powerstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
+						validatedMetrics["system.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
+						assert.Equal(t, "{powerstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.powerstate"], "Found a duplicate in the metrics slice: system.powerstate")
+						validatedMetrics["system.powerstate"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the power state of a system (-1 unknown, 0 off, 1 on).", ms.At(i).Description())
+						assert.Equal(t, "{powerstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.powerstate"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+					}
 				case "system.status.health":
-					assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
-					validatedMetrics["system.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
-					assert.Equal(t, "{statushealth}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
+						validatedMetrics["system.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.status.health"], "Found a duplicate in the metrics slice: system.status.health")
+						validatedMetrics["system.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a system (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+					}
 				case "system.status.state":
-					assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
-					validatedMetrics["system.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
-					assert.Equal(t, "{statusstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("system.id")
-					assert.True(t, ok)
-					assert.Equal(t, "system.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.asset_tag")
-					assert.True(t, ok)
-					assert.Equal(t, "system.asset_tag-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.bios_version")
-					assert.True(t, ok)
-					assert.Equal(t, "system.bios_version-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.model")
-					assert.True(t, ok)
-					assert.Equal(t, "system.model-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.name")
-					assert.True(t, ok)
-					assert.Equal(t, "system.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.manufacturer")
-					assert.True(t, ok)
-					assert.Equal(t, "system.manufacturer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.serial_number")
-					assert.True(t, ok)
-					assert.Equal(t, "system.serial_number-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.sku")
-					assert.True(t, ok)
-					assert.Equal(t, "system.sku-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("system.system_type")
-					assert.True(t, ok)
-					assert.Equal(t, "system.system_type-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
+						validatedMetrics["system.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						assert.Equal(t, "system.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						assert.Equal(t, "system.asset_tag-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						assert.Equal(t, "system.bios_version-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						assert.Equal(t, "system.model-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						assert.Equal(t, "system.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						assert.Equal(t, "system.manufacturer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						assert.Equal(t, "system.serial_number-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						assert.Equal(t, "system.sku-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+						assert.Equal(t, "system.system_type-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["system.status.state"], "Found a duplicate in the metrics slice: system.status.state")
+						validatedMetrics["system.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a system (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["system.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("system.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.asset_tag")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.bios_version")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.model")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.manufacturer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.serial_number")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.sku")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("system.system_type")
+						assert.True(t, ok)
+					}
 				case "temperature.reading":
-					assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
-					validatedMetrics["temperature.reading"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the reading of a chassis temperature.", ms.At(i).Description())
-					assert.Equal(t, "°C", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
+						validatedMetrics["temperature.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis temperature.", ms.At(i).Description())
+						assert.Equal(t, "°C", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.reading"], "Found a duplicate in the metrics slice: temperature.reading")
+						validatedMetrics["temperature.reading"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the reading of a chassis temperature.", ms.At(i).Description())
+						assert.Equal(t, "°C", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.reading"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+					}
 				case "temperature.status.health":
-					assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
-					validatedMetrics["temperature.status.health"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
-					assert.Equal(t, "{statushealth}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
+						validatedMetrics["temperature.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.status.health"], "Found a duplicate in the metrics slice: temperature.status.health")
+						validatedMetrics["temperature.status.health"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the health of a chassis temperature (-1 unknown, 0 critical, 1 ok, 2 warning).", ms.At(i).Description())
+						assert.Equal(t, "{statushealth}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.status.health"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+					}
 				case "temperature.status.state":
-					assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
-					validatedMetrics["temperature.status.state"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
-					assert.Equal(t, "{statusstate}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("chassis.id")
-					assert.True(t, ok)
-					assert.Equal(t, "chassis.id-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("temperature.name")
-					assert.True(t, ok)
-					assert.Equal(t, "temperature.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
+						validatedMetrics["temperature.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						assert.Equal(t, "chassis.id-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+						assert.Equal(t, "temperature.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["temperature.status.state"], "Found a duplicate in the metrics slice: temperature.status.state")
+						validatedMetrics["temperature.status.state"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Measures the state of a chassis temperature (-1 unknown, 0 disabled, 1 enabled).", ms.At(i).Description())
+						assert.Equal(t, "{statusstate}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["temperature.status.state"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("chassis.id")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("temperature.name")
+						assert.True(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/redfishreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/redfishreceiver/internal/metadata/testdata/config.yaml
@@ -3,28 +3,83 @@ all_set:
   metrics:
     chassis.powerstate:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.health:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.state:
       enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     fan.reading:
       enabled: true
+      attributes: ["chassis.id","fan.name","fan.reading_units"]
     fan.status.health:
       enabled: true
+      attributes: ["chassis.id","fan.name"]
     fan.status.state:
       enabled: true
+      attributes: ["chassis.id","fan.name"]
     system.powerstate:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.health:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.state:
       enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     temperature.reading:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.health:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.state:
       enabled: true
+      attributes: ["chassis.id","temperature.name"]
+  resource_attributes:
+    base_url:
+      enabled: true
+    system.host_name:
+      enabled: true
+reaggregate_set:
+  metrics:
+    chassis.powerstate:
+      enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
+    chassis.status.health:
+      enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
+    chassis.status.state:
+      enabled: true
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
+    fan.reading:
+      enabled: true
+      attributes: ["chassis.id","fan.name","fan.reading_units"]
+    fan.status.health:
+      enabled: true
+      attributes: ["chassis.id","fan.name"]
+    fan.status.state:
+      enabled: true
+      attributes: ["chassis.id","fan.name"]
+    system.powerstate:
+      enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
+    system.status.health:
+      enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
+    system.status.state:
+      enabled: true
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
+    temperature.reading:
+      enabled: true
+      attributes: ["chassis.id","temperature.name"]
+    temperature.status.health:
+      enabled: true
+      attributes: ["chassis.id","temperature.name"]
+    temperature.status.state:
+      enabled: true
+      attributes: ["chassis.id","temperature.name"]
   resource_attributes:
     base_url:
       enabled: true
@@ -34,28 +89,40 @@ none_set:
   metrics:
     chassis.powerstate:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.health:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     chassis.status.state:
       enabled: false
+      attributes: ["chassis.id","chassis.asset_tag","chassis.model","chassis.name","chassis.manufacturer","chassis.serial_number","chassis.sku","chassis.chassis_type"]
     fan.reading:
       enabled: false
+      attributes: ["chassis.id","fan.name","fan.reading_units"]
     fan.status.health:
       enabled: false
+      attributes: ["chassis.id","fan.name"]
     fan.status.state:
       enabled: false
+      attributes: ["chassis.id","fan.name"]
     system.powerstate:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.health:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     system.status.state:
       enabled: false
+      attributes: ["system.id","system.asset_tag","system.bios_version","system.model","system.name","system.manufacturer","system.serial_number","system.sku","system.system_type"]
     temperature.reading:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.health:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
     temperature.status.state:
       enabled: false
+      attributes: ["chassis.id","temperature.name"]
   resource_attributes:
     base_url:
       enabled: false

--- a/receiver/redfishreceiver/metadata.yaml
+++ b/receiver/redfishreceiver/metadata.yaml
@@ -7,6 +7,8 @@ status:
   codeowners:
     active: [steven-freed, khushijain21]
 
+reaggregation_enabled: true
+
 resource_attributes:
   base_url:
     description: base url.
@@ -21,63 +23,83 @@ attributes:
   chassis.asset_tag:
     description: Chassis asset tag.
     type: string
+    requirement_level: required
   chassis.chassis_type:
     description: Chassis type.
     type: string
+    requirement_level: required
   chassis.id:
     description: Chassis id.
     type: string
+    requirement_level: required
   chassis.manufacturer:
     description: Chassis manufacturer.
     type: string
+    requirement_level: required
   chassis.model:
     description: Chassis model.
     type: string
+    requirement_level: required
   chassis.name:
     description: Chassis name.
     type: string
+    requirement_level: required
   chassis.serial_number:
     description: Chassis serial number.
     type: string
+    requirement_level: required
   chassis.sku:
     description: Chassis sku.
     type: string
+    requirement_level: required
   fan.name:
     description: Fan name.
     type: string
+    requirement_level: required
   fan.reading_units:
     description: Fan reading units.
     type: string
+    requirement_level: required
   system.asset_tag:
     description: System asset tag.
     type: string
+    requirement_level: required
   system.bios_version:
     description: System bios version.
     type: string
+    requirement_level: required
   system.id:
     description: System id.
     type: string
+    requirement_level: required
   system.manufacturer:
     description: System manufacturer.
     type: string
+    requirement_level: required
   system.model:
     description: System model.
     type: string
+    requirement_level: required
   system.name:
     description: System name.
     type: string
+    requirement_level: required
   system.serial_number:
     description: System serial number.
     type: string
+    requirement_level: required
   system.sku:
     description: System sku.
     type: string
+    requirement_level: required
   system.system_type:
     description: System type.
     type: string
+    requirement_level: required
   temperature.name:
     description: Temperature name.
     type: string
+    requirement_level: required
 
 metrics:
   chassis.powerstate:


### PR DESCRIPTION
## Description

Enable the re-aggregation feature for the redfish receiver.

### Changes
- Set `reaggregation_enabled: true` in `metadata.yaml`
- Added `requirement_level: required` to all attributes
- Ran code generation (`go generate`) to update generated files
- All existing tests pass

### Link to tracking issue

Resolves #46375
Part of #45396