### PR TITLE
[receiver/githubreceiver] Enable re-aggregation feature

### DIFF
--- a/.chloggen/46385-github-enable-reaggregation.yaml
+++ b/.chloggen/46385-github-enable-reaggregation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/githubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable re-aggregation feature for the GitHub receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46385]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/githubreceiver/documentation.md
+++ b/receiver/githubreceiver/documentation.md
@@ -24,9 +24,9 @@ The number of changes (pull requests) in a repository, categorized by their stat
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
 
 ### vcs.change.duration
 
@@ -40,10 +40,10 @@ The time duration a change (pull request/merge request/changelist) has been in a
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
-| vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
+| vcs.change.state | The state of a change (pull request) | Str: ``open``, ``merged`` | Required |
 
 ### vcs.change.time_to_approval
 
@@ -57,9 +57,9 @@ The amount of time it took a change (pull request) to go from open to approved.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
 
 ### vcs.change.time_to_merge
 
@@ -73,9 +73,9 @@ The amount of time it took a change (pull request) to go from open to merged.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
 
 ### vcs.ref.count
 
@@ -89,9 +89,9 @@ The number of refs of type branch in a repository.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.type | The type of the reference in the repository. | Str: ``branch``, ``tag`` | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.type | The type of the reference in the repository. | Str: ``branch``, ``tag`` | Required |
 
 ### vcs.ref.lines_delta
 
@@ -105,13 +105,13 @@ The number of lines added/removed in a ref (branch) relative to the default bran
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
-| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Recommended |
-| vcs.ref.base.name | The name of the VCS base reference (branch/tag) for comparison. | Any Str | Recommended |
-| vcs.ref.base.type | The type of the base reference (branch, tag). | Str: ``branch``, ``tag`` | Recommended |
-| vcs.line_change.type | The type of line change being measured on a ref (branch). | Str: ``added``, ``removed`` | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
+| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Required |
+| vcs.ref.base.name | The name of the VCS base reference (branch/tag) for comparison. | Any Str | Required |
+| vcs.ref.base.type | The type of the base reference (branch, tag). | Str: ``branch``, ``tag`` | Required |
+| vcs.line_change.type | The type of line change being measured on a ref (branch). | Str: ``added``, ``removed`` | Required |
 
 ### vcs.ref.revisions_delta
 
@@ -125,13 +125,13 @@ The number of revisions (commits) a ref (branch) is ahead/behind the branch from
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
-| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Recommended |
-| vcs.ref.base.name | The name of the VCS base reference (branch/tag) for comparison. | Any Str | Recommended |
-| vcs.ref.base.type | The type of the base reference (branch, tag). | Str: ``branch``, ``tag`` | Recommended |
-| vcs.revision_delta.direction | The type of revision comparison. | Str: ``ahead``, ``behind`` | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
+| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Required |
+| vcs.ref.base.name | The name of the VCS base reference (branch/tag) for comparison. | Any Str | Required |
+| vcs.ref.base.type | The type of the base reference (branch, tag). | Str: ``branch``, ``tag`` | Required |
+| vcs.revision_delta.direction | The type of revision comparison. | Str: ``ahead``, ``behind`` | Required |
 
 ### vcs.ref.time
 
