### PR TITLE
Hec raw skip encoding

### DIFF
--- a/.chloggen/36571.yaml
+++ b/.chloggen/36571.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Splunk HEC timestamp accepts nanoseconds, microseconds, milliseconds, and seconds epoch.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36571]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/38464.yaml
+++ b/.chloggen/38464.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: splunk hec receiver accepts metrics with empty string Event field
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [38464]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -675,9 +675,10 @@ func buildHTTPHeaders(config *Config, buildInfo component.BuildInfo) map[string]
 	}
 }
 
-// marshalEvent marshals an event to JSON
+// marshalEvent marshals an event to JSON without HTML escaping, so that
+// characters like <, >, and & in Event.event are preserved as literal characters.
 func marshalEvent(event *splunk.Event, sizeLimit uint) ([]byte, error) {
-	b, err := json.Marshal(event)
+	b, err := json.MarshalWithOption(event, json.DisableHTMLEscape())
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -601,7 +601,7 @@ func TestReceiveLogs(t *testing.T) {
 			name: "1 log long event",
 			logs: func() plog.Logs {
 				l := createLogData(1, 1, 1)
-				l.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(strings.Repeat("a", 1800))
+				l.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(strings.Repeat("<", 1800))
 				return l
 			}(),
 			conf: func() *Config {
@@ -1481,6 +1481,37 @@ func TestInvalidJson(t *testing.T) {
 	}
 	_, err := json.Marshal(badEvent)
 	assert.Error(t, err)
+}
+
+func TestMarshalEventPreservesHTMLCharacters(t *testing.T) {
+	event := &splunk.Event{
+		Host:  "test",
+		Event: "<",
+	}
+	b, err := marshalEvent(event, 1024*1024)
+	require.NoError(t, err)
+	// Event.event should contain literal "<" not "\u003c"
+	assert.Contains(t, string(b), `"event":"<"`)
+	assert.NotContains(t, string(b), `\u003c`)
+
+	// Also verify > and & are preserved
+	event2 := &splunk.Event{
+		Host:  "test",
+		Event: ">",
+	}
+	b2, err := marshalEvent(event2, 1024*1024)
+	require.NoError(t, err)
+	assert.Contains(t, string(b2), `"event":">"`)
+	assert.NotContains(t, string(b2), `\u003e`)
+
+	event3 := &splunk.Event{
+		Host:  "test",
+		Event: "&",
+	}
+	b3, err := marshalEvent(event3, 1024*1024)
+	require.NoError(t, err)
+	assert.Contains(t, string(b3), `"event":"&"`)
+	assert.NotContains(t, string(b3), `\u0026`)
 }
 
 func Test_pushLogData_nil_Logs(t *testing.T) {

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -111,7 +111,7 @@ func mergeValue(dst map[string]any, k string, v any) {
 		if isArrayFlat(element) {
 			dst[k] = v
 		} else {
-			b, _ := json.Marshal(element)
+			b, _ := json.MarshalWithOption(element, json.DisableHTMLEscape())
 			dst[k] = string(b)
 		}
 	case map[string]any:
@@ -141,7 +141,7 @@ func flattenAndMergeMap(src, dst map[string]any, key string) {
 			if isArrayFlat(element) {
 				dst[current] = element
 			} else {
-				b, _ := json.Marshal(element)
+				b, _ := json.MarshalWithOption(element, json.DisableHTMLEscape())
 				dst[current] = string(b)
 			}
 

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -59,7 +59,7 @@ type Event struct {
 
 // IsMetric returns true if the Splunk event is a metric.
 func (e *Event) IsMetric() bool {
-	return e.Event == HecEventMetricType || (e.Event == nil && len(e.GetMetricValues()) > 0)
+	return e.Event == HecEventMetricType || len(e.GetMetricValues()) > 0
 }
 
 // checks if the field name matches the requirements for a metric datapoint field,

--- a/internal/splunk/common_test.go
+++ b/internal/splunk/common_test.go
@@ -52,6 +52,22 @@ func TestIsMetric(t *testing.T) {
 		Event: "metric",
 	}
 	assert.True(t, metric.IsMetric())
+	metric = Event{
+		Event: "",
+		Fields: map[string]any{
+			"metric_name": "foo",
+			"_value":      123,
+		},
+	}
+	assert.True(t, metric.IsMetric())
+	metric = Event{
+		Event: "any value",
+		Fields: map[string]any{
+			"metric_name": "foo",
+			"_value":      123,
+		},
+	}
+	assert.True(t, metric.IsMetric())
 	arr := Event{
 		Event: []any{"foo", "bar"},
 	}

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -427,22 +427,13 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			return
 		}
 
-		if msg.Event == nil {
-			r.failRequest(resp, http.StatusBadRequest, eventRequiredRespBody, nil)
-			return
-		}
-
-		if msg.Event == "" {
-			r.failRequest(resp, http.StatusBadRequest, eventBlankRespBody, nil)
-			return
-		}
-
 		for _, v := range msg.Fields {
 			if !isFlatJSONField(v) {
 				r.failRequest(resp, http.StatusBadRequest, []byte(fmt.Sprintf(responseErrHandlingIndexedFields, len(events)+len(metricEvents))), nil)
 				return
 			}
 		}
+
 		if msg.IsMetric() {
 			if r.metricsConsumer == nil {
 				r.failRequest(resp, http.StatusBadRequest, errUnsupportedMetricEvent, err)
@@ -450,6 +441,16 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			}
 			metricEvents = append(metricEvents, &msg)
 		} else {
+			if msg.Event == nil {
+				r.failRequest(resp, http.StatusBadRequest, eventRequiredRespBody, nil)
+				return
+			}
+
+			if msg.Event == "" {
+				r.failRequest(resp, http.StatusBadRequest, eventBlankRespBody, nil)
+				return
+			}
+
 			if r.logsConsumer == nil {
 				r.failRequest(resp, http.StatusBadRequest, errUnsupportedLogEvent, err)
 				return

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -418,7 +418,6 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 	var unfiltered []*splunk.Event
 	var firstEvent any
-	var isJsonArray bool
 	firstErr := dec.Decode(&firstEvent)
 
 	if firstErr != nil {
@@ -441,10 +440,15 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			return
 		}
 
+		// If event is JSON array, there should be no more tokens after the first one
+		if dec.More() {
+			r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, nil)
+			return
+		}
+
 		for _, item := range events {
 			unfiltered = append(unfiltered, &item)
 		}
-		isJsonArray = true
 	default:
 		// Single event
 		eventBytes, _ := jsoniter.Marshal(v)
@@ -454,17 +458,10 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			return
 		}
 		unfiltered = append(unfiltered, &event)
-		isJsonArray = false
 	}
 
 	var events []*splunk.Event
 	var metricEvents []*splunk.Event
-
-	// If event is JSON array, there should be no more tokens after the first one
-	if isJsonArray && dec.More() {
-		r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, nil)
-		return
-	}
 
 	for len(unfiltered) > 0 {
 		msg := unfiltered[0]

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -435,6 +435,12 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, err)
 			return
 		}
+
+		if len(events) == 0 {
+			r.failRequest(resp, http.StatusBadRequest, noDataRespBody, nil)
+			return
+		}
+
 		for _, item := range events {
 			unfiltered = append(unfiltered, &item)
 		}

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -454,6 +454,7 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 	var events []*splunk.Event
 	var metricEvents []*splunk.Event
 
+	// If event is JSON array, there should be no more tokens after the first one
 	if isJsonArray && dec.More() {
 		r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, nil)
 		return
@@ -500,6 +501,7 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 				r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, err)
 				return
 			}
