### PR TITLE
[extension/headerssetterextension] Add file-based credentials support

### DIFF
--- a/.chloggen/headersetter-file-credentials.yaml
+++ b/.chloggen/headersetter-file-credentials.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/headers_setter
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for file-based credentials via `value_file` configuration option. Files are watched for changes and header values are automatically updated.
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46473] # Update with PR number
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is useful for credentials that are rotated, such as Kubernetes secrets.
+  Example configuration:
+    headers_setter:
+      headers:
+        - key: X-API-Key
+          value_file: /var/secrets/api-key
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/headerssetterextension/README.md
+++ b/extension/headerssetterextension/README.md
@@ -41,6 +41,9 @@ The following settings are available:
         - `delete`: Deletes the header.
     - `value`: The header value is looked up from the `value` property of the
       extension configuration.
+    - `value_file`: The header value is read from a file. The file is watched for
+      changes and the header value is automatically updated when the file changes.
+      This is useful for credentials that are rotated, such as Kubernetes secrets.
     - `default_value`: (Optional) Value used if no entry for header key specified in `from_context` is present in request metadata.
     - `from_context`: The header value is looked up from the request metadata,
       such as HTTP headers, using the property value as the key (likely a header
@@ -48,7 +51,7 @@ The following settings are available:
     - `from_attribute`: The header value is taken from the request's authentication data,
       may include attributes like `subject` and `membership`.
 
-The `value`,`from_context,default_value` and `from_attribute,default_value` properties are mutually exclusive.
+The `value`, `value_file`, `from_context,default_value` and `from_attribute,default_value` properties are mutually exclusive.
 
 In order for `from_context` to work, other components in the pipeline also need to be configured appropriately:
 * If a [batch processor][batch-processor] is present in the pipeline, it must be configured to [preserve client metadata][batch-processor-preserve-metadata]. 
@@ -104,6 +107,41 @@ service:
       processors: [ batch ]
       exporters: [ loki ]
 ```
+
+#### File-Based Credentials Example
+
+The `value_file` option allows reading header values from files, which is useful
+for credentials that are rotated, such as Kubernetes secrets or other dynamic
+credentials:
+
+```yaml
+extensions:
+  headers_setter:
+    headers:
+      - key: X-API-Key
+        value_file: /var/secrets/api-key
+        action: upsert
+      - key: X-Tenant-ID
+        value_file: /etc/tenant/id
+        action: insert
+
+exporters:
+  otlphttp:
+    endpoint: https://api.example.com/v1/traces
+    auth:
+      authenticator: headers_setter
+
+service:
+  extensions: [headers_setter]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp]
+```
+
+The files are watched for changes, and header values are automatically updated
+when the files are modified. This is particularly useful in Kubernetes environments
+where secrets are mounted as files and can be rotated without restarting the collector.
 
 ## Chaining with other Auth Extensions
 

--- a/extension/headerssetterextension/config.go
+++ b/extension/headerssetterextension/config.go
@@ -13,8 +13,8 @@ import (
 var (
 	errMissingHeader        = errors.New("missing header name")
 	errMissingHeadersConfig = errors.New("missing headers configuration")
-	errMissingSource        = errors.New("missing header source, must be 'from_context', 'from_attribute' or 'value'")
-	errConflictingSources   = errors.New("invalid header source, must either 'from_context', 'from_attribute' or 'value'")
+	errMissingSource        = errors.New("missing header source, must be 'from_context', 'from_attribute', 'value', or 'value_file'")
+	errConflictingSources   = errors.New("invalid header source, must be only one of 'from_context', 'from_attribute', 'value', or 'value_file'")
 )
 
 type Config struct {
@@ -29,6 +29,7 @@ type HeaderConfig struct {
 	Action        ActionValue          `mapstructure:"action"`
 	Key           *string              `mapstructure:"key"`
 	Value         *string              `mapstructure:"value"`
+	ValueFile     *string              `mapstructure:"value_file"`
 	FromContext   *string              `mapstructure:"from_context"`
 	FromAttribute *string              `mapstructure:"from_attribute"`
 	DefaultValue  *configopaque.String `mapstructure:"default_value"`
@@ -63,12 +64,23 @@ func (cfg *Config) Validate() error {
 		}
 
 		if header.Action != DELETE {
-			if header.FromContext == nil && header.FromAttribute == nil && header.Value == nil {
+			if header.FromContext == nil && header.FromAttribute == nil && header.Value == nil && header.ValueFile == nil {
 				return errMissingSource
 			}
-			if (header.FromContext != nil && header.FromAttribute != nil) ||
-				(header.FromContext != nil && header.Value != nil) ||
-				(header.Value != nil && header.FromAttribute != nil) {
+			sourceCount := 0
+			if header.FromContext != nil {
+				sourceCount++
+			}
+			if header.FromAttribute != nil {
+				sourceCount++
+			}
+			if header.Value != nil {
+				sourceCount++
+			}
+			if header.ValueFile != nil {
+				sourceCount++
+			}
+			if sourceCount > 1 {
 				return errConflictingSources
 			}
 		}

--- a/extension/headerssetterextension/extension.go
+++ b/extension/headerssetterextension/extension.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension/internal/action"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension/internal/source"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile"
 )
 
 type header struct {
@@ -40,6 +41,8 @@ type headerSetterExtension struct {
 	headers        []header
 	additionalAuth *component.ID
 	host           component.Host
+	resolvers      []credentialsfile.ValueResolver
+	logger         *zap.Logger
 }
 
 // Dependencies implements extensioncapabilities.Dependent.
@@ -51,8 +54,30 @@ func (h *headerSetterExtension) Dependencies() []component.ID {
 }
 
 // Start stores the host for later use in getting the additional auth extension.
-func (h *headerSetterExtension) Start(_ context.Context, host component.Host) error {
+func (h *headerSetterExtension) start(ctx context.Context, host component.Host) error {
 	h.host = host
+
+	// Start all file resolvers
+	for _, resolver := range h.resolvers {
+		if err := resolver.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start value resolver: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Shutdown stops all file resolvers
+func (h *headerSetterExtension) shutdown(_ context.Context) error {
+	var errs []error
+	for _, resolver := range h.resolvers {
+		if err := resolver.Shutdown(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to shutdown resolvers: %v", errs)
+	}
 	return nil
 }
 
@@ -129,12 +154,23 @@ func newHeadersSetterExtension(cfg *Config, logger *zap.Logger) (*headerSetterEx
 	}
 
 	headers := make([]header, 0, len(cfg.HeadersConfig))
+	var resolvers []credentialsfile.ValueResolver
+
 	for _, h := range cfg.HeadersConfig {
 		var s source.Source
 		switch {
 		case h.Value != nil:
 			s = &source.StaticSource{
 				Value: *h.Value,
+			}
+		case h.ValueFile != nil:
+			resolver, err := credentialsfile.NewValueResolver("", *h.ValueFile, logger)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create value resolver for header %s: %w", *h.Key, err)
+			}
+			resolvers = append(resolvers, resolver)
+			s = &source.FileSource{
+				Resolver: resolver,
 			}
 		case h.FromAttribute != nil:
 			defaultValue := ""
@@ -177,11 +213,14 @@ func newHeadersSetterExtension(cfg *Config, logger *zap.Logger) (*headerSetterEx
 	ext := &headerSetterExtension{
 		headers:        headers,
 		additionalAuth: cfg.AdditionalAuth,
+		resolvers:      resolvers,
+		logger:         logger,
 	}
 
-	// Enable Start method if additional_auth is configured
-	if cfg.AdditionalAuth != nil {
-		ext.StartFunc = ext.Start
+	// Enable Start/Shutdown methods if additional_auth is configured or if we have file resolvers
+	if cfg.AdditionalAuth != nil || len(resolvers) > 0 {
+		ext.StartFunc = ext.start
+		ext.ShutdownFunc = ext.shutdown
 	}
 
 	return ext, nil

--- a/extension/headerssetterextension/extension_test.go
+++ b/extension/headerssetterextension/extension_test.go
@@ -5,10 +5,15 @@ package headerssetterextension
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configopaque"
 )
 
@@ -263,4 +268,193 @@ func stringp(str string) *string {
 
 func opaquep(stro configopaque.String) *configopaque.String {
 	return &stro
+}
+
+func TestRoundTripper_FileSource(t *testing.T) {
+	dir := t.TempDir()
+	apiKeyFile := filepath.Join(dir, "api-key")
+	require.NoError(t, os.WriteFile(apiKeyFile, []byte("secret123"), 0o600))
+
+	headerKey := "X-API-Key"
+	cfg := &Config{
+		HeadersConfig: []HeaderConfig{
+			{
+				Key:       &headerKey,
+				Action:    UPSERT,
+				ValueFile: &apiKeyFile,
+			},
+		},
+	}
+
+	ext, err := newHeadersSetterExtension(cfg, componenttest.NewNopTelemetrySettings().Logger)
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	require.NoError(t, ext.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, ext.shutdown(t.Context())) }()
+
+	roundTripper, err := ext.RoundTripper(mrt)
+	require.NoError(t, err)
+	require.NotNil(t, roundTripper)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, "secret123", resp.Header.Get("X-API-Key"))
+}
+
+func TestRoundTripper_FileSource_UpdatesOnChange(t *testing.T) {
+	dir := t.TempDir()
+	apiKeyFile := filepath.Join(dir, "api-key")
+	require.NoError(t, os.WriteFile(apiKeyFile, []byte("original"), 0o600))
+
+	headerKey := "X-API-Key"
+	cfg := &Config{
+		HeadersConfig: []HeaderConfig{
+			{
+				Key:       &headerKey,
+				Action:    UPSERT,
+				ValueFile: &apiKeyFile,
+			},
+		},
+	}
+
+	ext, err := newHeadersSetterExtension(cfg, componenttest.NewNopTelemetrySettings().Logger)
+	require.NoError(t, err)
+	require.NoError(t, ext.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, ext.shutdown(t.Context())) }()
+
+	roundTripper, err := ext.RoundTripper(mrt)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, "original", resp.Header.Get("X-API-Key"))
+
+	// Update the file
+	require.NoError(t, os.WriteFile(apiKeyFile, []byte("updated"), 0o600))
+
+	// Verify the header value updates
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "", http.NoBody)
+		assert.NoError(c, err)
+		resp, err := roundTripper.RoundTrip(req)
+		assert.NoError(c, err)
+		assert.Equal(c, "updated", resp.Header.Get("X-API-Key"))
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestPerRPCCredentials_FileSource(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("bearer-token-123"), 0o600))
+
+	headerKey := "Authorization"
+	cfg := &Config{
+		HeadersConfig: []HeaderConfig{
+			{
+				Key:       &headerKey,
+				Action:    INSERT,
+				ValueFile: &tokenFile,
+			},
+		},
+	}
+
+	ext, err := newHeadersSetterExtension(cfg, componenttest.NewNopTelemetrySettings().Logger)
+	require.NoError(t, err)
+	require.NoError(t, ext.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, ext.shutdown(t.Context())) }()
+
+	perRPC, err := ext.PerRPCCredentials()
+	require.NoError(t, err)
+	require.NotNil(t, perRPC)
+
+	metadata, err := perRPC.GetRequestMetadata(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "bearer-token-123", metadata["Authorization"])
+}
+
+func TestPerRPCCredentials_FileSource_UpdatesOnChange(t *testing.T) {
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-v1"), 0o600))
+
+	headerKey := "X-Auth-Token"
+	cfg := &Config{
+		HeadersConfig: []HeaderConfig{
+			{
+				Key:       &headerKey,
+				Action:    UPSERT,
+				ValueFile: &tokenFile,
+			},
+		},
+	}
+
+	ext, err := newHeadersSetterExtension(cfg, componenttest.NewNopTelemetrySettings().Logger)
+	require.NoError(t, err)
+	require.NoError(t, ext.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, ext.shutdown(t.Context())) }()
+
+	perRPC, err := ext.PerRPCCredentials()
+	require.NoError(t, err)
+
+	metadata, err := perRPC.GetRequestMetadata(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "token-v1", metadata["X-Auth-Token"])
+
+	// Update the file
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token-v2"), 0o600))
+
+	// Verify the metadata updates
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		metadata, err := perRPC.GetRequestMetadata(t.Context())
+		assert.NoError(c, err)
+		assert.Equal(c, "token-v2", metadata["X-Auth-Token"])
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestFileSource_MultipleHeaders(t *testing.T) {
+	dir := t.TempDir()
+	apiKeyFile := filepath.Join(dir, "api-key")
+	tokenFile := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(apiKeyFile, []byte("key123"), 0o600))
+	require.NoError(t, os.WriteFile(tokenFile, []byte("token456"), 0o600))
+
+	apiKeyHeader := "X-API-Key" //nolint:gosec // G101 - header name, not a credential
+	tokenHeader := "X-Token"
+	cfg := &Config{
+		HeadersConfig: []HeaderConfig{
+			{
+				Key:       &apiKeyHeader,
+				Action:    UPSERT,
+				ValueFile: &apiKeyFile,
+			},
+			{
+				Key:       &tokenHeader,
+				Action:    INSERT,
+				ValueFile: &tokenFile,
+			},
+		},
+	}
+
+	ext, err := newHeadersSetterExtension(cfg, componenttest.NewNopTelemetrySettings().Logger)
+	require.NoError(t, err)
+	require.NoError(t, ext.start(t.Context(), componenttest.NewNopHost()))
+	defer func() { require.NoError(t, ext.shutdown(t.Context())) }()
+
+	roundTripper, err := ext.RoundTripper(mrt)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := roundTripper.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, "key123", resp.Header.Get("X-API-Key"))
+	assert.Equal(t, "token456", resp.Header.Get("X-Token"))
 }

--- a/extension/headerssetterextension/go.mod
+++ b/extension/headerssetterextension/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/heade
 go 1.25.0
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile v0.146.2-0.20260219223409-66996adfaaf7
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/client v1.53.1-0.20260306010043-a44ab254898b
 	go.opentelemetry.io/collector/component v1.53.1-0.20260306010043-a44ab254898b
@@ -22,6 +23,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
@@ -58,3 +60,5 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile => ../internal/credentialsfile

--- a/extension/headerssetterextension/go.sum
+++ b/extension/headerssetterextension/go.sum
@@ -3,6 +3,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/extension/headerssetterextension/internal/source/file.go
+++ b/extension/headerssetterextension/internal/source/file.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package source // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension/internal/source"
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile"
+)
+
+var _ Source = (*FileSource)(nil)
+
+type FileSource struct {
+	Resolver credentialsfile.ValueResolver
+}
+
+func (fs *FileSource) Get(_ context.Context) (string, error) {
+	return fs.Resolver.Value(), nil
+}

--- a/extension/headerssetterextension/internal/source/file_test.go
+++ b/extension/headerssetterextension/internal/source/file_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/internal/credentialsfile"
+)
+
+func TestFileSource(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "header-value")
+	require.NoError(t, os.WriteFile(f, []byte("secret123"), 0o600))
+
+	resolver, err := credentialsfile.NewValueResolver("", f, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	require.NoError(t, resolver.Start(t.Context()))
+	defer func() { require.NoError(t, resolver.Shutdown()) }()
+
+	fs := &FileSource{Resolver: resolver}
+	value, err := fs.Get(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, "secret123", value)
+}
+
+func TestFileSource_UpdatesOnFileChange(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "header-value")
+	require.NoError(t, os.WriteFile(f, []byte("original"), 0o600))
+
+	resolver, err := credentialsfile.NewValueResolver("", f, zaptest.NewLogger(t))
+	require.NoError(t, err)
+	require.NoError(t, resolver.Start(t.Context()))
+	defer func() { require.NoError(t, resolver.Shutdown()) }()
+
+	fs := &FileSource{Resolver: resolver}
+	value, err := fs.Get(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, "original", value)
+
+	// Update file
+	require.NoError(t, os.WriteFile(f, []byte("updated"), 0o600))
+
+	// Wait for file watcher to pick up the change
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		value, err := fs.Get(t.Context())
+		assert.NoError(c, err)
+		assert.Equal(c, "updated", value)
+	}, 5*time.Second, 50*time.Millisecond)
+}


### PR DESCRIPTION
Add support for reading header values from files using the `value_file` configuration option. Files are watched for changes and header values are automatically updated when files are modified.

This is useful for credentials that are rotated, such as Kubernetes secrets or other dynamic credentials.

Configuration example:

```yaml
  headers_setter:
    headers:
      - key: X-API-Key
        value_file: /var/secrets/api-key
        action: upsert
```

Assisted-by: Kiro (Amazon Q Developer)