### PR TITLE
[chore] Exclude updates from deprecated Datadog semantics processor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -107,6 +107,7 @@
       "matchPaths": [
         "exporter/datadogexporter/**",
         "connector/datadogconnector/**",
+        "processor/datadogsemanticsprocessor/**",
         "internal/datadog/**",
         "pkg/datadog/**"
       ],


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->

Disables updates for deprecated component 'datadogsemantics' processor.

Follows #46107, #46311 and #46052
