### PR TITLE
[chore][receiver/elasticsearch] Fix integration tests

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -156,7 +156,7 @@ INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES),$(shell cat $(INTEGRATION_TE
 mod-integration-test:
 	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"
 	@if [ -n "$(INTEGRATION_TESTS)" ]; then \
-		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -v -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
+		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
 	else \
         echo "No integration tests in `pwd`"; \
 	fi

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -35,7 +35,7 @@ GOTEST_OPT?=$(GOTEST_RACE_OPT) -timeout $(GOTEST_TIMEOUT) -parallel 4 --tags=$(G
 GOTEST_INTEGRATION_OPT?=$(GOTEST_RACE_OPT) -timeout 360s -parallel 4 -skip Sudo
 GOTEST_INTEGRATION_OPT_SUDO?=$(GOTEST_RACE_OPT) -timeout 360s -parallel 4 -exec sudo -run Sudo
 COVER_OPT :=-cover -covermode=atomic -test.gocoverdir="$(COVER_DIR_ABS)"
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS)
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_INTEGRATION_SUDO=$(GOTEST_INTEGRATION_OPT_SUDO) -tags=integration,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_INTEGRATION_COVERAGE=$(GOTEST_OPT_WITH_INTEGRATION) -coverprofile=integration-coverage.txt -covermode=atomic
 
@@ -156,7 +156,7 @@ INTEGRATION_TESTS := $(if $(INTEGRATION_TEST_FILES),$(shell cat $(INTEGRATION_TE
 mod-integration-test:
 	@echo "running $(GOCMD) integration test $(INTEGRATION_TESTS) in `pwd`"
 	@if [ -n "$(INTEGRATION_TESTS)" ]; then \
-		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
+		$(GOTESTSUM) $(GOTESTSUM_OPT) --packages="./..." -- -v -run "$(INTEGRATION_TESTS)" $(GOTEST_OPT_WITH_INTEGRATION); \
 	else \
         echo "No integration tests in `pwd`"; \
 	fi

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -35,7 +35,7 @@ GOTEST_OPT?=$(GOTEST_RACE_OPT) -timeout $(GOTEST_TIMEOUT) -parallel 4 --tags=$(G
 GOTEST_INTEGRATION_OPT?=$(GOTEST_RACE_OPT) -timeout 360s -parallel 4 -skip Sudo
 GOTEST_INTEGRATION_OPT_SUDO?=$(GOTEST_RACE_OPT) -timeout 360s -parallel 4 -exec sudo -run Sudo
 COVER_OPT :=-cover -covermode=atomic -test.gocoverdir="$(COVER_DIR_ABS)"
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS)
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_INTEGRATION_SUDO=$(GOTEST_INTEGRATION_OPT_SUDO) -tags=integration,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_INTEGRATION_COVERAGE=$(GOTEST_OPT_WITH_INTEGRATION) -coverprofile=integration-coverage.txt -covermode=atomic
 

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -23,7 +23,7 @@ const elasticPort = "9200"
 
 func TestIntegration(t *testing.T) {
 	t.Run("7.9.3", integrationTest("7.9.3", "7_9_3"))
-	t.Run("7.16.3", integrationTest("7.16.3", "7_16_3"))
+	t.Run("7.17.26", integrationTest("7.17.26", "7_17_26"))
 }
 
 func integrationTest(version, name string) func(*testing.T) {

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -22,24 +22,23 @@ import (
 const elasticPort = "9200"
 
 func TestIntegration(t *testing.T) {
-	t.Skip("to be re-enabled after switching to IPv6")
-	t.Run("7.9.3", integrationTest("7_9_3"))
-	t.Run("7.16.3", integrationTest("7_16_3"))
+	t.Run("7.9.3", integrationTest("7.9.3", "7_9_3"))
+	t.Run("7.16.3", integrationTest("7.16.3", "7_16_3"))
 }
 
-func integrationTest(name string) func(*testing.T) {
-	dockerFile := fmt.Sprintf("Dockerfile.elasticsearch.%s", name)
+func integrationTest(version, name string) func(*testing.T) {
 	expectedFile := fmt.Sprintf("expected.%s.yaml", name)
 	return scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(
 			testcontainers.ContainerRequest{
-				FromDockerfile: testcontainers.FromDockerfile{
-					Context:    filepath.Join("testdata", "integration"),
-					Dockerfile: dockerFile,
-				},
+				Image:        fmt.Sprintf("docker.elastic.co/elasticsearch/elasticsearch:%s", version),
 				ExposedPorts: []string{elasticPort},
-				WaitingFor:   wait.ForListeningPort(elasticPort).WithStartupTimeout(2 * time.Minute),
+				Env: map[string]string{
+					"discovery.type": "single-node",
+					"ES_JAVA_OPTS":   "-Xms512m -Xmx512m",
+				},
+				WaitingFor: wait.ForListeningPort(elasticPort).WithStartupTimeout(2 * time.Minute),
 			}),
 		scraperinttest.WithCustomConfig(
 			func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {

--- a/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3
+++ b/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3
@@ -1,7 +1,0 @@
-FROM elasticsearch:7.16.3
-
-ENV discovery.type=single-node
-
-ENV ES_JAVA_OPTS='-Xms512m -Xmx512m'
-
-EXPOSE 9200

--- a/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_9_3
+++ b/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_9_3
@@ -1,7 +1,0 @@
-FROM elasticsearch:7.9.3
-
-ENV discovery.type=single-node
-
-ENV ES_JAVA_OPTS='-Xms512m -Xmx512m'
-
-EXPOSE 9200

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
@@ -2311,16 +2311,6 @@ resourceMetrics:
                         stringValue: completed
                     - key: thread_pool_name
                       value:
-                        stringValue: rollup_indexing
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: completed
-                    - key: thread_pool_name
-                      value:
                         stringValue: search
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -2651,16 +2641,6 @@ resourceMetrics:
                         stringValue: rejected
                     - key: thread_pool_name
                       value:
-                        stringValue: rollup_indexing
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: rejected
-                    - key: thread_pool_name
-                      value:
                         stringValue: search
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -2950,13 +2930,6 @@ resourceMetrics:
                   attributes:
                     - key: thread_pool_name
                       value:
-                        stringValue: rollup_indexing
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
                         stringValue: search
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
@@ -3233,16 +3206,6 @@ resourceMetrics:
                     - key: thread_pool_name
                       value:
                         stringValue: refresh
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -3573,16 +3536,6 @@ resourceMetrics:
                     - key: thread_pool_name
                       value:
                         stringValue: refresh
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: idle
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
@@ -1214,7 +1214,7 @@ resourceMetrics:
             stringValue: 8e63c4f981ab
         - key: elasticsearch.node.version
           value:
-            stringValue: 7.16.3
+            stringValue: 7.17.26
     scopeMetrics:
       - metrics:
           - description: Estimated memory used for the operation.

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_17_26.yaml
@@ -2441,7 +2441,7 @@ resourceMetrics:
                         stringValue: completed
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
+                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -2771,7 +2771,7 @@ resourceMetrics:
                         stringValue: rejected
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
+                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -3021,7 +3021,7 @@ resourceMetrics:
                   attributes:
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
+                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -3345,7 +3345,7 @@ resourceMetrics:
                         stringValue: active
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
+                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -3675,7 +3675,7 @@ resourceMetrics:
                         stringValue: idle
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
+                        stringValue: rollup_indexing
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR fixes the Elasticsearch receiver integration tests by avoiding building the images and directly using the official Elasticsearch images.

The build was only used to set environment variables, and that seems a bit over-engineering since we can set the environment variables needed into `testcontainers`.

The issue was not caused by IPv6 support but a JDK bug in the version packed with 7.16.3 of elasticsearch container.

See: https://bugs.java.com/bugdatabase/JDK-8287073 and https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/22437660442/job/64971691111?pr=46456

```sh
=== FAIL: . TestIntegration/7.16.3 (91.70s)
2026/02/26 10:21:39 No image auth found for docker.elastic.co. Setting empty credentials for the image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3. This is expected for public images. Details: credentials not found in native keychain
2026/02/26 10:21:51 🐳 Creating container for image docker.elastic.co/elasticsearch/elasticsearch:7.16.3
2026/02/26 10:21:51 🐳 Stopping container: 6f682f2a53e1
2026/02/26 10:21:51 🐳 Terminating container: 6f682f2a53e1
2026/02/26 10:21:51 🚫 Container terminated: 6f682f2a53e1
2026/02/26 10:21:51 🐳 Creating container for image testcontainers/ryuk:0.13.0
2026/02/26 10:21:51 ✅ Container created: e6f4e6199511
2026/02/26 10:21:51 🐳 Starting container: e6f4e6199511
2026/02/26 10:21:51 ✅ Container started: e6f4e6199511
2026/02/26 10:21:51 ⏳ Waiting for container id e6f4e6199511 image: testcontainers/ryuk:0.13.0. Waiting for: port 8080/tcp to be listening
2026/02/26 10:21:51 Shell not found in container
2026/02/26 10:21:51 🔔 Container is ready: e6f4e6199511
2026/02/26 10:21:51 ✅ Container created: e97582c0c2c2
2026/02/26 10:21:51 🐳 Starting container: e97582c0c2c2
2026/02/26 10:21:51 ✅ Container started: e97582c0c2c2
2026/02/26 10:21:51 ⏳ Waiting for container id e97582c0c2c2 image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3. Waiting for: port 9200 to be listening
2026/02/26 10:21:52 container logs (wait until ready: internal check: container exited with code 1):
2026-02-26 10:21:52,649 main ERROR Could not reconfigure JMX java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
	at java.management/java.lang.management.ManagementFactory.lambda$getPlatformMBeanServer$0(ManagementFactory.java:488)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.HashMap$ValueSpliterator.forEachRemaining(HashMap.java:1779)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at java.management/java.lang.management.ManagementFactory.getPlatformMBeanServer(ManagementFactory.java:489)
	at org.apache.logging.log4j.core.jmx.Server.reregisterMBeansAfterReconfigure(Server.java:140)
	at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:637)
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:302)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:209)
	at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:243)
	at org.apache.logging.log4j.core.config.Configurator.initialize(Configurator.java:219)
	at org.elasticsearch.common.logging.LogConfigurator.configureStatusLogger(LogConfigurator.java:251)
	at org.elasticsearch.common.logging.LogConfigurator.configureWithoutConfig(LogConfigurator.java:95)
	at org.elasticsearch.cli.CommandLoggingConfigurator.configureLoggingWithoutConfig(CommandLoggingConfigurator.java:29)
	at org.elasticsearch.cli.Command.main(Command.java:74)
	at org.elasticsearch.common.settings.KeyStoreCli.main(KeyStoreCli.java:33)
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:81)
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:113)
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:167)
	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:687)
	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:389)
	at org.elasticsearch.tools.launchers.DefaultSystemMemoryInfo.<init>(DefaultSystemMemoryInfo.java:29)
	at org.elasticsearch.tools.launchers.JvmOptionsParser.jvmOptions(JvmOptionsParser.java:125)
	at org.elasticsearch.tools.launchers.JvmOptionsParser.main(JvmOptionsParser.java:86)
2026/02/26 10:21:52 🐳 Creating container for image docker.elastic.co/elasticsearch/elasticsearch:7.16.3
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #46084
