### PR TITLE
[receiver/journald] add config for journal output format

### DIFF
--- a/.chloggen/journald-output-format-json-seq.yaml
+++ b/.chloggen/journald-output-format-json-seq.yaml
@@ -1,0 +1,36 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: receiver/journald
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `output_format` config option to select between `json` (default) and `json-seq` journalctl output formats
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Setting `output_format: json-seq` instructs journalctl to use the RFC 7464 JSON Text Sequences
+  format, where each record is prefixed with an ASCII Record Separator character (0x1E). This avoids
+  parsing failures that can occur when journal field values contain literal newlines, such as the
+  `_SELINUX_CONTEXT` field on some systems.
+
+  Example configuration:
+    receivers:
+      journald:
+        output_format: json-seq
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/journald-output-format-json-seq.yaml
+++ b/.chloggen/journald-output-format-json-seq.yaml
@@ -10,7 +10,7 @@ component: receiver/journald
 note: Add `output_format` config option to select between `json` (default) and `json-seq` journalctl output formats
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [46460]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/stanza/operator/input/journald/config.schema.yaml
+++ b/pkg/stanza/operator/input/journald/config.schema.yaml
@@ -32,6 +32,8 @@ $defs:
         type: boolean
       namespace:
         type: string
+      output_format:
+        type: string
       priority:
         type: string
       root_path:

--- a/pkg/stanza/operator/input/journald/config_all.go
+++ b/pkg/stanza/operator/input/journald/config_all.go
@@ -9,6 +9,14 @@ import (
 
 const operatorType = "journald_input"
 
+// OutputFormatJSON is the default journalctl JSON output format.
+const OutputFormatJSON = "json"
+
+// OutputFormatJSONSeq is the RFC 7464 JSON Text Sequences output format.
+// Each record is prefixed with an ASCII Record Separator (0x1E) character,
+// which avoids issues with field values that contain literal newlines.
+const OutputFormatJSONSeq = "json-seq"
+
 // NewConfig creates a new input config with default values
 func NewConfig() *Config {
 	return NewConfigWithID(operatorType)
@@ -21,6 +29,7 @@ func NewConfigWithID(operatorID string) *Config {
 		StartAt:        "end",
 		Priority:       "info",
 		JournalctlPath: "journalctl",
+		OutputFormat:   OutputFormatJSON,
 	}
 }
 
@@ -43,6 +52,7 @@ type Config struct {
 	Namespace           string        `mapstructure:"namespace,omitempty"`
 	ConvertMessageBytes bool          `mapstructure:"convert_message_bytes,omitempty"`
 	Merge               bool          `mapstructure:"merge,omitempty"`
+	OutputFormat        string        `mapstructure:"output_format,omitempty"`
 }
 
 type MatchConfig map[string]string

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -50,6 +50,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		InputOperator:       inputOperator,
 		newCmd:              newCmdFunc,
 		convertMessageBytes: c.ConvertMessageBytes,
+		outputFormat:        c.OutputFormat,
 	}, nil
 }
 
@@ -81,6 +82,12 @@ func (c Config) validate() error {
 		return errors.New("'journalctl_path' must be non-whitespace")
 	}
 
+	switch c.OutputFormat {
+	case OutputFormatJSON, OutputFormatJSONSeq:
+	default:
+		return fmt.Errorf("invalid value '%s' for parameter 'output_format', must be '%s' or '%s'", c.OutputFormat, OutputFormatJSON, OutputFormatJSONSeq)
+	}
+
 	return nil
 }
 