+			unfiltered = append(unfiltered, &msg)
 		}
 
 		unfiltered = unfiltered[1:]

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -509,7 +509,6 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 		unfiltered = unfiltered[1:]
 	}
-
 	resourceCustomizer := r.createResourceCustomizer(req)
 	if r.logsConsumer != nil && len(events) > 0 {
 		ld, err := splunkHecToLogData(r.settings.Logger, events, resourceCustomizer, r.config)

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -416,16 +416,51 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 	dec := jsoniter.NewDecoder(bodyReader)
 
-	var events []*splunk.Event
-	var metricEvents []*splunk.Event
+	var unfiltered []*splunk.Event
+	var firstEvent any
+	var isJsonArray bool
+	firstErr := dec.Decode(&firstEvent)
 
-	for dec.More() {
-		var msg splunk.Event
-		err := dec.Decode(&msg)
-		if err != nil {
+	if firstErr != nil {
+		r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, firstErr)
+		return
+	}
+
+	switch v := firstEvent.(type) {
+	case []any:
+		// Array of events
+		eventBytes, _ := jsoniter.Marshal(v)
+		var events []splunk.Event
+		if err := jsoniter.Unmarshal(eventBytes, &events); err != nil {
 			r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, err)
 			return
 		}
+		for _, item := range events {
+			unfiltered = append(unfiltered, &item)
+		}
+		isJsonArray = true
+	default:
+		// Single event
+		eventBytes, _ := jsoniter.Marshal(v)
+		var event splunk.Event
+		if err := jsoniter.Unmarshal(eventBytes, &event); err != nil {
+			r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, err)
+			return
+		}
+		unfiltered = append(unfiltered, &event)
+		isJsonArray = false
+	}
+
+	var events []*splunk.Event
+	var metricEvents []*splunk.Event
+
+	if isJsonArray && dec.More() {
+		r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, nil)
+		return
+	}
+
+	for len(unfiltered) > 0 {
+		msg := unfiltered[0]
 
 		for _, v := range msg.Fields {
 			if !isFlatJSONField(v) {
@@ -436,10 +471,10 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 		if msg.IsMetric() {
 			if r.metricsConsumer == nil {
-				r.failRequest(resp, http.StatusBadRequest, errUnsupportedMetricEvent, err)
+				r.failRequest(resp, http.StatusBadRequest, errUnsupportedMetricEvent, nil)
 				return
 			}
-			metricEvents = append(metricEvents, &msg)
+			metricEvents = append(metricEvents, msg)
 		} else {
 			if msg.Event == nil {
 				r.failRequest(resp, http.StatusBadRequest, eventRequiredRespBody, nil)
@@ -452,12 +487,24 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			}
 
 			if r.logsConsumer == nil {
-				r.failRequest(resp, http.StatusBadRequest, errUnsupportedLogEvent, err)
+				r.failRequest(resp, http.StatusBadRequest, errUnsupportedLogEvent, nil)
 				return
 			}
-			events = append(events, &msg)
+			events = append(events, msg)
 		}
+
+		if dec.More() {
+			var msg splunk.Event
+			err := dec.Decode(&msg)
+			if err != nil {
+				r.failRequest(resp, http.StatusBadRequest, invalidFormatRespBody, err)
+				return
+			}
+		}
+
+		unfiltered = unfiltered[1:]
 	}
+
 	resourceCustomizer := r.createResourceCustomizer(req)
 	if r.logsConsumer != nil && len(events) > 0 {
 		ld, err := splunkHecToLogData(r.settings.Logger, events, resourceCustomizer, r.config)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -250,7 +250,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "metric_msg_accepted",
 			req: func() *http.Request {
-				msgBytes, err := json.Marshal(buildSplunkHecMetricsMsg(3, 4, 3))
+				msgBytes, err := json.Marshal(buildSplunkHecMetricsMsg("metric", 3, 4, 3))
 				require.NoError(t, err)
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
@@ -367,7 +367,7 @@ func Test_consumer_err(t *testing.T) {
 
 func Test_consumer_err_metrics(t *testing.T) {
 	currentTime := float64(time.Now().UnixNano()) / 1e6
-	splunkMsg := buildSplunkHecMetricsMsg(currentTime, 13, 2)
+	splunkMsg := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
 	assert.True(t, splunkMsg.IsMetric())
 	config := createDefaultConfig().(*Config)
 	config.Endpoint = "localhost:0" // Actually not creating the endpoint\
@@ -569,7 +569,7 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 			currentTime := float64(time.Now().UnixNano()) / 1e6
 			var splunkhecMsg *splunk.Event
 			if tt.metric {
-				splunkhecMsg = buildSplunkHecMetricsMsg(currentTime, 1.0, 3)
+				splunkhecMsg = buildSplunkHecMetricsMsg("metric", currentTime, 1.0, 3)
 			} else {
 				splunkhecMsg = buildSplunkHecMsg(currentTime, 3)
 			}
@@ -737,18 +737,33 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 		name       string
 		index      string
 		sourcetype string
+		event      string
 	}{
 		{
-			name: "No index, no source type",
+			name:  "No index, no source type",
+			event: "metric",
 		},
 		{
 			name:  "Index, no source type",
 			index: "myindex",
+			event: "metric",
 		},
 		{
 			name:       "Index and source type",
 			index:      "myindex",
 			sourcetype: "source:type",
+			event:      "metric",
+		},
+		{
+			name:  "empty event",
+			event: "",
+		},
+		{
+			name:  "any value event",
+			event: "some event",
+		},
+		{
+			name: "nil event",
 		},
 	}
 
@@ -785,7 +800,7 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			rcv.metricsConsumer = exporter
 
 			currentTime := float64(time.Now().UnixNano()) / 1e6
-			splunkhecMsg := buildSplunkHecMetricsMsg(currentTime, 42, 3)
+			splunkhecMsg := buildSplunkHecMetricsMsg(tt.event, currentTime, 42, 3)
 			splunkhecMsg.Index = tt.index
 			splunkhecMsg.SourceType = tt.sourcetype
 			msgBytes, _ := json.Marshal(splunkhecMsg)
@@ -833,10 +848,10 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 	}
 }
 
-func buildSplunkHecMetricsMsg(time float64, value int64, dimensions uint) *splunk.Event {
+func buildSplunkHecMetricsMsg(event any, time float64, value int64, dimensions uint) *splunk.Event {
 	ev := &splunk.Event{
 		Time:  time,
-		Event: "metric",
+		Event: event,
 		Fields: map[string]any{
 			"metric_name:foo": value,
 		},

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -147,6 +147,108 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple events",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg2)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+		},
+		{
+			name: "JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+		},
+		{
+			name: "multiple JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages1 := []*splunk.Event{splunkMsg, splunkMsg2}
+				messages2 := []*splunk.Event{splunkMsg3}
+
+				msgBytes, err := json.Marshal(messages1)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(messages2)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
+			name: "JSON array with objects",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", nil)

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -150,6 +150,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			name: "multiple events",
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
 
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
@@ -157,7 +158,10 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes2, err := json.Marshal(splunkMsg2)
 				require.NoError(t, err)
 
-				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+				msgBytes3, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes), string(msgBytes2), string(msgBytes3)}, "")
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")
@@ -171,13 +175,18 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 					"code": float64(0),
 				}, body)
 			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 3)
+			},
 		},
 		{
 			name: "JSON array",
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
 
-				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+				messages := []*splunk.Event{splunkMsg, splunkMsg2, splunkMsg3}
 
 				msgBytes, err := json.Marshal(messages)
 				require.NoError(t, err)
@@ -193,6 +202,10 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 					"text": "Success",
 					"code": float64(0),
 				}, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 3)
 			},
 		},
 		{

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -151,6 +151,8 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
 				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+				splunkMetricMsg := buildSplunkHecMetricsMsg("metric", currentTime, 10, 2)
+				splunkMetricMsg2 := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
 
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
@@ -161,7 +163,22 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes3, err := json.Marshal(splunkMsg3)
 				require.NoError(t, err)
 
-				combined := strings.Join([]string{string(msgBytes), string(msgBytes2), string(msgBytes3)}, "")
+				metricMsgBytes, err := json.Marshal(splunkMetricMsg)
+				require.NoError(t, err)
+
+				metricMsgBytes2, err := json.Marshal(splunkMetricMsg2)
+				require.NoError(t, err)
+
+				combined := strings.Join(
+					[]string{
+						string(msgBytes),
+						string(msgBytes2),
+						string(msgBytes3),
+						string(metricMsgBytes),
+						string(metricMsgBytes2),
+					},
+					"",
+				)
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")
@@ -179,14 +196,20 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				assert.Len(t, sink.AllLogs(), 1)
 				assert.Equal(t, sink.LogRecordCount(), 3)
 			},
