### PR TITLE
[pkg/pdatatest] Add entity references comparison to CompareResource

### DIFF
--- a/.chloggen/pdatatest-entity-refs-46345.yaml
+++ b/.chloggen/pdatatest-entity-refs-46345.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add entity references comparison to CompareResource and IgnoreResourceEntityRefs option
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46345]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/golden/go.mod
+++ b/cmd/golden/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/cmd/golden/go.sum
+++ b/cmd/golden/go.sum
@@ -139,6 +139,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/exceptionsconnector/go.mod
+++ b/connector/exceptionsconnector/go.mod
@@ -51,6 +51,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect

--- a/connector/exceptionsconnector/go.sum
+++ b/connector/exceptionsconnector/go.sum
@@ -87,6 +87,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/otlpjsonconnector/go.mod
+++ b/connector/otlpjsonconnector/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/connector/otlpjsonconnector/go.sum
+++ b/connector/otlpjsonconnector/go.sum
@@ -83,6 +83,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -63,6 +63,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/connector/routingconnector/go.sum
+++ b/connector/routingconnector/go.sum
@@ -127,6 +127,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/signaltometricsconnector/go.mod
+++ b/connector/signaltometricsconnector/go.mod
@@ -67,6 +67,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect

--- a/connector/signaltometricsconnector/go.sum
+++ b/connector/signaltometricsconnector/go.sum
@@ -127,6 +127,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/slowsqlconnector/go.sum
+++ b/connector/slowsqlconnector/go.sum
@@ -87,6 +87,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1 h1:MbDzTt/R+aXWrLa+c3WfQx9Wjd/XK6pTgM4dcWLUdlE=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/spanmetricsconnector/go.sum
+++ b/connector/spanmetricsconnector/go.sum
@@ -93,6 +93,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1 h1:MbDzTt/R+aXWrLa+c3WfQx9Wjd/XK6pTgM4dcWLUdlE=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/connector/sumconnector/go.mod
+++ b/connector/sumconnector/go.mod
@@ -64,6 +64,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/connector/sumconnector/go.sum
+++ b/connector/sumconnector/go.sum
@@ -125,6 +125,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.mod
@@ -42,6 +42,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.sum
+++ b/extension/encoding/awscloudwatchmetricstreamsencodingextension/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/extension/encoding/awslogsencodingextension/go.mod
+++ b/extension/encoding/awslogsencodingextension/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/extension/encoding/awslogsencodingextension/go.sum
+++ b/extension/encoding/awslogsencodingextension/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/extension/encoding/azureencodingextension/go.mod
+++ b/extension/encoding/azureencodingextension/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/extension/encoding/azureencodingextension/go.sum
+++ b/extension/encoding/azureencodingextension/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/extension/encoding/googlecloudlogentryencodingextension/go.mod
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/extension/encoding/googlecloudlogentryencodingextension/go.sum
+++ b/extension/encoding/googlecloudlogentryencodingextension/go.sum
@@ -83,6 +83,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -40,6 +40,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect

--- a/extension/encoding/jsonlogencodingextension/go.sum
+++ b/extension/encoding/jsonlogencodingextension/go.sum
@@ -75,6 +75,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/extension/encoding/textencodingextension/go.mod
+++ b/extension/encoding/textencodingextension/go.mod
@@ -41,6 +41,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect

--- a/extension/encoding/textencodingextension/go.sum
+++ b/extension/encoding/textencodingextension/go.sum
@@ -73,6 +73,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -80,6 +80,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/internal/coreinternal/go.sum
+++ b/internal/coreinternal/go.sum
@@ -155,6 +155,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/receiver v1.52.1-0.20260219223409-66996adfaaf7 h1:VHwbhgu23yuIkmZsaKfRntgOfoqzhS8pZPxm6+drOjg=

--- a/internal/exp/metrics/go.mod
+++ b/internal/exp/metrics/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/exp/metrics/go.sum
+++ b/internal/exp/metrics/go.sum
@@ -34,6 +34,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/proto/slim/otlp v1.9.0 h1:fPVMv8tP3TrsqlkH1HWYUpbCY9cAIemx184VGkS6vlE=
 go.opentelemetry.io/proto/slim/otlp v1.9.0/go.mod h1:xXdeJJ90Gqyll+orzUkY4bOd2HECo5JofeoLpymVqdI=
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0 h1:o13nadWDNkH/quoDomDUClnQBpdQQ2Qqv0lQBjIXjE8=