@@ -88,9 +95,9 @@ func (c Config) buildArgs() ([]string, error) {
 	args := make([]string, 0, 10)
 
 	args = append(args,
-		"--utc",         // Export logs in UTC time
-		"--output=json", // Export logs as JSON
-		"--follow",      // Continue watching logs until cancelled
+		"--utc",                             // Export logs in UTC time
+		"--output="+c.OutputFormat,          // Export logs as JSON or JSON-seq
+		"--follow",                          // Continue watching logs until cancelled
 	)
 
 	if c.StartAt == "beginning" {

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -92,12 +92,18 @@ func (c Config) validate() error {
 }
 
 func (c Config) buildArgs() ([]string, error) {
+	switch c.OutputFormat {
+	case OutputFormatJSON, OutputFormatJSONSeq:
+	default:
+		return nil, fmt.Errorf("invalid value '%s' for parameter 'output_format', must be '%s' or '%s'", c.OutputFormat, OutputFormatJSON, OutputFormatJSONSeq)
+	}
+
 	args := make([]string, 0, 10)
 
 	args = append(args,
-		"--utc",                             // Export logs in UTC time
-		"--output="+c.OutputFormat,          // Export logs as JSON or JSON-seq
-		"--follow",                          // Continue watching logs until cancelled
+		"--utc",                    // Export logs in UTC time
+		"--output="+c.OutputFormat, // Export logs as JSON or JSON-seq
+		"--follow",                 // Continue watching logs until cancelled
 	)
 
 	if c.StartAt == "beginning" {

--- a/pkg/stanza/operator/input/journald/input.go
+++ b/pkg/stanza/operator/input/journald/input.go
@@ -7,6 +7,7 @@ package journald // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -32,6 +33,7 @@ type Input struct {
 
 	persister           operator.Persister
 	convertMessageBytes bool
+	outputFormat        string
 	cancel              context.CancelFunc
 	wg                  sync.WaitGroup
 	errChan             chan error
@@ -169,25 +171,60 @@ func (operator *Input) runJournalctl(ctx context.Context, jctl *journalctl) erro
 	operator.wg.Go(func() {
 		stdoutBuf := bufio.NewReader(jctl.stdout)
 
-		for {
-			line, err := stdoutBuf.ReadBytes('\n')
-			if err != nil {
-				if !errors.Is(err, io.EOF) {
-					operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
+		if operator.outputFormat == OutputFormatJSONSeq {
+			// json-seq format (RFC 7464): records are delimited by ASCII Record
+			// Separator (RS, 0x1E) characters rather than newlines. Reading until
+			// the next RS correctly handles field values that contain literal
+			// newline bytes, which would otherwise break newline-delimited parsing.
+			for {
+				chunk, err := stdoutBuf.ReadBytes(0x1e)
+				// Strip the trailing RS delimiter and surrounding whitespace so
+				// we can parse the JSON. Do this before the error check so that
+				// the last record at EOF (which has no trailing RS) is also handled.
+				if len(chunk) > 0 && chunk[len(chunk)-1] == 0x1e {
+					chunk = chunk[:len(chunk)-1]
 				}
-				return
+				line := bytes.TrimSpace(chunk)
+				if len(line) > 0 {
+					entry, cursor, parseErr := operator.parseJournalEntry(line)
+					if parseErr != nil {
+						operator.Logger().Warn("Failed to parse journal entry", zap.Error(parseErr))
+					} else {
+						if setErr := operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); setErr != nil {
+							operator.Logger().Warn("Failed to set offset", zap.Error(setErr))
+						}
+						if writeErr := operator.Write(ctx, entry); writeErr != nil {
+							operator.Logger().Error("failed to write entry", zap.Error(writeErr))
+						}
+					}
+				}
+				if err != nil {
+					if !errors.Is(err, io.EOF) {
+						operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
+					}
+					return
+				}
 			}
-
-			entry, cursor, err := operator.parseJournalEntry(line)
-			if err != nil {
-				operator.Logger().Warn("Failed to parse journal entry", zap.Error(err))
-				continue
-			}
-			if err = operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); err != nil {
-				operator.Logger().Warn("Failed to set offset", zap.Error(err))
-			}
-			if err = operator.Write(ctx, entry); err != nil {
-				operator.Logger().Error("failed to write entry", zap.Error(err))
+		} else {
+			for {
+				line, err := stdoutBuf.ReadBytes('\n')
+				if err != nil {
+					if !errors.Is(err, io.EOF) {
+						operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
+					}
+					return
+				}
+				entry, cursor, err := operator.parseJournalEntry(line)
+				if err != nil {
+					operator.Logger().Warn("Failed to parse journal entry", zap.Error(err))
+					continue
+				}
+				if err = operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); err != nil {
+					operator.Logger().Warn("Failed to set offset", zap.Error(err))
+				}
+				if err = operator.Write(ctx, entry); err != nil {
+					operator.Logger().Error("failed to write entry", zap.Error(err))
+				}
 			}
 		}
 	})

--- a/pkg/stanza/operator/input/journald/input.go
+++ b/pkg/stanza/operator/input/journald/input.go
@@ -171,60 +171,51 @@ func (operator *Input) runJournalctl(ctx context.Context, jctl *journalctl) erro
 	operator.wg.Go(func() {
 		stdoutBuf := bufio.NewReader(jctl.stdout)
 
+		// readNextLine returns the next log record as a trimmed byte slice.
+		// For json-seq (RFC 7464), records are delimited by ASCII Record Separator
+		// (0x1E) rather than newlines, which allows field values to contain literal
+		// newline bytes. The last record at EOF has no trailing RS, so we process
+		// the chunk before returning the error. For newline-delimited output, a
+		// partial last line at EOF is discarded (it cannot be a valid JSON object).
+		var readNextLine func() ([]byte, error)
 		if operator.outputFormat == OutputFormatJSONSeq {
-			// json-seq format (RFC 7464): records are delimited by ASCII Record
-			// Separator (RS, 0x1E) characters rather than newlines. Reading until
-			// the next RS correctly handles field values that contain literal
-			// newline bytes, which would otherwise break newline-delimited parsing.
-			for {
+			readNextLine = func() ([]byte, error) {
 				chunk, err := stdoutBuf.ReadBytes(0x1e)
-				// Strip the trailing RS delimiter and surrounding whitespace so
-				// we can parse the JSON. Do this before the error check so that
-				// the last record at EOF (which has no trailing RS) is also handled.
 				if len(chunk) > 0 && chunk[len(chunk)-1] == 0x1e {
 					chunk = chunk[:len(chunk)-1]
 				}
-				line := bytes.TrimSpace(chunk)
-				if len(line) > 0 {
-					entry, cursor, parseErr := operator.parseJournalEntry(line)
-					if parseErr != nil {
-						operator.Logger().Warn("Failed to parse journal entry", zap.Error(parseErr))
-					} else {
-						if setErr := operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); setErr != nil {
-							operator.Logger().Warn("Failed to set offset", zap.Error(setErr))
-						}
-						if writeErr := operator.Write(ctx, entry); writeErr != nil {
-							operator.Logger().Error("failed to write entry", zap.Error(writeErr))
-						}
-					}
-				}
-				if err != nil {
-					if !errors.Is(err, io.EOF) {
-						operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
-					}
-					return
-				}
+				return bytes.TrimSpace(chunk), err
 			}
 		} else {
-			for {
+			readNextLine = func() ([]byte, error) {
 				line, err := stdoutBuf.ReadBytes('\n')
-				if err != nil {
-					if !errors.Is(err, io.EOF) {
-						operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
+				if errors.Is(err, io.EOF) {
+					return nil, err
+				}
+				return line, err
+			}
+		}
+
+		for {
+			line, err := readNextLine()
+			if len(line) > 0 {
+				entry, cursor, parseErr := operator.parseJournalEntry(line)
+				if parseErr != nil {
+					operator.Logger().Warn("Failed to parse journal entry", zap.Error(parseErr))
+				} else {
+					if setErr := operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); setErr != nil {
+						operator.Logger().Warn("Failed to set offset", zap.Error(setErr))
 					}
-					return
+					if writeErr := operator.Write(ctx, entry); writeErr != nil {
+						operator.Logger().Error("failed to write entry", zap.Error(writeErr))
+					}
 				}
-				entry, cursor, err := operator.parseJournalEntry(line)
-				if err != nil {
-					operator.Logger().Warn("Failed to parse journal entry", zap.Error(err))
-					continue
+			}
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
 				}
-				if err = operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); err != nil {
-					operator.Logger().Warn("Failed to set offset", zap.Error(err))
-				}
-				if err = operator.Write(ctx, entry); err != nil {
-					operator.Logger().Error("failed to write entry", zap.Error(err))
-				}
+				return
 			}
 		}
 	})

--- a/pkg/stanza/operator/input/journald/input_test.go
+++ b/pkg/stanza/operator/input/journald/input_test.go
@@ -28,175 +28,113 @@ import (
 const journaldTestResponse = `{ "_BOOT_ID": "c4fa36de06824d21835c05ff80c54468", "_CAP_EFFECTIVE": "0", "_TRANSPORT": "journal", "_UID": "1000", "_EXE": "/usr/lib/systemd/systemd", "_AUDIT_LOGINUID": "1000", "MESSAGE": "run-docker-netns-4f76d707d45f.mount: Succeeded.", "_PID": "13894", "_CMDLINE": "/lib/systemd/systemd --user", "_MACHINE_ID": "d777d00e7caf45fbadedceba3975520d", "_SELINUX_CONTEXT": "unconfined\n", "CODE_FUNC": "unit_log_success", "SYSLOG_IDENTIFIER": "systemd", "_HOSTNAME": "myhostname", "MESSAGE_ID": "7ad2d189f7e94e70a38c781354912448", "_SYSTEMD_CGROUP": "/user.slice/user-1000.slice/user@1000.service/init.scope", "_SOURCE_REALTIME_TIMESTAMP": "1587047866229317", "USER_UNIT": "run-docker-netns-4f76d707d45f.mount", "SYSLOG_FACILITY": "3", "_SYSTEMD_SLICE": "user-1000.slice", "_AUDIT_SESSION": "286", "CODE_FILE": "../src/core/unit.c", "_SYSTEMD_USER_UNIT": "init.scope", "_COMM": "systemd", "USER_INVOCATION_ID": "88f7ca6bbf244dc8828fa901f9fe9be1", "CODE_LINE": "5487", "_SYSTEMD_INVOCATION_ID": "83f7fc7799064520b26eb6de1630429c", "PRIORITY": "6", "_GID": "1000", "__REALTIME_TIMESTAMP": "1587047866229555", "_SYSTEMD_UNIT": "user@1000.service", "_SYSTEMD_USER_SLICE": "-.slice", "__CURSOR": "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36", "__MONOTONIC_TIMESTAMP": "685540311557", "_SYSTEMD_OWNER_UID": "1000" }
 `
 
+// fakeJournaldCmd replaces the real journalctl command in tests.
 type fakeJournaldCmd struct {
-	startError error
-	exitError  *exec.ExitError
-	stdErr     string
+	startError    error
+	exitError     *exec.ExitError
+	stdErr        string
+	stdoutContent string
 }
 
-func (f *fakeJournaldCmd) Start() error {
-	return f.startError
-}
+func (f *fakeJournaldCmd) Start() error { return f.startError }
 
-func (*fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
-	reader := bytes.NewReader([]byte(journaldTestResponse))
-	return io.NopCloser(reader), nil
+func (f *fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte(f.stdoutContent))), nil
 }
 
 func (f *fakeJournaldCmd) StderrPipe() (io.ReadCloser, error) {
-	reader := bytes.NewReader([]byte(f.stdErr))
-	return io.NopCloser(reader), nil
+	return io.NopCloser(bytes.NewReader([]byte(f.stdErr))), nil
 }
 
 func (f *fakeJournaldCmd) Wait() error {
-	if f.exitError == nil {
-		return nil
+	if f.exitError != nil {
+		return f.exitError
 	}
-
-	return f.exitError
+	return nil
 }
 
-type fakeJournaldCmdJSONSeq struct {
-	fakeJournaldCmd
-}
-
-func (*fakeJournaldCmdJSONSeq) StdoutPipe() (io.ReadCloser, error) {
-	// Prefix the record with the RFC 7464 Record Separator (0x1E)
-	response := "\x1e" + journaldTestResponse
-	reader := bytes.NewReader([]byte(response))
-	return io.NopCloser(reader), nil
-}
-
-type fakeJournaldCmdJSONSeqWithNewline struct {
-	fakeJournaldCmd
-}
-
-func (*fakeJournaldCmdJSONSeqWithNewline) StdoutPipe() (io.ReadCloser, error) {
-	// First record: a JSON entry where the _SELINUX_CONTEXT field contains a
-	// literal (unescaped) newline byte, as can happen with some journald versions.
-	// With newline-based reading this would be split into two unparseable fragments.
-	// With RS-based reading the full record is read as one unit. The JSON is
-	// structurally incomplete (no closing brace), so parsing fails and a warning
-	// is logged. The second valid record must still be received.
-	invalidEntry := "\x1e{ \"_SELINUX_CONTEXT\": \"unconfined\n\"\n"
-	// Second record: a well-formed json-seq entry.
-	validEntry := "\x1e" + journaldTestResponse
-	reader := bytes.NewReader([]byte(invalidEntry + validEntry))
-	return io.NopCloser(reader), nil
-}
-
-type fakeJournaldCmdJSONWithNewline struct {
-	fakeJournaldCmd
-}
-
-func (*fakeJournaldCmdJSONWithNewline) StdoutPipe() (io.ReadCloser, error) {
-	// Entry where _SELINUX_CONTEXT contains a literal (unescaped) newline byte.
-	// In plain json format, ReadBytes('\n') splits this at the embedded newline,
-	// producing two fragments that both fail to parse. The entry is lost.
-	// A second valid entry follows to confirm processing continues.
-	invalidEntry := "{ \"_SELINUX_CONTEXT\": \"unconfined\n\", \"__REALTIME_TIMESTAMP\": \"1587047866229555\", \"__CURSOR\": \"cursor-invalid\" }\n"
-	validEntry := journaldTestResponse
-	reader := bytes.NewReader([]byte(invalidEntry + validEntry))
-	return io.NopCloser(reader), nil
-}
-
-func TestInputJournald(t *testing.T) {
+// startInputOp builds and starts a journald input operator for testing.
+// It returns a channel that receives processed entries and registers a cleanup
+// to stop the operator at the end of the test.
+func startInputOp(t *testing.T, mutateCfg func(*Config), newCmdFn func(context.Context, []byte) cmd) <-chan *entry.Entry {
+	t.Helper()
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
+	mutateCfg(cfg)
 
-	set := componenttest.NewNopTelemetrySettings()
-	op, err := cfg.Build(set)
+	op, err := cfg.Build(componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
-	mockOutput := testutil.NewMockOperator("output")
 	received := make(chan *entry.Entry)
+	mockOutput := testutil.NewMockOperator("output")
 	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		received <- args.Get(1).(*entry.Entry)
 	}).Return(nil)
 
-	err = op.SetOutputs([]operator.Operator{mockOutput})
-	require.NoError(t, err)
-
-	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
-		return &fakeJournaldCmd{}
-	}
+	require.NoError(t, op.SetOutputs([]operator.Operator{mockOutput}))
+	op.(*Input).newCmd = newCmdFn
 
 	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
-	defer func() {
-		require.NoError(t, op.Stop())
-	}()
+	t.Cleanup(func() { require.NoError(t, op.Stop()) })
 
-	expected := map[string]any{
-		"_BOOT_ID":                   "c4fa36de06824d21835c05ff80c54468",
-		"_CAP_EFFECTIVE":             "0",
-		"_TRANSPORT":                 "journal",
-		"_UID":                       "1000",
-		"_EXE":                       "/usr/lib/systemd/systemd",
-		"_AUDIT_LOGINUID":            "1000",
-		"MESSAGE":                    "run-docker-netns-4f76d707d45f.mount: Succeeded.",
-		"_PID":                       "13894",
-		"_CMDLINE":                   "/lib/systemd/systemd --user",
-		"_MACHINE_ID":                "d777d00e7caf45fbadedceba3975520d",
-		"_SELINUX_CONTEXT":           "unconfined\n",
-		"CODE_FUNC":                  "unit_log_success",
-		"SYSLOG_IDENTIFIER":          "systemd",
-		"_HOSTNAME":                  "myhostname",
-		"MESSAGE_ID":                 "7ad2d189f7e94e70a38c781354912448",
-		"_SYSTEMD_CGROUP":            "/user.slice/user-1000.slice/user@1000.service/init.scope",
-		"_SOURCE_REALTIME_TIMESTAMP": "1587047866229317",
-		"USER_UNIT":                  "run-docker-netns-4f76d707d45f.mount",
-		"SYSLOG_FACILITY":            "3",
-		"_SYSTEMD_SLICE":             "user-1000.slice",
-		"_AUDIT_SESSION":             "286",
-		"CODE_FILE":                  "../src/core/unit.c",
-		"_SYSTEMD_USER_UNIT":         "init.scope",
-		"_COMM":                      "systemd",
-		"USER_INVOCATION_ID":         "88f7ca6bbf244dc8828fa901f9fe9be1",
-		"CODE_LINE":                  "5487",
-		"_SYSTEMD_INVOCATION_ID":     "83f7fc7799064520b26eb6de1630429c",
-		"PRIORITY":                   "6",
-		"_GID":                       "1000",
-		"_SYSTEMD_UNIT":              "user@1000.service",
-		"_SYSTEMD_USER_SLICE":        "-.slice",
-		"__CURSOR":                   "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36",
-		"__MONOTONIC_TIMESTAMP":      "685540311557",
-		"_SYSTEMD_OWNER_UID":         "1000",
-	}
+	return received
+}
+
+func TestInputJournald(t *testing.T) {
+	received := startInputOp(t, func(*Config) {}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: journaldTestResponse}
+	})
 
 	select {
 	case e := <-received:
-		require.Equal(t, expected, e.Body)
+		require.Equal(t, map[string]any{
+			"_BOOT_ID":                   "c4fa36de06824d21835c05ff80c54468",
+			"_CAP_EFFECTIVE":             "0",
+			"_TRANSPORT":                 "journal",
+			"_UID":                       "1000",
+			"_EXE":                       "/usr/lib/systemd/systemd",
+			"_AUDIT_LOGINUID":            "1000",
+			"MESSAGE":                    "run-docker-netns-4f76d707d45f.mount: Succeeded.",
+			"_PID":                       "13894",
+			"_CMDLINE":                   "/lib/systemd/systemd --user",
+			"_MACHINE_ID":                "d777d00e7caf45fbadedceba3975520d",
+			"_SELINUX_CONTEXT":           "unconfined\n",
+			"CODE_FUNC":                  "unit_log_success",
+			"SYSLOG_IDENTIFIER":          "systemd",
+			"_HOSTNAME":                  "myhostname",
+			"MESSAGE_ID":                 "7ad2d189f7e94e70a38c781354912448",
+			"_SYSTEMD_CGROUP":            "/user.slice/user-1000.slice/user@1000.service/init.scope",
+			"_SOURCE_REALTIME_TIMESTAMP": "1587047866229317",
+			"USER_UNIT":                  "run-docker-netns-4f76d707d45f.mount",
+			"SYSLOG_FACILITY":            "3",
+			"_SYSTEMD_SLICE":             "user-1000.slice",
+			"_AUDIT_SESSION":             "286",
+			"CODE_FILE":                  "../src/core/unit.c",
+			"_SYSTEMD_USER_UNIT":         "init.scope",
+			"_COMM":                      "systemd",
+			"USER_INVOCATION_ID":         "88f7ca6bbf244dc8828fa901f9fe9be1",
+			"CODE_LINE":                  "5487",
+			"_SYSTEMD_INVOCATION_ID":     "83f7fc7799064520b26eb6de1630429c",
+			"PRIORITY":                   "6",
+			"_GID":                       "1000",
+			"_SYSTEMD_UNIT":              "user@1000.service",
+			"_SYSTEMD_USER_SLICE":        "-.slice",
+			"__CURSOR":                   "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36",
+			"__MONOTONIC_TIMESTAMP":      "685540311557",
+			"_SYSTEMD_OWNER_UID":         "1000",
+		}, e.Body)
 	case <-time.After(time.Second):
 		require.FailNow(t, "Timed out waiting for entry to be read")
 	}
 }
 
 func TestInputJournaldJSONSeq(t *testing.T) {
-	cfg := NewConfigWithID("my_journald_input")
-	cfg.OutputIDs = []string{"output"}
-	cfg.OutputFormat = OutputFormatJSONSeq
-
-	set := componenttest.NewNopTelemetrySettings()
-	op, err := cfg.Build(set)
-	require.NoError(t, err)
-
-	mockOutput := testutil.NewMockOperator("output")
-	received := make(chan *entry.Entry)
-	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		received <- args.Get(1).(*entry.Entry)
-	}).Return(nil)
-
-	err = op.SetOutputs([]operator.Operator{mockOutput})
-	require.NoError(t, err)
-
-	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
-		return &fakeJournaldCmdJSONSeq{}
-	}
-
-	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
-	defer func() {
-		require.NoError(t, op.Stop())
-	}()
+	received := startInputOp(t, func(cfg *Config) {
+		cfg.OutputFormat = OutputFormatJSONSeq
+	}, func(_ context.Context, _ []byte) cmd {
+		// Prefix the record with the RFC 7464 Record Separator (0x1E).
+		return &fakeJournaldCmd{stdoutContent: "\x1e" + journaldTestResponse}
+	})
 
 	select {
 	case e := <-received:
@@ -210,37 +148,45 @@ func TestInputJournaldJSONSeq(t *testing.T) {
 	}
 }
 
-func TestInputJournaldJSONSeqEmbeddedNewline(t *testing.T) {
-	cfg := NewConfigWithID("my_journald_input")
-	cfg.OutputIDs = []string{"output"}
-	cfg.OutputFormat = OutputFormatJSONSeq
+// embeddedNewlineInvalidEntry is a json-seq record whose JSON string value contains a
+// literal (unescaped) newline byte, making it invalid JSON. The RS-based reader reads
+// the full record as one unit, but parsing fails.
+const embeddedNewlineInvalidEntryJSONSeq = "\x1e{ \"_SELINUX_CONTEXT\": \"unconfined\n\"\n"
 
-	set := componenttest.NewNopTelemetrySettings()
-	op, err := cfg.Build(set)
-	require.NoError(t, err)
+// embeddedNewlineInvalidEntryJSON is the same broken content without an RS prefix,
+// for use with the newline-delimited json reader.
+const embeddedNewlineInvalidEntryJSON = "{ \"_SELINUX_CONTEXT\": \"unconfined\n\", \"__REALTIME_TIMESTAMP\": \"1587047866229555\", \"__CURSOR\": \"cursor-invalid\" }\n"
 
-	mockOutput := testutil.NewMockOperator("output")
-	received := make(chan *entry.Entry)
-	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		received <- args.Get(1).(*entry.Entry)
-	}).Return(nil)
+// TestInputJournaldJSONSeqEmbeddedNewlineInvalid verifies that a json-seq record
+// containing a literal (unescaped) newline byte inside a JSON string value is not
+// delivered. The RS-based reader reads the full record as one unit, but the literal
+// newline makes the JSON invalid so parsing fails and the entry is dropped.
+func TestInputJournaldJSONSeqEmbeddedNewlineInvalid(t *testing.T) {
+	received := startInputOp(t, func(cfg *Config) {
+		cfg.OutputFormat = OutputFormatJSONSeq
+	}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: embeddedNewlineInvalidEntryJSONSeq}
+	})
 
