### PR TITLE
[extension/filestorage] compaction: Fix nil pointer panic when reopen fails

### DIFF
--- a/.chloggen/fix_filestorage-nil-pointer-compact.yaml
+++ b/.chloggen/fix_filestorage-nil-pointer-compact.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: extension/file_storage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil pointer crash when bbolt reopen fails during on_rebound compaction
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [46489]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -217,21 +217,21 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 	c.db.Close()
 	compactedDb.Close()
 
-	var openErr error
 	// replace current db file with compacted db file
 	// we reopen the DB file irrespective of the success of the replace, as we can't leave it closed
 	moveErr := moveFileWithFallback(compactedDbPath, dbPath)
-	c.db, openErr = bbolt.Open(dbPath, 0o600, options)
-
-	// if we got errors for both rename and open, we'd rather return the open one
-	// this should not happen in any kind of normal circumstance - maybe we should panic instead?
+	newDb, openErr := bbolt.Open(dbPath, 0o600, options)
 	if openErr != nil {
+		// Leave c.db pointing at the old (closed) DB so that callers get
+		// errors from the closed DB instead of panicking on a nil pointer.
 		return fmt.Errorf("failed to open db after compaction: %w", openErr)
 	}
+	c.db = newDb
+
 	if moveErr != nil {
 		// if we only failed the remove, we're mostly ok and should just log a warning
 		var pathErr *os.PathError
-		if errors.As(err, &pathErr) {
+		if errors.As(moveErr, &pathErr) {
 			if pathErr.Op == "remove" {
 				c.logger.Warn("failed to remove temporary db after compaction",
 					zap.String(directoryKey, c.db.Path()),

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -399,6 +399,38 @@ func TestClientConcurrentCompaction(t *testing.T) {
 	}
 }
 
+func TestCompactReopenFailureReturnsErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	dbDir := filepath.Join(tempDir, "dbdir")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	dbFile := filepath.Join(dbDir, "my_db")
+	compactionDir := filepath.Join(tempDir, "compaction")
+	require.NoError(t, os.MkdirAll(compactionDir, 0o755))
+
+	client, err := newClient(zap.NewNop(), dbFile, time.Second, &CompactionConfig{}, false)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	require.NoError(t, client.Set(ctx, "key", []byte("value")))
+
+	// Remove the db directory while the db file is still open.
+	// On Linux the open file descriptor remains valid, so compaction
+	// reads succeed, but bbolt.Open fails when Compact tries to
+	// reopen the db at a path whose parent directory no longer exists.
+	require.NoError(t, os.RemoveAll(dbDir))
+
+	err = client.Compact(compactionDir, time.Second, 65536)
+	require.ErrorContains(t, err, "failed to open db after compaction")
+
+	// After a failed reopen, c.db points to the old (closed) DB.
+	// Operations return errors instead of panicking on a nil pointer.
+	_, err = client.Get(ctx, "key")
+	require.Error(t, err)
+
+	// Close is safe — double-close on a bbolt.DB is a no-op.
+	require.NoError(t, client.Close(ctx))
+}
+
 func BenchmarkClientGet(b *testing.B) {
 	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -420,7 +420,7 @@ func TestCompactReopenFailureReturnsErrors(t *testing.T) {
 	// but bbolt.Open fails when Compact tries to reopen.
 	// On Windows open files cannot be removed, so the scenario cannot
 	// be triggered — verify that and return early.
-	if err := os.RemoveAll(dbDir); err != nil {
+	if err = os.RemoveAll(dbDir); err != nil {
 		assert.Equal(t, "windows", runtime.GOOS)
 		assert.ErrorContains(t, err, "being used by another process")
 		assert.NoError(t, client.Close(ctx))

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 	"go.opentelemetry.io/collector/extension/xextension/storage"
@@ -414,21 +416,27 @@ func TestCompactReopenFailureReturnsErrors(t *testing.T) {
 	require.NoError(t, client.Set(ctx, "key", []byte("value")))
 
 	// Remove the db directory while the db file is still open.
-	// On Linux the open file descriptor remains valid, so compaction
-	// reads succeed, but bbolt.Open fails when Compact tries to
-	// reopen the db at a path whose parent directory no longer exists.
-	require.NoError(t, os.RemoveAll(dbDir))
+	// On Linux the open fd remains valid so compaction reads succeed,
+	// but bbolt.Open fails when Compact tries to reopen.
+	// On Windows open files cannot be removed, so the scenario cannot
+	// be triggered — verify that and return early.
+	if err := os.RemoveAll(dbDir); err != nil {
+		assert.Equal(t, "windows", runtime.GOOS)
+		assert.ErrorContains(t, err, "being used by another process")
+		assert.NoError(t, client.Close(ctx))
+		return
+	}
 
 	err = client.Compact(compactionDir, time.Second, 65536)
-	require.ErrorContains(t, err, "failed to open db after compaction")
+	assert.ErrorContains(t, err, "failed to open db after compaction")
 
 	// After a failed reopen, c.db points to the old (closed) DB.
 	// Operations return errors instead of panicking on a nil pointer.
 	_, err = client.Get(ctx, "key")
-	require.Error(t, err)
+	assert.Error(t, err)
 
 	// Close is safe — double-close on a bbolt.DB is a no-op.
-	require.NoError(t, client.Close(ctx))
+	assert.NoError(t, client.Close(ctx))
 }
 
 func BenchmarkClientGet(b *testing.B) {


### PR DESCRIPTION
#### Description

When `Compact()` fails to reopen the bbolt database (e.g. because the storage directory was removed), it sets `c.db` to `nil`. The `on_rebound` compaction loop then crashes the collector process with a nil pointer dereference (`SIGSEGV`) on the next `shouldCompact()` call, which invokes `c.db.View()`.

This PR fixes two bugs in `client.go`:

1. **Nil pointer crash:** `Compact()` used `c.db, openErr = bbolt.Open(...)`, which overwrites `c.db` with `nil` on failure. Changed to use a local variable and only assign to `c.db` on success. The old (closed) `*bbolt.DB` returns `bbolt.ErrDatabaseNotOpen` on all operations instead of panicking, so the compaction loop and callers degrade gracefully.

2. **Dead code in error handling:** `errors.As(err, &pathErr)` checked `err` (which holds the result of the earlier `bbolt.Compact` call — always `nil` at that point) instead of `moveErr`. Fixed to `errors.As(moveErr, &pathErr)`.

#### Link to tracking issue

Fixes #46489

#### Testing

`TestCompactReopenFailureReturnsErrors`: verifies that after a failed reopen, `Get()` returns an error (not a panic) and `Close()` is safe to call.

#### Documentation

N/A