@@ -145,10 +145,10 @@ Time a ref (branch) created from the default branch (trunk) has existed. The `vc
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
-| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Recommended |
-| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
+| vcs.ref.head.name | The name of the VCS head reference (branch). | Any Str | Required |
+| vcs.ref.head.type | The type of the head reference (branch, tag). | Str: ``branch``, ``tag`` | Required |
 
 ### vcs.repository.count
 
@@ -180,8 +180,8 @@ The number of unique contributors to a repository.
 
 | Name | Description | Values | Requirement Level |
 | ---- | ----------- | ------ | -------- |
-| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Recommended |
-| vcs.repository.name | The name of the VCS repository. | Any Str | Recommended |
+| vcs.repository.url.full | The canonical URL of the repository providing the complete HTTPS address. | Any Str | Required |
+| vcs.repository.name | The name of the VCS repository. | Any Str | Required |
 
 ## Resource Attributes
 

--- a/receiver/githubreceiver/generated_package_test.go
+++ b/receiver/githubreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package githubreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/githubreceiver/internal/metadata/generated_config.go
+++ b/receiver/githubreceiver/internal/metadata/generated_config.go
@@ -3,6 +3,9 @@
 package metadata
 
 import (
+	"fmt"
+	"slices"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/filter"
 )
@@ -11,6 +14,11 @@ import (
 type MetricConfig struct {
 	Enabled          bool `mapstructure:"enabled"`
 	enabledSetByUser bool
+
+	AggregationStrategy string   `mapstructure:"aggregation_strategy"`
+	EnabledAttributes   []string `mapstructure:"attributes"`
+	definedAttributes   []string
+	requiredAttributes  []string
 }
 
 func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
@@ -22,9 +30,32 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
+	for _, val := range ms.EnabledAttributes {
+		if !slices.Contains(ms.definedAttributes, val) {
+			return fmt.Errorf("%v is not defined in metadata.yaml", val)
+		}
+	}
+
+	for _, val := range ms.requiredAttributes {
+		if !slices.Contains(ms.EnabledAttributes, val) {
+			return fmt.Errorf("`attributes` field must contain required attribute: %v", val)
+		}
+	}
+
+	if ms.AggregationStrategy != AggregationStrategySum &&
+		ms.AggregationStrategy != AggregationStrategyAvg &&
+		ms.AggregationStrategy != AggregationStrategyMin &&
+		ms.AggregationStrategy != AggregationStrategyMax {
+		return fmt.Errorf("invalid aggregation strategy set: '%v'", ms.AggregationStrategy)
+	}
 
 	ms.enabledSetByUser = parser.IsSet("enabled")
 	return nil
+}
+
+// AttributeConfig holds configuration information for a particular metric.
+type AttributeConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 // MetricsConfig provides config for github metrics.
@@ -45,33 +76,83 @@ func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		VcsChangeCount: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.change.state", "vcs.repository.name"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.change.state", "vcs.repository.name"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.change.state", "vcs.repository.name"},
 		},
 		VcsChangeDuration: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.change.state"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.change.state"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.change.state"},
 		},
 		VcsChangeTimeToApproval: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
 		},
 		VcsChangeTimeToMerge: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
 		},
 		VcsContributorCount: MetricConfig{
 			Enabled: false,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name"},
 		},
 		VcsRefCount: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.type"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.type"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.type"},
 		},
 		VcsRefLinesDelta: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.line_change.type"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.line_change.type"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.line_change.type"},
 		},
 		VcsRefRevisionsDelta: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.revision_delta.direction"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.revision_delta.direction"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.revision_delta.direction"},
 		},
 		VcsRefTime: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type"},
+			definedAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type"},
+			EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type"},
 		},
 		VcsRepositoryCount: MetricConfig{
 			Enabled: true,
+
+			AggregationStrategy: AggregationStrategyAvg,
+			requiredAttributes:  []string{},
+			definedAttributes:   []string{},
+			EnabledAttributes:   []string{},
 		},
 	}
 }

--- a/receiver/githubreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/githubreceiver/internal/metadata/generated_config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
@@ -26,16 +27,56 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					VcsChangeCount:          MetricConfig{Enabled: true},
-					VcsChangeDuration:       MetricConfig{Enabled: true},
-					VcsChangeTimeToApproval: MetricConfig{Enabled: true},
-					VcsChangeTimeToMerge:    MetricConfig{Enabled: true},
-					VcsContributorCount:     MetricConfig{Enabled: true},
-					VcsRefCount:             MetricConfig{Enabled: true},
-					VcsRefLinesDelta:        MetricConfig{Enabled: true},
-					VcsRefRevisionsDelta:    MetricConfig{Enabled: true},
-					VcsRefTime:              MetricConfig{Enabled: true},
-					VcsRepositoryCount:      MetricConfig{Enabled: true},
+					VcsChangeCount: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.change.state", "vcs.repository.name"},
+					},
+					VcsChangeDuration: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.change.state"},
+					},
+					VcsChangeTimeToApproval: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+					},
+					VcsChangeTimeToMerge: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+					},
+					VcsContributorCount: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name"},
+					},
+					VcsRefCount: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.type"},
+					},
+					VcsRefLinesDelta: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.line_change.type"},
+					},
+					VcsRefRevisionsDelta: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.revision_delta.direction"},
+					},
+					VcsRefTime: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type"},
+					},
+					VcsRepositoryCount: MetricConfig{
+						Enabled:             true,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					VcsOwnerName:    ResourceAttributeConfig{Enabled: true},
@@ -47,16 +88,56 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					VcsChangeCount:          MetricConfig{Enabled: false},
-					VcsChangeDuration:       MetricConfig{Enabled: false},
-					VcsChangeTimeToApproval: MetricConfig{Enabled: false},
-					VcsChangeTimeToMerge:    MetricConfig{Enabled: false},
-					VcsContributorCount:     MetricConfig{Enabled: false},
-					VcsRefCount:             MetricConfig{Enabled: false},
-					VcsRefLinesDelta:        MetricConfig{Enabled: false},
-					VcsRefRevisionsDelta:    MetricConfig{Enabled: false},
-					VcsRefTime:              MetricConfig{Enabled: false},
-					VcsRepositoryCount:      MetricConfig{Enabled: false},
+					VcsChangeCount: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.change.state", "vcs.repository.name"},
+					},
+					VcsChangeDuration: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.change.state"},
+					},
+					VcsChangeTimeToApproval: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+					},
+					VcsChangeTimeToMerge: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name"},
+					},
+					VcsContributorCount: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name"},
+					},
+					VcsRefCount: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.type"},
+					},
+					VcsRefLinesDelta: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.line_change.type"},
+					},
+					VcsRefRevisionsDelta: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type", "vcs.ref.base.name", "vcs.ref.base.type", "vcs.revision_delta.direction"},
+					},
+					VcsRefTime: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{"vcs.repository.url.full", "vcs.repository.name", "vcs.ref.head.name", "vcs.ref.head.type"},
+					},
+					VcsRepositoryCount: MetricConfig{
+						Enabled:             false,
+						AggregationStrategy: AggregationStrategyAvg,
+						EnabledAttributes:   []string{},
+					},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					VcsOwnerName:    ResourceAttributeConfig{Enabled: false},

--- a/receiver/githubreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/githubreceiver/internal/metadata/generated_metrics.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -11,6 +12,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
+)
+
+const (
+	AggregationStrategySum = "sum"
+	AggregationStrategyAvg = "avg"
+	AggregationStrategyMin = "min"
+	AggregationStrategyMax = "max"
 )
 
 // AttributeVcsChangeState specifies the value vcs.change.state attribute.
@@ -220,9 +228,10 @@ type metricInfo struct {
 }
 
 type metricVcsChangeCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.change.count metric with initial data.
@@ -232,19 +241,54 @@ func (m *metricVcsChangeCount) init() {
 	m.data.SetUnit("{change}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsChangeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsChangeStateAttributeValue string, vcsRepositoryNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.change.state") {
+		dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -257,6 +301,11 @@ func (m *metricVcsChangeCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsChangeCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -274,9 +323,10 @@ func newMetricVcsChangeCount(cfg MetricConfig) metricVcsChangeCount {
 }
 
 type metricVcsChangeDuration struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.change.duration metric with initial data.
@@ -286,20 +336,57 @@ func (m *metricVcsChangeDuration) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsChangeDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsChangeStateAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.change.state") {
+		dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
-	dp.Attributes().PutStr("vcs.change.state", vcsChangeStateAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -312,6 +399,11 @@ func (m *metricVcsChangeDuration) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsChangeDuration) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -329,9 +421,10 @@ func newMetricVcsChangeDuration(cfg MetricConfig) metricVcsChangeDuration {
 }
 
 type metricVcsChangeTimeToApproval struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.change.time_to_approval metric with initial data.
@@ -341,19 +434,54 @@ func (m *metricVcsChangeTimeToApproval) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsChangeTimeToApproval) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -366,6 +494,11 @@ func (m *metricVcsChangeTimeToApproval) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsChangeTimeToApproval) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -383,9 +516,10 @@ func newMetricVcsChangeTimeToApproval(cfg MetricConfig) metricVcsChangeTimeToApp
 }
 
 type metricVcsChangeTimeToMerge struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.change.time_to_merge metric with initial data.
@@ -395,19 +529,54 @@ func (m *metricVcsChangeTimeToMerge) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsChangeTimeToMerge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -420,6 +589,11 @@ func (m *metricVcsChangeTimeToMerge) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsChangeTimeToMerge) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -437,9 +611,10 @@ func newMetricVcsChangeTimeToMerge(cfg MetricConfig) metricVcsChangeTimeToMerge 
 }
 
 type metricVcsContributorCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.contributor.count metric with initial data.
@@ -449,18 +624,51 @@ func (m *metricVcsContributorCount) init() {
 	m.data.SetUnit("{contributor}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsContributorCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -473,6 +681,11 @@ func (m *metricVcsContributorCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsContributorCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -490,9 +703,10 @@ func newMetricVcsContributorCount(cfg MetricConfig) metricVcsContributorCount {
 }
 
 type metricVcsRefCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.ref.count metric with initial data.
@@ -502,19 +716,54 @@ func (m *metricVcsRefCount) init() {
 	m.data.SetUnit("{ref}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsRefCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.type") {
+		dp.Attributes().PutStr("vcs.ref.type", vcsRefTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.type", vcsRefTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -527,6 +776,11 @@ func (m *metricVcsRefCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsRefCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -544,9 +798,10 @@ func newMetricVcsRefCount(cfg MetricConfig) metricVcsRefCount {
 }
 
 type metricVcsRefLinesDelta struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.ref.lines_delta metric with initial data.
@@ -556,23 +811,66 @@ func (m *metricVcsRefLinesDelta) init() {
 	m.data.SetUnit("{line}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsRefLinesDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsRefBaseNameAttributeValue string, vcsRefBaseTypeAttributeValue string, vcsLineChangeTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.type") {
+		dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.base.name") {
+		dp.Attributes().PutStr("vcs.ref.base.name", vcsRefBaseNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.base.type") {
+		dp.Attributes().PutStr("vcs.ref.base.type", vcsRefBaseTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.line_change.type") {
+		dp.Attributes().PutStr("vcs.line_change.type", vcsLineChangeTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.base.name", vcsRefBaseNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.base.type", vcsRefBaseTypeAttributeValue)
-	dp.Attributes().PutStr("vcs.line_change.type", vcsLineChangeTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -585,6 +883,11 @@ func (m *metricVcsRefLinesDelta) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsRefLinesDelta) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -602,9 +905,10 @@ func newMetricVcsRefLinesDelta(cfg MetricConfig) metricVcsRefLinesDelta {
 }
 
 type metricVcsRefRevisionsDelta struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.ref.revisions_delta metric with initial data.
@@ -614,23 +918,66 @@ func (m *metricVcsRefRevisionsDelta) init() {
 	m.data.SetUnit("{revision}")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsRefRevisionsDelta) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string, vcsRefBaseNameAttributeValue string, vcsRefBaseTypeAttributeValue string, vcsRevisionDeltaDirectionAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.type") {
+		dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.base.name") {
+		dp.Attributes().PutStr("vcs.ref.base.name", vcsRefBaseNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.base.type") {
+		dp.Attributes().PutStr("vcs.ref.base.type", vcsRefBaseTypeAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.revision_delta.direction") {
+		dp.Attributes().PutStr("vcs.revision_delta.direction", vcsRevisionDeltaDirectionAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.base.name", vcsRefBaseNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.base.type", vcsRefBaseTypeAttributeValue)
-	dp.Attributes().PutStr("vcs.revision_delta.direction", vcsRevisionDeltaDirectionAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -643,6 +990,11 @@ func (m *metricVcsRefRevisionsDelta) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsRefRevisionsDelta) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -660,9 +1012,10 @@ func newMetricVcsRefRevisionsDelta(cfg MetricConfig) metricVcsRefRevisionsDelta 
 }
 
 type metricVcsRefTime struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.ref.time metric with initial data.
@@ -672,20 +1025,57 @@ func (m *metricVcsRefTime) init() {
 	m.data.SetUnit("s")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsRefTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vcsRepositoryURLFullAttributeValue string, vcsRepositoryNameAttributeValue string, vcsRefHeadNameAttributeValue string, vcsRefHeadTypeAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.url.full") {
+		dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.repository.name") {
+		dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.name") {
+		dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
+	}
+	if slices.Contains(m.config.EnabledAttributes, "vcs.ref.head.type") {
+		dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
+	}
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
-	dp.Attributes().PutStr("vcs.repository.url.full", vcsRepositoryURLFullAttributeValue)
-	dp.Attributes().PutStr("vcs.repository.name", vcsRepositoryNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.name", vcsRefHeadNameAttributeValue)
-	dp.Attributes().PutStr("vcs.ref.head.type", vcsRefHeadTypeAttributeValue)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -698,6 +1088,11 @@ func (m *metricVcsRefTime) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsRefTime) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -715,9 +1110,10 @@ func newMetricVcsRefTime(cfg MetricConfig) metricVcsRefTime {
 }
 
 type metricVcsRepositoryCount struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	config   MetricConfig   // metric config provided by user.
-	capacity int            // max observed number of data points added to the metric.
+	data          pmetric.Metric // data buffer for generated metric.
+	config        MetricConfig   // metric config provided by user.
+	capacity      int            // max observed number of data points added to the metric.
+	aggDataPoints []int64        // slice containing number of aggregated datapoints at each index
 }
 
 // init fills vcs.repository.count metric with initial data.
@@ -726,16 +1122,45 @@ func (m *metricVcsRepositoryCount) init() {
 	m.data.SetDescription("The number of repositories in an organization.")
 	m.data.SetUnit("{repository}")
 	m.data.SetEmptyGauge()
+	m.aggDataPoints = m.aggDataPoints[:0]
 }
 
 func (m *metricVcsRepositoryCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.config.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+
+	dp := pmetric.NewNumberDataPoint()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
+
+	var s string
+	dps := m.data.Gauge().DataPoints()
+	for i := 0; i < dps.Len(); i++ {
+		dpi := dps.At(i)
+		if dp.Attributes().Equal(dpi.Attributes()) && dp.StartTimestamp() == dpi.StartTimestamp() && dp.Timestamp() == dpi.Timestamp() {
+			switch s = m.config.AggregationStrategy; s {
+			case AggregationStrategySum, AggregationStrategyAvg:
+				dpi.SetIntValue(dpi.IntValue() + val)
+				m.aggDataPoints[i] += 1
+				return
+			case AggregationStrategyMin:
+				if dpi.IntValue() > val {
+					dpi.SetIntValue(val)
+				}
+				return
+			case AggregationStrategyMax:
+				if dpi.IntValue() < val {
+					dpi.SetIntValue(val)
+				}
+				return
+			}
+		}
+	}
+
 	dp.SetIntValue(val)
+	m.aggDataPoints = append(m.aggDataPoints, 1)
+	dp.MoveTo(dps.AppendEmpty())
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -748,6 +1173,11 @@ func (m *metricVcsRepositoryCount) updateCapacity() {
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcsRepositoryCount) emit(metrics pmetric.MetricSlice) {
 	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		if m.config.AggregationStrategy == AggregationStrategyAvg {
+			for i, aggCount := range m.aggDataPoints {
+				m.data.Gauge().DataPoints().At(i).SetIntValue(m.data.Gauge().DataPoints().At(i).IntValue() / aggCount)
+			}
+		}
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/githubreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/githubreceiver/internal/metadata/generated_metrics_test.go
@@ -19,6 +19,7 @@ const (
 	testDataSetDefault testDataSet = iota
 	testDataSetAll
 	testDataSetNone
+	testDataSetReag
 )
 
 func TestMetricsBuilder(t *testing.T) {
@@ -35,6 +36,11 @@ func TestMetricsBuilder(t *testing.T) {
 			name:        "all_set",
 			metricsSet:  testDataSetAll,
 			resAttrsSet: testDataSetAll,
+		},
+		{
+			name:        "reaggregate_set",
+			metricsSet:  testDataSetReag,
+			resAttrsSet: testDataSetReag,
 		},
 		{
 			name:        "none_set",
@@ -60,9 +66,22 @@ func TestMetricsBuilder(t *testing.T) {
 			settings := receivertest.NewNopSettings(receivertest.NopType)
 			settings.Logger = zap.New(observedZapCore)
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, tt.name), settings, WithStartTime(start))
+			aggMap := make(map[string]string) // contains the aggregation strategies for each metric name
+			aggMap["VcsChangeCount"] = mb.metricVcsChangeCount.config.AggregationStrategy
+			aggMap["VcsChangeDuration"] = mb.metricVcsChangeDuration.config.AggregationStrategy
+			aggMap["VcsChangeTimeToApproval"] = mb.metricVcsChangeTimeToApproval.config.AggregationStrategy
+			aggMap["VcsChangeTimeToMerge"] = mb.metricVcsChangeTimeToMerge.config.AggregationStrategy
+			aggMap["VcsContributorCount"] = mb.metricVcsContributorCount.config.AggregationStrategy
+			aggMap["VcsRefCount"] = mb.metricVcsRefCount.config.AggregationStrategy
+			aggMap["VcsRefLinesDelta"] = mb.metricVcsRefLinesDelta.config.AggregationStrategy
+			aggMap["VcsRefRevisionsDelta"] = mb.metricVcsRefRevisionsDelta.config.AggregationStrategy
+			aggMap["VcsRefTime"] = mb.metricVcsRefTime.config.AggregationStrategy
+			aggMap["VcsRepositoryCount"] = mb.metricVcsRepositoryCount.config.AggregationStrategy
 
 			expectedWarnings := 0
-			assert.Equal(t, expectedWarnings, observedLogs.Len())
+			if tt.metricsSet != testDataSetReag {
+				assert.Equal(t, expectedWarnings, observedLogs.Len())
+			}
 
 			defaultMetricsCount := 0
 			allMetricsCount := 0
@@ -70,47 +89,89 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsChangeCountDataPoint(ts, 1, "vcs.repository.url.full-val", AttributeVcsChangeStateOpen, "vcs.repository.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsChangeCountDataPoint(ts, 3, "vcs.repository.url.full-val", AttributeVcsChangeStateOpen, "vcs.repository.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsChangeDurationDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsChangeStateOpen)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsChangeDurationDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsChangeStateOpen)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsChangeTimeToApprovalDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsChangeTimeToApprovalDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsChangeTimeToMergeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsChangeTimeToMergeDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val")
+			}
 
 			allMetricsCount++
 			mb.RecordVcsContributorCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val")
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsContributorCountDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val")
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsRefCountDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", AttributeVcsRefTypeBranch)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsRefCountDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", AttributeVcsRefTypeBranch)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsRefLinesDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, "vcs.ref.base.name-val", AttributeVcsRefBaseTypeBranch, AttributeVcsLineChangeTypeAdded)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsRefLinesDeltaDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, "vcs.ref.base.name-val", AttributeVcsRefBaseTypeBranch, AttributeVcsLineChangeTypeAdded)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsRefRevisionsDeltaDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, "vcs.ref.base.name-val", AttributeVcsRefBaseTypeBranch, AttributeVcsRevisionDeltaDirectionAhead)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsRefRevisionsDeltaDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch, "vcs.ref.base.name-val", AttributeVcsRefBaseTypeBranch, AttributeVcsRevisionDeltaDirectionAhead)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsRefTimeDataPoint(ts, 1, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsRefTimeDataPoint(ts, 3, "vcs.repository.url.full-val", "vcs.repository.name-val", "vcs.ref.head.name-val", AttributeVcsRefHeadTypeBranch)
+			}
 
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcsRepositoryCountDataPoint(ts, 1)
+			if tt.name == "reaggregate_set" {
+				mb.RecordVcsRepositoryCountDataPoint(ts, 3)
+			}
 
 			rb := mb.NewResourceBuilder()
 			rb.SetVcsOwnerName("vcs.owner.name-val")
 			rb.SetVcsProviderName("vcs.provider.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
+			if tt.name == "reaggregate_set" {
+				assert.Empty(t, mb.metricVcsChangeCount.aggDataPoints)
+				assert.Empty(t, mb.metricVcsChangeDuration.aggDataPoints)
+				assert.Empty(t, mb.metricVcsChangeTimeToApproval.aggDataPoints)
+				assert.Empty(t, mb.metricVcsChangeTimeToMerge.aggDataPoints)
+				assert.Empty(t, mb.metricVcsContributorCount.aggDataPoints)
+				assert.Empty(t, mb.metricVcsRefCount.aggDataPoints)
+				assert.Empty(t, mb.metricVcsRefLinesDelta.aggDataPoints)
+				assert.Empty(t, mb.metricVcsRefRevisionsDelta.aggDataPoints)
+				assert.Empty(t, mb.metricVcsRefTime.aggDataPoints)
+				assert.Empty(t, mb.metricVcsRepositoryCount.aggDataPoints)
+			}
 
 			if tt.expectEmpty {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -132,233 +193,535 @@ func TestMetricsBuilder(t *testing.T) {
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
 				case "vcs.change.count":
-					assert.False(t, validatedMetrics["vcs.change.count"], "Found a duplicate in the metrics slice: vcs.change.count")
-					validatedMetrics["vcs.change.count"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of changes (pull requests) in a repository, categorized by their state (either open or merged).", ms.At(i).Description())
-					assert.Equal(t, "{change}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.change.state")
-					assert.True(t, ok)
-					assert.Equal(t, "open", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.change.count"], "Found a duplicate in the metrics slice: vcs.change.count")
+						validatedMetrics["vcs.change.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of changes (pull requests) in a repository, categorized by their state (either open or merged).", ms.At(i).Description())
+						assert.Equal(t, "{change}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.change.state")
+						assert.True(t, ok)
+						assert.Equal(t, "open", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.change.count"], "Found a duplicate in the metrics slice: vcs.change.count")
+						validatedMetrics["vcs.change.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of changes (pull requests) in a repository, categorized by their state (either open or merged).", ms.At(i).Description())
+						assert.Equal(t, "{change}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.change.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.change.state")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+					}
 				case "vcs.change.duration":
-					assert.False(t, validatedMetrics["vcs.change.duration"], "Found a duplicate in the metrics slice: vcs.change.duration")
-					validatedMetrics["vcs.change.duration"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The time duration a change (pull request/merge request/changelist) has been in an open state.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.change.state")
-					assert.True(t, ok)
-					assert.Equal(t, "open", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.change.duration"], "Found a duplicate in the metrics slice: vcs.change.duration")
+						validatedMetrics["vcs.change.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The time duration a change (pull request/merge request/changelist) has been in an open state.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.change.state")
+						assert.True(t, ok)
+						assert.Equal(t, "open", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.change.duration"], "Found a duplicate in the metrics slice: vcs.change.duration")
+						validatedMetrics["vcs.change.duration"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The time duration a change (pull request/merge request/changelist) has been in an open state.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.change.duration"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.change.state")
+						assert.True(t, ok)
+					}
 				case "vcs.change.time_to_approval":
-					assert.False(t, validatedMetrics["vcs.change.time_to_approval"], "Found a duplicate in the metrics slice: vcs.change.time_to_approval")
-					validatedMetrics["vcs.change.time_to_approval"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The amount of time it took a change (pull request) to go from open to approved.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.change.time_to_approval"], "Found a duplicate in the metrics slice: vcs.change.time_to_approval")
+						validatedMetrics["vcs.change.time_to_approval"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The amount of time it took a change (pull request) to go from open to approved.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.change.time_to_approval"], "Found a duplicate in the metrics slice: vcs.change.time_to_approval")
+						validatedMetrics["vcs.change.time_to_approval"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The amount of time it took a change (pull request) to go from open to approved.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.change.time_to_approval"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+					}
 				case "vcs.change.time_to_merge":
-					assert.False(t, validatedMetrics["vcs.change.time_to_merge"], "Found a duplicate in the metrics slice: vcs.change.time_to_merge")
-					validatedMetrics["vcs.change.time_to_merge"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The amount of time it took a change (pull request) to go from open to merged.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.change.time_to_merge"], "Found a duplicate in the metrics slice: vcs.change.time_to_merge")
+						validatedMetrics["vcs.change.time_to_merge"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The amount of time it took a change (pull request) to go from open to merged.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.change.time_to_merge"], "Found a duplicate in the metrics slice: vcs.change.time_to_merge")
+						validatedMetrics["vcs.change.time_to_merge"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The amount of time it took a change (pull request) to go from open to merged.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.change.time_to_merge"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+					}
 				case "vcs.contributor.count":
-					assert.False(t, validatedMetrics["vcs.contributor.count"], "Found a duplicate in the metrics slice: vcs.contributor.count")
-					validatedMetrics["vcs.contributor.count"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of unique contributors to a repository.", ms.At(i).Description())
-					assert.Equal(t, "{contributor}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.contributor.count"], "Found a duplicate in the metrics slice: vcs.contributor.count")
+						validatedMetrics["vcs.contributor.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of unique contributors to a repository.", ms.At(i).Description())
+						assert.Equal(t, "{contributor}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.contributor.count"], "Found a duplicate in the metrics slice: vcs.contributor.count")
+						validatedMetrics["vcs.contributor.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of unique contributors to a repository.", ms.At(i).Description())
+						assert.Equal(t, "{contributor}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.contributor.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+					}
 				case "vcs.ref.count":
-					assert.False(t, validatedMetrics["vcs.ref.count"], "Found a duplicate in the metrics slice: vcs.ref.count")
-					validatedMetrics["vcs.ref.count"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of refs of type branch in a repository.", ms.At(i).Description())
-					assert.Equal(t, "{ref}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.ref.count"], "Found a duplicate in the metrics slice: vcs.ref.count")
+						validatedMetrics["vcs.ref.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of refs of type branch in a repository.", ms.At(i).Description())
+						assert.Equal(t, "{ref}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.ref.count"], "Found a duplicate in the metrics slice: vcs.ref.count")
+						validatedMetrics["vcs.ref.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of refs of type branch in a repository.", ms.At(i).Description())
+						assert.Equal(t, "{ref}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.ref.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.type")
+						assert.True(t, ok)
+					}
 				case "vcs.ref.lines_delta":
-					assert.False(t, validatedMetrics["vcs.ref.lines_delta"], "Found a duplicate in the metrics slice: vcs.ref.lines_delta")
-					validatedMetrics["vcs.ref.lines_delta"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of lines added/removed in a ref (branch) relative to the default branch (trunk).", ms.At(i).Description())
-					assert.Equal(t, "{line}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.base.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.base.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.base.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.line_change.type")
-					assert.True(t, ok)
-					assert.Equal(t, "added", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.ref.lines_delta"], "Found a duplicate in the metrics slice: vcs.ref.lines_delta")
+						validatedMetrics["vcs.ref.lines_delta"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of lines added/removed in a ref (branch) relative to the default branch (trunk).", ms.At(i).Description())
+						assert.Equal(t, "{line}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.base.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.base.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.base.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.line_change.type")
+						assert.True(t, ok)
+						assert.Equal(t, "added", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.ref.lines_delta"], "Found a duplicate in the metrics slice: vcs.ref.lines_delta")
+						validatedMetrics["vcs.ref.lines_delta"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of lines added/removed in a ref (branch) relative to the default branch (trunk).", ms.At(i).Description())
+						assert.Equal(t, "{line}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.ref.lines_delta"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.base.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.base.type")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.line_change.type")
+						assert.True(t, ok)
+					}
 				case "vcs.ref.revisions_delta":
-					assert.False(t, validatedMetrics["vcs.ref.revisions_delta"], "Found a duplicate in the metrics slice: vcs.ref.revisions_delta")
-					validatedMetrics["vcs.ref.revisions_delta"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).", ms.At(i).Description())
-					assert.Equal(t, "{revision}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.base.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.base.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.base.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.revision_delta.direction")
-					assert.True(t, ok)
-					assert.Equal(t, "ahead", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.ref.revisions_delta"], "Found a duplicate in the metrics slice: vcs.ref.revisions_delta")
+						validatedMetrics["vcs.ref.revisions_delta"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).", ms.At(i).Description())
+						assert.Equal(t, "{revision}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.base.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.base.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.base.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.revision_delta.direction")
+						assert.True(t, ok)
+						assert.Equal(t, "ahead", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.ref.revisions_delta"], "Found a duplicate in the metrics slice: vcs.ref.revisions_delta")
+						validatedMetrics["vcs.ref.revisions_delta"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of revisions (commits) a ref (branch) is ahead/behind the branch from trunk (default).", ms.At(i).Description())
+						assert.Equal(t, "{revision}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.ref.revisions_delta"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.base.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.base.type")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.revision_delta.direction")
+						assert.True(t, ok)
+					}
 				case "vcs.ref.time":
-					assert.False(t, validatedMetrics["vcs.ref.time"], "Found a duplicate in the metrics slice: vcs.ref.time")
-					validatedMetrics["vcs.ref.time"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.type` attribute will always be `branch`.", ms.At(i).Description())
-					assert.Equal(t, "s", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.repository.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
-					assert.True(t, ok)
-					assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
-					attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
-					assert.True(t, ok)
-					assert.Equal(t, "branch", attrVal.Str())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.ref.time"], "Found a duplicate in the metrics slice: vcs.ref.time")
+						validatedMetrics["vcs.ref.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.type` attribute will always be `branch`.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+						attrVal, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.url.full-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.repository.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						assert.Equal(t, "vcs.ref.head.name-val", attrVal.Str())
+						attrVal, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+						assert.Equal(t, "branch", attrVal.Str())
+					} else {
+						assert.False(t, validatedMetrics["vcs.ref.time"], "Found a duplicate in the metrics slice: vcs.ref.time")
+						validatedMetrics["vcs.ref.time"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "Time a ref (branch) created from the default branch (trunk) has existed. The `vcs.ref.type` attribute will always be `branch`.", ms.At(i).Description())
+						assert.Equal(t, "s", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.ref.time"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+						_, ok := dp.Attributes().Get("vcs.repository.url.full")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.repository.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.name")
+						assert.True(t, ok)
+						_, ok = dp.Attributes().Get("vcs.ref.head.type")
+						assert.True(t, ok)
+					}
 				case "vcs.repository.count":
-					assert.False(t, validatedMetrics["vcs.repository.count"], "Found a duplicate in the metrics slice: vcs.repository.count")
-					validatedMetrics["vcs.repository.count"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The number of repositories in an organization.", ms.At(i).Description())
-					assert.Equal(t, "{repository}", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
-					assert.Equal(t, int64(1), dp.IntValue())
+					if tt.name != "reaggregate_set" {
+						assert.False(t, validatedMetrics["vcs.repository.count"], "Found a duplicate in the metrics slice: vcs.repository.count")
+						validatedMetrics["vcs.repository.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of repositories in an organization.", ms.At(i).Description())
+						assert.Equal(t, "{repository}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						assert.Equal(t, int64(1), dp.IntValue())
+					} else {
+						assert.False(t, validatedMetrics["vcs.repository.count"], "Found a duplicate in the metrics slice: vcs.repository.count")
+						validatedMetrics["vcs.repository.count"] = true
+						assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+						assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+						assert.Equal(t, "The number of repositories in an organization.", ms.At(i).Description())
+						assert.Equal(t, "{repository}", ms.At(i).Unit())
+						dp := ms.At(i).Gauge().DataPoints().At(0)
+						assert.Equal(t, start, dp.StartTimestamp())
+						assert.Equal(t, ts, dp.Timestamp())
+						assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+						switch aggMap["vcs.repository.count"] {
+						case "sum":
+							assert.Equal(t, int64(4), dp.IntValue())
+						case "avg":
+							assert.Equal(t, int64(2), dp.IntValue())
+						case "min":
+							assert.Equal(t, int64(1), dp.IntValue())
+						case "max":
+							assert.Equal(t, int64(3), dp.IntValue())
+						}
+					}
 				}
 			}
 		})