-	err = op.SetOutputs([]operator.Operator{mockOutput})
-	require.NoError(t, err)
-
-	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
-		return &fakeJournaldCmdJSONSeqWithNewline{}
+	select {
+	case <-received:
+		require.FailNow(t, "Invalid entry must not be delivered")
+	case <-time.After(100 * time.Millisecond):
+		// correct: no entry was delivered
 	}
+}
 
-	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
-	defer func() {
-		require.NoError(t, op.Stop())
-	}()
+// TestInputJournaldJSONSeqEmbeddedNewlineValid verifies that the RS-based reader
+// continues processing after a failed parse. After the invalid record from
+// TestInputJournaldJSONSeqEmbeddedNewlineInvalid, a well-formed second record
+// must still be received.
+func TestInputJournaldJSONSeqEmbeddedNewlineValid(t *testing.T) {
+	received := startInputOp(t, func(cfg *Config) {
+		cfg.OutputFormat = OutputFormatJSONSeq
+	}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: embeddedNewlineInvalidEntryJSONSeq + "\x1e" + journaldTestResponse}
+	})
 
-	// The first record has a literal unescaped newline in the JSON text, making
-	// it invalid JSON. The RS-based reader reads the full record across the newline
-	// boundary; parsing fails and a warning is logged. The second valid record
-	// must still be received, proving error recovery works correctly.
 	select {
 	case e := <-received:
 		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
@@ -249,53 +195,144 @@ func TestInputJournaldJSONSeqEmbeddedNewline(t *testing.T) {
 	}
 }
 
