### PR TITLE
feat(receiver/tlscheck): enable re-aggregation feature

### DIFF
--- a/.chloggen/46383-tlscheck-enable-reaggregation.yaml
+++ b/.chloggen/46383-tlscheck-enable-reaggregation.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/tlscheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable re-aggregation feature for the tlscheck receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46383]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Set reaggregation_enabled to true and requirement_level to required on all attributes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/tlscheckreceiver/documentation.md
+++ b/receiver/tlscheckreceiver/documentation.md
@@ -24,9 +24,9 @@ Time in seconds until certificate expiry, as specified by `NotAfter` field in th
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| tlscheck.x509.issuer | The entity that issued the certificate. | Any Str | Recommended |
-| tlscheck.x509.cn | The commonName in the subject of the certificate. | Any Str | Recommended |
-| tlscheck.x509.san | The Subject Alternative Name of the certificate. | Any Slice | Recommended |
+| tlscheck.x509.issuer | The entity that issued the certificate. | Any Str | Required |
+| tlscheck.x509.cn | The commonName in the subject of the certificate. | Any Str | Required |
+| tlscheck.x509.san | The Subject Alternative Name of the certificate. | Any Slice | Required |
 
 ## Resource Attributes
 

--- a/receiver/tlscheckreceiver/generated_package_test.go
+++ b/receiver/tlscheckreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package tlscheckreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/tlscheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_config.go
@@ -3,6 +3,9 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
@@ -11,6 +14,11 @@ import (
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []string `mapstructure:"attributes"`
+	definedAttributes   []string
+	requiredAttributes  []string
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -22,9 +30,32 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
+	for _, val := range ms.EnabledAttributes {
+		if !slices.Contains(ms.definedAttributes, val) {
+			return fmt.Errorf("%v is not defined in metadata.yaml", val)
+		}
+	}
+
+	for _, val := range ms.requiredAttributes {
+		if !slices.Contains(ms.EnabledAttributes, val) {
+			return fmt.Errorf("`attributes` field must contain required attribute: %v", val)
+		}
+	}
+
+	if ms.AggregationStrategy != AggregationStrategySum &&
+		ms.AggregationStrategy != AggregationStrategyAvg &&
+		ms.AggregationStrategy != AggregationStrategyMin &&
+		ms.AggregationStrategy != AggregationStrategyMax {
+		return fmt.Errorf("invalid aggregation strategy set: '%v'", ms.AggregationStrategy)
+	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
+}
+
+// AttributeConfig holds configuration information for a particular metric.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // MetricsConfig provides config for tlscheck metrics.
@@ -36,6 +67,11 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		TlscheckTimeLeft: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"tlscheck.x509.issuer", "tlscheck.x509.cn", "tlscheck.x509.san"},
+			definedAttributes:   []string{"tlscheck.x509.issuer", "tlscheck.x509.cn", "tlscheck.x509.san"},
+			EnabledAttributes:   []string{"tlscheck.x509.issuer", "tlscheck.x509.cn", "tlscheck.x509.san"},
 		},
 	}
 }