--- a/internal/filter/go.sum
+++ b/internal/filter/go.sum
@@ -107,6 +107,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/internal/pdatautil/go.mod
+++ b/internal/pdatautil/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/pdatautil/go.sum
+++ b/internal/pdatautil/go.sum
@@ -36,6 +36,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/proto/slim/otlp v1.9.0 h1:fPVMv8tP3TrsqlkH1HWYUpbCY9cAIemx184VGkS6vlE=
 go.opentelemetry.io/proto/slim/otlp v1.9.0/go.mod h1:xXdeJJ90Gqyll+orzUkY4bOd2HECo5JofeoLpymVqdI=
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0 h1:o13nadWDNkH/quoDomDUClnQBpdQQ2Qqv0lQBjIXjE8=

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.146.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/pkg/ottl/go.sum
+++ b/pkg/ottl/go.sum
@@ -91,6 +91,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/pkg/pdatatest/go.mod
+++ b/pkg/pdatatest/go.mod
@@ -9,6 +9,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/pdatatest/go.sum
+++ b/pkg/pdatatest/go.sum
@@ -36,6 +36,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/proto/slim/otlp v1.9.0 h1:fPVMv8tP3TrsqlkH1HWYUpbCY9cAIemx184VGkS6vlE=
 go.opentelemetry.io/proto/slim/otlp v1.9.0/go.mod h1:xXdeJJ90Gqyll+orzUkY4bOd2HECo5JofeoLpymVqdI=
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0 h1:o13nadWDNkH/quoDomDUClnQBpdQQ2Qqv0lQBjIXjE8=

--- a/pkg/pdatatest/internal/util.go
+++ b/pkg/pdatatest/internal/util.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/xpdata/entity"
 	"go.uber.org/multierr"
 )
 
@@ -51,7 +52,46 @@ func CompareResource(expected, actual pcommon.Resource) error {
 	return multierr.Combine(
 		CompareAttributes(expected.Attributes(), actual.Attributes()),
 		CompareDroppedAttributesCount(expected.DroppedAttributesCount(), actual.DroppedAttributesCount()),
+		CompareEntityRefs(entity.ResourceEntityRefs(expected), entity.ResourceEntityRefs(actual)),
 	)
+}
+
+func MaskResourceEntityRefs(res pcommon.Resource) {
+	refs := entity.ResourceEntityRefs(res)
+	refs.RemoveIf(func(_ entity.EntityRef) bool {
+		return true
+	})
+}
+
+func CompareEntityRefs(expected, actual entity.EntityRefSlice) error {
+	if expected.Len() != actual.Len() {
+		return fmt.Errorf("number of entity refs doesn't match expected: %d, actual: %d",
+			expected.Len(), actual.Len())
+	}
+
+	var errs error
+	for i := 0; i < expected.Len(); i++ {
+		e := expected.At(i)
+		a := actual.At(i)
+		if e.Type() != a.Type() {
+			errs = multierr.Append(errs, fmt.Errorf("entity ref %d type doesn't match expected: %s, actual: %s",
+				i, e.Type(), a.Type()))
+			continue
+		}
+		if e.SchemaUrl() != a.SchemaUrl() {
+			errs = multierr.Append(errs, fmt.Errorf("entity ref %d schema url doesn't match expected: %s, actual: %s",
+				i, e.SchemaUrl(), a.SchemaUrl()))
+		}
+		if !reflect.DeepEqual(e.IdKeys().AsRaw(), a.IdKeys().AsRaw()) {
+			errs = multierr.Append(errs, fmt.Errorf("entity ref %d id keys don't match expected: %v, actual: %v",
+				i, e.IdKeys().AsRaw(), a.IdKeys().AsRaw()))
+		}
+		if !reflect.DeepEqual(e.DescriptionKeys().AsRaw(), a.DescriptionKeys().AsRaw()) {
+			errs = multierr.Append(errs, fmt.Errorf("entity ref %d description keys don't match expected: %v, actual: %v",
+				i, e.DescriptionKeys().AsRaw(), a.DescriptionKeys().AsRaw()))
+		}
+	}
+	return errs
 }
 
 func CompareInstrumentationScope(expected, actual pcommon.InstrumentationScope) error {

--- a/pkg/pdatatest/plogtest/options.go
+++ b/pkg/pdatatest/plogtest/options.go
@@ -49,6 +49,22 @@ func (opt ignoreResourceAttributeValue) maskLogsResourceAttributeValue(logs plog
 	}
 }
 