-func TestInputJournaldJSONEmbeddedNewline(t *testing.T) {
-	cfg := NewConfigWithID("my_journald_input")
-	cfg.OutputIDs = []string{"output"}
-	// Default json format — newline-delimited reading.
+// TestInputJournaldJSONEmbeddedNewlineInvalid verifies that with the default json
+// (newline-delimited) format, a record containing a literal newline in a field value
+// is not delivered. ReadBytes('\n') splits the JSON at the embedded newline, producing
+// fragments that both fail to parse — the same outcome as
+// TestInputJournaldJSONSeqEmbeddedNewlineInvalid, but via splitting rather than a
+// single failed parse.
+func TestInputJournaldJSONEmbeddedNewlineInvalid(t *testing.T) {
+	received := startInputOp(t, func(*Config) {}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: embeddedNewlineInvalidEntryJSON}
+	})
 
-	set := componenttest.NewNopTelemetrySettings()
-	op, err := cfg.Build(set)
-	require.NoError(t, err)
-
-	mockOutput := testutil.NewMockOperator("output")
-	received := make(chan *entry.Entry)
-	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		received <- args.Get(1).(*entry.Entry)
-	}).Return(nil)
-
-	err = op.SetOutputs([]operator.Operator{mockOutput})
-	require.NoError(t, err)
-
-	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
-		return &fakeJournaldCmdJSONWithNewline{}
+	select {
+	case <-received:
+		require.FailNow(t, "Invalid entry must not be delivered")
+	case <-time.After(100 * time.Millisecond):
+		// correct: no entry was delivered
 	}