--- a/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,7 +27,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TlscheckTimeLeft: MetricConfig{Enabled: true},
+					TlscheckTimeLeft: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"tlscheck.x509.issuer", "tlscheck.x509.cn", "tlscheck.x509.san"},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					TlscheckTarget: ResourceAttributeConfig{Enabled: true},
@@ -37,7 +42,11 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					TlscheckTimeLeft: MetricConfig{Enabled: false},
+					TlscheckTimeLeft: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"tlscheck.x509.issuer", "tlscheck.x509.cn", "tlscheck.x509.san"},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					TlscheckTarget: ResourceAttributeConfig{Enabled: false},

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -10,6 +11,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 var MetricsInfo = metricsInfo{
@@ -27,9 +35,10 @@ type metricInfo struct {
 }
 
 type metricTlscheckTimeLeft struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills tlscheck.time_left metric with initial data.
@@ -39,19 +48,54 @@ func (m *metricTlscheckTimeLeft) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricTlscheckTimeLeft) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tlscheckX509IssuerAttributeValue string, tlscheckX509CnAttributeValue string, tlscheckX509SanAttributeValue []any) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "tlscheck.x509.issuer") {
+		dp.Attributes().PutStr("tlscheck.x509.issuer", tlscheckX509IssuerAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "tlscheck.x509.cn") {
+		dp.Attributes().PutStr("tlscheck.x509.cn", tlscheckX509CnAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "tlscheck.x509.san") {
+		dp.Attributes().PutEmptySlice("tlscheck.x509.san").FromRaw(tlscheckX509SanAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("tlscheck.x509.issuer", tlscheckX509IssuerAttributeValue)
-	dp.Attributes().PutStr("tlscheck.x509.cn", tlscheckX509CnAttributeValue)
-	dp.Attributes().PutEmptySlice("tlscheck.x509.san").FromRaw(tlscheckX509SanAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -64,6 +108,11 @@ func (m *metricTlscheckTimeLeft) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricTlscheckTimeLeft) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/tlscheckreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,13 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["TlscheckTimeLeft"] = mb.metricTlscheckTimeLeft.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,11 +80,17 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordTlscheckTimeLeftDataPoint(ts, 1, "tlscheck.x509.issuer-val", "tlscheck.x509.cn-val", []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"})
+			if tt.name == "reaggregate_set" {
+				mb.RecordTlscheckTimeLeftDataPoint(ts, 3, "tlscheck.x509.issuer-val", "tlscheck.x509.cn-val", []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"})
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetTlscheckTarget("tlscheck.target-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricTlscheckTimeLeft.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -96,26 +112,55 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				case "tlscheck.time_left":
-					assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
-					validatedMetrics["tlscheck.time_left"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("tlscheck.x509.issuer")
-					assert.True(t, ok)
-					assert.Equal(t, "tlscheck.x509.issuer-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("tlscheck.x509.cn")
-					assert.True(t, ok)
-					assert.Equal(t, "tlscheck.x509.cn-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("tlscheck.x509.san")
-					assert.True(t, ok)
-					assert.Equal(t, []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"}, attrVal.Slice().AsRaw())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
+						validatedMetrics["tlscheck.time_left"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("tlscheck.x509.issuer")
+						assert.True(t, ok)
+						assert.Equal(t, "tlscheck.x509.issuer-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("tlscheck.x509.cn")
+						assert.True(t, ok)
+						assert.Equal(t, "tlscheck.x509.cn-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("tlscheck.x509.san")
+						assert.True(t, ok)
+						assert.Equal(t, []any{"tlscheck.x509.san-item1", "tlscheck.x509.san-item2"}, attrVal.Slice().AsRaw())
+					} else {
+						assert.False(t, validatedMetrics["tlscheck.time_left"], "Found a duplicate in the metrics slice: tlscheck.time_left")
+						validatedMetrics["tlscheck.time_left"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time in seconds until certificate expiry, as specified by `NotAfter` field in the x.509 certificate. Negative values represent time in seconds since expiration.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["tlscheck.time_left"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("tlscheck.x509.issuer")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("tlscheck.x509.cn")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("tlscheck.x509.san")
+						assert.True(t, ok)
+					}
 				}
 			}
 		})

--- a/receiver/tlscheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/tlscheckreceiver/internal/metadata/testdata/config.yaml
@@ -3,6 +3,15 @@ all_set:
   metrics:
     tlscheck.time_left:
       enabled: true
+      attributes: ["tlscheck.x509.issuer","tlscheck.x509.cn","tlscheck.x509.san"]
+  resource_attributes:
+    tlscheck.target:
+      enabled: true
+reaggregate_set:
+  metrics:
+    tlscheck.time_left:
+      enabled: true
+      attributes: ["tlscheck.x509.issuer","tlscheck.x509.cn","tlscheck.x509.san"]
   resource_attributes:
     tlscheck.target:
       enabled: true
@@ -10,6 +19,7 @@ none_set:
   metrics:
     tlscheck.time_left:
       enabled: false
+      attributes: ["tlscheck.x509.issuer","tlscheck.x509.cn","tlscheck.x509.san"]
   resource_attributes:
     tlscheck.target:
       enabled: false

--- a/receiver/tlscheckreceiver/metadata.yaml
+++ b/receiver/tlscheckreceiver/metadata.yaml
@@ -8,6 +8,8 @@ status:
   codeowners:
     active: [atoulme, michael-burt]
 
+reaggregation_enabled: true
+
 resource_attributes:
   tlscheck.target:
     enabled: true
@@ -18,12 +20,15 @@ attributes:
   tlscheck.x509.cn:
     description: The commonName in the subject of the certificate.
     type: string
+    requirement_level: required
   tlscheck.x509.issuer:
     description: The entity that issued the certificate.
     type: string
+    requirement_level: required
   tlscheck.x509.san:
     description: The Subject Alternative Name of the certificate.
     type: slice
+    requirement_level: required
 
 metrics:
   tlscheck.time_left:


### PR DESCRIPTION
## Description

Enable the re-aggregation feature for the tlscheck receiver.

### Changes
- Set `reaggregation_enabled: true` in `metadata.yaml`
- Set `requirement_level: required` on all attributes (`tlscheck.x509.cn`, `tlscheck.x509.issuer`, `tlscheck.x509.san`)
- Regenerated code via `go generate ./...`
- All existing tests pass

Fixes #46383

Part of #45396