+// IgnoreResourceEntityRefs is a CompareLogsOption that clears entity references
+// on all resources.
+func IgnoreResourceEntityRefs() CompareLogsOption {
+	return compareLogsOptionFunc(func(expected, actual plog.Logs) {
+		maskLogsResourceEntityRefs(expected)
+		maskLogsResourceEntityRefs(actual)
+	})
+}
+
+func maskLogsResourceEntityRefs(logs plog.Logs) {
+	rls := logs.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		internal.MaskResourceEntityRefs(rls.At(i).Resource())
+	}
+}
+
 // IgnoreLogRecordAttributeValue is a CompareLogsOption that sets the value of an attribute
 // to empty bytes for every log record
 func IgnoreLogRecordAttributeValue(attributeName string) CompareLogsOption {

--- a/pkg/pdatatest/pmetrictest/options.go
+++ b/pkg/pdatatest/pmetrictest/options.go
@@ -641,6 +641,22 @@ func maskMetricsResourceAttributeValue(metrics pmetric.Metrics, attributeName st
 	}
 }
 
+// IgnoreResourceEntityRefs is a CompareMetricsOption that clears entity references
+// on all resources.
+func IgnoreResourceEntityRefs() CompareMetricsOption {
+	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
+		maskMetricsResourceEntityRefs(expected)
+		maskMetricsResourceEntityRefs(actual)
+	})
+}
+
+func maskMetricsResourceEntityRefs(metrics pmetric.Metrics) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		internal.MaskResourceEntityRefs(rms.At(i).Resource())
+	}
+}
+
 func ChangeResourceAttributeValue(attributeName string, changeFn func(string) string) CompareMetricsOption {
 	return compareMetricsOptionFunc(func(expected, actual pmetric.Metrics) {
 		changeMetricsResourceAttributeValue(expected, attributeName, changeFn)

--- a/pkg/pdatatest/pprofiletest/options.go
+++ b/pkg/pdatatest/pprofiletest/options.go
@@ -49,7 +49,23 @@ func (opt ignoreResourceAttributeValue) maskProfilesResourceAttributeValue(profi
 	}
 }
 
-// IgnoreResourceAttributeValue is a CompareProfilesOption that removes a resource attribute
+// IgnoreResourceEntityRefs is a CompareProfilesOption that clears entity references
+// on all resources.
+func IgnoreResourceEntityRefs() CompareProfilesOption {
+	return compareProfilesOptionFunc(func(expected, actual pprofile.Profiles) {
+		maskProfilesResourceEntityRefs(expected)
+		maskProfilesResourceEntityRefs(actual)
+	})
+}
+
+func maskProfilesResourceEntityRefs(profiles pprofile.Profiles) {
+	rps := profiles.ResourceProfiles()
+	for i := 0; i < rps.Len(); i++ {
+		internal.MaskResourceEntityRefs(rps.At(i).Resource())
+	}
+}
+
+// IgnoreScopeAttributeValue is a CompareProfilesOption that removes a scope attribute
 // from all resources.
 func IgnoreScopeAttributeValue(attributeName string) CompareProfilesOption {
 	return ignoreScopeAttributeValue{

--- a/pkg/pdatatest/ptracetest/options.go
+++ b/pkg/pdatatest/ptracetest/options.go
@@ -41,6 +41,22 @@ func maskTracesResourceAttributeValue(traces ptrace.Traces, attributeName string
 	}
 }
 
+// IgnoreResourceEntityRefs is a CompareTracesOption that clears entity references
+// on all resources.
+func IgnoreResourceEntityRefs() CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		maskTracesResourceEntityRefs(expected)
+		maskTracesResourceEntityRefs(actual)
+	})
+}
+
+func maskTracesResourceEntityRefs(traces ptrace.Traces) {
+	rss := traces.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		internal.MaskResourceEntityRefs(rss.At(i).Resource())
+	}
+}
+
 // IgnoreResourceSpansOrder is a CompareTracesOption that ignores the order of resource traces/metrics/logs.
 func IgnoreResourceSpansOrder() CompareTracesOption {
 	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {

--- a/pkg/resourcetotelemetry/go.sum
+++ b/pkg/resourcetotelemetry/go.sum
@@ -88,8 +88,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
-go.opentelemetry.io/collector/pdata/xpdata v0.146.1 h1:kbjTAH6IsyzSXB9kh7cCeHloGAauGToWB9SFGeBjyJo=
-go.opentelemetry.io/collector/pdata/xpdata v0.146.1/go.mod h1:UR/HuN42zhocRh0JTrTQKeywNOEzKU5HCOQpIMgyPS0=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.1 h1:BG+d2LjF87d6wnJg0d9iQxLzMcawY0Nldg7LpVkfkno=

--- a/pkg/translator/azure/go.mod
+++ b/pkg/translator/azure/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.146.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/translator/azure/go.sum
+++ b/pkg/translator/azure/go.sum
@@ -48,6 +48,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/pkg/translator/azurelogs/go.mod
+++ b/pkg/translator/azurelogs/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/translator/azurelogs/go.sum
+++ b/pkg/translator/azurelogs/go.sum
@@ -48,6 +48,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/pkg/translator/faro/go.mod
+++ b/pkg/translator/faro/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect

--- a/pkg/translator/faro/go.sum
+++ b/pkg/translator/faro/go.sum
@@ -71,6 +71,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/pkg/translator/loki/go.sum
+++ b/pkg/translator/loki/go.sum
@@ -153,6 +153,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 h1:ssfIgGNANqpVFCndZvcuyKbl0g+UAVcbBcqGkG28H0Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0/go.mod h1:GQ/474YrbE4Jx8gZ4q5I4hrhUzM6UPzyrqJYV2AqPoQ=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=

--- a/pkg/translator/signalfx/go.mod
+++ b/pkg/translator/signalfx/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.146.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/translator/signalfx/go.sum
+++ b/pkg/translator/signalfx/go.sum
@@ -56,6 +56,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/proto/slim/otlp v1.9.0 h1:fPVMv8tP3TrsqlkH1HWYUpbCY9cAIemx184VGkS6vlE=
 go.opentelemetry.io/proto/slim/otlp v1.9.0/go.mod h1:xXdeJJ90Gqyll+orzUkY4bOd2HECo5JofeoLpymVqdI=
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.2.0 h1:o13nadWDNkH/quoDomDUClnQBpdQQ2Qqv0lQBjIXjE8=

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -65,6 +65,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/attributesprocessor/go.sum
+++ b/processor/attributesprocessor/go.sum
@@ -123,6 +123,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/cumulativetodeltaprocessor/go.mod
+++ b/processor/cumulativetodeltaprocessor/go.mod
@@ -48,6 +48,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/cumulativetodeltaprocessor/go.sum
+++ b/processor/cumulativetodeltaprocessor/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -73,6 +73,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect

--- a/processor/filterprocessor/go.sum
+++ b/processor/filterprocessor/go.sum
@@ -121,6 +121,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/processor/intervalprocessor/go.mod
+++ b/processor/intervalprocessor/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/intervalprocessor/go.sum
+++ b/processor/intervalprocessor/go.sum
@@ -77,6 +77,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/logdedupprocessor/go.mod
+++ b/processor/logdedupprocessor/go.mod
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/logdedupprocessor/go.sum
+++ b/processor/logdedupprocessor/go.sum
@@ -117,6 +117,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -61,6 +61,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/processor/logstransformprocessor/go.sum
+++ b/processor/logstransformprocessor/go.sum
@@ -104,6 +104,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/metricsgenerationprocessor/go.sum
+++ b/processor/metricsgenerationprocessor/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/metricstarttimeprocessor/go.mod
+++ b/processor/metricstarttimeprocessor/go.mod
@@ -46,6 +46,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/processor/metricstarttimeprocessor/go.sum
+++ b/processor/metricstarttimeprocessor/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -47,6 +47,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/metricstransformprocessor/go.sum
+++ b/processor/metricstransformprocessor/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -171,6 +171,7 @@ require (
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver v1.52.1-0.20260219223409-66996adfaaf7 // indirect

--- a/processor/resourcedetectionprocessor/go.sum
+++ b/processor/resourcedetectionprocessor/go.sum
@@ -470,6 +470,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/processor/resourceprocessor/go.mod
+++ b/processor/resourceprocessor/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/processor/resourceprocessor/go.sum
+++ b/processor/resourceprocessor/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/schemaprocessor/go.mod
+++ b/processor/schemaprocessor/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect

--- a/processor/schemaprocessor/go.sum
+++ b/processor/schemaprocessor/go.sum
@@ -131,6 +131,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -63,6 +63,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/processor/spanprocessor/go.sum
+++ b/processor/spanprocessor/go.sum
@@ -119,6 +119,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/tailsamplingprocessor/go.sum
+++ b/processor/tailsamplingprocessor/go.sum
@@ -117,6 +117,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -76,6 +76,7 @@ require (
 	go.opentelemetry.io/collector/component/componentstatus v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect

--- a/processor/transformprocessor/go.sum
+++ b/processor/transformprocessor/go.sum
@@ -121,6 +121,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/processor/unrollprocessor/go.mod
+++ b/processor/unrollprocessor/go.mod
@@ -44,6 +44,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor/xprocessor v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/processor/unrollprocessor/go.sum
+++ b/processor/unrollprocessor/go.sum
@@ -79,6 +79,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 h1:Crz11ojpySZfYYsD2rKQHkEb3qNdut8ekKRIfnYd1WA=

--- a/receiver/activedirectorydsreceiver/go.mod
+++ b/receiver/activedirectorydsreceiver/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/activedirectorydsreceiver/go.sum
+++ b/receiver/activedirectorydsreceiver/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/aerospikereceiver/go.mod
+++ b/receiver/aerospikereceiver/go.mod
@@ -96,6 +96,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/aerospikereceiver/go.sum
+++ b/receiver/aerospikereceiver/go.sum
@@ -199,6 +199,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/apachereceiver/go.mod
+++ b/receiver/apachereceiver/go.mod
@@ -103,6 +103,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/apachereceiver/go.sum
+++ b/receiver/apachereceiver/go.sum
@@ -211,6 +211,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/apachesparkreceiver/go.mod
+++ b/receiver/apachesparkreceiver/go.mod
@@ -104,6 +104,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/apachesparkreceiver/go.sum
+++ b/receiver/apachesparkreceiver/go.sum
@@ -211,6 +211,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -73,6 +73,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/awscloudwatchreceiver/go.sum
+++ b/receiver/awscloudwatchreceiver/go.sum
@@ -136,6 +136,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -68,6 +68,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect

--- a/receiver/awsfirehosereceiver/go.sum
+++ b/receiver/awsfirehosereceiver/go.sum
@@ -135,6 +135,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/receiver v1.52.1-0.20260219223409-66996adfaaf7 h1:VHwbhgu23yuIkmZsaKfRntgOfoqzhS8pZPxm6+drOjg=

--- a/receiver/awslambdareceiver/go.mod
+++ b/receiver/awslambdareceiver/go.mod
@@ -67,6 +67,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/receiver/awslambdareceiver/go.sum
+++ b/receiver/awslambdareceiver/go.sum
@@ -125,6 +125,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/receiver v1.52.1-0.20260219223409-66996adfaaf7 h1:VHwbhgu23yuIkmZsaKfRntgOfoqzhS8pZPxm6+drOjg=

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -76,6 +76,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/receiver/awsxrayreceiver/go.sum
+++ b/receiver/awsxrayreceiver/go.sum
@@ -133,6 +133,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/azureeventhubreceiver/go.sum
+++ b/receiver/azureeventhubreceiver/go.sum
@@ -136,6 +136,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1 h1:MbDzTt/R+aXWrLa+c3WfQx9Wjd/XK6pTgM4dcWLUdlE=
 go.opentelemetry.io/collector/pdata/testdata v0.146.1/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -62,6 +62,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/azuremonitorreceiver/go.sum
+++ b/receiver/azuremonitorreceiver/go.sum
@@ -124,6 +124,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/cloudflarereceiver/go.mod
+++ b/receiver/cloudflarereceiver/go.mod
@@ -54,6 +54,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/cloudflarereceiver/go.sum
+++ b/receiver/cloudflarereceiver/go.sum
@@ -97,6 +97,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -67,6 +67,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/collectdreceiver/go.sum
+++ b/receiver/collectdreceiver/go.sum
@@ -129,6 +129,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/couchdbreceiver/go.mod
+++ b/receiver/couchdbreceiver/go.mod
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/couchdbreceiver/go.sum
+++ b/receiver/couchdbreceiver/go.sum
@@ -131,6 +131,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -91,6 +91,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/dockerstatsreceiver/go.sum
+++ b/receiver/dockerstatsreceiver/go.sum
@@ -171,6 +171,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -104,6 +104,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/elasticsearchreceiver/go.sum
+++ b/receiver/elasticsearchreceiver/go.sum
@@ -211,6 +211,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/envoyalsreceiver/go.mod
+++ b/receiver/envoyalsreceiver/go.mod
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/envoyalsreceiver/go.sum
+++ b/receiver/envoyalsreceiver/go.sum
@@ -133,6 +133,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/expvarreceiver/go.mod
+++ b/receiver/expvarreceiver/go.mod
@@ -66,6 +66,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/expvarreceiver/go.sum
+++ b/receiver/expvarreceiver/go.sum
@@ -127,6 +127,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/faroreceiver/go.mod
+++ b/receiver/faroreceiver/go.mod
@@ -53,6 +53,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/faroreceiver/go.sum
+++ b/receiver/faroreceiver/go.sum
@@ -155,6 +155,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -65,6 +65,7 @@ require (
 	go.opentelemetry.io/collector/extension/xextension v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/filelogreceiver/go.sum
+++ b/receiver/filelogreceiver/go.sum
@@ -108,6 +108,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/filestatsreceiver/go.mod
+++ b/receiver/filestatsreceiver/go.mod
@@ -87,6 +87,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/filestatsreceiver/go.sum
+++ b/receiver/filestatsreceiver/go.sum
@@ -169,6 +169,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/flinkmetricsreceiver/go.mod
+++ b/receiver/flinkmetricsreceiver/go.mod
@@ -68,6 +68,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/flinkmetricsreceiver/go.sum
+++ b/receiver/flinkmetricsreceiver/go.sum
@@ -131,6 +131,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/fluentforwardreceiver/go.sum
+++ b/receiver/fluentforwardreceiver/go.sum
@@ -85,6 +85,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/googlecloudmonitoringreceiver/go.mod
+++ b/receiver/googlecloudmonitoringreceiver/go.mod
@@ -36,6 +36,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/googlecloudmonitoringreceiver/go.sum
+++ b/receiver/googlecloudmonitoringreceiver/go.sum
@@ -104,6 +104,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/haproxyreceiver/go.mod
+++ b/receiver/haproxyreceiver/go.mod
@@ -104,6 +104,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/haproxyreceiver/go.sum
+++ b/receiver/haproxyreceiver/go.sum
@@ -211,6 +211,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -100,6 +100,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/hostmetricsreceiver/go.sum
+++ b/receiver/hostmetricsreceiver/go.sum
@@ -176,6 +176,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/httpcheckreceiver/go.sum
+++ b/receiver/httpcheckreceiver/go.sum
@@ -133,6 +133,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/huaweicloudcesreceiver/go.mod
+++ b/receiver/huaweicloudcesreceiver/go.mod
@@ -76,6 +76,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/huaweicloudcesreceiver/go.sum
+++ b/receiver/huaweicloudcesreceiver/go.sum
@@ -198,6 +198,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/icmpcheckreceiver/go.mod
+++ b/receiver/icmpcheckreceiver/go.mod
@@ -87,6 +87,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/icmpcheckreceiver/go.sum
+++ b/receiver/icmpcheckreceiver/go.sum
@@ -169,6 +169,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/iisreceiver/go.mod
+++ b/receiver/iisreceiver/go.mod
@@ -87,6 +87,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/iisreceiver/go.sum
+++ b/receiver/iisreceiver/go.sum
@@ -167,6 +167,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -109,6 +109,7 @@ require (
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/k8sobjectsreceiver/go.sum
+++ b/receiver/k8sobjectsreceiver/go.sum
@@ -240,6 +240,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -112,6 +112,7 @@ require (
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/telemetry v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/kubeletstatsreceiver/go.sum
+++ b/receiver/kubeletstatsreceiver/go.sum
@@ -238,6 +238,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/lokireceiver/go.mod
+++ b/receiver/lokireceiver/go.mod
@@ -87,6 +87,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/lokireceiver/go.sum
+++ b/receiver/lokireceiver/go.sum
@@ -236,6 +236,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -86,6 +86,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/memcachedreceiver/go.sum
+++ b/receiver/memcachedreceiver/go.sum
@@ -169,6 +169,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -81,6 +81,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/mongodbatlasreceiver/go.sum
+++ b/receiver/mongodbatlasreceiver/go.sum
@@ -137,6 +137,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/mongodbreceiver/go.mod
+++ b/receiver/mongodbreceiver/go.mod
@@ -101,6 +101,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/mongodbreceiver/go.sum
+++ b/receiver/mongodbreceiver/go.sum
@@ -198,6 +198,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -51,6 +51,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/mysqlreceiver/go.sum
+++ b/receiver/mysqlreceiver/go.sum
@@ -218,6 +218,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -103,6 +103,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/nginxreceiver/go.sum
+++ b/receiver/nginxreceiver/go.sum
@@ -211,6 +211,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/nsxtreceiver/go.mod
+++ b/receiver/nsxtreceiver/go.mod
@@ -70,6 +70,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/nsxtreceiver/go.sum
+++ b/receiver/nsxtreceiver/go.sum
@@ -137,6 +137,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -59,6 +59,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/oracledbreceiver/go.sum
+++ b/receiver/oracledbreceiver/go.sum
@@ -119,6 +119,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -107,6 +107,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/postgresqlreceiver/go.sum
+++ b/receiver/postgresqlreceiver/go.sum
@@ -222,6 +222,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/prometheusremotewritereceiver/go.mod
+++ b/receiver/prometheusremotewritereceiver/go.mod
@@ -112,6 +112,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/processor v1.52.1-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/prometheusremotewritereceiver/go.sum
+++ b/receiver/prometheusremotewritereceiver/go.sum
@@ -395,6 +395,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/rabbitmqreceiver/go.mod
+++ b/receiver/rabbitmqreceiver/go.mod
@@ -68,6 +68,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/rabbitmqreceiver/go.sum
+++ b/receiver/rabbitmqreceiver/go.sum
@@ -131,6 +131,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -94,6 +94,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/redisreceiver/go.sum
+++ b/receiver/redisreceiver/go.sum
@@ -197,6 +197,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/riakreceiver/go.mod
+++ b/receiver/riakreceiver/go.mod
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/riakreceiver/go.sum
+++ b/receiver/riakreceiver/go.sum
@@ -131,6 +131,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/saphanareceiver/go.mod
+++ b/receiver/saphanareceiver/go.mod
@@ -57,6 +57,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/saphanareceiver/go.sum
+++ b/receiver/saphanareceiver/go.sum
@@ -103,6 +103,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -99,6 +99,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/snowflakereceiver/go.sum
+++ b/receiver/snowflakereceiver/go.sum
@@ -208,6 +208,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/splunkenterprisereceiver/go.mod
+++ b/receiver/splunkenterprisereceiver/go.mod
@@ -69,6 +69,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/splunkenterprisereceiver/go.sum
+++ b/receiver/splunkenterprisereceiver/go.sum
@@ -127,6 +127,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -164,6 +164,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/sqlqueryreceiver/go.sum
+++ b/receiver/sqlqueryreceiver/go.sum
@@ -350,6 +350,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -111,6 +111,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/sqlserverreceiver/go.sum
+++ b/receiver/sqlserverreceiver/go.sum
@@ -247,6 +247,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/sshcheckreceiver/go.mod
+++ b/receiver/sshcheckreceiver/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/sshcheckreceiver/go.sum
+++ b/receiver/sshcheckreceiver/go.sum
@@ -91,6 +91,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/systemdreceiver/go.mod
+++ b/receiver/systemdreceiver/go.mod
@@ -56,6 +56,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/systemdreceiver/go.sum
+++ b/receiver/systemdreceiver/go.sum
@@ -109,6 +109,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/tcpcheckreceiver/go.mod
+++ b/receiver/tcpcheckreceiver/go.mod
@@ -51,6 +51,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/tcpcheckreceiver/go.sum
+++ b/receiver/tcpcheckreceiver/go.sum
@@ -87,6 +87,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/vcenterreceiver/go.mod
+++ b/receiver/vcenterreceiver/go.mod
@@ -96,6 +96,7 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/vcenterreceiver/go.sum
+++ b/receiver/vcenterreceiver/go.sum
@@ -191,6 +191,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -49,6 +49,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/windowsperfcountersreceiver/go.sum
+++ b/receiver/windowsperfcountersreceiver/go.sum
@@ -81,6 +81,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -84,6 +84,7 @@ require (
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.146.2-0.20260219223409-66996adfaaf7 // indirect

--- a/receiver/zookeeperreceiver/go.sum
+++ b/receiver/zookeeperreceiver/go.sum
@@ -169,6 +169,8 @@ go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfa
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7 h1:nGf3hzMq7oUSu3asG4M+ybk73HHgpYmaRZgg/a6hnys=
 go.opentelemetry.io/collector/pdata/testdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:IcY6Hg13ObCFc3gpv6MRjZqUa0kCmLC5pojMmwlTj3U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/pipeline/xpipeline v0.146.2-0.20260219223409-66996adfaaf7 h1:YgWudM7gTkhB3ckpI/8gSLrhe/KEE5AE+FJkfHwBXrw=

--- a/scraper/zookeeperscraper/go.mod
+++ b/scraper/zookeeperscraper/go.mod
@@ -42,6 +42,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 // indirect
+	go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect

--- a/scraper/zookeeperscraper/go.sum
+++ b/scraper/zookeeperscraper/go.sum
@@ -69,6 +69,8 @@ go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 h1:fnX
 go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:+w6A2FXrMDDIwjRgQaud11Ifobng/j/FW3upZtaVKHc=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7 h1:biy3Lio7MROQxN6F7TnSBHcZs7+jtISMXRP5H6EfcL4=
 go.opentelemetry.io/collector/pdata/pprofile v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:gNaqTrI/3sdZxtwYcR4yei89Kd3T1rXKGFpVonPQv/U=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7 h1:Xb+2uGxHcSj5UpAcIQkRVcvD1w/fUVWHkCJKBfy05EM=
+go.opentelemetry.io/collector/pdata/xpdata v0.146.2-0.20260219223409-66996adfaaf7/go.mod h1:rOeWBaq86aRNxeHXRTNGvoSIhOZOFfxWjhicbvvKO04=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7 h1:urn13PVH9dGfARcMLScaIcLE0Zk6a+T7BjCl2H4x7m0=
 go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7/go.mod h1:RD90NG3Jbk965Xaqym3JyHkuol4uZJjQVUkD9ddXJIs=
 go.opentelemetry.io/collector/scraper v0.146.2-0.20260219223409-66996adfaaf7 h1:xDSqdUxvfGTjwph552LWjov5/BUigAIqxUjcI5cIdl4=


### PR DESCRIPTION
## Summary

Fixes #46345

`CompareResource` in `pkg/pdatatest` only compared `Attributes` and `DroppedAttributesCount`, ignoring `EntityRefs` entirely. This meant two resources differing only in entity references were considered equal.

This PR:
- Adds `CompareEntityRefs` to `internal/util.go` which compares entity ref type, schema URL, ID keys, and description keys
- Integrates it into `CompareResource` so all signal types (metrics, logs, traces, profiles) automatically benefit
- Adds `IgnoreResourceEntityRefs()` option to all four signal packages for callers who don't want to assert on entity refs
- Adds tests covering equal refs, count/type/key mismatches, and the ignore option

## Test plan

- [x] Added `TestCompareMetricsEntityRefs` with subtests for all comparison scenarios
- [x] All existing tests continue to pass (`go test ./...` in `pkg/pdatatest`)