+}
 
-	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
-	defer func() {
-		require.NoError(t, op.Stop())
-	}()
+// TestInputJournaldJSONEmbeddedNewlineValid verifies that the newline-delimited reader
+// continues processing after dropping a broken record. After the invalid entry from
+// TestInputJournaldJSONEmbeddedNewlineInvalid, a well-formed second entry must still
+// be received.
+func TestInputJournaldJSONEmbeddedNewlineValid(t *testing.T) {
+	received := startInputOp(t, func(*Config) {}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: embeddedNewlineInvalidEntryJSON + journaldTestResponse}
+	})
 
-	// With json (newline-delimited) format, the literal newline in _SELINUX_CONTEXT
-	// causes ReadBytes('\n') to split the JSON into two unparseable fragments.
-	// Both fragments fail to parse and the entry with cursor "cursor-invalid" is lost.
-	// The second valid entry must still be received.
 	select {
 	case e := <-received:
 		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
-		// The broken entry must not have been delivered.
 		require.NotEqual(t, "cursor-invalid", e.Body.(map[string]any)["__CURSOR"])
 	case <-time.After(time.Second):
 		require.FailNow(t, "Timed out waiting for entry to be read")
 	}
 }
 
-func TestBuildConfigArgs(t *testing.T) {
+// TestInputJournaldJSONSeqMultilineEntry verifies that the RS-based reader correctly
+// parses a valid JSON entry that is formatted across multiple lines (newlines between
+// tokens, not inside string values). Because records are delimited by RS (0x1E), the
+// reader collects the entire multi-line object as one unit before parsing it.
+// The counterpart test TestInputJournaldJSONMultilineEntry shows the same content is
+// lost when using the newline-delimited json format.
+func TestInputJournaldJSONSeqMultilineEntry(t *testing.T) {
+	received := startInputOp(t, func(cfg *Config) {
+		cfg.OutputFormat = OutputFormatJSONSeq
+	}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: "\x1e" + multilineJSONEntry}
+	})
+
+	select {
+	case e := <-received:
+		require.Equal(t, "hello from multiline", e.Body.(map[string]any)["MESSAGE"])
+		require.Equal(t, "cursor-multiline", e.Body.(map[string]any)["__CURSOR"])
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
+	}
+}
+
+// multilineJSONEntry is a valid JSON object spread across multiple lines.
+// The RS-based json-seq reader handles this correctly; the newline-delimited
+// json reader splits it into fragments and loses the entry.
+const multilineJSONEntry = "{\n" +
+	"  \"MESSAGE\": \"hello from multiline\",\n" +
+	"  \"__CURSOR\": \"cursor-multiline\",\n" +
+	"  \"__REALTIME_TIMESTAMP\": \"1587047866229555\"\n" +
+	"}\n"
+
+// TestInputJournaldJSONMultilineEntryInvalid verifies that a valid JSON entry formatted
+// across multiple lines is not delivered by the newline-delimited json reader.
+// ReadBytes('\n') stops at the first newline between tokens, producing fragments that
+// each fail JSON parsing. Compare with TestInputJournaldJSONSeqMultilineEntry which
+// parses the same content correctly using the RS-based reader.
+func TestInputJournaldJSONMultilineEntryInvalid(t *testing.T) {
+	received := startInputOp(t, func(*Config) {}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: multilineJSONEntry}
+	})
+
+	select {
+	case <-received:
+		require.FailNow(t, "Multi-line entry must not be delivered by the json reader")
+	case <-time.After(100 * time.Millisecond):
+		// correct: no entry was delivered
+	}
+}
+
+// TestInputJournaldJSONMultilineEntryValid verifies that the newline-delimited reader
+// continues processing after dropping a multi-line entry. A well-formed single-line
+// entry following the multi-line one must still be received.
+func TestInputJournaldJSONMultilineEntryValid(t *testing.T) {
+	received := startInputOp(t, func(*Config) {}, func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{stdoutContent: multilineJSONEntry + journaldTestResponse}
+	})
+
+	select {
+	case e := <-received:
+		require.NotEqual(t, "cursor-multiline", e.Body.(map[string]any)["__CURSOR"])
+		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
+	}
+}
+
+func TestInputJournaldError(t *testing.T) {
+	cfg := NewConfigWithID("my_journald_input")
+	cfg.OutputIDs = []string{"output"}
+
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger, _ = zap.NewDevelopment()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.NewMockOperator("output")
+	received := make(chan *entry.Entry)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		received <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = op.SetOutputs([]operator.Operator{mockOutput})
+	require.NoError(t, err)
+
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmd{
+			exitError:  &exec.ExitError{},
+			startError: errors.New("fail to start"),
+		}
+	}
+
+	err = op.Start(testutil.NewUnscopedMockPersister())
+	assert.EqualError(t, err, "journalctl command failed: start journalctl: fail to start")
+	require.NoError(t, op.Stop())
+}
+
+func TestBuildConfigArgsValid(t *testing.T) {
 	testCases := []struct {
-		Name          string
-		Config        func(_ *Config)
-		Expected      []string
-		ExpectedError string
+		Name     string
+		Config   func(*Config)
+		Expected []string
 	}{
 		{
 			Name:     "empty config",
@@ -315,13 +352,6 @@ func TestBuildConfigArgs(t *testing.T) {
 				cfg.OutputFormat = OutputFormatJSONSeq
 			},
 			Expected: []string{"--utc", "--output=json-seq", "--follow", "--priority", "info"},
-		},
-		{
-			Name: "invalid output_format",
-			Config: func(cfg *Config) {
-				cfg.OutputFormat = "invalid"
-			},
-			ExpectedError: "invalid value 'invalid' for parameter 'output_format'",
 		},
 		{
 			Name: "units",
@@ -347,17 +377,6 @@ func TestBuildConfigArgs(t *testing.T) {
 				}
 			},
 			Expected: []string{"--utc", "--output=json", "--follow", "--priority", "info", "_SYSTEMD_UNIT=dbus.service", "+", "_SYSTEMD_UNIT=user@1000.service", "_UID=1000"},
-		},
-		{
-			Name: "invalid match",
-			Config: func(cfg *Config) {
-				cfg.Matches = []MatchConfig{
-					{
-						"-SYSTEMD_UNIT": "dbus.service",
-					},
-				}
-			},
-			ExpectedError: "'-SYSTEMD_UNIT' is not a valid Systemd field name",
 		},
 		{
 			Name: "units and matches",
@@ -420,14 +439,45 @@ func TestBuildConfigArgs(t *testing.T) {
 			cfg := NewConfigWithID("my_journald_input")
 			tt.Config(cfg)
 			args, err := cfg.buildArgs()
-
-			if tt.ExpectedError != "" {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tt.ExpectedError)
-				return
-			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.Expected, args)
+		})
+	}
+}
+
+func TestBuildConfigArgsInvalid(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Config        func(*Config)
+		ExpectedError string
+	}{
+		{
+			Name: "invalid output_format",
+			Config: func(cfg *Config) {
+				cfg.OutputFormat = "invalid"
+			},
+			ExpectedError: "invalid value 'invalid' for parameter 'output_format'",
+		},
+		{
+			Name: "invalid match",
+			Config: func(cfg *Config) {
+				cfg.Matches = []MatchConfig{
+					{
+						"-SYSTEMD_UNIT": "dbus.service",
+					},
+				}
+			},
+			ExpectedError: "'-SYSTEMD_UNIT' is not a valid Systemd field name",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			cfg := NewConfigWithID("my_journald_input")
+			tt.Config(cfg)
+			_, err := cfg.buildArgs()
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.ExpectedError)
 		})
 	}
 }
