### PR TITLE
Add attributes to http output for the healthcheck extension

### DIFF
--- a/.chloggen/healthcheckv2-status-attributes.yaml
+++ b/.chloggen/healthcheckv2-status-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/healthcheckv2
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add component status event attributes to the HTTP status endpoint JSON response.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [43606]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/extension/healthcheckv2extension/README.md
+++ b/extension/healthcheckv2extension/README.md
@@ -186,8 +186,9 @@ relevant.
 
 The detailed response body for collector health will include the overall status for the
 collector, the overall status for each pipeline in the collector, and the statuses for the
-individual components in each pipeline. The non-detailed response will only contain the overall
-collector health.
+individual components in each pipeline. Components may include an `attributes` field containing
+additional context or metadata about the status event. The non-detailed response will only
+contain the overall collector health.
 
 **Verbose Example**
 
@@ -225,7 +226,10 @@ response body such as:
                     "healthy": true,
                     "status": "StatusRecoverableError",
                     "error": "rpc error: code = ResourceExhausted desc = resource exhausted",
-                    "status_time": "2024-01-18T17:27:32.572301-08:00"
+                    "status_time": "2024-01-18T17:27:32.572301-08:00",
+                    "attributes": {
+                        "endpoint": "staging.example.com:4317"
+                    }
                 },
                 "processor:batch": {
                     "healthy": true,
@@ -270,6 +274,9 @@ Note the following based on this response:
   is set to `false` or it is `true` and the recovery duration has not yet passed.
 - `pipeline:metrics/grpc` has a matching status, as does `exporter:otlp_grpc/staging`. This implicates
   the exporter as the root cause for the pipeline and overall collector status.
+- `exporter:otlp/staging` includes an `attributes` field with additional context about the status
+  event. Attributes are set by the component reporting the status and are only present when a
+  component provides them. The field is omitted when there are no attributes.
 - `pipeline:traces/http` is completely healthy.
 
 **Non-verbose Response example**

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/extension/extensiontest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/service"
 	"go.uber.org/zap"
@@ -983,6 +984,10 @@ func (m mockStatusEvent) Err() error {
 
 func (m mockStatusEvent) Timestamp() time.Time {
 	return m.timestamp
+}
+
+func (m mockStatusEvent) Attributes() pcommon.Map {
+	return pcommon.NewMap()
 }
 
 func newTestOpampAgent(cfg *Config, set extension.Settings, mockOpampClient *mockOpAMPClient, sa *mockStatusAggregator) *opampAgent {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -986,7 +986,7 @@ func (m mockStatusEvent) Timestamp() time.Time {
 	return m.timestamp
 }
 
-func (m mockStatusEvent) Attributes() pcommon.Map {
+func (mockStatusEvent) Attributes() pcommon.Map {
 	return pcommon.NewMap()
 }
 

--- a/internal/healthcheck/go.mod
+++ b/internal/healthcheck/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/extension v1.52.1-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.146.2-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/extension/extensiontest v0.146.2-0.20260219223409-66996adfaaf7
+	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -63,7 +64,6 @@ require (
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.146.2-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.146.2-0.20260219223409-66996adfaaf7 // indirect
-	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/internal/healthcheck/internal/http/serialization.go
+++ b/internal/healthcheck/internal/http/serialization.go
@@ -34,10 +34,11 @@ type serializableStatus struct {
 
 // SerializableEvent is exported for json.Unmarshal
 type SerializableEvent struct {
-	Healthy      bool      `json:"healthy"`
-	StatusString string    `json:"status"`
-	Error        string    `json:"error,omitempty"`
-	Timestamp    time.Time `json:"status_time"`
+	Healthy      bool           `json:"healthy"`
+	StatusString string         `json:"status"`
+	Error        string         `json:"error,omitempty"`
+	Timestamp    time.Time      `json:"status_time"`
+	Attributes   map[string]any `json:"attributes,omitempty"`
 }
 
 var stringToStatusMap = map[string]componentstatus.Status{
@@ -66,6 +67,9 @@ func toSerializableEvent(ev status.Event, isHealthy bool) *SerializableEvent {
 	}
 	if ev.Err() != nil {
 		se.Error = ev.Err().Error()
+	}
+	if attrs := ev.Attributes(); attrs.Len() > 0 {
+		se.Attributes = attrs.AsRaw()
 	}
 	return se
 }

--- a/internal/healthcheck/internal/http/serialization_test.go
+++ b/internal/healthcheck/internal/http/serialization_test.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
+)
+
+func TestToSerializableEventWithAttributes(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("error_msg", "connection refused")
+	attrs.PutInt("retry_count", 3)
+
+	ev := componentstatus.NewEvent(
+		componentstatus.StatusRecoverableError,
+		componentstatus.WithAttributes(attrs),
+	)
+
+	se := toSerializableEvent(ev, true)
+
+	require.NotNil(t, se.Attributes)
+	assert.Equal(t, "connection refused", se.Attributes["error_msg"])
+	assert.Equal(t, int64(3), se.Attributes["retry_count"])
+}
+
+func TestToSerializableEventWithoutAttributes(t *testing.T) {
+	ev := componentstatus.NewEvent(componentstatus.StatusOK)
+	se := toSerializableEvent(ev, true)
+
+	assert.Nil(t, se.Attributes)
+}
+
+func TestToSerializableStatusAttributesOnLeafOnly(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("scraper", "cpu")
+
+	leafEvent := componentstatus.NewEvent(
+		componentstatus.StatusRecoverableError,
+		componentstatus.WithAttributes(attrs),
+	)
+
+	// Build a simple aggregate: pipeline with one component that has attributes
+	aggStatus := &status.AggregateStatus{
+		// Aggregated event (no attributes since aggregation doesn't propagate them)
+		Event: componentstatus.NewEvent(componentstatus.StatusRecoverableError),
+		ComponentStatusMap: map[string]*status.AggregateStatus{
+			"receiver:hostmetrics": {
+				Event: leafEvent,
+			},
+		},
+	}
+
+	sst := toSerializableStatus(aggStatus, &serializationOptions{})
+
+	// The aggregated (parent) node should have no attributes
+	assert.Nil(t, sst.Attributes)
+
+	// The leaf component should have attributes
+	leaf := sst.ComponentStatuses["receiver:hostmetrics"]
+	require.NotNil(t, leaf)
+	require.NotNil(t, leaf.Attributes)
+	assert.Equal(t, "cpu", leaf.Attributes["scraper"])
+}

--- a/pkg/status/aggregation.go
+++ b/pkg/status/aggregation.go
@@ -37,7 +37,7 @@ func (ev *statusEvent) Timestamp() time.Time {
 }
 
 // Attributes returns an empty map for synthetic aggregated events.
-func (ev *statusEvent) Attributes() pcommon.Map {
+func (*statusEvent) Attributes() pcommon.Map {
 	return pcommon.NewMap()
 }
 

--- a/pkg/status/aggregation.go
+++ b/pkg/status/aggregation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 // statusEvent contains a status and timestamp, and can contain an error. Note:
@@ -33,6 +34,11 @@ func (ev *statusEvent) Err() error {
 // Timestamp returns the timestamp associated with the StatusEvent
 func (ev *statusEvent) Timestamp() time.Time {
 	return ev.timestamp
+}
+
+// Attributes returns an empty map for synthetic aggregated events.
+func (ev *statusEvent) Attributes() pcommon.Map {
+	return pcommon.NewMap()
 }
 
 type ErrorPriority int

--- a/pkg/status/aggregator.go
+++ b/pkg/status/aggregator.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 )
 
@@ -21,6 +22,7 @@ type Event interface {
 	Status() componentstatus.Status
 	Err() error
 	Timestamp() time.Time
+	Attributes() pcommon.Map
 }
 
 // Scope refers to a part of an AggregateStatus. The zero-value, aka ScopeAll,

--- a/pkg/status/aggregator_test.go
+++ b/pkg/status/aggregator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pipeline"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status"
@@ -538,4 +539,63 @@ func assertNoEventsRecvd(t *testing.T, chans ...<-chan *status.AggregateStatus) 
 		default:
 		}
 	}
+}
+
+func TestAggregateStatusAttributes(t *testing.T) {
+	agg := status.NewAggregator(status.PriorityPermanent)
+	traces := testhelpers.NewPipelineMetadata(pipeline.SignalTraces)
+	tracesKey := toPipelineKey(traces.PipelineID)
+
+	testhelpers.SeedAggregator(agg, traces.InstanceIDs(), componentstatus.StatusOK)
+
+	// Record an error with attributes on the exporter
+	attrs := pcommon.NewMap()
+	attrs.PutStr("error_msg", "connection refused")
+	agg.RecordStatus(
+		traces.ExporterID,
+		componentstatus.NewEvent(
+			componentstatus.StatusRecoverableError,
+			componentstatus.WithError(assert.AnError),
+			componentstatus.WithAttributes(attrs),
+		),
+	)
+
+	st, ok := agg.AggregateStatus(status.ScopeAll, status.Verbose)
+	require.True(t, ok)
+
+	// Leaf component should have attributes
+	exporterKey := toComponentKey(traces.ExporterID)
+	leafStatus := st.ComponentStatusMap[tracesKey].ComponentStatusMap[exporterKey]
+	require.NotNil(t, leafStatus)
+	assert.Equal(t, "connection refused", leafStatus.Event.Attributes().AsRaw()["error_msg"])
+
+	// Components without attributes should have empty attributes
+	receiverKey := toComponentKey(traces.ReceiverID)
+	receiverStatus := st.ComponentStatusMap[tracesKey].ComponentStatusMap[receiverKey]
+	require.NotNil(t, receiverStatus)
+	assert.Equal(t, 0, receiverStatus.Event.Attributes().Len())
+}
+
+func TestAggregateStatusSyntheticEventHasNoAttributes(t *testing.T) {
+	agg := status.NewAggregator(status.PriorityPermanent)
+	traces := testhelpers.NewPipelineMetadata(pipeline.SignalTraces)
+	tracesKey := toPipelineKey(traces.PipelineID)
+
+	// Seed with StatusOK for all components
+	testhelpers.SeedAggregator(agg, traces.InstanceIDs(), componentstatus.StatusOK)
+
+	// Move one component to StatusStopping — this forces a synthetic event at the
+	// pipeline level (mixed OK + Stopping = aggregate Stopping via synthetic event)
+	agg.RecordStatus(
+		traces.ReceiverID,
+		componentstatus.NewEvent(componentstatus.StatusStopping),
+	)
+
+	st, ok := agg.AggregateStatus(status.ScopeAll, status.Verbose)
+	require.True(t, ok)
+
+	// Pipeline-level status is a synthetic event and should have empty attributes
+	pipelineStatus := st.ComponentStatusMap[tracesKey]
+	assert.Equal(t, componentstatus.StatusStopping, pipelineStatus.Status())
+	assert.Equal(t, 0, pipelineStatus.Event.Attributes().Len())
 }

--- a/pkg/status/go.mod
+++ b/pkg/status/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.52.1-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/component/componentstatus v0.146.2-0.20260219223409-66996adfaaf7
+	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7
 	go.opentelemetry.io/collector/pipeline v1.52.1-0.20260219223409-66996adfaaf7
 	go.uber.org/goleak v1.3.0
 )
@@ -19,7 +20,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.52.1-0.20260219223409-66996adfaaf7 // indirect
-	go.opentelemetry.io/collector/pdata v1.52.1-0.20260219223409-66996adfaaf7 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

https://github.com/open-telemetry/opentelemetry-collector/pull/13348 added attributes to the status events. This exposes those attributes over the HTTP interface for the `healthcheck` extension.

This only keeps the attributes on the leaf nodes, it does not propagate the attributes up the status aggregator because it didn't seem like it should conflate the overall status of a group of components with attributes that are not for the whole group.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #43606

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Add tests for serialization and that attributes are only on leaf nodes.

<!--Describe the documentation added.-->
#### Documentation

Added to the documentation showing an example of the attributes in the output.