--- a/receiver/githubreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/githubreceiver/internal/metadata/testdata/config.yaml
@@ -3,24 +3,71 @@ all_set:
   metrics:
     vcs.change.count:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.change.state","vcs.repository.name"]
     vcs.change.duration:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.change.state"]
     vcs.change.time_to_approval:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
     vcs.change.time_to_merge:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
     vcs.contributor.count:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name"]
     vcs.ref.count:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.type"]
     vcs.ref.lines_delta:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.line_change.type"]
     vcs.ref.revisions_delta:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.revision_delta.direction"]
     vcs.ref.time:
       enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type"]
     vcs.repository.count:
       enabled: true
+      attributes: []
+  resource_attributes:
+    vcs.owner.name:
+      enabled: true
+    vcs.provider.name:
+      enabled: true
+reaggregate_set:
+  metrics:
+    vcs.change.count:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.change.state","vcs.repository.name"]
+    vcs.change.duration:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.change.state"]
+    vcs.change.time_to_approval:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
+    vcs.change.time_to_merge:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
+    vcs.contributor.count:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name"]
+    vcs.ref.count:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.type"]
+    vcs.ref.lines_delta:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.line_change.type"]
+    vcs.ref.revisions_delta:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.revision_delta.direction"]
+    vcs.ref.time:
+      enabled: true
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type"]
+    vcs.repository.count:
+      enabled: true
+      attributes: []
   resource_attributes:
     vcs.owner.name:
       enabled: true