@@ -512,16 +562,32 @@ func TestBuildConfigCmdCursor(t *testing.T) {
 	assert.NotContains(t, cmd.Args, "--after-cursor")
 }
 
-func TestConfigValidation(t *testing.T) {
+func TestConfigValidationValid(t *testing.T) {
 	testCases := []struct {
-		Name          string
-		Config        func(_ *Config)
-		ExpectedError string
+		Name   string
+		Config func(*Config)
 	}{
 		{
 			Name:   "empty config",
 			Config: func(_ *Config) {},
 		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			cfg := NewConfigWithID("my_journald_input")
+			tt.Config(cfg)
+			require.NoError(t, cfg.validate())
+		})
+	}
+}
+
+func TestConfigValidationInvalid(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Config        func(*Config)
+		ExpectedError string
+	}{
 		{
 			Name: "invalid journalctl_path",
 			Config: func(cfg *Config) {
@@ -566,43 +632,8 @@ func TestConfigValidation(t *testing.T) {
 			cfg := NewConfigWithID("my_journald_input")
 			tt.Config(cfg)
 			err := cfg.validate()
-
-			if tt.ExpectedError != "" {
-				require.Error(t, err)
-				require.ErrorContains(t, err, tt.ExpectedError)
-				return
-			}
-			require.NoError(t, err)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.ExpectedError)
 		})
 	}
-}
-
-func TestInputJournaldError(t *testing.T) {
-	cfg := NewConfigWithID("my_journald_input")
-	cfg.OutputIDs = []string{"output"}
-
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger, _ = zap.NewDevelopment()
-	op, err := cfg.Build(set)
-	require.NoError(t, err)
-
-	mockOutput := testutil.NewMockOperator("output")
-	received := make(chan *entry.Entry)
-	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		received <- args.Get(1).(*entry.Entry)
-	}).Return(nil)
-
-	err = op.SetOutputs([]operator.Operator{mockOutput})
-	require.NoError(t, err)
-
-	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
-		return &fakeJournaldCmd{
-			exitError:  &exec.ExitError{},
-			startError: errors.New("fail to start"),
-		}
-	}
-
-	err = op.Start(testutil.NewUnscopedMockPersister())
-	assert.EqualError(t, err, "journalctl command failed: start journalctl: fail to start")
-	require.NoError(t, op.Stop())
 }