+			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, sink.DataPointCount(), 2)
+			},
 		},
 		{
 			name: "JSON array",
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
 				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+				splunkMetricMsg := buildSplunkHecMetricsMsg("metric", currentTime, 10, 2)
+				splunkMetricMsg2 := buildSplunkHecMetricsMsg("metric", currentTime, 13, 2)
 
-				messages := []*splunk.Event{splunkMsg, splunkMsg2, splunkMsg3}
+				messages := []*splunk.Event{splunkMsg, splunkMsg2, splunkMsg3, splunkMetricMsg, splunkMetricMsg2}
 
 				msgBytes, err := json.Marshal(messages)
 				require.NoError(t, err)
@@ -206,6 +229,10 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
 				assert.Len(t, sink.AllLogs(), 1)
 				assert.Equal(t, sink.LogRecordCount(), 3)
+			},
+			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
+				assert.Len(t, sink.AllMetrics(), 1)
+				assert.Equal(t, sink.DataPointCount(), 2)
 			},
 		},
 		{

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -304,7 +304,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
-			name: "JSON array with objects",
+			name: "JSON array first with objects",
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
 				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
@@ -318,6 +318,32 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				require.NoError(t, err)
 
 				combined := strings.Join([]string{string(msgBytes), string(msgBytes2)}, "")
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{"code": float64(6), "text": "Invalid data format"}, body)
+			},
+		},
+		{
+			name: "objects first with JSON array",
+			req: func() *http.Request {
+				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
+				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)
+
+				messages := []*splunk.Event{splunkMsg, splunkMsg2}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				msgBytes2, err := json.Marshal(splunkMsg3)
+				require.NoError(t, err)
+
+				combined := strings.Join([]string{string(msgBytes2), string(msgBytes)}, "")
 
 				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte(combined)))
 				req.Header.Set("Content-Type", "application/not-json")

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -202,7 +202,48 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
-			name: "JSON array",
+			name: "empty JSON array",
+			req: func() *http.Request {
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte("[]")))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusBadRequest, status)
+				assert.Equal(t, map[string]any{
+					"text": "No data",
+					"code": float64(5),
+				}, body)
+			},
+		},
+		{
+			name: "one object in JSON array",
+			req: func() *http.Request {
+				messages := []*splunk.Event{splunkMsg}
+
+				msgBytes, err := json.Marshal(messages)
+				require.NoError(t, err)
+
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{
+					"text": "Success",
+					"code": float64(0),
+				}, body)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Len(t, sink.AllLogs(), 1)
+				assert.Equal(t, sink.LogRecordCount(), 1)
+			},
+		},
+		{
+			name: "multiple objects in JSON array",
 			req: func() *http.Request {
 				splunkMsg2 := buildSplunkHecMsg(currentTime, 1)
 				splunkMsg3 := buildSplunkHecMsg(currentTime, 2)

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -52,9 +52,7 @@ func splunkHecToLogData(logger *zap.Logger, events []*splunk.Event, resourceCust
 			return ld, err
 		}
 
-		// Splunk timestamps are in seconds so convert to nanos by multiplying
-		// by 1 billion.
-		logRecord.SetTimestamp(pcommon.Timestamp(event.Time * 1e9))
+		logRecord.SetTimestamp(convertTimestamp(event.Time))
 
 		// Set event fields first, so the specialized attributes overwrite them if needed.
 		keys := make([]string, 0, len(event.Fields))

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -459,6 +459,58 @@ func TestGroupMetricsByResource(t *testing.T) {
 	assert.EqualValues(t, metrics, md)
 }
 
+func TestConvertTimestamp(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		time     float64
+		expected pcommon.Timestamp
+	}{
+		{
+			name: "nanoseconds",
+			time: 1234567890123456789,
+			// not exact because of floating point accuracy
+			expected: pcommon.Timestamp(1234567890123456768),
+		},
+		{
+			name:     "microseconds",
+			time:     1234567890123456,
+			expected: pcommon.Timestamp(1234567890123456000),
+		},
+		{
+			name:     "milliseconds",
+			time:     1234567890456,
+			expected: pcommon.Timestamp(1234567890456000000),
+		},
+		{
+			name:     "seconds",
+			time:     1234567890,
+			expected: pcommon.Timestamp(1234567890000000000),
+		},
+		{
+			name: "dot nanoseconds",
+			time: 1234567890.123456789,
+			// not exact because of floating point accuracy
+			expected: pcommon.Timestamp(1234567890123456768),
+		},
+		{
+			name:     "dot microseconds",
+			time:     1234567890.123456,
+			expected: pcommon.Timestamp(1234567890123456000),
+		},
+		{
+			name:     "dot milliseconds",
+			time:     1234567890.456,
+			expected: pcommon.Timestamp(1234567890456000000),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, convertTimestamp(tt.time))
+		})
+	}
+}
+
 func buildDefaultMetricsData(time int64) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Go’s JSON marshaling escapes HTML characters (<, >, &) as Unicode sequences (\u003c, \u003e, \u0026). That caused log bodies and other Event.event values containing these characters to be sent to Splunk with escapes instead of the original characters.
This change uses json.MarshalWithOption(..., json.DisableHTMLEscape()) in the Splunk HEC exporter so that:
marshalEvent in client.go preserves literal HTML characters in the Event payload.
Nested marshaling in logdata_to_splunk.go (mergeValue and flattenAndMergeMap) does the same for nested structures in Fields.
This keeps HEC payloads readable and matches the original event content when it contains <, >, or &.


<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added TestMarshalEventPreservesHTMLCharacters in client_test.go to verify that <, >, and & are preserved in the marshaled JSON and not replaced with Unicode escapes.

Ran go test ./... for the splunkhecexporter package; all tests pass.

<!--Describe the documentation added.-->
#### Documentation
No documentation changes. The behavior is unchanged from the user’s perspective; only the JSON encoding is adjusted to avoid HTML escaping.
<!--Please delete paragraphs that you did not use before submitting.-->