@@ -30,24 +77,34 @@ none_set:
   metrics:
     vcs.change.count:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.change.state","vcs.repository.name"]
     vcs.change.duration:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.change.state"]
     vcs.change.time_to_approval:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
     vcs.change.time_to_merge:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name"]
     vcs.contributor.count:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name"]
     vcs.ref.count:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.type"]
     vcs.ref.lines_delta:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.line_change.type"]
     vcs.ref.revisions_delta:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type","vcs.ref.base.name","vcs.ref.base.type","vcs.revision_delta.direction"]
     vcs.ref.time:
       enabled: false
+      attributes: ["vcs.repository.url.full","vcs.repository.name","vcs.ref.head.name","vcs.ref.head.type"]
     vcs.repository.count:
       enabled: false
+      attributes: []
   resource_attributes:
     vcs.owner.name:
       enabled: false

--- a/receiver/githubreceiver/metadata.yaml
+++ b/receiver/githubreceiver/metadata.yaml
@@ -12,6 +12,8 @@ status:
   codeowners:
     active: [adrielp, crobert-1, TylerHelmuth]
 
+reaggregation_enabled: true
+
 resource_attributes:
   vcs.owner.name:
     enabled: true
@@ -26,48 +28,58 @@ attributes:
   vcs.change.state:
     description: The state of a change (pull request)
     type: string