--- a/pkg/stanza/operator/input/journald/input_test.go
+++ b/pkg/stanza/operator/input/journald/input_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
+const journaldTestResponse = `{ "_BOOT_ID": "c4fa36de06824d21835c05ff80c54468", "_CAP_EFFECTIVE": "0", "_TRANSPORT": "journal", "_UID": "1000", "_EXE": "/usr/lib/systemd/systemd", "_AUDIT_LOGINUID": "1000", "MESSAGE": "run-docker-netns-4f76d707d45f.mount: Succeeded.", "_PID": "13894", "_CMDLINE": "/lib/systemd/systemd --user", "_MACHINE_ID": "d777d00e7caf45fbadedceba3975520d", "_SELINUX_CONTEXT": "unconfined\n", "CODE_FUNC": "unit_log_success", "SYSLOG_IDENTIFIER": "systemd", "_HOSTNAME": "myhostname", "MESSAGE_ID": "7ad2d189f7e94e70a38c781354912448", "_SYSTEMD_CGROUP": "/user.slice/user-1000.slice/user@1000.service/init.scope", "_SOURCE_REALTIME_TIMESTAMP": "1587047866229317", "USER_UNIT": "run-docker-netns-4f76d707d45f.mount", "SYSLOG_FACILITY": "3", "_SYSTEMD_SLICE": "user-1000.slice", "_AUDIT_SESSION": "286", "CODE_FILE": "../src/core/unit.c", "_SYSTEMD_USER_UNIT": "init.scope", "_COMM": "systemd", "USER_INVOCATION_ID": "88f7ca6bbf244dc8828fa901f9fe9be1", "CODE_LINE": "5487", "_SYSTEMD_INVOCATION_ID": "83f7fc7799064520b26eb6de1630429c", "PRIORITY": "6", "_GID": "1000", "__REALTIME_TIMESTAMP": "1587047866229555", "_SYSTEMD_UNIT": "user@1000.service", "_SYSTEMD_USER_SLICE": "-.slice", "__CURSOR": "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36", "__MONOTONIC_TIMESTAMP": "685540311557", "_SYSTEMD_OWNER_UID": "1000" }
+`
+
 type fakeJournaldCmd struct {
 	startError error
 	exitError  *exec.ExitError
@@ -36,9 +39,7 @@ func (f *fakeJournaldCmd) Start() error {
 }
 
 func (*fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
-	response := `{ "_BOOT_ID": "c4fa36de06824d21835c05ff80c54468", "_CAP_EFFECTIVE": "0", "_TRANSPORT": "journal", "_UID": "1000", "_EXE": "/usr/lib/systemd/systemd", "_AUDIT_LOGINUID": "1000", "MESSAGE": "run-docker-netns-4f76d707d45f.mount: Succeeded.", "_PID": "13894", "_CMDLINE": "/lib/systemd/systemd --user", "_MACHINE_ID": "d777d00e7caf45fbadedceba3975520d", "_SELINUX_CONTEXT": "unconfined\n", "CODE_FUNC": "unit_log_success", "SYSLOG_IDENTIFIER": "systemd", "_HOSTNAME": "myhostname", "MESSAGE_ID": "7ad2d189f7e94e70a38c781354912448", "_SYSTEMD_CGROUP": "/user.slice/user-1000.slice/user@1000.service/init.scope", "_SOURCE_REALTIME_TIMESTAMP": "1587047866229317", "USER_UNIT": "run-docker-netns-4f76d707d45f.mount", "SYSLOG_FACILITY": "3", "_SYSTEMD_SLICE": "user-1000.slice", "_AUDIT_SESSION": "286", "CODE_FILE": "../src/core/unit.c", "_SYSTEMD_USER_UNIT": "init.scope", "_COMM": "systemd", "USER_INVOCATION_ID": "88f7ca6bbf244dc8828fa901f9fe9be1", "CODE_LINE": "5487", "_SYSTEMD_INVOCATION_ID": "83f7fc7799064520b26eb6de1630429c", "PRIORITY": "6", "_GID": "1000", "__REALTIME_TIMESTAMP": "1587047866229555", "_SYSTEMD_UNIT": "user@1000.service", "_SYSTEMD_USER_SLICE": "-.slice", "__CURSOR": "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36", "__MONOTONIC_TIMESTAMP": "685540311557", "_SYSTEMD_OWNER_UID": "1000" }
-`
-	reader := bytes.NewReader([]byte(response))
+	reader := bytes.NewReader([]byte(journaldTestResponse))
 	return io.NopCloser(reader), nil
 }
 
@@ -53,6 +54,50 @@ func (f *fakeJournaldCmd) Wait() error {
 	}
 
 	return f.exitError
+}
+
+type fakeJournaldCmdJSONSeq struct {
+	fakeJournaldCmd
+}
+
+func (*fakeJournaldCmdJSONSeq) StdoutPipe() (io.ReadCloser, error) {
+	// Prefix the record with the RFC 7464 Record Separator (0x1E)
+	response := "\x1e" + journaldTestResponse
+	reader := bytes.NewReader([]byte(response))
+	return io.NopCloser(reader), nil
+}
+
+type fakeJournaldCmdJSONSeqWithNewline struct {
+	fakeJournaldCmd
+}
+
+func (*fakeJournaldCmdJSONSeqWithNewline) StdoutPipe() (io.ReadCloser, error) {
+	// First record: a JSON entry where the _SELINUX_CONTEXT field contains a
+	// literal (unescaped) newline byte, as can happen with some journald versions.
+	// With newline-based reading this would be split into two unparseable fragments.
+	// With RS-based reading the full record is read as one unit; parsing still fails
+	// because the JSON is technically invalid, so a warning is logged and the entry
+	// is skipped. The second valid record must still be received.
+	invalidEntry := "\x1e{ \"_SELINUX_CONTEXT\": \"unconfined\n\", \"__REALTIME_TIMESTAMP\": \"1587047866229555\", \"__CURSOR\": \"cursor-invalid\" }\n"
+	// Second record: a well-formed json-seq entry.
+	validEntry := "\x1e" + journaldTestResponse
+	reader := bytes.NewReader([]byte(invalidEntry + validEntry))
+	return io.NopCloser(reader), nil
+}
+
+type fakeJournaldCmdJSONWithNewline struct {
+	fakeJournaldCmd
+}
+
+func (*fakeJournaldCmdJSONWithNewline) StdoutPipe() (io.ReadCloser, error) {
+	// Entry where _SELINUX_CONTEXT contains a literal (unescaped) newline byte.
+	// In plain json format, ReadBytes('\n') splits this at the embedded newline,
+	// producing two fragments that both fail to parse. The entry is lost.
+	// A second valid entry follows to confirm processing continues.
+	invalidEntry := "{ \"_SELINUX_CONTEXT\": \"unconfined\n\", \"__REALTIME_TIMESTAMP\": \"1587047866229555\", \"__CURSOR\": \"cursor-invalid\" }\n"
+	validEntry := journaldTestResponse
+	reader := bytes.NewReader([]byte(invalidEntry + validEntry))
+	return io.NopCloser(reader), nil
 }
 
 func TestInputJournald(t *testing.T) {
@@ -126,6 +171,125 @@ func TestInputJournald(t *testing.T) {
 	}
 }
 
