### PR TITLE
[receiver/tlscheck] enable dynamic metric reaggregation

### DIFF
--- a/receiver/tlscheckreceiver/scraper.go
+++ b/receiver/tlscheckreceiver/scraper.go
@@ -32,31 +32,27 @@ import (
 
 var errMissingTargets = errors.New(`No targets specified`)
 
+// certResult holds parsed certificate data returned by a worker.
+type certResult struct {
+	target string
+	cert   *x509.Certificate
+}
+
+type scrapeResult struct {
+	certs []certResult
+	err   error
+}
+
+type resourceGroup struct {
+	target  string
+	results []certResult
+}
+
 type scraper struct {
 	cfg                *Config
 	settings           receiver.Settings
 	getConnectionState func(endpoint string) (tls.ConnectionState, error)
-}
-
-// listens to the error channel and combines errors sent from different go routines,
-// returning the combined error list should context timeout or a nil error value is
-// sent in the channel signifying the end of a scrape cycle
-func errorListener(ctx context.Context, eQueue <-chan error, eOut chan<- *scrapererror.ScrapeErrors) {
-	errs := &scrapererror.ScrapeErrors{}
-
-	for {
-		select {
-		case <-ctx.Done():
-			eOut <- errs
-			return
-		case err, ok := <-eQueue:
-			if !ok {
-				eOut <- errs
-				return
-			}
-			errs.AddPartial(1, err)
-		}
-	}
+	mb                 *metadata.MetricsBuilder
 }
 
 func validatePort(port string) error {
@@ -128,12 +124,7 @@ func getConnectionState(endpoint string) (tls.ConnectionState, error) {
 	return conn.ConnectionState(), nil
 }
 
-// extractCertMetrics records the tlscheck.time_left metric for a single leaf certificate.
-// target is the resource label (endpoint string or file path).
-func (s *scraper) extractCertMetrics(target string, cert *x509.Certificate, metrics *pmetric.Metrics, mux *sync.Mutex) {
-	issuer := cert.Issuer.String()
-	commonName := cert.Subject.CommonName
-
+func certSANs(cert *x509.Certificate) []any {
 	sans := make([]any, 0, len(cert.DNSNames)+len(cert.IPAddresses)+len(cert.URIs)+len(cert.EmailAddresses))
 	for _, ip := range cert.IPAddresses {
 		sans = append(sans, ip.String())
@@ -147,86 +138,100 @@ func (s *scraper) extractCertMetrics(target string, cert *x509.Certificate, metr
 	for _, emailAddress := range cert.EmailAddresses {
 		sans = append(sans, emailAddress)
 	}
-
-	currentTime := time.Now()
-	timeLeft := cert.NotAfter.Sub(currentTime).Seconds()
-	timeLeftInt := int64(timeLeft)
-	now := pcommon.NewTimestampFromTime(currentTime)
-
-	// Build per-certificate metrics outside the critical section to reduce lock contention.
-	mb := metadata.NewMetricsBuilder(s.cfg.MetricsBuilderConfig, s.settings, metadata.WithStartTime(pcommon.NewTimestampFromTime(currentTime)))
-	rb := mb.NewResourceBuilder()
-	rb.SetTlscheckTarget(target)
-	mb.RecordTlscheckTimeLeftDataPoint(now, timeLeftInt, issuer, commonName, sans)
-	resourceMetrics := mb.Emit(metadata.WithResource(rb.Emit()))
-
-	// Only guard the mutation of the shared metrics object with the mutex.
-	mux.Lock()
-	resourceMetrics.ResourceMetrics().At(0).MoveTo(metrics.ResourceMetrics().AppendEmpty())
-	mux.Unlock()
+	return sans
 }
 
-func (s *scraper) scrapeEndpoint(endpoint string, metrics *pmetric.Metrics, wg *sync.WaitGroup, mux *sync.Mutex, errs chan error) {
-	defer wg.Done()
+func (s *scraper) resourceGroupKey(target string) string {
+	if s.cfg.ResourceAttributes.TlscheckTarget.Enabled {
+		return target
+	}
+	return ""
+}
+
+func (s *scraper) groupByResource(results []certResult) []resourceGroup {
+	groups := make([]resourceGroup, 0, len(results))
+	groupIndex := make(map[string]int, len(results))
+
+	for _, result := range results {
+		key := s.resourceGroupKey(result.target)
+		if idx, ok := groupIndex[key]; ok {
+			groups[idx].results = append(groups[idx].results, result)
+			continue
+		}
+
+		groupIndex[key] = len(groups)
+		groups = append(groups, resourceGroup{
+			target:  result.target,
+			results: []certResult{result},
+		})
+	}
+
+	return groups
+}
+
+func (s *scraper) recordCertMetrics(now time.Time, ts pcommon.Timestamp, cert *x509.Certificate) {
+	s.mb.RecordTlscheckTimeLeftDataPoint(
+		ts,
+		int64(cert.NotAfter.Sub(now).Seconds()),
+		cert.Issuer.String(),
+		cert.Subject.CommonName,
+		certSANs(cert),
+	)
+}
+
+func (s *scraper) scrapeEndpoint(endpoint string) ([]certResult, error) {
 	if err := validateEndpoint(endpoint); err != nil {
 		s.settings.Logger.Error("Failed to validate endpoint", zap.String("endpoint", endpoint), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	state, err := s.getConnectionState(endpoint)
 	if err != nil {
 		s.settings.Logger.Error("TCP connection error encountered", zap.String("endpoint", endpoint), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	s.settings.Logger.Debug("Peer Certificates", zap.Int("certificates_count", len(state.PeerCertificates)))
 	if len(state.PeerCertificates) == 0 {
 		err := fmt.Errorf("no TLS certificates found for endpoint: %s. Verify the endpoint serves TLS certificates", endpoint)
 		s.settings.Logger.Error(err.Error(), zap.String("endpoint", endpoint))
-		errs <- err
-		return
+		return nil, err
 	}
 
-	s.extractCertMetrics(endpoint, state.PeerCertificates[0], metrics, mux)
+	return []certResult{{target: endpoint, cert: state.PeerCertificates[0]}}, nil
 }
 
-func (s *scraper) scrapeFile(target *CertificateTarget, metrics *pmetric.Metrics, wg *sync.WaitGroup, mux *sync.Mutex, errs chan error) {
-	defer wg.Done()
+func (s *scraper) scrapeFile(target *CertificateTarget) ([]certResult, error) {
 	filePath := target.FilePath
 
 	if err := validateFilepath(filePath); err != nil {
 		s.settings.Logger.Error("Failed to validate certificate file", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	format := resolveFileFormat(target.FileFormat, filePath)
 
 	switch format {
 	case FileFormatJKS:
-		s.scrapeJKS(target, metrics, mux, errs)
+		return s.scrapeJKS(target)
 	case FileFormatPKCS12:
-		s.scrapePKCS12(target, metrics, mux, errs)
+		return s.scrapePKCS12(target)
 	default:
-		s.scrapePEM(filePath, metrics, mux, errs)
+		return s.scrapePEM(filePath)
 	}
 }
 
-func (s *scraper) scrapePEM(filePath string, metrics *pmetric.Metrics, mux *sync.Mutex, errs chan error) {
+func (s *scraper) scrapePEM(filePath string) ([]certResult, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		s.settings.Logger.Error("Failed to open certificate file", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 	defer file.Close()
 	data, err := io.ReadAll(file)
 	if err != nil {
 		s.settings.Logger.Error("Failed to read certificate file", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	var certs []*x509.Certificate
@@ -246,8 +251,7 @@ func (s *scraper) scrapePEM(filePath string, metrics *pmetric.Metrics, mux *sync
 		cert, parseErr := x509.ParseCertificate(block.Bytes)
 		if parseErr != nil {
 			s.settings.Logger.Error("Failed to parse certificate", zap.String("file_path", filePath), zap.Error(parseErr))
-			errs <- parseErr
-			return
+			return nil, parseErr
 		}
 		certs = append(certs, cert)
 	}
@@ -255,44 +259,40 @@ func (s *scraper) scrapePEM(filePath string, metrics *pmetric.Metrics, mux *sync
 	if len(certs) == 0 {
 		err := fmt.Errorf("no valid certificates found in PEM file: %s", filePath)
 		s.settings.Logger.Error(err.Error(), zap.String("file_path", filePath))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	s.settings.Logger.Debug("Found certificates in chain", zap.String("file_path", filePath), zap.Int("count", len(certs)))
 
 	// Use the leaf certificate (first in file)
-	s.extractCertMetrics(filePath, certs[0], metrics, mux)
+	return []certResult{{target: filePath, cert: certs[0]}}, nil
 }
 
-func (s *scraper) scrapeJKS(target *CertificateTarget, metrics *pmetric.Metrics, mux *sync.Mutex, errs chan error) {
+func (s *scraper) scrapeJKS(target *CertificateTarget) ([]certResult, error) {
 	filePath := target.FilePath
 	password := []byte(string(target.Password))
 
 	file, err := os.Open(filePath)
 	if err != nil {
 		s.settings.Logger.Error("Failed to open JKS file", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 	defer file.Close()
 
 	ks := keystore.New()
 	if err := ks.Load(file, password); err != nil {
 		s.settings.Logger.Error("Failed to load JKS keystore", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	aliases := ks.Aliases()
 	if len(aliases) == 0 {
 		err := fmt.Errorf("no entries found in JKS keystore: %s", filePath)
 		s.settings.Logger.Error(err.Error(), zap.String("file_path", filePath))
-		errs <- err
-		return
+		return nil, err
 	}
 
-	foundAny := false
+	results := make([]certResult, 0, len(aliases))
 	var lastAliasErr error
 	for _, alias := range aliases {
 		if entry, err := ks.GetTrustedCertificateEntry(alias); err == nil {
@@ -304,8 +304,7 @@ func (s *scraper) scrapeJKS(target *CertificateTarget, metrics *pmetric.Metrics,
 					zap.Error(parseErr))
 				continue
 			}
-			s.extractCertMetrics(filePath, cert, metrics, mux)
-			foundAny = true
+			results = append(results, certResult{target: filePath, cert: cert})
 		} else if entry, err := ks.GetPrivateKeyEntry(alias, password); err == nil {
 			if len(entry.CertificateChain) == 0 {
 				continue
@@ -319,8 +318,7 @@ func (s *scraper) scrapeJKS(target *CertificateTarget, metrics *pmetric.Metrics,
 					zap.Error(parseErr))
 				continue
 			}
-			s.extractCertMetrics(filePath, cert, metrics, mux)
-			foundAny = true
+			results = append(results, certResult{target: filePath, cert: cert})
 		} else {
 			lastAliasErr = err
 			s.settings.Logger.Debug("Failed to read alias from JKS keystore",
@@ -330,81 +328,123 @@ func (s *scraper) scrapeJKS(target *CertificateTarget, metrics *pmetric.Metrics,
 		}
 	}
 
-	if !foundAny {
+	if len(results) == 0 {
 		err := fmt.Errorf("no parseable certificates found in JKS keystore: %s", filePath)
 		if lastAliasErr != nil {
 			err = fmt.Errorf("%w: last alias error: %w", err, lastAliasErr)
 		}
 		s.settings.Logger.Error(err.Error(), zap.String("file_path", filePath))
-		errs <- err
+		return nil, err
 	}
+
+	return results, nil
 }
 
-func (s *scraper) scrapePKCS12(target *CertificateTarget, metrics *pmetric.Metrics, mux *sync.Mutex, errs chan error) {
+func (s *scraper) scrapePKCS12(target *CertificateTarget) ([]certResult, error) {
 	filePath := target.FilePath
 	password := string(target.Password)
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		s.settings.Logger.Error("Failed to read PKCS#12 file", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	_, cert, _, err := pkcs12.DecodeChain(data, password)
 	if err != nil {
 		s.settings.Logger.Error("Failed to decode PKCS#12 keystore", zap.String("file_path", filePath), zap.Error(err))
-		errs <- err
-		return
+		return nil, err
 	}
 
 	if cert == nil {
 		err := fmt.Errorf("no leaf certificate found in PKCS#12 file: %s", filePath)
 		s.settings.Logger.Error(err.Error(), zap.String("file_path", filePath))
-		errs <- err
-		return
+		return nil, err
 	}
 
-	s.extractCertMetrics(filePath, cert, metrics, mux)
+	return []certResult{{target: filePath, cert: cert}}, nil
 }
 
 func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
-	var errs *scrapererror.ScrapeErrors
-
-	errOut := make(chan *scrapererror.ScrapeErrors)
-	errChan := make(chan error, len(s.cfg.Targets))
-	go func() {
-		errorListener(ctx, errChan, errOut)
-	}()
-
 	if s.cfg == nil || len(s.cfg.Targets) == 0 {
 		return pmetric.NewMetrics(), errMissingTargets
+	}
+	if err := ctx.Err(); err != nil {
+		return pmetric.NewMetrics(), err
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(len(s.cfg.Targets))
-	var mux sync.Mutex
-
-	metrics := pmetric.NewMetrics()
+	resultsCh := make(chan scrapeResult, len(s.cfg.Targets))
 
 	for _, target := range s.cfg.Targets {
-		if target.FilePath != "" {
-			go s.scrapeFile(target, &metrics, &wg, &mux, errChan)
-		} else {
-			go s.scrapeEndpoint(target.Endpoint, &metrics, &wg, &mux, errChan)
-		}
+		go func(target *CertificateTarget) {
+			defer wg.Done()
+
+			var (
+				certs []certResult
+				err   error
+			)
+			if target.FilePath != "" {
+				certs, err = s.scrapeFile(target)
+			} else {
+				certs, err = s.scrapeEndpoint(target.Endpoint)
+			}
+
+			resultsCh <- scrapeResult{certs: certs, err: err}
+		}(target)
 	}
 
-	wg.Wait()
-	close(errChan)
-	errs = <-errOut
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	errs := &scrapererror.ScrapeErrors{}
+	results := make([]certResult, 0, len(s.cfg.Targets))
+	for result := range resultsCh {
+		results = append(results, result.certs...)
+		if result.err != nil {
+			errs.AddPartial(1, result.err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		errs.AddPartial(1, err)
+	}
+
+	if len(results) == 0 {
+		return pmetric.NewMetrics(), errs.Combine()
+	}
+
+	now := time.Now()
+	ts := pcommon.NewTimestampFromTime(now)
+	s.mb.Reset(metadata.WithStartTime(ts))
+
+	for _, group := range s.groupByResource(results) {
+		rb := s.mb.NewResourceBuilder()
+		rb.SetTlscheckTarget(group.target)
+
+		for _, result := range group.results {
+			s.recordCertMetrics(now, ts, result.cert)
+		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
+	}
+
+	metrics := s.mb.Emit()
 	return metrics, errs.Combine()
 }
 
 func newScraper(cfg *Config, settings receiver.Settings, getConnectionState func(endpoint string) (tls.ConnectionState, error)) *scraper {
+	var mb *metadata.MetricsBuilder
+	if cfg != nil {
+		mb = metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings)
+	}
+
 	return &scraper{
 		cfg:                cfg,
 		settings:           settings,
 		getConnectionState: getConnectionState,
+		mb:                 mb,
 	}
 }

--- a/receiver/tlscheckreceiver/scraper_test.go
+++ b/receiver/tlscheckreceiver/scraper_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 	"testing"
@@ -143,6 +144,56 @@ func createMockJKSFile(t *testing.T, expiry time.Time, password string) string {
 	require.NoError(t, err)
 
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-keystore-*.jks")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	require.NoError(t, ks.Store(tmpFile, []byte(password)))
+	require.NoError(t, tmpFile.Close())
+
+	return tmpFile.Name()
+}
+
+// createMockMultiAliasJKSFile creates a JKS keystore containing one TrustedCertificateEntry
+// per expiry and returns its absolute path.
+func createMockMultiAliasJKSFile(t *testing.T, expiries []time.Time, password string) string {
+	t.Helper()
+
+	ks := keystorego.New()
+	for i, expiry := range expiries {
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		issuerTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(int64(i + 100)),
+			Subject:      pkix.Name{CommonName: fmt.Sprintf("JKSMultiIssuer-%d", i+1)},
+			NotBefore:    time.Now().Add(-1 * time.Hour),
+			NotAfter:     expiry,
+			IsCA:         true,
+		}
+		issuerCertDER, err := x509.CreateCertificate(rand.Reader, issuerTemplate, issuerTemplate, &privKey.PublicKey, privKey)
+		require.NoError(t, err)
+		issuerCert, err := x509.ParseCertificate(issuerCertDER)
+		require.NoError(t, err)
+
+		leafTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(int64(i + 10)),
+			Subject:      pkix.Name{CommonName: fmt.Sprintf("jks-test-%d.example.com", i+1)},
+			NotBefore:    time.Now().Add(-1 * time.Hour),
+			NotAfter:     expiry,
+		}
+		certDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, issuerCert, &privKey.PublicKey, privKey)
+		require.NoError(t, err)
+
+		err = ks.SetTrustedCertificateEntry(fmt.Sprintf("test-alias-%d", i+1), keystorego.TrustedCertificateEntry{
+			Certificate: keystorego.Certificate{
+				Type:    "X.509",
+				Content: certDER,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-multi-keystore-*.jks")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
 
@@ -509,6 +560,104 @@ func TestScrape_ExpiredJKSCertificate(t *testing.T) {
 
 	dp := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0)
 	require.Negative(t, dp.IntValue(), "Time left should be negative for an expired JKS cert")
+}
+
+func TestScrape_JKSReaggregation(t *testing.T) {
+	baseTime := time.Now().UTC().Truncate(time.Second)
+	expiries := []time.Time{
+		baseTime.Add(24 * time.Hour),
+		baseTime.Add(48 * time.Hour),
+		baseTime.Add(72 * time.Hour),
+	}
+	jksFile := createMockMultiAliasJKSFile(t, expiries, "changeit")
+
+	cfg := &Config{
+		Targets: []*CertificateTarget{
+			{
+				FilePath:   jksFile,
+				FileFormat: FileFormatJKS,
+				Password:   configopaque.String("changeit"),
+			},
+		},
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.TlscheckTimeLeft.AggregationStrategy = metadata.AggregationStrategySum
+	cfg.Metrics.TlscheckTimeLeft.EnabledAttributes = nil
+
+	factory := receivertest.NewNopFactory()
+	s := newScraper(cfg, receivertest.NewNopSettings(factory.Type()), mockGetConnectionStateValid)
+
+	metrics, err := s.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, metrics.ResourceMetrics().Len())
+
+	rm := metrics.ResourceMetrics().At(0)
+	require.Equal(t, 1, rm.ScopeMetrics().Len())
+	require.Equal(t, 1, rm.ScopeMetrics().At(0).Metrics().Len())
+
+	dps := rm.ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints()
+	require.Equal(t, 1, dps.Len())
+
+	dp := dps.At(0)
+	require.Equal(t, 0, dp.Attributes().Len())
+
+	var expected int64
+	timestamp := dp.Timestamp().AsTime()
+	for _, expiry := range expiries {
+		expected += int64(expiry.Sub(timestamp).Seconds())
+	}
+	require.Equal(t, expected, dp.IntValue())
+}
+
+func TestScrape_JKSReaggregationWithAttributes(t *testing.T) {
+	baseTime := time.Now().UTC().Truncate(time.Second)
+	expiries := []time.Time{
+		baseTime.Add(24 * time.Hour),
+		baseTime.Add(48 * time.Hour),
+		baseTime.Add(72 * time.Hour),
+	}
+	jksFile := createMockMultiAliasJKSFile(t, expiries, "changeit")
+
+	cfg := &Config{
+		Targets: []*CertificateTarget{
+			{
+				FilePath:   jksFile,
+				FileFormat: FileFormatJKS,
+				Password:   configopaque.String("changeit"),
+			},
+		},
+		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+	}
+	cfg.Metrics.TlscheckTimeLeft.AggregationStrategy = metadata.AggregationStrategySum
+	cfg.Metrics.TlscheckTimeLeft.EnabledAttributes = []metadata.TlscheckTimeLeftMetricAttributeKey{
+		metadata.TlscheckTimeLeftMetricAttributeKeyTlscheckX509Issuer,
+	}
+
+	factory := receivertest.NewNopFactory()
+	s := newScraper(cfg, receivertest.NewNopSettings(factory.Type()), mockGetConnectionStateValid)
+
+	metrics, err := s.scrape(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, metrics.ResourceMetrics().Len())
+
+	dps := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints()
+	require.Equal(t, 3, dps.Len())
+
+	issuers := make([]string, 0, dps.Len())
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		require.Equal(t, 1, dp.Attributes().Len())
+
+		issuer, ok := dp.Attributes().Get("tlscheck.x509.issuer")
+		require.True(t, ok)
+		issuers = append(issuers, issuer.AsString())
+	}
+
+	assert.ElementsMatch(t, []string{
+		"CN=JKSMultiIssuer-1",
+		"CN=JKSMultiIssuer-2",
+		"CN=JKSMultiIssuer-3",
+	}, issuers)
 }
 
 func TestScrape_WrongPasswordJKS(t *testing.T) {


### PR DESCRIPTION
#### Description

This PR was originally created to enable dynamic metric reaggregation for `receiver/tlscheck`. While the configuration-level changes to expose this feature were recently merged via #47736, this PR completes the workflow by refactoring the scraper so that the reaggregation actually works correctly for multi-certificate targets such as JKS keystores.

Previously, each parsed certificate was recorded through its own `MetricsBuilder` with its own `time.Now()` value. The generated reaggregation logic only merges datapoints that are recorded through the same builder and share the exact same timestamp. Therefore, certificates from the same target could not collapse even when users disabled distinguishing metric attributes.

This change:
- Refactors the scraper into a two-phase process (concurrent fetch + serial emit).
- Groups certificates by produced resource and records them with **one shared timestamp baseline** and a single `MetricsBuilder` per scrape.

This ensures `tlscheck.time_left` can be successfully reaggregated when users opt out of distinguishing attributes, without breaking backward compatibility for single-certificate targets.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46383
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45396

#### Testing

- added `TestScrape_JKSReaggregation` to verify multiple certificates from one JKS collapse into one datapoint when attributes are disabled and aggregation is enabled
- added `TestScrape_JKSReaggregationWithAttributes` to verify datapoints stay separate when `tlscheck.x509.issuer` remains enabled
- preserved existing scraper coverage for endpoint and file-based targets

#### Documentation

- No manual docs were added.