+    requirement_level: required
     enum:
       - open
       - merged
   vcs.line_change.type:
     description: The type of line change being measured on a ref (branch).
     type: string
+    requirement_level: required
     enum:
       - added
       - removed
   vcs.ref.base.name:
     description: The name of the VCS base reference (branch/tag) for comparison.
     type: string
+    requirement_level: required
   vcs.ref.base.type:
     description: The type of the base reference (branch, tag).
     type: string
+    requirement_level: required
     enum:
       - branch
       - tag
   vcs.ref.head.name:
     description: The name of the VCS head reference (branch).
     type: string
+    requirement_level: required
   vcs.ref.head.type:
     description: The type of the head reference (branch, tag).
     type: string
+    requirement_level: required
     enum:
       - branch
       - tag
   vcs.ref.type:
     description: The type of the reference in the repository.
     type: string
+    requirement_level: required
     enum:
       - branch
       - tag
   vcs.repository.name:
     description: The name of the VCS repository.
     type: string
+    requirement_level: required
   vcs.repository.url.full:
     description: The canonical URL of the repository providing the complete HTTPS address.
     type: string
+    requirement_level: required
   vcs.revision_delta.direction:
     description: The type of revision comparison.
     type: string
+    requirement_level: required
     enum:
       - ahead
       - behind


### PR DESCRIPTION
## Description

Enable the re-aggregation feature for the GitHub receiver.

### Changes
- Set `reaggregation_enabled: true` in `metadata.yaml`
- Added `requirement_level: required` on all metric attributes
- Ran `go generate ./...` to regenerate code
- All existing tests pass

### Link to tracking issue

Closes #46385
Part of #45396