+func TestInputJournaldJSONSeq(t *testing.T) {
+	cfg := NewConfigWithID("my_journald_input")
+	cfg.OutputIDs = []string{"output"}
+	cfg.OutputFormat = OutputFormatJSONSeq
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.NewMockOperator("output")
+	received := make(chan *entry.Entry)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		received <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = op.SetOutputs([]operator.Operator{mockOutput})
+	require.NoError(t, err)
+
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmdJSONSeq{}
+	}
+
+	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+	defer func() {
+		require.NoError(t, op.Stop())
+	}()
+
+	select {
+	case e := <-received:
+		// Verify the RS prefix was stripped and the entry was correctly parsed,
+		// including a field whose value contains a JSON-escaped newline character.
+		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
+		require.Equal(t, "unconfined\n", e.Body.(map[string]any)["_SELINUX_CONTEXT"])
+		require.Equal(t, "s=b1e713b587ae4001a9ca482c4b12c005;i=1eed30;b=c4fa36de06824d21835c05ff80c54468;m=9f9d630205;t=5a369604ee333;x=16c2d4fd4fdb7c36", e.Body.(map[string]any)["__CURSOR"])
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
+	}
+}
+
+func TestInputJournaldJSONSeqEmbeddedNewline(t *testing.T) {
+	cfg := NewConfigWithID("my_journald_input")
+	cfg.OutputIDs = []string{"output"}
+	cfg.OutputFormat = OutputFormatJSONSeq
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.NewMockOperator("output")
+	received := make(chan *entry.Entry)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		received <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = op.SetOutputs([]operator.Operator{mockOutput})
+	require.NoError(t, err)
+
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmdJSONSeqWithNewline{}
+	}
+
+	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+	defer func() {
+		require.NoError(t, op.Stop())
+	}()
+
+	// The first record has a literal unescaped newline in the JSON text, making
+	// it invalid JSON. The RS-based reader reads the full record across the newline
+	// boundary; parsing fails and a warning is logged. The second valid record
+	// must still be received, proving error recovery works correctly.
+	select {
+	case e := <-received:
+		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
+	}
+}
+
+func TestInputJournaldJSONEmbeddedNewline(t *testing.T) {
+	cfg := NewConfigWithID("my_journald_input")
+	cfg.OutputIDs = []string{"output"}
+	// Default json format — newline-delimited reading.
+
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(set)
+	require.NoError(t, err)
+
+	mockOutput := testutil.NewMockOperator("output")
+	received := make(chan *entry.Entry)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		received <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = op.SetOutputs([]operator.Operator{mockOutput})
+	require.NoError(t, err)
+
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
+		return &fakeJournaldCmdJSONWithNewline{}
+	}
+
+	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+	defer func() {
+		require.NoError(t, op.Stop())
+	}()
+
+	// With json (newline-delimited) format, the literal newline in _SELINUX_CONTEXT
+	// causes ReadBytes('\n') to split the JSON into two unparseable fragments.
+	// Both fragments fail to parse and the entry with cursor "cursor-invalid" is lost.
+	// The second valid entry must still be received.
+	select {
+	case e := <-received:
+		require.Equal(t, "run-docker-netns-4f76d707d45f.mount: Succeeded.", e.Body.(map[string]any)["MESSAGE"])
+		// The broken entry must not have been delivered.
+		require.NotEqual(t, "cursor-invalid", e.Body.(map[string]any)["__CURSOR"])
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
+	}
+}
+
 func TestBuildConfigArgs(t *testing.T) {
 	testCases := []struct {
 		Name          string
@@ -137,6 +301,27 @@ func TestBuildConfigArgs(t *testing.T) {
 			Name:     "empty config",
 			Config:   func(_ *Config) {},
 			Expected: []string{"--utc", "--output=json", "--follow", "--priority", "info"},
+		},
+		{
+			Name: "output_format json",
+			Config: func(cfg *Config) {
+				cfg.OutputFormat = OutputFormatJSON
+			},
+			Expected: []string{"--utc", "--output=json", "--follow", "--priority", "info"},
+		},
+		{
+			Name: "output_format json-seq",
+			Config: func(cfg *Config) {
+				cfg.OutputFormat = OutputFormatJSONSeq
+			},
+			Expected: []string{"--utc", "--output=json-seq", "--follow", "--priority", "info"},
+		},
+		{
+			Name: "invalid output_format",
+			Config: func(cfg *Config) {
+				cfg.OutputFormat = "invalid"
+			},
+			ExpectedError: "invalid value 'invalid' for parameter 'output_format'",
 		},
 		{
 			Name: "units",
@@ -366,6 +551,13 @@ func TestConfigValidation(t *testing.T) {
 				cfg.StartAt = "middle"
 			},
 			ExpectedError: "invalid value 'middle' for parameter 'start_at'",
+		},
+		{
+			Name: "invalid output_format",
+			Config: func(cfg *Config) {
+				cfg.OutputFormat = "json-pretty"
+			},
+			ExpectedError: "invalid value 'json-pretty' for parameter 'output_format'",
 		},
 	}
 

--- a/pkg/stanza/operator/input/journald/input_test.go
+++ b/pkg/stanza/operator/input/journald/input_test.go
@@ -75,10 +75,10 @@ func (*fakeJournaldCmdJSONSeqWithNewline) StdoutPipe() (io.ReadCloser, error) {
 	// First record: a JSON entry where the _SELINUX_CONTEXT field contains a
 	// literal (unescaped) newline byte, as can happen with some journald versions.
 	// With newline-based reading this would be split into two unparseable fragments.
-	// With RS-based reading the full record is read as one unit; parsing still fails
-	// because the JSON is technically invalid, so a warning is logged and the entry
-	// is skipped. The second valid record must still be received.
-	invalidEntry := "\x1e{ \"_SELINUX_CONTEXT\": \"unconfined\n\", \"__REALTIME_TIMESTAMP\": \"1587047866229555\", \"__CURSOR\": \"cursor-invalid\" }\n"
+	// With RS-based reading the full record is read as one unit. The JSON is
+	// structurally incomplete (no closing brace), so parsing fails and a warning
+	// is logged. The second valid record must still be received.
+	invalidEntry := "\x1e{ \"_SELINUX_CONTEXT\": \"unconfined\n\"\n"
 	// Second record: a well-formed json-seq entry.
 	validEntry := "\x1e" + journaldTestResponse
 	reader := bytes.NewReader([]byte(invalidEntry + validEntry))


### PR DESCRIPTION
#### Description
Setting `output_format: json-seq` instructs journalctl to use the RFC 7464 JSON Text Sequences
format, where each record is prefixed with an ASCII Record Separator character (0x1E). This avoids
parsing failures that can occur when journal field values contain literal newlines, such as the
`_SELINUX_CONTEXT` field on some systems.

#### Testing

Unit test

#### Issue

closes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46460

#### Documentation

see https://man7.org/linux/man-pages/man1/journalctl.1.html 
Output options
